### PR TITLE
198/Account users/Search

### DIFF
--- a/static/js/src/advantage/users/AccountUsers.test.tsx
+++ b/static/js/src/advantage/users/AccountUsers.test.tsx
@@ -85,3 +85,51 @@ it("allows to edit only a single user at a time", async () => {
   await waitFor(() => expect(screen.getByLabelText(EDIT_ANGELA)).toBeEnabled());
   expect(screen.getByLabelText(EDIT_KAREN)).toBeEnabled();
 });
+
+it("displays 'No results' when there are no search results", () => {
+  const testUser: User = {
+    id: "1",
+    name: "User",
+    email: "user@ecorp.com",
+    role: "admin",
+    lastLoginAt: "2021-02-15T13:45:00Z",
+  };
+
+  render(
+    <AccountUsers
+      organisationName="ECorp"
+      users={[...mockData.users, testUser]}
+    />
+  );
+
+  expect(screen.queryByText("No results")).not.toBeInTheDocument();
+  userEvent.type(
+    screen.getByRole("searchbox", { name: "Search for users" }),
+    "Lorem ipsum"
+  );
+  expect(screen.getByText("No results")).toBeInTheDocument();
+});
+
+it("displays correct search results", () => {
+  const testUser: User = {
+    id: "1",
+    name: "User",
+    email: "user@ecorp.com",
+    role: "admin",
+    lastLoginAt: "2021-02-15T13:45:00Z",
+  };
+
+  const mockUsers = [...mockData.users, testUser];
+
+  render(<AccountUsers organisationName="ECorp" users={mockUsers} />);
+
+  expect(screen.getAllByLabelText("email")).toHaveLength(mockUsers.length);
+  userEvent.type(
+    screen.getByRole("searchbox", { name: "Search for users" }),
+    "user@ecorp.com"
+  );
+  expect(screen.getAllByLabelText("email")).toHaveLength(1);
+
+  userEvent.click(screen.getByRole("button", { name: "clear" }));
+  expect(screen.getAllByLabelText("email")).toHaveLength(mockUsers.length);
+});

