### PR TITLE
Copy update on /kubernetes/compare

### DIFF
--- a/templates/kubernetes/compare.html
+++ b/templates/kubernetes/compare.html
@@ -382,13 +382,12 @@
                 height="28",
                 hi_def=True,
                 loading="lazy",
-                attrs={"class": "p-heading-icon__img p-heading-icon__img--small"},
               ) | safe
           }}
-          <h4 class="p-heading-icon__title">DATA SHEET</h4>
+          <h4>Data sheet</h4>
         </div>
       </div>
-      <h3 class="p-heading--four"><a href="https://assets.ubuntu.com/v1/b5f9ae49-Enterprise_Kubernetes_Datasheet.pdf">Kubernetes for the enterprise</a></h3>
+      <p class="p-heading--four"><a href="https://assets.ubuntu.com/v1/b5f9ae49-Enterprise_Kubernetes_Datasheet.pdf">Kubernetes for the enterprise</a></p>
     </div>
 
     <div class="col-4 p-divider__block">
@@ -402,33 +401,30 @@
                 height="28",
                 hi_def=True,
                 loading="lazy",
-                attrs={"class": "p-heading-icon__img p-heading-icon__img--small"},
               ) | safe
           }}
-          <h4 class="p-heading-icon__title">WEBINAR ON DEMAND</h4>
+          <h4>Webinar on demand</h4>
         </div>
       </div>
-      <h3 class="p-heading--four"><a class="p-link--external" href="https://www.brighttalk.com/webcast/6793/435999/how-to-accelerate-kubernetes-deployment-in-the-enterprise">How to accelerate Kubernetes deployment in the enterprise</a></h3>
+      <p class="p-heading--four"><a class="p-link--external" href="https://www.brighttalk.com/webcast/6793/435999/how-to-accelerate-kubernetes-deployment-in-the-enterprise">How to accelerate Kubernetes deployment in the enterprise</a></p>
     </div>
 
     <div class="col-4 p-divider__block">
       <div class="p-heading-icon--muted">
-      <div class="p-heading-icon__header">
-          {{
-            image(
-                url="https://assets.ubuntu.com/v1/b061c401-White+paper.svg",
-                alt="",
-                width="32",
-                height="28",
-                hi_def=True,
-                loading="lazy",
-                attrs={"class": "p-heading-icon__img p-heading-icon__img--small"},
-              ) | safe
+        <div class="p-heading-icon__header">
+          {{ image (
+            url="https://assets.ubuntu.com/v1/f6d6f78b-Case+study.svg",
+            alt="",
+            width="32",
+            height="28",
+            hi_def=True,
+            loading="lazy"
+            ) | safe
           }}
-          <h4 class="p-heading-icon__title">CASE STUDY</h4>
+          <h4>Case study</h4>
         </div>
       </div>
-      <h3 class="p-heading--four"><a href="/engage/atresmedia-charmed-kubernetes-case-study">Atresmedia dominates Spain's OTT media market with Charmed Kubernetes</a></h3>
+      <p class="p-heading--four"><a href="/engage/atresmedia-charmed-kubernetes-case-study">Atresmedia dominates Spain's OTT media market with Charmed Kubernetes</a></p>
     </div>
   </div>
 </section>


### PR DESCRIPTION
## Done

- Updated icon from whitepaper to case study
- Replaced the muted headings with `h4` as per design advice [here](https://github.com/canonical-web-and-design/vanilla-framework/pull/3935#issuecomment-903651888). We are no longer to use the whitepaper/case-study/webinar icons with the muted heading. 

## QA

- View page at: https://ubuntu-com-10549.demos.haus/kubernetes/compare
- Check the icon is now a case study instead of a whitepaper
- Check the headings are `h4` not muted. 


## Issue / Card

Fixes [#4470](https://github.com/canonical-web-and-design/web-squad/issues/4470)

## Screenshots

![Screenshot 2021-10-01 at 13 43 57](https://user-images.githubusercontent.com/58959073/135621435-f45daed9-21a6-4d86-9736-5365af49d0f4.png)

