### PR TITLE
Update the renewal settings via the API

### DIFF
--- a/static/js/src/advantage/react/components/Subscriptions/SubscriptionList/RenewalSettings/RenewalSettingsFields/RenewalSettingsFields.test.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/SubscriptionList/RenewalSettings/RenewalSettingsFields/RenewalSettingsFields.test.tsx
@@ -1,18 +1,45 @@
 import React from "react";
 import { mount } from "enzyme";
-import { Formik } from "formik";
 
 import RenewalSettingsFields from "./RenewalSettingsFields";
+import { act } from "react-dom/test-utils";
+import { ActionButton } from "@canonical/react-components";
+import { Formik } from "formik";
 
 describe("RenewalSettingsFields", () => {
-  it("closes the form when the cancel button is clicked", () => {
-    const setMenuOpen = jest.fn();
+  it("closes the menu when clicking the cancel button", async () => {
+    const onCloseMenu = jest.fn();
     const wrapper = mount(
       <Formik initialValues={{}} onSubmit={jest.fn()}>
-        <RenewalSettingsFields setMenuOpen={setMenuOpen} />
+        <RenewalSettingsFields onCloseMenu={onCloseMenu} />
       </Formik>
     );
     wrapper.find("Button[data-test='cancel-button']").simulate("click");
-    expect(setMenuOpen).toHaveBeenCalled();
+    wrapper.update();
+    expect(onCloseMenu).toHaveBeenCalled();
+  });
+
+  it("disables the submit button when the form hasn't changed", async () => {
+    const wrapper = mount(
+      <Formik initialValues={{ shouldAutoRenew: true }} onSubmit={jest.fn()}>
+        <RenewalSettingsFields onCloseMenu={jest.fn()} />
+      </Formik>
+    );
+    expect(wrapper.find(ActionButton).prop("disabled")).toBe(true);
+  });
+
+  it("enables the submit button when the form has changed", async () => {
+    const wrapper = mount(
+      <Formik initialValues={{ shouldAutoRenew: true }} onSubmit={jest.fn()}>
+        <RenewalSettingsFields onCloseMenu={jest.fn()} />
+      </Formik>
+    );
+    await act(async () => {
+      wrapper.find("input[name='shouldAutoRenew']").simulate("change", {
+        target: { name: "shouldAutoRenew", value: false },
+      });
+    });
+    wrapper.update();
+    expect(wrapper.find(ActionButton).prop("disabled")).toBe(false);
   });
 });

--- a/static/js/src/advantage/react/components/Subscriptions/SubscriptionList/RenewalSettings/RenewalSettingsFields/RenewalSettingsFields.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/SubscriptionList/RenewalSettings/RenewalSettingsFields/RenewalSettingsFields.tsx
@@ -4,17 +4,23 @@ import { useFormikContext } from "formik";
 import FormikField from "advantage/react/components/FormikField";
 
 type Props = {
-  setMenuOpen: (menuOpen: boolean) => void;
+  onCloseMenu: () => void;
+  loading?: boolean;
+  success?: boolean;
 };
 
-const RenewalSettingsFields = ({ setMenuOpen }: Props): JSX.Element => {
-  const { handleSubmit } = useFormikContext();
+const RenewalSettingsFields = ({
+  loading,
+  onCloseMenu,
+  success,
+}: Props): JSX.Element => {
+  const { dirty, handleSubmit, isValid } = useFormikContext();
   return (
     <form onSubmit={handleSubmit}>
       <FormikField
         label="Auto-renewal"
         labelClassName="u-no-margin--bottom"
-        name="should_auto_renew"
+        name="shouldAutoRenew"
         type="checkbox"
         wrapperClassName="u-sv4"
       />
@@ -23,12 +29,19 @@ const RenewalSettingsFields = ({ setMenuOpen }: Props): JSX.Element => {
           appearance="neutral"
           className="u-no-margin--bottom"
           data-test="cancel-button"
-          onClick={() => setMenuOpen(false)}
+          onClick={onCloseMenu}
           type="button"
         >
           Cancel changes
         </Button>
-        <ActionButton appearance="positive" className="u-no-margin--bottom">
+        <ActionButton
+          appearance="positive"
+          className="u-no-margin--bottom"
+          disabled={!dirty || !isValid}
+          loading={loading}
+          success={success}
+          type="submit"
+        >
           Save changes
         </ActionButton>
       </div>

--- a/static/js/src/advantage/react/hooks/index.ts
+++ b/static/js/src/advantage/react/hooks/index.ts
@@ -2,6 +2,7 @@ export { useCancelContract } from "./useCancelContract";
 export { useContractToken } from "./useContractToken";
 export { useLastPurchaseIds } from "./useLastPurchaseIds";
 export { useLoadWindowData } from "./useLoadWindowData";
+export { useSetAutoRenewal } from "./useSetAutoRenewal";
 export { useStripePublishableKey } from "./useStripePublishableKey";
 export { useURLs } from "./useURLs";
 export { useUserInfo } from "./useUserInfo";

--- a/static/js/src/advantage/react/hooks/useSetAutoRenewal.test.tsx
+++ b/static/js/src/advantage/react/hooks/useSetAutoRenewal.test.tsx
@@ -1,0 +1,69 @@
+import React, { PropsWithChildren } from "react";
+import { renderHook, WrapperComponent } from "@testing-library/react-hooks";
+import type { ReactNode } from "react";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { useSetAutoRenewal } from "./useSetAutoRenewal";
+
+import * as contracts from "advantage/api/contracts";
+import { userInfoFactory } from "advantage/tests/factories/api";
+import { UserInfo } from "advantage/api/types";
+
+describe("useSetAutoRenewal", () => {
+  let setAutoRenewalSpy: jest.SpyInstance;
+  let queryClient: QueryClient;
+  let wrapper: WrapperComponent<ReactNode>;
+  let userInfo: UserInfo;
+
+  beforeEach(() => {
+    setAutoRenewalSpy = jest.spyOn(contracts, "setAutoRenewal");
+    setAutoRenewalSpy.mockImplementation(() => Promise.resolve({}));
+    queryClient = new QueryClient();
+    userInfo = userInfoFactory.build();
+    queryClient.setQueryData("userInfo", userInfo);
+    const Wrapper = ({ children }: PropsWithChildren<ReactNode>) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    wrapper = Wrapper;
+  });
+
+  it("can make the request to update the setting", async () => {
+    const { result, waitForNextUpdate } = renderHook(
+      () => useSetAutoRenewal(),
+      { wrapper }
+    );
+    result.current.mutate(true);
+    await waitForNextUpdate();
+    expect(setAutoRenewalSpy).toHaveBeenCalledWith(true);
+  });
+
+  it("handles errors", async () => {
+    setAutoRenewalSpy.mockImplementation(() =>
+      Promise.resolve({
+        errors: "Uh oh",
+      })
+    );
+    const onError = jest.fn();
+    const { result, waitForNextUpdate } = renderHook(
+      () => useSetAutoRenewal(),
+      { wrapper }
+    );
+    result.current.mutate(true, {
+      onError: (error) => onError(error.message),
+    });
+    await waitForNextUpdate();
+    expect(onError).toHaveBeenCalledWith("Uh oh");
+  });
+
+  it("invalidates queries when successful", async () => {
+    const { result, waitForNextUpdate } = renderHook(
+      () => useSetAutoRenewal(),
+      { wrapper }
+    );
+    let userInfoState = queryClient.getQueryState("userInfo");
+    expect(userInfoState?.isInvalidated).toBe(false);
+    result.current.mutate(true);
+    await waitForNextUpdate();
+    userInfoState = queryClient.getQueryState("userInfo");
+    expect(userInfoState?.isInvalidated).toBe(true);
+  });
+});

--- a/static/js/src/advantage/react/hooks/useSetAutoRenewal.ts
+++ b/static/js/src/advantage/react/hooks/useSetAutoRenewal.ts
@@ -1,0 +1,22 @@
+import { setAutoRenewal } from "advantage/api/contracts";
+import { useMutation, useQueryClient } from "react-query";
+
+export const useSetAutoRenewal = () => {
+  const queryClient = useQueryClient();
+  const mutation = useMutation<unknown, Error, boolean>(
+    (shouldAutoRenew) =>
+      setAutoRenewal(shouldAutoRenew).then((response) => {
+        if (response.errors) {
+          throw new Error(response.errors);
+        }
+        return response;
+      }),
+    {
+      onSuccess: () => {
+        // Invalidate the user info so it fetches the updated data.
+        queryClient.invalidateQueries("userInfo");
+      },
+    }
+  );
+  return mutation;
+};


### PR DESCRIPTION
## Done

- Add API support for updating renewal settings.
- Update the renewal settings from the form.

## QA

- Visit [/advantage?test_backend=true](https://ubuntu-com-10455.demos.haus/advantage?test_backend=true) and log in.
- Open the 'Renewal settings' dropdown at the top of the list.
- Change the setting and click save.
- Open the form again.
- The form should show the new state.

## Issue / Card

Fixes https://github.com/canonical-web-and-design/commercial-squad/issues/272.