### PR TITLE
Update /cube contact forms

### DIFF
--- a/templates/shared/_cube-contact-us-form.html
+++ b/templates/shared/_cube-contact-us-form.html
@@ -13,22 +13,22 @@
           <ul class="p-list">
             <li  class="p-list__item  ">
               <label for="FirstName" id="LblFirstName"  >First name:</label>
-              <input id="FirstName" name="FirstName" maxlength="255" aria-labelledby="LblFirstName" type="text" class="is-required" required="" aria-required="true" >
+              <input id="FirstName" name="firstName" maxlength="255" aria-labelledby="LblFirstName" type="text" class="is-required" required="" aria-required="true" >
             </li>
 
             <li  class="p-list__item  ">
               <label for="LastName" id="LblLastName"  >Last name:</label>
-              <input id="LastName" name="LastName" maxlength="255" aria-labelledby="LblLastName InstructLastName" type="text" class="is-required" required="" aria-required="true" >
+              <input id="LastName" name="lastName" maxlength="255" aria-labelledby="LblLastName InstructLastName" type="text" class="is-required" required="" aria-required="true" >
             </li>
 
             <li  class="p-list__item  ">
               <label for="Email" id="LblEmail"  >Work email:</label>
-              <input id="Email" name="Email" maxlength="255" aria-labelledby="LblEmail InstructEmail" type="email" class="is-required" aria-required="true" autocomplete="email" >
+              <input id="Email" name="email" maxlength="255" aria-labelledby="LblEmail InstructEmail" type="email" class="is-required" aria-required="true" autocomplete="email" >
             </li>
 
             <li  class="p-list__item  ">
               <label for="Company" id="LblCompany"  >Current employer:</label>
-              <input id="Company" name="Company" maxlength="255" aria-labelledby="LblCompany InstructCompany" type="text" class="is-required" required="" aria-required="true" >
+              <input id="Company" name="company" maxlength="255" aria-labelledby="LblCompany InstructCompany" type="text" class="is-required" required="" aria-required="true" >
             </li>
 
             <li  class="p-list__item  ">

--- a/templates/shared/_cube-contact-us-form.html
+++ b/templates/shared/_cube-contact-us-form.html
@@ -11,25 +11,105 @@
         <fieldset class="u-no-margin--bottom">
           <h3>About you</h3>
           <ul class="p-list">
-            <li class="mktFormReq mktField p-list__item">
-              <label for="firstName" class="mktoLabel">First name:</label>
-              <input required id="firstName" name="firstName" maxlength="255" type="text" class="mktoField mktoRequired" />
+            <li  class="p-list__item  ">
+              <label for="FirstName" id="LblFirstName"  >First name:</label>
+              <input id="FirstName" name="FirstName" maxlength="255" aria-labelledby="LblFirstName" type="text" class="is-required" required="" aria-required="true" >
             </li>
-            <li class="mktFormReq mktField p-list__item">
-              <label for="lastName" class="mktoLabel">Last name:</label>
-              <input required id="lastName" name="lastName" maxlength="255" type="text" class="mktoField mktoRequired" />
+
+            <li  class="p-list__item  ">
+              <label for="LastName" id="LblLastName"  >Last name:</label>
+              <input id="LastName" name="LastName" maxlength="255" aria-labelledby="LblLastName InstructLastName" type="text" class="is-required" required="" aria-required="true" >
             </li>
