### PR TITLE
K8sDocs - minor updates

### DIFF
--- a/templates/kubernetes/docs/1.21/charm-kubernetes-worker.md
+++ b/templates/kubernetes/docs/1.21/charm-kubernetes-worker.md
@@ -597,5 +597,5 @@ juju run-action kubernetes-worker ACTION [parameters] [--wait]
 
 
 <!-- LINKS -->
-[charm-kubernetes-master]: /charm-kubernetes-master
+[charm-kubernetes-master]: /kubernetes/docs/charm-kubernetes-master
 [kubelet-docs]: https://kubernetes.io/docs/reference/command-line-tools-reference/kubelet/

--- a/templates/kubernetes/docs/1.22/components.md
+++ b/templates/kubernetes/docs/1.22/components.md
@@ -89,7 +89,7 @@ release. These charms are maintained by the Charmed Kubernetes team.
   <td> <a href="/kubernetes/docs/1.22/charm-calico">docs</a> </td>
   <td> <a href="https://github.com/juju-solutions/layer-calico"> source </a> </td>
   <td> <a href="https://bugs.launchpad.net/charmed-kubernetes"> bugs</a> </td>
-  <td> <a href="https://jaas.ai/u/containers/calico/785"> 785 </a> </td>
+  <td> <a href="https://jaas.ai/u/containers/calico/826"> 826 </a> </td>
   <td> -- </td>
 </tr>
 <tr>

--- a/templates/kubernetes/docs/docker-registry.md
+++ b/templates/kubernetes/docs/docker-registry.md
@@ -181,7 +181,7 @@ juju config kubernetes-master image-registry=$REGISTRY
 
 <!-- LINKS -->
 
-[registry-charm]: http://jujucharms.com/u/containers/docker-registry
+[registry-charm]: https://jaas.ai/u/containers/docker-registry
 [upstream-registry]: https://docs.docker.com/registry/
 [quickstart]: /kubernetes/docs/quickstart
 [container-runtime]: /kubernetes/docs/container-runtime


### PR DESCRIPTION
## Done

a few minor fixes for k8s docs:

- fix some broken links
- update the calico charm reference
## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
