### PR TITLE
Add Observability section to footer

### DIFF
--- a/templates/templates/footer.html
+++ b/templates/templates/footer.html
@@ -63,6 +63,9 @@
           {% with section=nav_sections.download %}
           {% include 'templates/_footer_item.html' %}
           {% endwith %}
+          {% with section=nav_sections.observability %}
+          {% include 'templates/_footer_item.html' %}
+          {% endwith %}
           {% with section=nav_sections.appliance %}
           {% include 'templates/_footer_item.html' %}
           {% endwith %}
@@ -102,9 +105,6 @@
               {% include 'templates/_footer_item_small.html' %}
               {% endwith %}
               {% with section=nav_sections.ubuntu1604 %}
-              {% include 'templates/_footer_item_small.html' %}
-              {% endwith %}
-              {% with section=nav_sections.observability %}
               {% include 'templates/_footer_item_small.html' %}
               {% endwith %}
             </ul>


### PR DESCRIPTION
## Done

- Add Observability section to footer as it has 2 pages now
- Remove single link to section

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Scroll to the footer and see the section


## Issue / Card

Fixes #10496

## Screenshots

![image](https://user-images.githubusercontent.com/441217/134872603-cd9d5bfa-6b89-4e0e-8346-4c0f568647ee.png)