-            <li class="mktFormReq mktField p-list__item">
-              <label for="email" class="mktoLabel">Email address:</label>
-              <input required id="email" name="email" maxlength="255" type="email" class="mktoField mktoEmailField mktoRequired" />
+
+            <li  class="p-list__item  ">
+              <label for="Email" id="LblEmail"  >Work email:</label>
+              <input id="Email" name="Email" maxlength="255" aria-labelledby="LblEmail InstructEmail" type="email" class="is-required" aria-required="true" autocomplete="email" >
+            </li>
+
+            <li  class="p-list__item  ">
+              <label for="Company" id="LblCompany"  >Current employer:</label>
+              <input id="Company" name="Company" maxlength="255" aria-labelledby="LblCompany InstructCompany" type="text" class="is-required" required="" aria-required="true" >
+            </li>
+
+            <li  class="p-list__item  ">
+              <label for="Job_Role__c" id="LblJob_Role__c"  >Job role:</label>
+              <select class="is-required" required="" id="Job_Role__c" name="Job_Role__c" aria-labelledby="LblJob_Role__c InstructJob_Role__c" aria-required="true" >
+                <option value=""  disabled="disabled" selected="">Select...</option>
+                <option value="Business and Project Management">Business and Project Management</option>
+                <option value="Database Development and Administration">Database Development and Administration</option>
+                <option value="Education">Education</option>
+                <option value="Enterprise Systems Analysis & Integration">Enterprise Systems Analysis & Integration</option>
+                <option value="Hardware Operations and Management">Hardware Operations and Management</option>
+                <option value="Home User">Home User</option>
+                <option value="Network Design and Administration">Network Design and Administration</option>
+                <option value="Owner/Self Employed">Owner/Self Employed</option>
+                <option value="Press and Communications">Press and Communications</option>
+                <option value="Programming/Software Engineering">Programming/Software Engineering</option>
+                <option value="Smartphone User">Smartphone User</option>
+                <option value="Technical Support">Technical Support</option>
+                <option value="Technical Writing">Technical Writing</option>
+                <option value="Ubuntu Enthusiast">Ubuntu Enthusiast</option>
+                <option value="Web Development and Administration">Web Development and Administration</option>
+                <option value="Individual">Individual</option>
+              </select>
+            </li>
+
+            <li  class="p-list__item ">
+              <label for="cube_ubuntu_experience" id="Lblcube_ubuntu_experience"  >What is your experience with Ubuntu?</label>
+              <select id="cube_ubuntu_experience" name="cube_ubuntu_experience" aria-labelledby="Lblcube_ubuntu_experience" class="is-required" required="" >
+                <option value="" disabled="disabled" selected="">Select...</option>
+                <option value="none">None or very minimal experience </option>
+                <option value="self">Only hands-on experience </option>
+                <option value="formal">Formally educated and/or training </option>
+              </select>
             </li>
           </ul>
         </fieldset>
+
+        <fieldset class="u-no-margin--bottom">
+          <h3>About your interest in CUBE</h3>
+          <ul class="p-list">
+            <li class="p-list__item">
+              <label class="p-checkbox" >
+                <input name="cube_workplace_required"  type="checkbox" value="yes" aria-labelledby="cube_workplace_required-lb" class="p-checkbox__input">
+                <span class="p-checkbox__label" id="cube_workplace_required-lb">
+                  Does your workplace require Ubuntu?
+                </span>
+              </label>
+            </li>
+            <li class="p-list__item ">
+              <label for="cube_microcert_interest" id="Lblcube_microcert_interest"  >Which microcert are you most interested in taking?</label>
+              <select id="cube_microcert_interest" name="cube_microcert_interest" aria-labelledby="Lblcube_microcert_interest Instructcube_microcert_interest" class="is-required" required="" >
+                <option value="" disabled="disabled" selected="">Select...</option>
+                <option value="Ubuntu System Architecture">Ubuntu System Architecture</option>
+                <option value="Managing Packages in Ubuntu">Managing Packages in Ubuntu</option>
+                <option value="Using command line tools">Using command line tools</option>
+                <option value="Linux devices and filesystems">Linux devices and filesystems</option>
+                <option value="Bash shell scripting">Bash shell scripting</option>
+                <option value="Performing administrative tasks">Performing administrative tasks</option>
+                <option value="Managing System Services">Managing System Services</option>
+                <option value="Networking on Ubuntu">Networking on Ubuntu</option>
+                <option value="Securing Ubuntu">Securing Ubuntu</option>
+                <option value="Ubuntu Kernels">Ubuntu Kernels</option>
+                <option value="Configuring enterprise storage">Configuring enterprise storage</option>
+                <option value="Virtualisation">Virtualisation </option>
+                <option value="MicroK8s">MicroK8s</option>
+                <option value="MaaS">MaaS</option>
+                <option value="Juju">Juju</option>
+              </select>
+            </li>
+            <li  class="p-list__item  " id="comments">
+              <label for="Comments_from_lead__c" id="LblComments_from_lead__c"  >Why do you want CUBE certification?</label>
+              <textarea class="is-required" required="" id="Comments_from_lead__c" name="Comments_from_lead__c" rows="4" aria-labelledby="LblComments_from_lead__c InstructComments_from_lead__c" class="  mktoRequired" maxlength="2000" aria-required="true" ></textarea>
+            </li>
+          </ul>
+        </fieldset>
+
         <fieldset class="u-no-margin--bottom">
           <ul class="p-list">
