### PR TITLE
Conditional ua subscriptions group

### DIFF
--- a/static/js/src/advantage/react/components/Subscriptions/SubscriptionList/SubscriptionList.test.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/SubscriptionList/SubscriptionList.test.tsx
@@ -50,6 +50,23 @@ describe("SubscriptionList", () => {
     );
   });
 
+  it("does not display the UA subscriptions group if there are none", () => {
+    const subscriptions = [
+      userSubscriptionFactory.build({
+        marketplace: UserSubscriptionMarketplace.Free,
+      }),
+    ];
+    queryClient.setQueryData("userSubscriptions", subscriptions);
+    const wrapper = mount(
+      <QueryClientProvider client={queryClient}>
+        <SubscriptionList onSetActive={jest.fn()} />
+      </QueryClientProvider>
+    );
+    expect(
+      wrapper.find("ListGroup[data-test='ua-subscriptions-group']").exists()
+    ).toBe(false);
+  });
+
   it("sorts the UA subscriptions by most recently started", () => {
     const subscriptions = [
       userSubscriptionFactory.build({
@@ -108,8 +125,16 @@ describe("SubscriptionList", () => {
   });
 
   it("shows the renewal settings if there are monthly subs", () => {
-    userInfo = userInfoFactory.build({ has_monthly_subscription: true });
+    userInfo = userInfoFactory.build({
+      has_monthly_subscription: true,
+    });
     queryClient.setQueryData("userInfo", userInfo);
+    const subscriptions = [
+      userSubscriptionFactory.build({
+        marketplace: UserSubscriptionMarketplace.CanonicalUA,
+      }),
+    ];
+    queryClient.setQueryData("userSubscriptions", subscriptions);
     const wrapper = mount(
       <QueryClientProvider client={queryClient}>
         <SubscriptionList
@@ -124,8 +149,16 @@ describe("SubscriptionList", () => {
   });
 
   it("does not show the renewal settings if there are no monthly subs", () => {
-    userInfo = userInfoFactory.build({ has_monthly_subscription: false });
+    userInfo = userInfoFactory.build({
+      has_monthly_subscription: false,
+    });
     queryClient.setQueryData("userInfo", userInfo);
+    const subscriptions = [
+      userSubscriptionFactory.build({
+        marketplace: UserSubscriptionMarketplace.CanonicalUA,
+      }),
+    ];
+    queryClient.setQueryData("userSubscriptions", subscriptions);
     const wrapper = mount(
       <QueryClientProvider client={queryClient}>
         <SubscriptionList

--- a/static/js/src/advantage/react/components/Subscriptions/SubscriptionList/SubscriptionList.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/SubscriptionList/SubscriptionList.tsx
@@ -58,12 +58,16 @@ const SubscriptionList = ({ selectedId, onSetActive }: Props) => {
   return (
     <div className="p-subscriptions__list">
       <div className="p-subscriptions__list-scroll">
-        <ListGroup
-          title="Ubuntu Advantage"
-          showRenewalSettings={userInfo?.has_monthly_subscription}
-        >
-          {uaSubscriptions}
-        </ListGroup>
+        {sortedUASubscriptions.length ? (
+          <ListGroup
+            data-test="ua-subscriptions-group"
+            title="Ubuntu Advantage"
+            showRenewalSettings={userInfo?.has_monthly_subscription}
+          >
+            {uaSubscriptions}
+          </ListGroup>
+        ) : null}
+
         {freeSubscription ? (
           <ListGroup title="Free personal token" showRenewalSettings={false}>
             <ListCard


### PR DESCRIPTION
## Done

- Only display the ua subscriptions group if there are ua subscriptions.

## QA

- Visit [/advantage?test_backend=true](https://ubuntu-com-10489.demos.haus/advantage?test_backend=true) and log into an account without any UA subscriptions (e.g. a new account).
- You should not see the "UBUNTU ADVANTAGE" group in the list.
- Log out and log back in with account that does have ua subs.
- You should now see the "UBUNTU ADVANTAGE" group.


## Issue / Card

Fixes https://github.com/canonical-web-and-design/commercial-squad/issues/286.

## Screenshots

<img width="512" alt="Screen Shot 2021-09-24 at 2 34 48 pm" src="https://user-images.githubusercontent.com/361637/134618866-a8199691-1b6a-405c-b727-f8dc605eeb95.png">