--- a/static/js/src/advantage/users/AccountUsers.test.tsx
+++ b/static/js/src/advantage/users/AccountUsers.test.tsx
@@ -54,14 +54,12 @@ it("allows to edit only a single user at a time", async () => {
   const users: User[] = [
     {
       ...mockUserBase,
-      id: "1",
       name: "Karen",
       email: "karen@ecorp.com",
       role: "billing",
     },
     {
       ...mockUserBase,
-      id: "3",
       name: "Angela",
       email: "angela@ecorp.com",
       role: "technical",
@@ -88,7 +86,6 @@ it("allows to edit only a single user at a time", async () => {
 
 it("displays 'No results' when there are no search results", () => {
   const testUser: User = {
-    id: "1",
     name: "User",
     email: "user@ecorp.com",
     role: "admin",
@@ -112,7 +109,6 @@ it("displays 'No results' when there are no search results", () => {
 
 it("displays correct search results", () => {
   const testUser: User = {
-    id: "1",
     name: "User",
     email: "user@ecorp.com",
     role: "admin",

--- a/static/js/src/advantage/users/AccountUsers.tsx
+++ b/static/js/src/advantage/users/AccountUsers.tsx
@@ -103,7 +103,7 @@ const AccountUsers = ({
   const userInEditMode: User | undefined = React.useMemo(
     () =>
       typeof userInEditModeById === "string"
-        ? filteredUsers.find((user) => user.id === userInEditModeById)
+        ? filteredUsers.find((user) => user.email === userInEditModeById)
         : undefined,
     [userInEditModeById, filteredUsers]
   );

--- a/static/js/src/advantage/users/AccountUsers.tsx
+++ b/static/js/src/advantage/users/AccountUsers.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import { useQueryClient, useMutation } from "react-query";
 import {
   User,
@@ -11,6 +11,8 @@ import Organisation from "./components/Organisation";
 import AddNewUser from "./components/AddNewUser/AddNewUser";
 import TableView from "./components/TableView/TableView";
 import DeleteConfirmationModal from "./components/DeleteConfirmationModal/DeleteConfirmationModal";
+import UserSearch from "./components/UserSearch/UserSearch";
+
 import { requestAddUser, requestDeleteUser, requestUpdateUser } from "./api";
 import { getErrorMessage } from "./utils";
 
@@ -95,13 +97,18 @@ const AccountUsers = ({
   const [userInEditModeById, setUserInEditModeById] = useState<string | null>(
     null
   );
+
+  const [filteredUsers, setFilteredUsers] = useState<User[]>(users);
+
   const userInEditMode: User | undefined = React.useMemo(
     () =>
       typeof userInEditModeById === "string"
-        ? users.find((user) => user.id === userInEditModeById)
+        ? filteredUsers.find((user) => user.id === userInEditModeById)
         : undefined,
-    [userInEditModeById, users]
+    [userInEditModeById, filteredUsers]
   );
+
+  const [searchQuery, setSearchQuery] = useState("");
 
   const dismissEditMode = () => setUserInEditModeById(null);
   const handleDeleteConfirmationModalClose = () => {
@@ -109,6 +116,19 @@ const AccountUsers = ({
   };
   const handleDeleteConfirmationModalOpen = () =>
     setIsDeleteConfirmationModalOpen(true);
+
+  const handleSearch = (value: string) => {
+    dismissEditMode();
+    setSearchQuery(value);
+  };
+
+  useEffect(() => {
+    const filteredUsers = users.filter((user) =>
+      user.email.includes(searchQuery)
+    );
+
+    setFilteredUsers(filteredUsers);
+  }, [searchQuery, users]);
 
   return (
     <div>
@@ -124,6 +144,9 @@ const AccountUsers = ({
               handleSubmit={handleAddNewUser}
               onAfterModalOpen={() => setNotification(null)}
             />
+          </div>
+          <div className="col-6">
+            <UserSearch handleSearch={handleSearch} />
           </div>
         </div>
         {notification ? (
@@ -152,8 +175,8 @@ const AccountUsers = ({
         <div className="row">
           <div className="col-12">
             <TableView
-              users={users}
-              userInEditModeById={userInEditModeById}
+              users={filteredUsers}
+              userInEditMode={userInEditMode}
               setUserInEditModeById={setUserInEditModeById}
               dismissEditMode={dismissEditMode}
               handleEditSubmit={handleUpdateUser}

--- a/static/js/src/advantage/users/api.ts
+++ b/static/js/src/advantage/users/api.ts
@@ -58,7 +58,7 @@ const handleResponse = async (response: Response): Promise<unknown> => {
   return responseJson;
 };
 
-const fetchJSON = async (input: RequestInfo, init?: RequestInit) =>
+const fetchJSON = (input: RequestInfo, init?: RequestInit) =>
   fetch(input, init).then(handleResponse);
 
 const requestAddUser = ({

--- a/static/js/src/advantage/users/api.ts
+++ b/static/js/src/advantage/users/api.ts
@@ -24,7 +24,6 @@ const parseAccountsResponse = (
   accountId: response.account_id,
   organisationName: response.name,
   users: response.users.map((user) => ({
-    id: user.email,
     name: user.name,
     email: user.email,
     role: user.user_role_on_account,

--- a/static/js/src/advantage/users/app.tsx
+++ b/static/js/src/advantage/users/app.tsx
@@ -11,7 +11,7 @@ const oneHour = 1000 * 60 * 60;
 const queryClient = new QueryClient({
   defaultOptions: {
     queries: {
-      refetchOnWindowFocus: false,
+      refetchOnWindowFocus: true,
       refetchOnMount: false,
       refetchOnReconnect: false,
       staleTime: oneHour,

--- a/static/js/src/advantage/users/components/DeleteConfirmationModal/DeleteConfirmationModal.test.tsx
+++ b/static/js/src/advantage/users/components/DeleteConfirmationModal/DeleteConfirmationModal.test.tsx
@@ -18,6 +18,7 @@ it("displays confirmation message correctly", () => {
       handleClose={mockHandleClose}
     />
   );
+
   expect(
     getByTextContent(
       "Are you sure you want to remove philip.p@ecorp.com from your organisation?"
@@ -26,7 +27,7 @@ it("displays confirmation message correctly", () => {
 });
 
 it("makes a correct call to handleConfirmDelete", () => {
-  const mockHandleConfirmDelete = jest.fn();
+  const mockHandleConfirmDelete = jest.fn(Promise.resolve);
   const mockHandleClose = jest.fn();
 
   render(

--- a/static/js/src/advantage/users/components/DeleteConfirmationModal/DeleteConfirmationModal.test.tsx
+++ b/static/js/src/advantage/users/components/DeleteConfirmationModal/DeleteConfirmationModal.test.tsx
@@ -38,5 +38,5 @@ it("makes a correct call to handleConfirmDelete", () => {
     />
   );
   userEvent.click(screen.getByText("Yes, remove user"));
-  expect(mockHandleConfirmDelete).toHaveBeenCalledWith(mockUser.id);
+  expect(mockHandleConfirmDelete).toHaveBeenCalledWith(mockUser.email);
 });

--- a/static/js/src/advantage/users/components/DeleteConfirmationModal/DeleteConfirmationModal.tsx
+++ b/static/js/src/advantage/users/components/DeleteConfirmationModal/DeleteConfirmationModal.tsx
@@ -24,7 +24,7 @@ const DeleteConfirmationModal = ({
   const onSubmit = async () => {
     setIsLoading(true);
     try {
-      await handleConfirmDelete(user?.id);
+      await handleConfirmDelete(user?.email);
       handleClose();
     } catch (error) {
       setErrorMessage(getErrorMessage((error as any)?.message));

--- a/static/js/src/advantage/users/components/TableView/TableView.test.tsx
+++ b/static/js/src/advantage/users/components/TableView/TableView.test.tsx
@@ -6,7 +6,6 @@ import TableView from "./TableView";
 
 it("displays user details in a correct format", () => {
   const testUser: User = {
-    id: "1",
     name: "User",
     email: "user@ecorp.com",
     role: "admin",

--- a/static/js/src/advantage/users/components/TableView/TableView.test.tsx
+++ b/static/js/src/advantage/users/components/TableView/TableView.test.tsx
@@ -16,7 +16,7 @@ it("displays user details in a correct format", () => {
   render(
     <TableView
       users={[testUser]}
-      userInEditModeById={null}
+      userInEditMode={null}
       setUserInEditModeById={jest.fn()}
       handleEditSubmit={jest.fn()}
       dismissEditMode={jest.fn()}

--- a/static/js/src/advantage/users/components/TableView/TableView.tsx
+++ b/static/js/src/advantage/users/components/TableView/TableView.tsx
@@ -11,10 +11,10 @@ import UserRow from "./UserRow";
 
 export type UserRowVariant = "regular" | "editing" | "disabled";
 
-const getVariant = (userId: string, userInEditMode?: User | null) => {
+const getVariant = (userEmail: string, userInEditMode?: User | null) => {
   if (userInEditMode == null) {
     return "regular";
-  } else if (userId !== userInEditMode?.email) {
+  } else if (userEmail !== userInEditMode?.email) {
     return "disabled";
   } else {
     return "editing";
@@ -24,7 +24,7 @@ const getVariant = (userId: string, userInEditMode?: User | null) => {
 type Props = {
   users: Users;
   userInEditMode?: User | null;
-  setUserInEditModeById: (userId: string | null) => void;
+  setUserInEditModeById: (userEmail: string | null) => void;
   dismissEditMode: () => void;
   handleEditSubmit: ({
     email,
@@ -81,9 +81,9 @@ const TableView = ({
         <tbody>
           {usersPage.map((user) => (
             <UserRow
-              key={user.id}
+              key={user.email}
               user={user}
-              variant={getVariant(user.id, userInEditMode)}
+              variant={getVariant(user.email, userInEditMode)}
               setUserInEditModeById={setUserInEditModeById}
               dismissEditMode={dismissEditMode}
               handleEditSubmit={handleEditSubmit}

--- a/static/js/src/advantage/users/components/TableView/TableView.tsx
+++ b/static/js/src/advantage/users/components/TableView/TableView.tsx
@@ -6,17 +6,15 @@ import {
 } from "@canonical/react-components/dist/components/TableHeader";
 import { Table, TableRow, Pagination } from "@canonical/react-components";
 
-import { UserRole, Users } from "../../types";
+import { UserRole, Users, User } from "../../types";
 import UserRow from "./UserRow";
 
 export type UserRowVariant = "regular" | "editing" | "disabled";
 
-type UserId = string;
-
-const getVariant = (userId: UserId, userInEditMode: UserId | null) => {
-  if (userInEditMode === null) {
+const getVariant = (userId: string, userInEditMode?: User | null) => {
+  if (userInEditMode == null) {
     return "regular";
-  } else if (userId !== userInEditMode) {
+  } else if (userId !== userInEditMode?.email) {
     return "disabled";
   } else {
     return "editing";
@@ -25,8 +23,8 @@ const getVariant = (userId: UserId, userInEditMode: UserId | null) => {
 
 type Props = {
   users: Users;
-  userInEditModeById: UserId | null;
-  setUserInEditModeById: (userId: UserId | null) => void;
+  userInEditMode?: User | null;
+  setUserInEditModeById: (userId: string | null) => void;
   dismissEditMode: () => void;
   handleEditSubmit: ({
     email,
@@ -49,7 +47,7 @@ const UsersTableHeader = ({
 
 const TableView = ({
   users,
-  userInEditModeById,
+  userInEditMode,
   setUserInEditModeById,
   dismissEditMode,
   handleEditSubmit,
@@ -85,7 +83,7 @@ const TableView = ({
             <UserRow
               key={user.id}
               user={user}
-              variant={getVariant(user.id, userInEditModeById)}
+              variant={getVariant(user.id, userInEditMode)}
               setUserInEditModeById={setUserInEditModeById}
               dismissEditMode={dismissEditMode}
               handleEditSubmit={handleEditSubmit}
@@ -96,6 +94,9 @@ const TableView = ({
           ))}
         </tbody>
       </Table>
+      {usersPage.length < 1 ? (
+        <p className="u-align--center">No results</p>
+      ) : null}
       <Pagination
         currentPage={pageNumber}
         itemsPerPage={pageSize}

--- a/static/js/src/advantage/users/components/TableView/UserRow.test.tsx
+++ b/static/js/src/advantage/users/components/TableView/UserRow.test.tsx
@@ -5,7 +5,6 @@ import { User } from "../../types";
 import UserRow from "./UserRow";
 
 const testUser: User = {
-  id: "1",
   name: "User",
   email: "user@ecorp.com",
   role: "admin",

--- a/static/js/src/advantage/users/components/TableView/UserRow.tsx
+++ b/static/js/src/advantage/users/components/TableView/UserRow.tsx
@@ -114,7 +114,7 @@ const FormattedDate = ({ dateISO }: { dateISO: string | null }) =>
   );
 
 type UserRowProps = {
-  setUserInEditModeById: (id: string) => void;
+  setUserInEditModeById: (email: string) => void;
   dismissEditMode: () => void;
   handleEditSubmit: ({
     email,
@@ -226,7 +226,7 @@ const UserRowNonEditable = ({
         <Button
           small
           dense
-          onClick={() => setUserInEditModeById(user.id)}
+          onClick={() => setUserInEditModeById(user.email)}
           disabled={variant === "disabled"}
           aria-label={`Edit user ${user.email}`}
         >

--- a/static/js/src/advantage/users/components/UserSearch/UserSearch.tsx
+++ b/static/js/src/advantage/users/components/UserSearch/UserSearch.tsx
@@ -1,0 +1,54 @@
+import React from "react";
+
+const UserSearch = ({
+  handleSearch,
+}: {
+  handleSearch: (value: string) => void;
+}) => {
+  const [searchInputValue, setSearchInputValue] = React.useState("");
+
+  const handleSearchInputChange: React.ChangeEventHandler<HTMLInputElement> = (
+    event
+  ) => {
+    setSearchInputValue(event?.currentTarget?.value);
+  };
+
+  React.useEffect(() => {
+    handleSearch(searchInputValue);
+  }, [searchInputValue]);
+
+  return (
+    <form
+      className="p-search-box"
+      onSubmit={(e) => {
+        e.preventDefault();
+        handleSearch(searchInputValue);
+      }}
+    >
+      <input
+        aria-label="search"
+        type="search"
+        className="p-search-box__input"
+        placeholder="Search"
+        name="search"
+        autoComplete="off"
+        value={searchInputValue}
+        onChange={handleSearchInputChange}
+      />
+      {searchInputValue.length > 0 ? (
+        <button
+          type="reset"
+          className="p-search-box__reset"
+          onClick={() => setSearchInputValue("")}
+        >
+          <i className="p-icon--close"></i>
+        </button>
+      ) : null}
+      <button type="submit" className="p-search-box__button">
+        <i className="p-icon--search"></i>
+      </button>
+    </form>
+  );
+};
+
+export default UserSearch;

--- a/static/js/src/advantage/users/components/UserSearch/UserSearch.tsx
+++ b/static/js/src/advantage/users/components/UserSearch/UserSearch.tsx
@@ -26,10 +26,10 @@ const UserSearch = ({
       }}
     >
       <input
-        aria-label="search"
+        aria-label="Search for users"
         type="search"
         className="p-search-box__input"
-        placeholder="Search"
+        placeholder="Search for users"
         name="search"
         autoComplete="off"
         value={searchInputValue}

--- a/static/js/src/advantage/users/components/UserSearch/UserSearch.tsx
+++ b/static/js/src/advantage/users/components/UserSearch/UserSearch.tsx
@@ -38,13 +38,18 @@ const UserSearch = ({
       {searchInputValue.length > 0 ? (
         <button
           type="reset"
+          aria-label="clear"
           className="p-search-box__reset"
           onClick={() => setSearchInputValue("")}
         >
           <i className="p-icon--close"></i>
         </button>
       ) : null}
-      <button type="submit" className="p-search-box__button">
+      <button
+        type="submit"
+        className="p-search-box__button"
+        aria-label="search"
+      >
         <i className="p-icon--search"></i>
       </button>
     </form>

--- a/static/js/src/advantage/users/mockData.ts
+++ b/static/js/src/advantage/users/mockData.ts
@@ -1,7 +1,6 @@
 import { User, AccountUsersData } from "./types";
 
 export const mockUser: User = {
-  id: "1",
   email: "philip.p@ecorp.com",
   name: "Philip",
   role: "admin",
@@ -16,14 +15,12 @@ export const mockData: AccountUsersData = {
     mockUser,
     {
       ...mockUser,
-      id: "2",
       name: "Karen",
       email: "karen@ecorp.com",
       role: "billing",
     },
     {
       ...mockUser,
-      id: "3",
       name: "Angela",
       email: "angela@ecorp.com",
       role: "technical",

--- a/static/js/src/advantage/users/types.ts
+++ b/static/js/src/advantage/users/types.ts
@@ -1,7 +1,6 @@
 export type UserRole = "admin" | "technical" | "billing";
 
 export type User = {
-  id: string;
   name: string | null;
   email: string;
   role: UserRole;

--- a/tests/cypress/integration/advantage-users_spec.js
+++ b/tests/cypress/integration/advantage-users_spec.js
@@ -19,6 +19,10 @@ context("Advantage", () => {
     cy.findByLabelText("Role").select("technical");
     cy.findByRole("button", { name: "Add new user" }).click();
     cy.findByText(/User added successfully/).should("exist");
+
+    // check that search works correctly
+    cy.findByLabelText("Search for users").type(email);
+    cy.findAllByLabelText("email").should("have.length", 1);
     cy.findByText(email).should("exist");
 
     cy.findByLabelText(`Edit user ${email}`).click();

--- a/tests/cypress/integration/advantage-users_spec.js
+++ b/tests/cypress/integration/advantage-users_spec.js
@@ -21,7 +21,7 @@ context("Advantage", () => {
     cy.findByText(/User added successfully/).should("exist");
 
     // check that search works correctly
-    cy.findByLabelText("Search for users").type(email);
+    cy.findByRole("searchbox", { name: "Search for users" }).type(email);
     cy.findAllByLabelText("email").should("have.length", 1);
     cy.findByText(email).should("exist");
 


### PR DESCRIPTION
## Done
- add search to account users page
  - remove `async` from `fetchJSON` - https://github.com/canonical-web-and-design/ubuntu.com/pull/10509#discussion_r716504047 @carkod 
  - remove redundant `id` from `User` type (some ids are missing, this can't be used as a unique ID - use email as a unique identifier instead)

## QA

- go to https://ubuntu-com-10524.demos.haus/advantage/users and login
- type in the searchbox and verify that correct results are shown
- try to break things


## Issue / Card

https://github.com/canonical-web-and-design/commercial-squad/issues/198

## Screenshots
https://user-images.githubusercontent.com/7452681/135111859-f64da05c-2f30-40b2-acb0-1e88847f1ad5.mp4