-            <li class="mktField p-list__item">
-              <input class="mktoField" value="yes" id="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox" />
-              <label class="mktoLabel mktoHasWidth" for="canonicalUpdatesOptIn">I agree to receive information about Canonical's products and services.</label>
+            <li class=" p-list__item">
+              <input  value="yes" id="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox" />
+              <label class="mktoHasWidth" for="canonicalUpdatesOptIn">I agree to receive information about Canonical's products and services.</label>
             </li>
             <li class="p-list__item">
               In submitting this form, I confirm that I have read and agree to <a href="/legal/data-privacy/contact">Canonical's Privacy Notice</a> and <a href="/legal/data-privacy">Privacy Policy</a>.
@@ -41,21 +121,21 @@
             </li>
           </ul>
           <ul class="p-list">
-            <li class="mktField p-list__item">
+            <li class=" p-list__item">
               <button type="submit" class="mktoButton p-button--positive" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Form', 'eventAction' : 'cloud contact-us', 'eventLabel' : '{{product}}', 'eventValue' : undefined });">Submit</button>
             </li>
           </ul>
           <!-- hidden fields -->
-          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formid" class="mktoField" value="{{formid}}" />
+          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formid"  value="{{formid}}" />
           <input type="hidden" aria-hidden="true" aria-label="hidden field" name="returnURL" value="{{returnURL}}" />
           <input type="hidden" aria-hidden="true" aria-label="hidden field" name="Consent_to_Processing__c" value="yes" />
-          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" class="mktoField" id="utm_campaign" value="" />
-          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" class="mktoField" id="utm_medium" value="" />
-          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" class="mktoField" id="utm_source" value="" />
-          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content" class="mktoField" id="utm_content" value="" />
-          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" class="mktoField" id="utm_term" value="" />
-          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="GCLID__c" class="mktoField" id="GCLID__c" value="" />
-          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="FBCLID__c" class="mktoField" id="FBLID__c" value="" />
+          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign"  id="utm_campaign" value="" />
+          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium"  id="utm_medium" value="" />
+          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source"  id="utm_source" value="" />
+          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content"  id="utm_content" value="" />
+          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term"  id="utm_term" value="" />
+          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="GCLID__c"  id="GCLID__c" value="" />
+          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="FBCLID__c"  id="FBLID__c" value="" />
         </fieldset>
       </form>
     </div>

--- a/templates/shared/_cube-contact-us-form.html
+++ b/templates/shared/_cube-contact-us-form.html
@@ -94,7 +94,7 @@
                 <option value="Configuring enterprise storage">Configuring enterprise storage</option>
                 <option value="Virtualisation">Virtualisation </option>
                 <option value="MicroK8s">MicroK8s</option>
-                <option value="MaaS">MaaS</option>
+                <option value="MAAS">MAAS</option>
                 <option value="Juju">Juju</option>
               </select>
             </li>

