### PR TITLE
Removed the maintenance updates from the release cycle

### DIFF
--- a/static/js/src/chart-data.js
+++ b/static/js/src/chart-data.js
@@ -58,17 +58,10 @@ export var smallReleases = [
 export var serverAndDesktopReleases = [
   {
     startDate: new Date("2014-04-01T00:00:00"),
-    endDate: new Date("2016-09-30T00:00:00"),
+    endDate: new Date("2019-04-02T00:00:00"),
     taskName: "Ubuntu 14.04 LTS",
     status: "HARDWARE_AND_MAINTENANCE_UPDATES",
   },
-  {
-    startDate: new Date("2016-09-30T00:00:00"),
-    endDate: new Date("2019-04-02T00:00:00"),
-    taskName: "Ubuntu 14.04 LTS",
-    status: "MAINTENANCE_UPDATES",
-  },
-
   {
     startDate: new Date("2019-04-02T00:00:00"),
     endDate: new Date("2024-04-02T00:00:00"),
@@ -77,15 +70,9 @@ export var serverAndDesktopReleases = [
   },
   {
     startDate: new Date("2016-04-01T00:00:00"),
-    endDate: new Date("2018-10-01T00:00:00"),
-    taskName: "Ubuntu 16.04 LTS",
-    status: "HARDWARE_AND_MAINTENANCE_UPDATES",
-  },
-  {
-    startDate: new Date("2018-10-01T00:00:00"),
     endDate: new Date("2021-04-02T00:00:00"),
     taskName: "Ubuntu 16.04 LTS",
-    status: "MAINTENANCE_UPDATES",
+    status: "HARDWARE_AND_MAINTENANCE_UPDATES",
   },
   {
     startDate: new Date("2021-04-02T00:00:00"),
@@ -95,15 +82,9 @@ export var serverAndDesktopReleases = [
   },
   {
     startDate: new Date("2018-04-01T00:00:00"),
-    endDate: new Date("2020-09-30T00:00:00"),
-    taskName: "Ubuntu 18.04 LTS",
-    status: "HARDWARE_AND_MAINTENANCE_UPDATES",
-  },
-  {
-    startDate: new Date("2020-09-30T00:00:00"),
     endDate: new Date("2023-04-02T00:00:00"),
     taskName: "Ubuntu 18.04 LTS",
-    status: "MAINTENANCE_UPDATES",
+    status: "HARDWARE_AND_MAINTENANCE_UPDATES",
   },
   {
     startDate: new Date("2023-04-02T00:00:00"),
@@ -113,15 +94,9 @@ export var serverAndDesktopReleases = [
   },
   {
     startDate: new Date("2020-04-01T00:00:00"),
-    endDate: new Date("2022-10-01T00:00:00"),
-    taskName: "Ubuntu 20.04 LTS",
-    status: "HARDWARE_AND_MAINTENANCE_UPDATES",
-  },
-  {
-    startDate: new Date("2022-10-01T00:00:00"),
     endDate: new Date("2025-04-02T00:00:00"),
     taskName: "Ubuntu 20.04 LTS",
-    status: "MAINTENANCE_UPDATES",
+    status: "HARDWARE_AND_MAINTENANCE_UPDATES",
   },
   {
     startDate: new Date("2025-04-02T00:00:00"),
@@ -149,15 +124,9 @@ export var serverAndDesktopReleases = [
   },
   {
     startDate: new Date("2022-04-01T00:00:00"),
-    endDate: new Date("2024-09-30T00:00:00"),
-    taskName: "Ubuntu 22.04 LTS",
-    status: "HARDWARE_AND_MAINTENANCE_UPDATES",
-  },
-  {
-    startDate: new Date("2024-09-30T00:00:00"),
     endDate: new Date("2027-04-01T00:00:00"),
     taskName: "Ubuntu 22.04 LTS",
-    status: "MAINTENANCE_UPDATES",
+    status: "HARDWARE_AND_MAINTENANCE_UPDATES",
   },
   {
     startDate: new Date("2027-04-01T00:00:00"),

--- a/static/js/src/release-chart.js
+++ b/static/js/src/release-chart.js
@@ -45,6 +45,7 @@ function buildCharts() {
     );
   }
   if (document.querySelector("#server-desktop-eol")) {
+    delete desktopServerStatus.MAINTENANCE_UPDATES;
     createChart(
       "#server-desktop-eol",
       desktopServerReleaseNames,
@@ -53,6 +54,7 @@ function buildCharts() {
     );
   }
   if (document.querySelector("#eol-1604")) {
+    delete desktopServerStatus.MAINTENANCE_UPDATES;
     createChart(
       "#eol-1604",
       desktopServerReleaseNames,


### PR DESCRIPTION
## Done

- Removed the maintenance updates from the release cycle in the page ubuntu.com/about/release-cycle as requested in the [copy doc](https://docs.google.com/document/d/1-l3B7AoyDoETaL80UhlfEWCVKmMWPdy3zoF5LpsGcYQ/edit#)

## QA

- Go to the website https://ubuntu-com-10512.demos.haus/about/release-cycle
- Make sure that the maintenance updates are removed as mentioned in the [copy doc](https://docs.google.com/document/d/1-l3B7AoyDoETaL80UhlfEWCVKmMWPdy3zoF5LpsGcYQ/edit#) and mark the discussion in the [doc](https://docs.google.com/document/d/1-l3B7AoyDoETaL80UhlfEWCVKmMWPdy3zoF5LpsGcYQ/edit#) as done

## Issue / Card

Fixes #10504

## Screenshots

### Before

![Screenshot from 2021-09-27 12-55-19](https://user-images.githubusercontent.com/36013798/134898377-10c21d90-6cf7-479f-8b9e-5bb10e90b307.png)

### After

![Screenshot from 2021-09-27 13-16-08](https://user-images.githubusercontent.com/36013798/134898395-bf53ee5a-2b7b-486e-88af-da0adbee04ed.png)


