### PR TITLE
Disable JS minification in development

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ The simplest way to run the site locally is using the [`dotrun`](https://github.
 
 ```bash
 docker-compose up -d
-dotrun
+NODE_ENV=development dotrun
 ```
 
 Once the server has started, you can visit <http://127.0.0.1:8001> in your browser.

--- a/build.js
+++ b/build.js
@@ -25,22 +25,22 @@ let entries = {
   openstackDeploymentChart: "./static/js/src/openstack-deployment-chart.js",
 };
 
+const isDev = process && process.env && process.env.NODE_ENV === "development";
+
 for (const [key, value] of Object.entries(entries)) {
   const options = {
     entryPoints: [value],
     bundle: true,
-    minify: true,
-    sourcemap: true,
+    minify: isDev ? false : true,
+    sourcemap: isDev ? false : true,
     outfile: "static/js/dist/" + key + ".js",
     target: ["chrome58", "firefox57", "safari11", "edge16"],
     define: {
       "process.env.NODE_ENV":
         // Explicitly check for 'development' so that this defaults to
         // 'production' in all other cases.
-        process && process.env && process.env.NODE_ENV === "development"
-          ? '"development"'
-          : '"production"'
-    }
+        isDev ? '"development"' : '"production"',
+    },
   };
 
   esbuild


### PR DESCRIPTION
## Done

- disable JS minification in development
- add `NODE_ENV=development` to README.md

##
- checkout this branch locally and run `dotrun` verifying nothing has changed
- run `NODE_ENV=development dotrun` and verify JS is no longer minified (and you can see full component names in React DevTools)

## Screenshots
**Component names are no longer obfuscated** in development.

### React DevTools
#### before
![image](https://user-images.githubusercontent.com/7452681/134650516-849df2b0-aecd-448f-96a7-785dd4b0580f.png)
#### after
![image](https://user-images.githubusercontent.com/7452681/134650511-19b85b78-0e4c-4c95-8e8f-8848a553e046.png)

