### PR TITLE
Reorder docs links

### DIFF
--- a/static/js/src/advantage/react/components/Subscriptions/SubscriptionDetails/DetailsTabs/DetailsTabs.test.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/SubscriptionDetails/DetailsTabs/DetailsTabs.test.tsx
@@ -73,6 +73,42 @@ describe("DetailsTabs", () => {
     expect(docsLinks.at(0).text()).toBe("ESM Infra & ESM Apps");
   });
 
+  it("reorders FIPS, CC-EAL, and CIS to the end", () => {
+    subscription = userSubscriptionFactory.build({
+      entitlements: [
+        userSubscriptionEntitlementFactory.build({
+          enabled_by_default: true,
+          type: EntitlementType.EsmApps,
+        }),
+        userSubscriptionEntitlementFactory.build({
+          enabled_by_default: true,
+          type: EntitlementType.Fips,
+        }),
+        userSubscriptionEntitlementFactory.build({
+          enabled_by_default: true,
+          type: EntitlementType.CcEal,
+        }),
+        userSubscriptionEntitlementFactory.build({
+          enabled_by_default: true,
+          type: EntitlementType.Cis,
+        }),
+        userSubscriptionEntitlementFactory.build({
+          enabled_by_default: true,
+          type: EntitlementType.Livepatch,
+        }),
+      ],
+    });
+    const wrapper = mount(<DetailsTabs subscription={subscription} />);
+    // Switch to the docs tab:
+    wrapper.find("[data-test='docs-tab']").simulate("click");
+    const docsLinks = wrapper.find("[data-test='doc-link']");
+    expect(docsLinks.at(0).text()).toBe("ESM Infra & ESM Apps");
+    expect(docsLinks.at(1).text()).toBe("Livepatch");
+    expect(docsLinks.at(2).text()).toBe("FIPS setup instructions");
+    expect(docsLinks.at(3).text()).toBe("CC-EAL2 setup instructions");
+    expect(docsLinks.at(4).text()).toBe("CIS setup instructions");
+  });
+
   it("can display a contract token", () => {
     const wrapper = mount(
       <DetailsTabs

--- a/static/js/src/advantage/react/components/Subscriptions/SubscriptionDetails/DetailsTabs/DetailsTabs.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/SubscriptionDetails/DetailsTabs/DetailsTabs.tsx
@@ -54,54 +54,81 @@ const generateList = (title: string, items: ListItem[]) => (
   </>
 );
 
+const isEntitlementTypeEnum = (
+  entitlementType: UserSubscriptionEntitlement["type"]
+): entitlementType is EntitlementType =>
+  Object.values<string>(EntitlementType).includes(entitlementType);
+
+const showLast = (entitlement: UserSubscriptionEntitlement) =>
+  isEntitlementTypeEnum(entitlement.type) &&
+  [EntitlementType.Fips, EntitlementType.CcEal, EntitlementType.Cis].includes(
+    entitlement.type
+  );
+
+const sortEntitlements = (
+  entitlements: UserSubscriptionEntitlement[]
+): UserSubscriptionEntitlement[] =>
+  [...entitlements].sort((a, b) => {
+    if (showLast(b) && !showLast(a)) {
+      return -1;
+    }
+    if (showLast(a) && !showLast(b)) {
+      return 1;
+    }
+    return 0;
+  });
+
 const generateDocLinks = (
   entitlements: UserSubscriptionEntitlement[]
 ): DocsLink[] =>
-  entitlements.reduce<DocsLink[]>((collection, entitlement) => {
-    let link: DocsLink | null = null;
-    switch (entitlement.type) {
-      case EntitlementType.EsmApps:
-      case EntitlementType.EsmInfra:
-        link = {
-          label: "ESM Infra & ESM Apps",
-          url:
-            "https://support.canonical.com/staff/s/article/Obtaining-ESM-Credentials-And-Enabling-ESM-On-Ubuntu ",
-        };
-        break;
-      case EntitlementType.Livepatch:
-      case EntitlementType.LivepatchOnprem:
-        link = {
-          label: "Livepatch",
-          url: "/security/livepatch/docs",
-        };
-        break;
-      case EntitlementType.Support:
-        link = { label: "Support", url: "https://support.canonical.com/" };
-        break;
-      case EntitlementType.Cis:
-        link = {
-          label: "CIS setup instructions",
-          url: "/security/certifications/docs/cis",
-        };
-        break;
-      case EntitlementType.CcEal:
-        link = {
-          label: "CC-EAL2 setup instructions",
-          url: "/security/certifications/docs/cc",
-        };
-        break;
-      case EntitlementType.Fips:
-        link = {
-          label: "FIPS setup instructions",
-          url: "/security/certifications/docs/fips ",
-        };
-        break;
-    }
-    if (link && !collection.find(({ label }) => label === link?.label)) {
-      collection.push(link);
-    }
-    return collection;
-  }, []);
+  sortEntitlements(entitlements).reduce<DocsLink[]>(
+    (collection, entitlement) => {
+      let link: DocsLink | null = null;
+      switch (entitlement.type) {
+        case EntitlementType.EsmApps:
+        case EntitlementType.EsmInfra:
+          link = {
+            label: "ESM Infra & ESM Apps",
+            url:
+              "https://support.canonical.com/staff/s/article/Obtaining-ESM-Credentials-And-Enabling-ESM-On-Ubuntu ",
+          };
+          break;
+        case EntitlementType.Livepatch:
+        case EntitlementType.LivepatchOnprem:
+          link = {
+            label: "Livepatch",
+            url: "/security/livepatch/docs",
+          };
+          break;
+        case EntitlementType.Support:
+          link = { label: "Support", url: "https://support.canonical.com/" };
+          break;
+        case EntitlementType.Cis:
+          link = {
+            label: "CIS setup instructions",
+            url: "/security/certifications/docs/cis",
+          };
+          break;
+        case EntitlementType.CcEal:
+          link = {
+            label: "CC-EAL2 setup instructions",
+            url: "/security/certifications/docs/cc",
+          };
+          break;
+        case EntitlementType.Fips:
+          link = {
+            label: "FIPS setup instructions",
+            url: "/security/certifications/docs/fips ",
+          };
+          break;
+      }
+      if (link && !collection.find(({ label }) => label === link?.label)) {
+        collection.push(link);
+      }
+      return collection;
+    },
+    []
+  );
 
 const DetailsTabs = ({ subscription, token, ...wrapperProps }: Props) => {
   const [activeTab, setActiveTab] = useState<ActiveTab>(ActiveTab.FEATURES);


### PR DESCRIPTION
## Done

- Reorder the docs links.

## QA

- Visit [/advantage?test_backend=true](https://ubuntu-com-10490.demos.haus/advantage?test_backend=true) and log in.
- Click on the Documentation tab.
- FIPS, CC-EAL and CIS should be the last in the list (before the "to attach..." entry).

## Issue / Card

Fixes:  https://github.com/canonical-web-and-design/commercial-squad/issues/289.

## Screenshots

<img width="598" alt="Screen Shot 2021-09-24 at 3 06 11 pm" src="https://user-images.githubusercontent.com/361637/134621232-afb1a2ff-9ea0-41cc-adf5-c8142ac93411.png">

