### PR TITLE
Fix the render of enabled free trials in step two

### DIFF
--- a/static/js/src/advantage/subscribe/react/components/ModalSteps/StepTwo.tsx
+++ b/static/js/src/advantage/subscribe/react/components/ModalSteps/StepTwo.tsx
@@ -216,18 +216,23 @@ function StepOne({ setStep, error, setError }: StepOneProps) {
     });
   };
 
-  const TrialNotAvailable = getIsFreeTrialEnabled() ? (
-    <Row>
-      <Col size={10} emptyLarge={2}>
-        <p>
-          <strong>
-            Free Trial is not available for this account.{" "}
-            <a href="/contact-us">Contact us</a> for further information.
-          </strong>
-        </p>
-      </Col>
-    </Row>
-  ) : null;
+  const trialNotAvailable = () => {
+    if (getIsFreeTrialEnabled()) {
+      return (
+        <Row>
+          <Col size={10} emptyLarge={2}>
+            <p>
+              <strong>
+                Free Trial is not available for this account.{" "}
+                <a href="/contact-us">Contact us</a> for further information.
+              </strong>
+            </p>
+          </Col>
+        </Row>
+      );
+    }
+    return null;
+  };
 
   return (
     <>
@@ -245,7 +250,7 @@ function StepOne({ setStep, error, setError }: StepOneProps) {
               setIsUsingFreeTrial={setIsUsingFreeTrial}
             />
           ) : (
-            { TrialNotAvailable }
+            trialNotAvailable()
           )}
           <PaymentMethodSummary setStep={setStep} />
           <Row className="u-no-padding">


### PR DESCRIPTION
## Done
Fix the render of enabled free trials in step two

## QA
- Go to http://0.0.0.0:8001/advantage/subscribe?test_backend=true
- Step through the purchase and see the purchase model load up
- Purchase with 4242 all the way and see it works