### PR TITLE
Update forms with field canonicalOptIn to canonicalUpdatesOptIn

### DIFF
--- a/templates/shared/contextual_footers/_iot_newsletter_signup.html
+++ b/templates/shared/contextual_footers/_iot_newsletter_signup.html
@@ -10,7 +10,7 @@
       </li>
       <li class="mktField mktLblRight p-list__item">
         <span class="mktInput mktLblRight">
-          <input class="mktFormCheckbox" name="canonicalOptIn" id="canonicalOptIn" value="yes" type="checkbox" />
+          <input class="mktFormCheckbox" name="canonicalUpdatesOptIn" id="canonicalOptIn" value="yes" type="checkbox" />
           <label class="contextual-footer__text--label" for="canonicalOptIn">I agree to receive information about Canonical's products and services.</label>&nbsp;<span class="mktFormMsg"></span>
         </span>
       </li>

--- a/templates/shared/contextual_footers/_robotics_newsletter_signup.html
+++ b/templates/shared/contextual_footers/_robotics_newsletter_signup.html
@@ -10,7 +10,7 @@
       </li>
       <li class="mktField mktLblRight p-list__item">
         <span class="mktInput mktLblRight">
-          <input class="mktFormCheckbox" name="canonicalOptIn" id="canonicalOptIn" value="yes" type="checkbox" />
+          <input class="mktFormCheckbox" name="canonicalUpdatesOptIn" id="canonicalOptIn" value="yes" type="checkbox" />
           <label class="contextual-footer__text--label" for="canonicalOptIn">I agree to receive information about Canonical's products and services.</label>&nbsp;<span class="mktFormMsg"></span>
         </span>
       </li>


### PR DESCRIPTION
## Done

- Updated two forms with field `canonicalOptIn` to `canonicalUpdatesOptIn` which is the correct field name

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/internet-of-things/edgex and http://0.0.0.0:8001/robotics
- Go to the newsletter sign-up and see that it submits

## Fixes

#10537