### PR TITLE
Remove local style for .is-crossed

### DIFF
--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -710,27 +710,6 @@ summary {
   }
 }
 
-.is-ticked__cross {
-  background-image: url("https://assets.ubuntu.com/v1/9cdb5b1e-cross-darkaubergine.svg");
-  background-position-y: 0.65rem;
-  background-repeat: no-repeat;
-  background-size: 0.875rem;
-  padding-left: 2rem;
-}
-
-// This is a custom style for a crossed list item
-// https://github.com/canonical-web-and-design/vanilla-framework/issues/3403
-// https://github.com/canonical-web-and-design/vanilla-framework/issues/3405
-.is-crossed {
-  @extend .is-ticked;
-
-  background-image: url("#{$assets-path}9cdb5b1e-cross-darkaubergine.svg");
-}
-
-.u-inline {
-  display: inline;
-}
-
 // XXX Steve: workaround for image template wrapping image in `div`
 // Bug: https://github.com/canonical-web-and-design/canonicalwebteam.image-template/issues/43
 .p-heading-icon__header {

--- a/templates/kubernetes/what-is-kubernetes.html
+++ b/templates/kubernetes/what-is-kubernetes.html
@@ -488,15 +488,15 @@
           It is important to distinguish between the two solutions. Kubernetes, as opposed to PaaS does not:
         </p>
         <ul class="p-list is-split">
-          <li class="p-list__item is-ticked__cross">Limit the types of supported applications or require a dependency handling framework
+          <li class="p-list__item is-crossed">Limit the types of supported applications or require a dependency handling framework
           </li>
-          <li class="p-list__item is-ticked__cross">Require applications to be written in a specific programming language nor does it dictate a specific configuration language/system.
+          <li class="p-list__item is-crossed">Require applications to be written in a specific programming language nor does it dictate a specific configuration language/system.
           </li>
-          <li class="p-list__item is-ticked__cross">Deploy source code and does not build applications, although it can be used to build CI/CD pipelines
+          <li class="p-list__item is-crossed">Deploy source code and does not build applications, although it can be used to build CI/CD pipelines
           </li>
-          <li class="p-list__item is-ticked__cross">Provide application-level services, such as middleware, databases and storage clusters out-of-the box. Such components can be integrated with k8s through add-ons.
+          <li class="p-list__item is-crossed">Provide application-level services, such as middleware, databases and storage clusters out-of-the box. Such components can be integrated with k8s through add-ons.
           </li>
-          <li class="p-list__item is-ticked__cross">Provide nor dictate specific logging, monitoring and alerting components
+          <li class="p-list__item is-crossed">Provide nor dictate specific logging, monitoring and alerting components
           </li>
         </ul>
       </div>


### PR DESCRIPTION
## Done

- Remove local style for `.is-crossed` as Vanilla has updated it to a red cross
- Removed `.is-ticked__cross` and `.u-inline` as they are not in use

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/cloud
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See the vanilla red cross

## Issue / Card

Fixes #10415

## Screenshots

![image](https://user-images.githubusercontent.com/441217/134876995-440c5757-3a61-4c11-b36c-339fed731582.png)