--- a/templates/shared/_telco-contact-us.html
+++ b/templates/shared/_telco-contact-us.html
@@ -107,19 +107,19 @@
                   <ul class="p-list">
                     <li class="mktFormReq mktField p-list__item">
                       <label for="FirstName" class="mktoLabel">First name:</label>
-                      <input required id="FirstName" name="FirstName" maxlength="255" type="text" class="mktoField mktoRequired" required="required" />
+                      <input required id="FirstName" name="firstName" maxlength="255" type="text" class="mktoField mktoRequired" required="required" />
                     </li>
                     <li class="mktFormReq mktField p-list__item">
                       <label for="LastName" class="mktoLabel">Last name:</label>
-                      <input required id="LastName" name="LastName" maxlength="255" type="text" class="mktoField mktoRequired" required="required" />
+                      <input required id="LastName" name="lastName" maxlength="255" type="text" class="mktoField mktoRequired" required="required" />
                     </li>
                     <li class="mktFormReq mktField p-list__item">
                       <label for="Email" class="mktoLabel">Email:</label>
-                      <input required id="Email" name="Email" maxlength="255" type="email" class="mktoField mktoEmailField mktoRequired" required="required" />
+                      <input required id="Email" name="email" maxlength="255" type="email" class="mktoField mktoEmailField mktoRequired" required="required" />
                     </li>
                     <li class="mktFormReq mktField p-list__item">
                       <label for="Phone" class="mktoLabel ">Mobile/cell phone number:</label>
-                      <input required id="Phone" name="Phone" maxlength="255" type="tel" class="mktoField mktoTelField  mktoRequired" required="required" />
+                      <input required id="Phone" name="phone" maxlength="255" type="tel" class="mktoField mktoTelField  mktoRequired" required="required" />
                     </li>
                     <li class="mktField p-list__item">
                       <input class="mktoField" value="yes" id="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox" />

--- a/templates/shared/contextual_footers/_openstack_install_newsletter.html
+++ b/templates/shared/contextual_footers/_openstack_install_newsletter.html
@@ -4,7 +4,7 @@
         <ul class="p-list mktoFormRow u-clearfix">
             <li class="mktoFormCol p-list__item">
                 <label class="u-off-screen mktoLabel" for="Email">Your email</label>
-                <input type="email" placeholder="Your email" class="mktoField mktoTextField" name="Email" id="Email" required />
+                <input type="email" placeholder="Your email" class="mktoField mktoTextField" name="email" id="Email" required />
             </li>
             <li class="mktField mktLblRight p-list__item">
                 <span class="mktInput mktLblRight">

--- a/templates/shared/forms/interactive/cube-beta.html
+++ b/templates/shared/forms/interactive/cube-beta.html
@@ -9,7 +9,7 @@
       <div class="row u-no-padding">
         <div class="col-12">
           <form action="/marketo/submit" method="post" id="mktoForm_%% formid %%" class="modal-form marketo-form">
-            <fieldset>
+            <fieldset class="u-no-margin--bottom">
               <h3 class="p-heading--four">About you</h3>
               <ul class="p-list">
                 <li class="p-list__item">
@@ -67,7 +67,7 @@
               </ul>
             </fieldset>
 
-            <fieldset>
+            <fieldset class="u-no-margin--bottom">
               <h3 class="p-heading--four">About your interest in CUBE</h3>
               <ul class="p-list">
                 <li class="p-list__item">
@@ -106,7 +106,7 @@
               </ul>
             </fieldset>
 
-            <fieldset>
+            <fieldset class="u-no-margin--bottom">
               <ul class="p-list">
                 <li class="mktField p-list__item">
                   <input class="mktoField" value="yes" id="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox" />

--- a/templates/shared/forms/interactive/cube-beta.html
+++ b/templates/shared/forms/interactive/cube-beta.html
@@ -7,56 +7,134 @@
     <div class="js-pagination js-pagination--1">
       <h3 class="p-heading--five">Provide your contact information to join the beta candidate pool.</h3>
       <div class="row u-no-padding">
