### PR TITLE
Fix PR checks: Install Docker beta before dotrun

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -162,11 +162,11 @@ jobs:
           sudo snap install dotrun
           sudo chown root:root /
 
-      - name: Install dependencies
-        run: /snap/bin/dotrun exec pip3 install coverage
-
       - name: Install node dependencies
         run: /snap/bin/dotrun install
+
+      - name: Install dependencies
+        run: /snap/bin/dotrun exec pip3 install coverage
 
       - name: Build resources
         run: /snap/bin/dotrun build

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -163,7 +163,7 @@ jobs:
           sudo chown root:root /
 
       - name: Install dependencies
-        run: sudo pip3 install coverage
+        run: /snap/bin/dotrun exec pip3 install coverage
 
       - name: Install node dependencies
         run: /snap/bin/dotrun install

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -54,6 +54,7 @@ jobs:
 
       - name: Install dotrun
         run: |
+          sudo snap install --beta docker
           sudo snap install dotrun
           sudo chown root:root /
 
@@ -157,6 +158,7 @@ jobs:
 
       - name: Install dotrun
         run: |
+          sudo snap install --beta docker
           sudo snap install dotrun
           sudo chown root:root /
 


### PR DESCRIPTION
Dotrun can't be installed with the stable version of the docker snap. There is a fix for this problem in the beta channel.

## QA

See that the "run-dotrun" check passes.

See that the "test-python" check now fails because tests are broken, which is a good reason.