### PR TITLE
Update marketo field for security ebook

### DIFF
--- a/templates/download/shared/_get-ebook-security.html
+++ b/templates/download/shared/_get-ebook-security.html
@@ -57,7 +57,7 @@
             {% include "shared/forms/_state.html" %}
             <li class="mktFormReq mktField p-list__item">
               <label for="mktoPersonNotes" class="mktoLabel">Are you working on a commercial IoT deployment?</label>
-              <select required id="mktoPersonNotes" name="MktoPersonNotes" class="mktoField mktoRequired mktoInvalid"><option value="">Select...</option>
+              <select required id="mktoPersonNotes" name="mktoPersonNotes" class="mktoField mktoRequired mktoInvalid"><option value="">Select...</option>
               <option value="Working on a commercial IoT deployment">Yes</option>
               <option value="Not working on a commercial IoT deployment">No</option></select>
             </li>


### PR DESCRIPTION
## Done

- Updated `MktoPersonNotes` to `mktoPersonNotes` to make the form submit

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
http://0.0.0.0:8001/download/up-squared-iot-grove-server, http://0.0.0.0:8001/download/intel-nuc-desktop, http://0.0.0.0:8001/download/intel-iei-tank-870, http://0.0.0.0:8001/download/qualcomm-dragonboard-410c, http://0.0.0.0:8001/download/kvm, http://0.0.0.0:8001/download/raspberry-pi-coreand http://0.0.0.0:8001/download/intel-nuc
- See that the security ebook form now submits.