-        <div class="col-6">
+        <div class="col-12">
           <form action="/marketo/submit" method="post" id="mktoForm_%% formid %%" class="modal-form marketo-form">
-            <ul class="p-list">
-              <li class="mktFormReq mktField p-list__item">
-                <label for="firstName" class="mktoLabel">First name:</label>
-                <input required id="firstName" name="firstName" maxlength="255" type="text" class="mktoField mktoRequired" />
-              </li>
-              <li class="mktFormReq mktField p-list__item">
-                <label for="lastName" class="mktoLabel">Last name:</label>
-                <input required id="lastName" name="lastName" maxlength="255" type="text" class="mktoField mktoRequired" />
-              </li>
-              <li class="mktFormReq mktField p-list__item">
-                <label for="email" class="mktoLabel">Email:</label>
-                <input required id="email" name="email" maxlength="255" type="email" class="mktoField mktoEmailField mktoRequired" />
-              </li>
-              <li class="mktField p-list__item">
-                <input class="mktoField" value="yes" id="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox" />
-                <label class="mktoLabel mktoHasWidth" for="canonicalUpdatesOptIn">I agree to receive information about Canonical’s products and services.</label>
-              </li>
-              <br>
-              <li class="p-list__item">In submitting this form, I confirm that I have read and agree to <a href="/legal/data-privacy/contact">Canonical&rsquo;s Privacy Notice</a> and <a href="/legal/data-privacy">Privacy Policy</a>.</li>
-              <br>
-              <li class="p-list__item">
-                <div class="g-recaptcha" data-sitekey="{{ CAPTCHA_TESTING_API_KEY }}"></div>
-              </li>
-            </ul>
-
-            <div class="u-hide">
-              <h3>Your comments</h3>
+            <fieldset>
+              <h3 class="p-heading--four">About you</h3>
               <ul class="p-list">
-                <li class="mktFormReq mktField p-list__item">
-                  <label for="Comments_from_lead__c" class="mktoLabel">What would you like to talk to us about?</label>
-                  <textarea id="Comments_from_lead__c" name="Comments_from_lead__c" rows="5" class="mktoField" maxlength="2000"></textarea>
+                <li class="p-list__item">
+                  <label for="FirstName" id="LblFirstName" >First name:</label>
+                  <input id="FirstName" name="FirstName" maxlength="255" aria-labelledby="LblFirstName" type="text" class="is-required" required="" aria-required="true" >
+                </li>
+
+                <li class="p-list__item">
+                  <label for="LastName" id="LblLastName" >Last name:</label>
+                  <input id="LastName" name="LastName" maxlength="255" aria-labelledby="LblLastName InstructLastName" type="text" class="is-required" required="" aria-required="true" >
+                </li>
+
+                <li class="p-list__item">
+                  <label for="Email" id="LblEmail" >Work email:</label>
+                  <input id="Email" name="Email" maxlength="255" aria-labelledby="LblEmail InstructEmail" type="email" class="is-required" aria-required="true" autocomplete="email" >
+                </li>
+
+                <li class="p-list__item">
+                  <label for="Company" id="LblCompany" >Current employer:</label>
+                  <input id="Company" name="Company" maxlength="255" aria-labelledby="LblCompany InstructCompany" type="text" class="is-required" required="" aria-required="true" >
+                </li>
+
+                <li class="p-list__item">
+                  <label for="Job_Role__c" id="LblJob_Role__c" >Job role:</label>
+                  <select class="is-required" required="" id="Job_Role__c" name="Job_Role__c" aria-labelledby="LblJob_Role__c InstructJob_Role__c" aria-required="true" >
+                    <option value="" disabled="disabled" selected="">Select...</option>
+                    <option value="Business and Project Management">Business and Project Management</option>
+                    <option value="Database Development and Administration">Database Development and Administration</option>
+                    <option value="Education">Education</option>
+                    <option value="Enterprise Systems Analysis & Integration">Enterprise Systems Analysis & Integration</option>
+                    <option value="Hardware Operations and Management">Hardware Operations and Management</option>
+                    <option value="Home User">Home User</option>
+                    <option value="Network Design and Administration">Network Design and Administration</option>
+                    <option value="Owner/Self Employed">Owner/Self Employed</option>
+                    <option value="Press and Communications">Press and Communications</option>
+                    <option value="Programming/Software Engineering">Programming/Software Engineering</option>
+                    <option value="Smartphone User">Smartphone User</option>
+                    <option value="Technical Support">Technical Support</option>
+                    <option value="Technical Writing">Technical Writing</option>
+                    <option value="Ubuntu Enthusiast">Ubuntu Enthusiast</option>
+                    <option value="Web Development and Administration">Web Development and Administration</option>
+                    <option value="Individual">Individual</option>
+                  </select>
+                </li>
+
+                <li class="p-list__item ">
+                  <label for="cube_ubuntu_experience" id="Lblcube_ubuntu_experience" >What is your experience with Ubuntu?</label>
+                  <select id="cube_ubuntu_experience" name="cube_ubuntu_experience" aria-labelledby="Lblcube_ubuntu_experience" class="is-required" required="" >
+                    <option value="" disabled="disabled" selected="">Select...</option>
+                    <option value="none">None or very minimal experience </option>
+                    <option value="self">Only hands-on experience </option>
+                    <option value="formal">Formally educated and/or training </option>
+                  </select>
                 </li>
               </ul>
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formid" class="mktoField" value="%% formid %%" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="Consent_to_Processing__c" value="yes" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" class="mktoField" id="utm_campaign" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" class="mktoField" id="utm_medium" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" class="mktoField" id="utm_source" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content" class="mktoField" id="utm_content" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" class="mktoField" id="utm_term" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="GCLID__c" class="mktoField" id="GCLID__c" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="FBCLID__c" class="mktoField" id="FBLID__c" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="productContext" id="product-context" value="{{ product }}" />
-            </div>
+            </fieldset>
 
-            <div class="pagination">
-              <button type="submit" class="pagination__link--next p-button--positive mktoButton" aria-label="Submit">Join the beta</button>
-            </div>
+            <fieldset>
+              <h3 class="p-heading--four">About your interest in CUBE</h3>
+              <ul class="p-list">
+                <li class="p-list__item">
+                  <label class="p-checkbox" >
+                    <input name="cube_workplace_required" type="checkbox" value="yes" aria-labelledby="cube_workplace_required-lb" class="p-checkbox__input">
+                    <span class="p-checkbox__label" id="cube_workplace_required-lb">
+                      Does your workplace require Ubuntu?
+                    </span>
+                  </label>
+                </li>
+                <li class="p-list__item ">
+                  <label for="cube_microcert_interest" id="Lblcube_microcert_interest" >Which microcert are you most interested in taking?</label>
+                  <select id="cube_microcert_interest" name="cube_microcert_interest" aria-labelledby="Lblcube_microcert_interest Instructcube_microcert_interest" class="is-required" required="" >
+                    <option value="" disabled="disabled" selected="">Select...</option>
+                    <option value="Ubuntu System Architecture">Ubuntu System Architecture</option>
+                    <option value="Managing Packages in Ubuntu">Managing Packages in Ubuntu</option>
+                    <option value="Using command line tools">Using command line tools</option>
+                    <option value="Linux devices and filesystems">Linux devices and filesystems</option>
+                    <option value="Bash shell scripting">Bash shell scripting</option>
+                    <option value="Performing administrative tasks">Performing administrative tasks</option>
+                    <option value="Managing System Services">Managing System Services</option>
+                    <option value="Networking on Ubuntu">Networking on Ubuntu</option>
+                    <option value="Securing Ubuntu">Securing Ubuntu</option>
+                    <option value="Ubuntu Kernels">Ubuntu Kernels</option>
+                    <option value="Configuring enterprise storage">Configuring enterprise storage</option>
+                    <option value="Virtualisation">Virtualisation </option>
+                    <option value="MicroK8s">MicroK8s</option>
+                    <option value="MaaS">MaaS</option>
+                    <option value="Juju">Juju</option>
+                  </select>
+                </li>
+                <li class="p-list__item" id="comments">
+                  <label for="Comments_from_lead__c" id="LblComments_from_lead__c" >Why do you want CUBE certification?</label>
+                  <textarea class="is-required" required="" id="Comments_from_lead__c" name="Comments_from_lead__c" rows="4" aria-labelledby="LblComments_from_lead__c InstructComments_from_lead__c" class=" mktoRequired" maxlength="2000" aria-required="true" ></textarea>
+                </li>
+              </ul>
+            </fieldset>
+
+            <fieldset>
+              <ul class="p-list">
+                <li class="mktField p-list__item">
+                  <input class="mktoField" value="yes" id="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox" />
+                  <label for="canonicalUpdatesOptIn">I agree to receive information about Canonical’s products and services.</label>
+                </li>
+                <br>
+                <li class="p-list__item">In submitting this form, I confirm that I have read and agree to <a href="/legal/data-privacy/contact">Canonical&rsquo;s Privacy Notice</a> and <a href="/legal/data-privacy">Privacy Policy</a>.</li>
+                <br>
+                <li class="p-list__item">
+                  <div class="g-recaptcha" data-sitekey="{{ CAPTCHA_TESTING_API_KEY }}"></div>
+                </li>
+              </ul>
+              <div class="u-hide">
+                <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formid" class="mktoField" value="%% formid %%" />
+                <input type="hidden" aria-hidden="true" aria-label="hidden field" name="Consent_to_Processing__c" value="yes" />
+                <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" class="mktoField" id="utm_campaign" value="" />
+                <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" class="mktoField" id="utm_medium" value="" />
+                <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" class="mktoField" id="utm_source" value="" />
+                <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content" class="mktoField" id="utm_content" value="" />
+                <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" class="mktoField" id="utm_term" value="" />
+                <input type="hidden" aria-hidden="true" aria-label="hidden field" name="GCLID__c" class="mktoField" id="GCLID__c" value="" />
+                <input type="hidden" aria-hidden="true" aria-label="hidden field" name="FBCLID__c" class="mktoField" id="FBLID__c" value="" />
+                <input type="hidden" aria-hidden="true" aria-label="hidden field" name="productContext" id="product-context" value="{{ product }}" />
+              </div>
+              <div class="pagination">
+                <button type="submit" class="pagination__link--next p-button--positive mktoButton" aria-label="Submit">Join the beta</button>
+              </div>
+            </fieldset>
           </form>
         </div>
       </div>
@@ -66,7 +144,7 @@
       <div class="row u-no-padding">
         <div class="u-equal-height">
           <div class="col-7">
-            <h3 class="p-heading--two">Thank you for enquiring about the CUBE beta</h3>
+            <h3 >Thank you for enquiring about the CUBE beta</h3>
             <p class="p-heading--four">We will be in touch if you are selected for the beta.</p>
           </div>
           <div class="col-5 u-vertically-center u-align--center u-hide--small">

--- a/templates/shared/forms/interactive/cube-beta.html
+++ b/templates/shared/forms/interactive/cube-beta.html
@@ -14,22 +14,22 @@
               <ul class="p-list">
                 <li class="p-list__item">
                   <label for="FirstName" id="LblFirstName" >First name:</label>
-                  <input id="FirstName" name="FirstName" maxlength="255" aria-labelledby="LblFirstName" type="text" class="is-required" required="" aria-required="true" >
+                  <input id="FirstName" name="firstName" maxlength="255" aria-labelledby="LblFirstName" type="text" class="is-required" required="" aria-required="true" >
                 </li>
 
                 <li class="p-list__item">
                   <label for="LastName" id="LblLastName" >Last name:</label>
-                  <input id="LastName" name="LastName" maxlength="255" aria-labelledby="LblLastName InstructLastName" type="text" class="is-required" required="" aria-required="true" >
+                  <input id="LastName" name="lastName" maxlength="255" aria-labelledby="LblLastName InstructLastName" type="text" class="is-required" required="" aria-required="true" >
                 </li>
 
                 <li class="p-list__item">
                   <label for="Email" id="LblEmail" >Work email:</label>
-                  <input id="Email" name="Email" maxlength="255" aria-labelledby="LblEmail InstructEmail" type="email" class="is-required" aria-required="true" autocomplete="email" >
+                  <input id="Email" name="email" maxlength="255" aria-labelledby="LblEmail InstructEmail" type="email" class="is-required" aria-required="true" autocomplete="email" >
                 </li>
 
                 <li class="p-list__item">
                   <label for="Company" id="LblCompany" >Current employer:</label>
-                  <input id="Company" name="Company" maxlength="255" aria-labelledby="LblCompany InstructCompany" type="text" class="is-required" required="" aria-required="true" >
+                  <input id="Company" name="company" maxlength="255" aria-labelledby="LblCompany InstructCompany" type="text" class="is-required" required="" aria-required="true" >
                 </li>
 
                 <li class="p-list__item">

--- a/templates/shared/forms/interactive/observability-contact-us.html
+++ b/templates/shared/forms/interactive/observability-contact-us.html
@@ -181,19 +181,19 @@
             <ul class="p-list">
               <li class="mktFormReq mktField p-list__item">
                 <label for="FirstName" class="mktoLabel">First name:</label>
-                <input required id="FirstName" name="FirstName" maxlength="255" type="text" class="mktoField mktoRequired" required="required" />
+                <input required id="FirstName" name="firstName" maxlength="255" type="text" class="mktoField mktoRequired" required="required" />
               </li>
               <li class="mktFormReq mktField p-list__item">
                 <label for="LastName" class="mktoLabel">Last name:</label>
-                <input required id="LastName" name="LastName" maxlength="255" type="text" class="mktoField mktoRequired" required="required" />
+                <input required id="LastName" name="lastName" maxlength="255" type="text" class="mktoField mktoRequired" required="required" />
               </li>
               <li class="mktFormReq mktField p-list__item">
                 <label for="Email" class="mktoLabel">Email:</label>
-                <input required id="Email" name="Email" maxlength="255" type="email" class="mktoField mktoEmailField mktoRequired" required="required" />
+                <input required id="Email" name="email" maxlength="255" type="email" class="mktoField mktoEmailField mktoRequired" required="required" />
               </li>
               <li class="mktFormReq mktField p-list__item">
                 <label for="Phone" class="mktoLabel ">Mobile/cell phone number:</label>
-                <input required id="Phone" name="Phone" maxlength="255" type="tel" class="mktoField mktoTelField  mktoRequired" required="required" />
+                <input required id="Phone" name="phone" maxlength="255" type="tel" class="mktoField mktoTelField  mktoRequired" required="required" />
               </li>
               <li class="mktField p-list__item">
                 <input class="mktoField" value="yes" id="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox" />


### PR DESCRIPTION
## Done

- Update /cube/contact-us and /cube#get-in-touch forms with new fields per the [brief](https://docs.google.com/document/d/14p8YZpe9z7H65pN_C5ebuVEajlLSgLU59zfIgepCwH8/edit)

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/cube/contact-us and http://0.0.0.0:8001/cube#get-in-touch
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that the fields match the brief and that the form works


## Issue / Card

Fixes #10481 and #10482

## Screenshots

![image](https://user-images.githubusercontent.com/441217/135063198-574dde35-edf5-4d1b-83a4-55ffd12d0a2b.png)

