### PR TITLE
Add regex pattern for email address form fields

### DIFF
--- a/static/js/src/advantage/subscribe/react/components/PaymentMethodForm.jsx
+++ b/static/js/src/advantage/subscribe/react/components/PaymentMethodForm.jsx
@@ -180,7 +180,7 @@ function PaymentMethodForm({ setCardValid }) {
         stacked
         help="We'll also send setup instructions to this address."
         label="Email my receipt to:"
-        type="email"
+        type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,6}$"
         id="email"
         name="email"
         validate={validateEmail}

--- a/static/js/src/advantage/subscribe/react/components/PaymentMethodForm.jsx
+++ b/static/js/src/advantage/subscribe/react/components/PaymentMethodForm.jsx
@@ -180,7 +180,7 @@ function PaymentMethodForm({ setCardValid }) {
         stacked
         help="We'll also send setup instructions to this address."
         label="Email my receipt to:"
-        type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,6}$"
+        type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$"
         id="email"
         name="email"
         validate={validateEmail}

--- a/static/js/src/advantage/subscribe/react/components/PaymentMethodForm.jsx
+++ b/static/js/src/advantage/subscribe/react/components/PaymentMethodForm.jsx
@@ -180,7 +180,8 @@ function PaymentMethodForm({ setCardValid }) {
         stacked
         help="We'll also send setup instructions to this address."
         label="Email my receipt to:"
-        type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$"
+        type="email"
+        pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$"
         id="email"
         name="email"
         validate={validateEmail}

--- a/templates/advantage/_stripe-modal.html
+++ b/templates/advantage/_stripe-modal.html
@@ -37,7 +37,7 @@
             </div>
 
             <div class="col-9">
-              <input class="p-form-validation__input" name="email" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,6}$" required value="{{ user_info.email }}" />
+              <input class="p-form-validation__input" name="email" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" required value="{{ user_info.email }}" />
             </div>
 
             <div class="col-9 col-start-large-4">

--- a/templates/advantage/_stripe-modal.html
+++ b/templates/advantage/_stripe-modal.html
@@ -37,7 +37,7 @@
             </div>
 
             <div class="col-9">
-              <input class="p-form-validation__input" name="email" type="email" required value="{{ user_info.email }}" />
+              <input class="p-form-validation__input" name="email" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,6}$" required value="{{ user_info.email }}" />
             </div>
 
             <div class="col-9 col-start-large-4">

--- a/templates/blog/newsletter-form.html
+++ b/templates/blog/newsletter-form.html
@@ -37,7 +37,7 @@
       <div class="mktFormReq mktField">
         <label>
           <span class="u-no-margin--top">Work email: <span>*</span></span>
-          <input required id="email" name="email" maxlength="255" type="email" class="mktoField mktoEmailField mktoRequired" />
+          <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,6}$" class="mktoField mktoEmailField mktoRequired" />
         </label>
       </div>
 

--- a/templates/blog/newsletter-form.html
+++ b/templates/blog/newsletter-form.html
@@ -37,7 +37,7 @@
       <div class="mktFormReq mktField">
         <label>
           <span class="u-no-margin--top">Work email: <span>*</span></span>
-          <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,6}$" class="mktoField mktoEmailField mktoRequired" />
+          <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" class="mktoField mktoEmailField mktoRequired" />
         </label>
       </div>
 

--- a/templates/download/desktop/thank-you.html
+++ b/templates/download/desktop/thank-you.html
@@ -193,7 +193,7 @@
             <div class="mktFormReq mktField">
               <label>
                 <span class="u-no-margin--top">Work email: <span>*</span></span>
-                <input required  id="email" name="email" maxlength="255" type="email" class="mktoField mktoEmailField  mktoRequired" />
+                <input required  id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,6}$" class="mktoField mktoEmailField  mktoRequired" />
               </label>
             </div>
             <div class="mktField mktLblRight">

--- a/templates/download/desktop/thank-you.html
+++ b/templates/download/desktop/thank-you.html
@@ -193,7 +193,7 @@
             <div class="mktFormReq mktField">
               <label>
                 <span class="u-no-margin--top">Work email: <span>*</span></span>
-                <input required  id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,6}$" class="mktoField mktoEmailField  mktoRequired" />
+                <input required  id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" class="mktoField mktoEmailField  mktoRequired" />
               </label>
             </div>
             <div class="mktField mktLblRight">

--- a/templates/download/server/s390x.html
+++ b/templates/download/server/s390x.html
@@ -41,7 +41,7 @@
             </li>
             <li class="mktFormReq mktField p-list__item">
               <label for="email" aria-label="Email" class="mktoLabel">Email address: <span>*</span></label>
-              <input required id="email" name="email" maxlength="255" type="email" class="mktoField mktoEmailField  mktoRequired">
+              <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,6}$" class="mktoField mktoEmailField  mktoRequired">
             </li>
             <li class="mktFormReq mktField p-list__item">
               <label for="phone" aria-label="phone" class="mktoLabel">Mobile/cell phone number: <span>*</span></label>

--- a/templates/download/server/s390x.html
+++ b/templates/download/server/s390x.html
@@ -41,7 +41,7 @@
             </li>
             <li class="mktFormReq mktField p-list__item">
               <label for="email" aria-label="Email" class="mktoLabel">Email address: <span>*</span></label>
-              <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,6}$" class="mktoField mktoEmailField  mktoRequired">
+              <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" class="mktoField mktoEmailField  mktoRequired">
             </li>
             <li class="mktFormReq mktField p-list__item">
               <label for="phone" aria-label="phone" class="mktoLabel">Mobile/cell phone number: <span>*</span></label>

--- a/templates/download/shared/_get-ebook-security.html
+++ b/templates/download/shared/_get-ebook-security.html
@@ -47,7 +47,7 @@
             </li>
             <li class="mktFormReq mktField p-list__item">
               <label for="email" class="mktoLabel ">Work email address:</label>
-              <input required  id="email" name="email" maxlength="255" type="email" class="mktoField mktoEmailField mktoRequired">
+              <input required  id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,6}$" class="mktoField mktoEmailField mktoRequired">
             </li>
             <li class="mktFormReq mktField p-list__item">
               <label for="phone" class="mktoLabel">Mobile/cell phone number:</label>

--- a/templates/download/shared/_get-ebook-security.html
+++ b/templates/download/shared/_get-ebook-security.html
@@ -47,7 +47,7 @@
             </li>
             <li class="mktFormReq mktField p-list__item">
               <label for="email" class="mktoLabel ">Work email address:</label>
-              <input required  id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,6}$" class="mktoField mktoEmailField mktoRequired">
+              <input required  id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" class="mktoField mktoEmailField mktoRequired">
             </li>
             <li class="mktFormReq mktField p-list__item">
               <label for="phone" class="mktoLabel">Mobile/cell phone number:</label>

--- a/templates/download/shared/_get_ebook_maas.html
+++ b/templates/download/shared/_get_ebook_maas.html
@@ -58,7 +58,7 @@
 
             <li class="mktFormReq mktField p-list__item">
               <label for="1-Email" class="mktoLabel">Email:</label>
-              <input required id="1-Email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,6}$" class="mktoField mktoEmailField  mktoRequired">
+              <input required id="1-Email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" class="mktoField mktoEmailField  mktoRequired">
             </li>
 
             {% include "shared/forms/_country.html" %}

--- a/templates/download/shared/_get_ebook_maas.html
+++ b/templates/download/shared/_get_ebook_maas.html
@@ -58,7 +58,7 @@
 
             <li class="mktFormReq mktField p-list__item">
               <label for="1-Email" class="mktoLabel">Email:</label>
-              <input required id="1-Email" name="email" maxlength="255" type="email" class="mktoField mktoEmailField  mktoRequired">
+              <input required id="1-Email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,6}$" class="mktoField mktoEmailField  mktoRequired">
             </li>
 
             {% include "shared/forms/_country.html" %}

--- a/templates/download/shared/_server_weekly_news.html
+++ b/templates/download/shared/_server_weekly_news.html
@@ -18,7 +18,7 @@
           <label for="title" class="mktoLabel">Job title:</label>
           <input required  id="title" name="title" maxlength="255" type="text" class="mktoField mktoRequired">
           <label for="email" class="mktoLabel ">Work email:</label>
-          <input required  id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,6}$" class="mktoField mktoEmailField mktoRequired">
+          <input required  id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" class="mktoField mktoEmailField mktoRequired">
           <label for="phone" class="mktoLabel ">Mobile/cell phone number:</label>
           <input required id="phone" name="phone" maxlength="255" type="tel" class="mktoField mktoTelField  mktoRequired" required="required" />
         </div>

--- a/templates/download/shared/_server_weekly_news.html
+++ b/templates/download/shared/_server_weekly_news.html
@@ -18,7 +18,7 @@
           <label for="title" class="mktoLabel">Job title:</label>
           <input required  id="title" name="title" maxlength="255" type="text" class="mktoField mktoRequired">
           <label for="email" class="mktoLabel ">Work email:</label>
-          <input required  id="email" name="email" maxlength="255" type="email" class="mktoField mktoEmailField mktoRequired">
+          <input required  id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,6}$" class="mktoField mktoEmailField mktoRequired">
           <label for="phone" class="mktoLabel ">Mobile/cell phone number:</label>
           <input required id="phone" name="phone" maxlength="255" type="tel" class="mktoField mktoTelField  mktoRequired" required="required" />
         </div>

--- a/templates/engage/shared/_de_engage_form.html
+++ b/templates/engage/shared/_de_engage_form.html
@@ -12,7 +12,7 @@
       </li>
       <li class="mktFormReq mktField">
         <label for="email" class="mktoLabel ">Email beruflich:</label>
-        <input required id="email" name="email" maxlength="255" class="mktoField mktoEmailField  mktoRequired" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,6}$" aria-label="Email">
+        <input required id="email" name="email" maxlength="255" class="mktoField mktoEmailField  mktoRequired" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" aria-label="Email">
       </li>
       <li class="mktFormReq mktField">
         <label for="company" class="mktoLabel ">Name des Unternehmens:</label>

--- a/templates/engage/shared/_de_engage_form.html
+++ b/templates/engage/shared/_de_engage_form.html
@@ -12,7 +12,7 @@
       </li>
       <li class="mktFormReq mktField">
         <label for="email" class="mktoLabel ">Email beruflich:</label>
-        <input required id="email" name="email" maxlength="255" class="mktoField mktoEmailField  mktoRequired" type="email" aria-label="Email">
+        <input required id="email" name="email" maxlength="255" class="mktoField mktoEmailField  mktoRequired" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,6}$" aria-label="Email">
       </li>
       <li class="mktFormReq mktField">
         <label for="company" class="mktoLabel ">Name des Unternehmens:</label>

--- a/templates/engage/shared/_en_engage_form.html
+++ b/templates/engage/shared/_en_engage_form.html
@@ -14,7 +14,7 @@
       </li>
       <li class="mktFormReq mktField">
         <label for="email" class="mktoLabel ">Work email:</label>
-        <input required id="email" name="email" maxlength="255" class="mktoField mktoEmailField  mktoRequired" type="email"
+        <input required id="email" name="email" maxlength="255" class="mktoField mktoEmailField  mktoRequired" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,6}$"
           aria-label="Email">
       </li>
       <li class="mktFormReq mktField">

--- a/templates/engage/shared/_en_engage_form.html
+++ b/templates/engage/shared/_en_engage_form.html
@@ -14,7 +14,7 @@
       </li>
       <li class="mktFormReq mktField">
         <label for="email" class="mktoLabel ">Work email:</label>
-        <input required id="email" name="email" maxlength="255" class="mktoField mktoEmailField  mktoRequired" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,6}$"
+        <input required id="email" name="email" maxlength="255" class="mktoField mktoEmailField  mktoRequired" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$"
           aria-label="Email">
       </li>
       <li class="mktFormReq mktField">

--- a/templates/engage/shared/_es_engage_form.html
+++ b/templates/engage/shared/_es_engage_form.html
@@ -14,7 +14,7 @@
       </li>
       <li class="mktFormReq mktField">
         <label for="email" class="mktoLabel ">E-mail de trabajo:</label>
-        <input required id="email" name="email" maxlength="255" class="mktoField mktoEmailField  mktoRequired" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,6}$"
+        <input required id="email" name="email" maxlength="255" class="mktoField mktoEmailField  mktoRequired" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$"
           aria-label="E-mail de trabajo">
       </li>
       <li class="mktFormReq mktField">

--- a/templates/engage/shared/_es_engage_form.html
+++ b/templates/engage/shared/_es_engage_form.html
@@ -14,7 +14,7 @@
       </li>
       <li class="mktFormReq mktField">
         <label for="email" class="mktoLabel ">E-mail de trabajo:</label>
-        <input required id="email" name="email" maxlength="255" class="mktoField mktoEmailField  mktoRequired" type="email"
+        <input required id="email" name="email" maxlength="255" class="mktoField mktoEmailField  mktoRequired" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,6}$"
           aria-label="E-mail de trabajo">
       </li>
       <li class="mktFormReq mktField">

--- a/templates/engage/shared/_fr_engage_form.html
+++ b/templates/engage/shared/_fr_engage_form.html
@@ -12,7 +12,7 @@
       </li>
       <li class="mktFormReq mktField p-list__item">
         <label for="email" class="mktoLabel">Adresse électronique professionnelle :</label>
-        <input required id="email" name="email" maxlength="255" type="email" class="mktoField mktoEmailField mktoRequired" />
+        <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,6}$" class="mktoField mktoEmailField mktoRequired" />
       </li>
       <li class="mktFormReq mktField p-list__item">
         <label for="phone" class="mktoLabel">N° de téléphone portable:</label>

--- a/templates/engage/shared/_fr_engage_form.html
+++ b/templates/engage/shared/_fr_engage_form.html
@@ -12,7 +12,7 @@
       </li>
       <li class="mktFormReq mktField p-list__item">
         <label for="email" class="mktoLabel">Adresse électronique professionnelle :</label>
-        <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,6}$" class="mktoField mktoEmailField mktoRequired" />
+        <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" class="mktoField mktoEmailField mktoRequired" />
       </li>
       <li class="mktFormReq mktField p-list__item">
         <label for="phone" class="mktoLabel">N° de téléphone portable:</label>

--- a/templates/engage/shared/_it_engage_form.html
+++ b/templates/engage/shared/_it_engage_form.html
@@ -14,7 +14,7 @@
       </li>
       <li class="mktFormReq mktField">
         <label for="email" class="mktoLabel ">E-mail lavorativa:</label>
-        <input required id="email" name="email" maxlength="255" class="mktoField mktoEmailField  mktoRequired" type="email"
+        <input required id="email" name="email" maxlength="255" class="mktoField mktoEmailField  mktoRequired" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,6}$"
           aria-label="E-mail lavorativa">
       </li>
       <li class="mktFormReq mktField">

--- a/templates/engage/shared/_it_engage_form.html
+++ b/templates/engage/shared/_it_engage_form.html
@@ -14,7 +14,7 @@
       </li>
       <li class="mktFormReq mktField">
         <label for="email" class="mktoLabel ">E-mail lavorativa:</label>
-        <input required id="email" name="email" maxlength="255" class="mktoField mktoEmailField  mktoRequired" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,6}$"
+        <input required id="email" name="email" maxlength="255" class="mktoField mktoEmailField  mktoRequired" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$"
           aria-label="E-mail lavorativa">
       </li>
       <li class="mktFormReq mktField">

--- a/templates/engage/shared/_pt_engage_form.html
+++ b/templates/engage/shared/_pt_engage_form.html
@@ -14,7 +14,7 @@
       </li>
       <li class="mktFormReq mktField">
         <label for="email" class="mktoLabel ">Email do trabalho:</label>
-        <input required id="email" name="email" maxlength="255" class="mktoField mktoEmailField  mktoRequired" type="email"
+        <input required id="email" name="email" maxlength="255" class="mktoField mktoEmailField  mktoRequired" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,6}$"
           aria-label="Email">
       </li>
       <li class="mktFormReq mktField">

--- a/templates/engage/shared/_pt_engage_form.html
+++ b/templates/engage/shared/_pt_engage_form.html
@@ -14,7 +14,7 @@
       </li>
       <li class="mktFormReq mktField">
         <label for="email" class="mktoLabel ">Email do trabalho:</label>
-        <input required id="email" name="email" maxlength="255" class="mktoField mktoEmailField  mktoRequired" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,6}$"
+        <input required id="email" name="email" maxlength="255" class="mktoField mktoEmailField  mktoRequired" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$"
           aria-label="Email">
       </li>
       <li class="mktFormReq mktField">

--- a/templates/gov/form.html
+++ b/templates/gov/form.html
@@ -180,7 +180,7 @@
               </li>
               <li class="mktFormReq mktField p-list__item">
                 <label for="email" class="mktoLabel">Work email:</label>
-                <input required id="email" name="email" maxlength="255" type="email" class="mktoField mktoEmailField mktoRequired" required="required" />
+                <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,6}$" class="mktoField mktoEmailField mktoRequired" required="required" />
               </li>
               <li class="mktFormReq mktField p-list__item">
                 <label for="phone" class="mktoLabel ">Work phone:</label>

--- a/templates/gov/form.html
+++ b/templates/gov/form.html
@@ -180,7 +180,7 @@
               </li>
               <li class="mktFormReq mktField p-list__item">
                 <label for="email" class="mktoLabel">Work email:</label>
-                <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,6}$" class="mktoField mktoEmailField mktoRequired" required="required" />
+                <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" class="mktoField mktoEmailField mktoRequired" required="required" />
               </li>
               <li class="mktFormReq mktField p-list__item">
                 <label for="phone" class="mktoLabel ">Work phone:</label>

--- a/templates/internet-of-things/edgex.html
+++ b/templates/internet-of-things/edgex.html
@@ -116,7 +116,7 @@
         <form action="/marketo/submit" method="post" id="mktoForm_3415" class="p-form--stacked">
           <div class="p-form__group">
             <label for="email">Email:*</label>
-            <input class="u-no-margin--bottom" id="email" placeholder="Email" name="email" maxlength="255" type="email" required="">
+            <input class="u-no-margin--bottom" id="email" placeholder="Email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,6}$" required="">
           </div>
           <div class="p-form__group">
             <label for="company">Company:</label>

--- a/templates/internet-of-things/edgex.html
+++ b/templates/internet-of-things/edgex.html
@@ -116,7 +116,7 @@
         <form action="/marketo/submit" method="post" id="mktoForm_3415" class="p-form--stacked">
           <div class="p-form__group">
             <label for="email">Email:*</label>
-            <input class="u-no-margin--bottom" id="email" placeholder="Email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,6}$" required="">
+            <input class="u-no-margin--bottom" id="email" placeholder="Email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" required="">
           </div>
           <div class="p-form__group">
             <label for="company">Company:</label>

--- a/templates/kubernetes/_get_ebook.html
+++ b/templates/kubernetes/_get_ebook.html
@@ -45,7 +45,7 @@
 
           <li class="mktFormReq mktField p-list__item">
             <label for="3-Email" class="mktoLabel">Email:</label>
-            <input required id="3-Email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,6}$" class="mktoField mktoEmailField  mktoRequired">
+            <input required id="3-Email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" class="mktoField mktoEmailField  mktoRequired">
           </li>
 
           {% include "shared/forms/_country.html" %}

--- a/templates/kubernetes/_get_ebook.html
+++ b/templates/kubernetes/_get_ebook.html
@@ -45,7 +45,7 @@
 
           <li class="mktFormReq mktField p-list__item">
             <label for="3-Email" class="mktoLabel">Email:</label>
-            <input required id="3-Email" name="email" maxlength="255" type="email" class="mktoField mktoEmailField  mktoRequired">
+            <input required id="3-Email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,6}$" class="mktoField mktoEmailField  mktoRequired">
           </li>
 
           {% include "shared/forms/_country.html" %}

--- a/templates/rfp/index.html
+++ b/templates/rfp/index.html
@@ -51,7 +51,7 @@
 
             <li class="mktFormReq mktField p-list__item">
               <label for="email" class="mktoLabel ">Email:</label>
-              <input required="" id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,6}$" class="mktoField mktoEmailField  mktoRequired">
+              <input required="" id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" class="mktoField mktoEmailField  mktoRequired">
             </li>
 
             <li class="mktFormReq mktField p-list__item">

--- a/templates/rfp/index.html
+++ b/templates/rfp/index.html
@@ -51,7 +51,7 @@
 
             <li class="mktFormReq mktField p-list__item">
               <label for="email" class="mktoLabel ">Email:</label>
-              <input required="" id="email" name="email" maxlength="255" type="email" class="mktoField mktoEmailField  mktoRequired">
+              <input required="" id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,6}$" class="mktoField mktoEmailField  mktoRequired">
             </li>
 
             <li class="mktFormReq mktField p-list__item">

--- a/templates/shared/_blender-contact-us-form.html
+++ b/templates/shared/_blender-contact-us-form.html
@@ -31,7 +31,7 @@
             </li>
             <li class="mktFormReq mktField p-list__item">
               <label for="Email" class="mktoLabel">Email address:</label>
-              <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,6}$" class="mktoField mktoEmailField mktoRequired" />
+              <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" class="mktoField mktoEmailField mktoRequired" />
             </li>
             <li class="mktFormReq mktField p-list__item">
               <label for="Phone" class="mktoLabel">Mobile/cell phone number:</label>

--- a/templates/shared/_blender-contact-us-form.html
+++ b/templates/shared/_blender-contact-us-form.html
@@ -31,7 +31,7 @@
             </li>
             <li class="mktFormReq mktField p-list__item">
               <label for="Email" class="mktoLabel">Email address:</label>
-              <input required id="email" name="email" maxlength="255" type="email" class="mktoField mktoEmailField mktoRequired" />
+              <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,6}$" class="mktoField mktoEmailField mktoRequired" />
             </li>
             <li class="mktFormReq mktField p-list__item">
               <label for="Phone" class="mktoLabel">Mobile/cell phone number:</label>

--- a/templates/shared/_client-contact-us-form.html
+++ b/templates/shared/_client-contact-us-form.html
@@ -21,7 +21,7 @@
             </li>
             <li class="mktFormReq mktField p-list__item">
               <label for="email" class="mktoLabel">Email address:</label>
-              <input required id="email" name="email" maxlength="255" type="email" class="mktoField mktoEmailField mktoRequired" />
+              <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,6}$" class="mktoField mktoEmailField mktoRequired" />
             </li>
             <li class="mktFormReq mktField p-list__item">
               <label for="phone" class="mktoLabel">Mobile/cell phone number:</label>

--- a/templates/shared/_client-contact-us-form.html
+++ b/templates/shared/_client-contact-us-form.html
@@ -21,7 +21,7 @@
             </li>
             <li class="mktFormReq mktField p-list__item">
               <label for="email" class="mktoLabel">Email address:</label>
-              <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,6}$" class="mktoField mktoEmailField mktoRequired" />
+              <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" class="mktoField mktoEmailField mktoRequired" />
             </li>
             <li class="mktFormReq mktField p-list__item">
               <label for="phone" class="mktoLabel">Mobile/cell phone number:</label>

--- a/templates/shared/_cloud-contact-us-form-german.html
+++ b/templates/shared/_cloud-contact-us-form-german.html
@@ -23,7 +23,7 @@
             </li>
             <li class="mktFormReq mktField p-list__item">
               <label for="email" class="mktoLabel">Email-Adresse:</label>
-              <input required id="email" name="email" maxlength="255" type="email" class="mktoField mktoEmailField mktoRequired" />
+              <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,6}$" class="mktoField mktoEmailField mktoRequired" />
             </li>
             <li class="mktFormReq mktField p-list__item">
               <label for="phone" class="mktoLabel">Handynummer:</label>

--- a/templates/shared/_cloud-contact-us-form-german.html
+++ b/templates/shared/_cloud-contact-us-form-german.html
@@ -23,7 +23,7 @@
             </li>
             <li class="mktFormReq mktField p-list__item">
               <label for="email" class="mktoLabel">Email-Adresse:</label>
-              <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,6}$" class="mktoField mktoEmailField mktoRequired" />
+              <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" class="mktoField mktoEmailField mktoRequired" />
             </li>
             <li class="mktFormReq mktField p-list__item">
               <label for="phone" class="mktoLabel">Handynummer:</label>

--- a/templates/shared/_cloud-contact-us-form.html
+++ b/templates/shared/_cloud-contact-us-form.html
@@ -21,7 +21,7 @@
             </li>
             <li class="mktFormReq mktField p-list__item">
               <label for="email" class="mktoLabel">Email address:</label>
-              <input required id="email" name="email" maxlength="255" type="email" class="mktoField mktoEmailField mktoRequired" />
+              <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,6}$" class="mktoField mktoEmailField mktoRequired" />
             </li>
             <li class="mktFormReq mktField p-list__item">
               <label for="phone" class="mktoLabel">Mobile/cell phone number:</label>

--- a/templates/shared/_cloud-contact-us-form.html
+++ b/templates/shared/_cloud-contact-us-form.html
@@ -21,7 +21,7 @@
             </li>
             <li class="mktFormReq mktField p-list__item">
               <label for="email" class="mktoLabel">Email address:</label>
-              <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,6}$" class="mktoField mktoEmailField mktoRequired" />
+              <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" class="mktoField mktoEmailField mktoRequired" />
             </li>
             <li class="mktFormReq mktField p-list__item">
               <label for="phone" class="mktoLabel">Mobile/cell phone number:</label>

--- a/templates/shared/_cube-contact-us-form.html
+++ b/templates/shared/_cube-contact-us-form.html
@@ -23,7 +23,7 @@
 
             <li  class="p-list__item  ">
               <label for="Email" id="LblEmail"  >Work email:</label>
-              <input id="Email" name="email" maxlength="255" aria-labelledby="LblEmail InstructEmail" type="email" class="is-required" aria-required="true" autocomplete="email" >
+              <input id="Email" name="email" maxlength="255" aria-labelledby="LblEmail InstructEmail" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,6}$" class="is-required" aria-required="true" autocomplete="email" >
             </li>
 
             <li  class="p-list__item  ">

--- a/templates/shared/_cube-contact-us-form.html
+++ b/templates/shared/_cube-contact-us-form.html
@@ -23,7 +23,7 @@
 
             <li  class="p-list__item  ">
               <label for="Email" id="LblEmail"  >Work email:</label>
-              <input id="Email" name="email" maxlength="255" aria-labelledby="LblEmail InstructEmail" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,6}$" class="is-required" aria-required="true" autocomplete="email" >
+              <input id="Email" name="email" maxlength="255" aria-labelledby="LblEmail InstructEmail" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" class="is-required" aria-required="true" autocomplete="email" >
             </li>
 
             <li  class="p-list__item  ">

--- a/templates/shared/_telco-contact-us.html
+++ b/templates/shared/_telco-contact-us.html
@@ -115,7 +115,7 @@
                     </li>
                     <li class="mktFormReq mktField p-list__item">
                       <label for="Email" class="mktoLabel">Email:</label>
-                      <input required id="Email" name="email" maxlength="255" type="email" class="mktoField mktoEmailField mktoRequired" required="required" />
+                      <input required id="Email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,6}$" class="mktoField mktoEmailField mktoRequired" required="required" />
                     </li>
                     <li class="mktFormReq mktField p-list__item">
                       <label for="Phone" class="mktoLabel ">Mobile/cell phone number:</label>

--- a/templates/shared/_telco-contact-us.html
+++ b/templates/shared/_telco-contact-us.html
@@ -115,7 +115,7 @@
                     </li>
                     <li class="mktFormReq mktField p-list__item">
                       <label for="Email" class="mktoLabel">Email:</label>
-                      <input required id="Email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,6}$" class="mktoField mktoEmailField mktoRequired" required="required" />
+                      <input required id="Email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" class="mktoField mktoEmailField mktoRequired" required="required" />
                     </li>
                     <li class="mktFormReq mktField p-list__item">
                       <label for="Phone" class="mktoLabel ">Mobile/cell phone number:</label>

--- a/templates/shared/contextual_footers/_cloud_newsletter.html
+++ b/templates/shared/contextual_footers/_cloud_newsletter.html
@@ -4,7 +4,7 @@
     <ul class="p-list mktoFormRow u-clearfix">
       <li class="mktoFormCol p-list__item">
         <label class="u-off-screen mktoLabel" for="email">Your email</label>
-        <input type="email" placeholder="Your email" class="mktoField mktoTextField" name="email" id="email" required />
+        <input type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,6}$" placeholder="Your email" class="mktoField mktoTextField" name="email" id="email" required />
       </li>
       <li class="mktField mktLblRight p-list__item">
         <span class="mktInput mktLblRight">

--- a/templates/shared/contextual_footers/_cloud_newsletter.html
+++ b/templates/shared/contextual_footers/_cloud_newsletter.html
@@ -4,7 +4,7 @@
     <ul class="p-list mktoFormRow u-clearfix">
       <li class="mktoFormCol p-list__item">
         <label class="u-off-screen mktoLabel" for="email">Your email</label>
-        <input type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,6}$" placeholder="Your email" class="mktoField mktoTextField" name="email" id="email" required />
+        <input type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" placeholder="Your email" class="mktoField mktoTextField" name="email" id="email" required />
       </li>
       <li class="mktField mktLblRight p-list__item">
         <span class="mktInput mktLblRight">

--- a/templates/shared/contextual_footers/_devices_newsletter_signup.html
+++ b/templates/shared/contextual_footers/_devices_newsletter_signup.html
@@ -17,7 +17,7 @@
           <ul class="u-clearfix">
               <li class="p-list">
                   <label class="u-off-screen" for="mce-EMAIL">Your email</label>
-                  <input type="email" placeholder="Your email" value="" name="EMAIL" class="required email" id="mce-EMAIL" />
+                  <input type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,6}$" placeholder="Your email" value="" name="EMAIL" class="required email" id="mce-EMAIL" />
                   <div id="mce-responses">
                       <div class="response" id="mce-error-response" style="display: none; width: 100%;"></div>
                       <div class="response" id="mce-success-response" style="display: none; width: 100%;"></div>

--- a/templates/shared/contextual_footers/_devices_newsletter_signup.html
+++ b/templates/shared/contextual_footers/_devices_newsletter_signup.html
@@ -17,7 +17,7 @@
           <ul class="u-clearfix">
               <li class="p-list">
                   <label class="u-off-screen" for="mce-EMAIL">Your email</label>
-                  <input type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,6}$" placeholder="Your email" value="" name="EMAIL" class="required email" id="mce-EMAIL" />
+                  <input type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" placeholder="Your email" value="" name="EMAIL" class="required email" id="mce-EMAIL" />
                   <div id="mce-responses">
                       <div class="response" id="mce-error-response" style="display: none; width: 100%;"></div>
                       <div class="response" id="mce-success-response" style="display: none; width: 100%;"></div>

--- a/templates/shared/contextual_footers/_iot_newsletter_signup.html
+++ b/templates/shared/contextual_footers/_iot_newsletter_signup.html
@@ -6,7 +6,7 @@
     <ul class="p-list">
       <li class="mktFormReq mktField p-list__item">
         <label for="email" class="mktoLabel contextual-footer__text--label">Your email address:</label>
-        <input required id="email" name="email" maxlength="255" type="email" class="mktoField mktoEmailField mktoRequired">
+        <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,6}$" class="mktoField mktoEmailField mktoRequired">
       </li>
       <li class="mktField mktLblRight p-list__item">
         <span class="mktInput mktLblRight">

--- a/templates/shared/contextual_footers/_iot_newsletter_signup.html
+++ b/templates/shared/contextual_footers/_iot_newsletter_signup.html
@@ -6,7 +6,7 @@
     <ul class="p-list">
       <li class="mktFormReq mktField p-list__item">
         <label for="email" class="mktoLabel contextual-footer__text--label">Your email address:</label>
-        <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,6}$" class="mktoField mktoEmailField mktoRequired">
+        <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" class="mktoField mktoEmailField mktoRequired">
       </li>
       <li class="mktField mktLblRight p-list__item">
         <span class="mktInput mktLblRight">

--- a/templates/shared/contextual_footers/_kubeflow_news_signup.html
+++ b/templates/shared/contextual_footers/_kubeflow_news_signup.html
@@ -6,7 +6,7 @@
     <ul class="p-list">
       <li class="mktFormReq mktField p-list__item">
         <label for="email" class="mktoLabel contextual-footer__text--label">Work email:</label>
-        <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,6}$" class="mktoField mktoEmailField mktoRequired">
+        <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" class="mktoField mktoEmailField mktoRequired">
       </li>
       <li class="p-list__item u-no-margin--top">
         <p>

--- a/templates/shared/contextual_footers/_kubeflow_news_signup.html
+++ b/templates/shared/contextual_footers/_kubeflow_news_signup.html
@@ -6,7 +6,7 @@
     <ul class="p-list">
       <li class="mktFormReq mktField p-list__item">
         <label for="email" class="mktoLabel contextual-footer__text--label">Work email:</label>
-        <input required id="email" name="email" maxlength="255" type="email" class="mktoField mktoEmailField mktoRequired">
+        <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,6}$" class="mktoField mktoEmailField mktoRequired">
       </li>
       <li class="p-list__item u-no-margin--top">
         <p>

--- a/templates/shared/contextual_footers/_openstack_install_newsletter.html
+++ b/templates/shared/contextual_footers/_openstack_install_newsletter.html
@@ -4,7 +4,7 @@
         <ul class="p-list mktoFormRow u-clearfix">
             <li class="mktoFormCol p-list__item">
                 <label class="u-off-screen mktoLabel" for="Email">Your email</label>
-                <input type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,6}$" placeholder="Your email" class="mktoField mktoTextField" name="email" id="Email" required />
+                <input type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" placeholder="Your email" class="mktoField mktoTextField" name="email" id="Email" required />
             </li>
             <li class="mktField mktLblRight p-list__item">
                 <span class="mktInput mktLblRight">

--- a/templates/shared/contextual_footers/_openstack_install_newsletter.html
+++ b/templates/shared/contextual_footers/_openstack_install_newsletter.html
@@ -4,7 +4,7 @@
         <ul class="p-list mktoFormRow u-clearfix">
             <li class="mktoFormCol p-list__item">
                 <label class="u-off-screen mktoLabel" for="Email">Your email</label>
-                <input type="email" placeholder="Your email" class="mktoField mktoTextField" name="email" id="Email" required />
+                <input type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,6}$" placeholder="Your email" class="mktoField mktoTextField" name="email" id="Email" required />
             </li>
             <li class="mktField mktLblRight p-list__item">
                 <span class="mktInput mktLblRight">

--- a/templates/shared/contextual_footers/_robotics_newsletter_signup.html
+++ b/templates/shared/contextual_footers/_robotics_newsletter_signup.html
@@ -6,7 +6,7 @@
     <ul class="p-list">
       <li class="mktFormReq mktField p-list__item">
         <label for="Email" class="mktoLabel contextual-footer__text--label">Your email address:</label>
-        <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,6}$" class="mktoField mktoEmailField mktoRequired">
+        <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" class="mktoField mktoEmailField mktoRequired">
       </li>
       <li class="mktField mktLblRight p-list__item">
         <span class="mktInput mktLblRight">

--- a/templates/shared/contextual_footers/_robotics_newsletter_signup.html
+++ b/templates/shared/contextual_footers/_robotics_newsletter_signup.html
@@ -6,7 +6,7 @@
     <ul class="p-list">
       <li class="mktFormReq mktField p-list__item">
         <label for="Email" class="mktoLabel contextual-footer__text--label">Your email address:</label>
-        <input required id="email" name="email" maxlength="255" type="email" class="mktoField mktoEmailField mktoRequired">
+        <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,6}$" class="mktoField mktoEmailField mktoRequired">
       </li>
       <li class="mktField mktLblRight p-list__item">
         <span class="mktInput mktLblRight">

--- a/templates/shared/forms/interactive/_appliance.html
+++ b/templates/shared/forms/interactive/_appliance.html
@@ -132,7 +132,7 @@
               </li>
               <li class="mktFormReq mktField p-list__item">
                 <label for="email" class="mktoLabel">Work email:</label>
-                <input required id="email" name="email" maxlength="255" type="email" class="mktoField mktoEmailField mktoRequired" required="required" />
+                <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,6}$" class="mktoField mktoEmailField mktoRequired" required="required" />
               </li>
               <li class="mktField p-list__item">
                 <input class="mktoField" value="yes" id="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox" />

--- a/templates/shared/forms/interactive/_appliance.html
+++ b/templates/shared/forms/interactive/_appliance.html
@@ -132,7 +132,7 @@
               </li>
               <li class="mktFormReq mktField p-list__item">
                 <label for="email" class="mktoLabel">Work email:</label>
-                <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,6}$" class="mktoField mktoEmailField mktoRequired" required="required" />
+                <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" class="mktoField mktoEmailField mktoRequired" required="required" />
               </li>
               <li class="mktField p-list__item">
                 <input class="mktoField" value="yes" id="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox" />

--- a/templates/shared/forms/interactive/advantage-beta.html
+++ b/templates/shared/forms/interactive/advantage-beta.html
@@ -111,7 +111,7 @@
               </li>
               <li class="mktFormReq mktField p-list__item">
                 <label for="email" class="mktoLabel">Work email:</label>
-                <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,6}$" class="mktoField mktoEmailField mktoRequired" required="required" />
+                <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" class="mktoField mktoEmailField mktoRequired" required="required" />
               </li>
               <li class="mktField p-list__item">
                 <input class="mktoField" value="yes" id="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox" />

--- a/templates/shared/forms/interactive/advantage-beta.html
+++ b/templates/shared/forms/interactive/advantage-beta.html
@@ -111,7 +111,7 @@
               </li>
               <li class="mktFormReq mktField p-list__item">
                 <label for="email" class="mktoLabel">Work email:</label>
-                <input required id="email" name="email" maxlength="255" type="email" class="mktoField mktoEmailField mktoRequired" required="required" />
+                <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,6}$" class="mktoField mktoEmailField mktoRequired" required="required" />
               </li>
               <li class="mktField p-list__item">
                 <input class="mktoField" value="yes" id="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox" />

--- a/templates/shared/forms/interactive/aws.html
+++ b/templates/shared/forms/interactive/aws.html
@@ -122,7 +122,7 @@
               </li>
               <li class="mktFormReq mktField p-list__item">
                 <label for="email" class="mktoLabel">Work email:</label>
-                <input required id="email" name="email" maxlength="255" type="email" class="mktoField mktoEmailField mktoRequired" required="required" />
+                <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,6}$" class="mktoField mktoEmailField mktoRequired" required="required" />
               </li>
               <li class="mktFormReq mktField p-list__item">
                 <label for="phone" class="mktoLabel ">Mobile/cell phone number:</label>

--- a/templates/shared/forms/interactive/aws.html
+++ b/templates/shared/forms/interactive/aws.html
@@ -122,7 +122,7 @@
               </li>
               <li class="mktFormReq mktField p-list__item">
                 <label for="email" class="mktoLabel">Work email:</label>
-                <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,6}$" class="mktoField mktoEmailField mktoRequired" required="required" />
+                <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" class="mktoField mktoEmailField mktoRequired" required="required" />
               </li>
               <li class="mktFormReq mktField p-list__item">
                 <label for="phone" class="mktoLabel ">Mobile/cell phone number:</label>

--- a/templates/shared/forms/interactive/azure-1604.html
+++ b/templates/shared/forms/interactive/azure-1604.html
@@ -127,7 +127,7 @@
                 </li>
                 <li class="mktFormReq mktField p-list__item">
                   <label for="email" class="mktoLabel">Work email:</label>
-                  <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,6}$" class="mktoField mktoEmailField mktoRequired" />
+                  <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" class="mktoField mktoEmailField mktoRequired" />
                 </li>
                 <li class="mktField p-list__item">
                   <input class="mktoField" value="yes" id="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox" />

--- a/templates/shared/forms/interactive/azure-1604.html
+++ b/templates/shared/forms/interactive/azure-1604.html
@@ -127,7 +127,7 @@
                 </li>
                 <li class="mktFormReq mktField p-list__item">
                   <label for="email" class="mktoLabel">Work email:</label>
-                  <input required id="email" name="email" maxlength="255" type="email" class="mktoField mktoEmailField mktoRequired" />
+                  <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,6}$" class="mktoField mktoEmailField mktoRequired" />
                 </li>
                 <li class="mktField p-list__item">
                   <input class="mktoField" value="yes" id="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox" />

--- a/templates/shared/forms/interactive/azure.html
+++ b/templates/shared/forms/interactive/azure.html
@@ -122,7 +122,7 @@
               </li>
               <li class="mktFormReq mktField p-list__item">
                 <label for="email" class="mktoLabel">Work email:</label>
-                <input required id="email" name="email" maxlength="255" type="email" class="mktoField mktoEmailField mktoRequired" required="required" />
+                <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,6}$" class="mktoField mktoEmailField mktoRequired" required="required" />
               </li>
               <li class="mktFormReq mktField p-list__item">
                 <label for="phone" class="mktoLabel ">Mobile/cell phone number:</label>

--- a/templates/shared/forms/interactive/azure.html
+++ b/templates/shared/forms/interactive/azure.html
@@ -122,7 +122,7 @@
               </li>
               <li class="mktFormReq mktField p-list__item">
                 <label for="email" class="mktoLabel">Work email:</label>
-                <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,6}$" class="mktoField mktoEmailField mktoRequired" required="required" />
+                <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" class="mktoField mktoEmailField mktoRequired" required="required" />
               </li>
               <li class="mktFormReq mktField p-list__item">
                 <label for="phone" class="mktoLabel ">Mobile/cell phone number:</label>

--- a/templates/shared/forms/interactive/bootstack.html
+++ b/templates/shared/forms/interactive/bootstack.html
@@ -315,7 +315,7 @@
               </li>
               <li class="mktFormReq mktField p-list__item">
                 <label for="email" class="mktoLabel">Work email:</label>
-                <input required id="email" name="email" maxlength="255" type="email" class="mktoField mktoEmailField mktoRequired" required="required" />
+                <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,6}$" class="mktoField mktoEmailField mktoRequired" required="required" />
               </li>
               <li class="mktFormReq mktField p-list__item">
                 <label for="phone" class="mktoLabel ">Mobile/cell phone number:</label>

--- a/templates/shared/forms/interactive/bootstack.html
+++ b/templates/shared/forms/interactive/bootstack.html
@@ -315,7 +315,7 @@
               </li>
               <li class="mktFormReq mktField p-list__item">
                 <label for="email" class="mktoLabel">Work email:</label>
-                <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,6}$" class="mktoField mktoEmailField mktoRequired" required="required" />
+                <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" class="mktoField mktoEmailField mktoRequired" required="required" />
               </li>
               <li class="mktFormReq mktField p-list__item">
                 <label for="phone" class="mktoLabel ">Mobile/cell phone number:</label>

--- a/templates/shared/forms/interactive/cube-beta.html
+++ b/templates/shared/forms/interactive/cube-beta.html
@@ -24,7 +24,7 @@
 
                 <li class="p-list__item">
                   <label for="Email" id="LblEmail" >Work email:</label>
-                  <input id="Email" name="email" maxlength="255" aria-labelledby="LblEmail InstructEmail" type="email" class="is-required" aria-required="true" autocomplete="email" >
+                  <input id="Email" name="email" maxlength="255" aria-labelledby="LblEmail InstructEmail" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,6}$" class="is-required" aria-required="true" autocomplete="email" >
                 </li>
 
                 <li class="p-list__item">

--- a/templates/shared/forms/interactive/cube-beta.html
+++ b/templates/shared/forms/interactive/cube-beta.html
@@ -24,7 +24,7 @@
 
                 <li class="p-list__item">
                   <label for="Email" id="LblEmail" >Work email:</label>
-                  <input id="Email" name="email" maxlength="255" aria-labelledby="LblEmail InstructEmail" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,6}$" class="is-required" aria-required="true" autocomplete="email" >
+                  <input id="Email" name="email" maxlength="255" aria-labelledby="LblEmail InstructEmail" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" class="is-required" aria-required="true" autocomplete="email" >
                 </li>
 
                 <li class="p-list__item">

--- a/templates/shared/forms/interactive/embedded.html
+++ b/templates/shared/forms/interactive/embedded.html
@@ -159,7 +159,7 @@
               </li>
               <li class="mktFormReq mktField p-list__item">
                 <label for="email" class="mktoLabel">Email address:</label>
-                <input required id="email" name="email" maxlength="255" type="email" class="mktoField mktoEmailField mktoRequired" required="required" />
+                <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,6}$" class="mktoField mktoEmailField mktoRequired" required="required" />
               </li>
               <li class="mktFormReq mktField p-list__item">
                 <label for="phone" class="mktoLabel ">Mobile/cell phone number:</label>

--- a/templates/shared/forms/interactive/embedded.html
+++ b/templates/shared/forms/interactive/embedded.html
@@ -159,7 +159,7 @@
               </li>
               <li class="mktFormReq mktField p-list__item">
                 <label for="email" class="mktoLabel">Email address:</label>
-                <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,6}$" class="mktoField mktoEmailField mktoRequired" required="required" />
+                <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" class="mktoField mktoEmailField mktoRequired" required="required" />
               </li>
               <li class="mktFormReq mktField p-list__item">
                 <label for="phone" class="mktoLabel ">Mobile/cell phone number:</label>

--- a/templates/shared/forms/interactive/esm.html
+++ b/templates/shared/forms/interactive/esm.html
@@ -99,7 +99,7 @@
               </li>
               <li class="mktFormReq mktField p-list__item">
                 <label for="email" class="mktoLabel">Work email:</label>
-                <input required id="email" name="email" maxlength="255" type="email" class="mktoField mktoEmailField mktoRequired" />
+                <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,6}$" class="mktoField mktoEmailField mktoRequired" />
               </li>
               <li class="mktFormReq mktField p-list__item">
                 <label for="phone" class="mktoLabel ">Mobile number:</label>

--- a/templates/shared/forms/interactive/esm.html
+++ b/templates/shared/forms/interactive/esm.html
@@ -99,7 +99,7 @@
               </li>
               <li class="mktFormReq mktField p-list__item">
                 <label for="email" class="mktoLabel">Work email:</label>
-                <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,6}$" class="mktoField mktoEmailField mktoRequired" />
+                <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" class="mktoField mktoEmailField mktoRequired" />
               </li>
               <li class="mktFormReq mktField p-list__item">
                 <label for="phone" class="mktoLabel ">Mobile number:</label>

--- a/templates/shared/forms/interactive/financial.html
+++ b/templates/shared/forms/interactive/financial.html
@@ -113,7 +113,7 @@
               </li>
               <li class="mktFormReq mktField p-list__item">
                 <label for="email" class="mktoLabel">Work email:</label>
-                <input required id="email" name="email" maxlength="255" type="email" class="mktoField mktoEmailField mktoRequired" />
+                <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,6}$" class="mktoField mktoEmailField mktoRequired" />
               </li>
               <li class="mktField p-list__item">
                 <input class="mktoField" value="yes" id="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox" />

--- a/templates/shared/forms/interactive/financial.html
+++ b/templates/shared/forms/interactive/financial.html
@@ -113,7 +113,7 @@
               </li>
               <li class="mktFormReq mktField p-list__item">
                 <label for="email" class="mktoLabel">Work email:</label>
-                <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,6}$" class="mktoField mktoEmailField mktoRequired" />
+                <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" class="mktoField mktoEmailField mktoRequired" />
               </li>
               <li class="mktField p-list__item">
                 <input class="mktoField" value="yes" id="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox" />

--- a/templates/shared/forms/interactive/gcp.html
+++ b/templates/shared/forms/interactive/gcp.html
@@ -122,7 +122,7 @@
                     </li>
                     <li class="mktFormReq mktField p-list__item">
                     <label for="email" class="mktoLabel">Work email:</label>
-                    <input required id="email" name="email" maxlength="255" type="email" class="mktoField mktoEmailField mktoRequired" required="required" />
+                    <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,6}$" class="mktoField mktoEmailField mktoRequired" required="required" />
                     </li>
                     <li class="mktFormReq mktField p-list__item">
                     <label for="phone" class="mktoLabel ">Phone number:</label>

--- a/templates/shared/forms/interactive/gcp.html
+++ b/templates/shared/forms/interactive/gcp.html
@@ -122,7 +122,7 @@
                     </li>
                     <li class="mktFormReq mktField p-list__item">
                     <label for="email" class="mktoLabel">Work email:</label>
-                    <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,6}$" class="mktoField mktoEmailField mktoRequired" required="required" />
+                    <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" class="mktoField mktoEmailField mktoRequired" required="required" />
                     </li>
                     <li class="mktFormReq mktField p-list__item">
                     <label for="phone" class="mktoLabel ">Phone number:</label>

--- a/templates/shared/forms/interactive/general.html
+++ b/templates/shared/forms/interactive/general.html
@@ -191,7 +191,7 @@
               </li>
               <li class="mktFormReq mktField p-list__item">
                 <label for="email" class="mktoLabel">Work email:</label>
-                <input required id="email" name="email" maxlength="255" type="email" class="mktoField mktoEmailField mktoRequired" />
+                <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,6}$" class="mktoField mktoEmailField mktoRequired" />
               </li>
               <li class="mktFormReq mktField p-list__item">
                 <label for="phone" class="mktoLabel ">Mobile/cell phone number:</label>

--- a/templates/shared/forms/interactive/general.html
+++ b/templates/shared/forms/interactive/general.html
@@ -191,7 +191,7 @@
               </li>
               <li class="mktFormReq mktField p-list__item">
                 <label for="email" class="mktoLabel">Work email:</label>
-                <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,6}$" class="mktoField mktoEmailField mktoRequired" />
+                <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" class="mktoField mktoEmailField mktoRequired" />
               </li>
               <li class="mktFormReq mktField p-list__item">
                 <label for="phone" class="mktoLabel ">Mobile/cell phone number:</label>

--- a/templates/shared/forms/interactive/internet-of-things.html
+++ b/templates/shared/forms/interactive/internet-of-things.html
@@ -71,7 +71,7 @@
               </li>
               <li class="mktFormReq mktField p-list__item">
                 <label for="email" class="mktoLabel">Email:</label>
-                <input required id="email" name="email" maxlength="255" type="email" class="mktoField mktoEmailField mktoRequired" required="required" />
+                <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,6}$" class="mktoField mktoEmailField mktoRequired" required="required" />
               </li>
               <li class="mktFormReq mktField p-list__item">
                 <label for="phone" class="mktoLabel ">Mobile/cell phone number:</label>

--- a/templates/shared/forms/interactive/internet-of-things.html
+++ b/templates/shared/forms/interactive/internet-of-things.html
@@ -71,7 +71,7 @@
               </li>
               <li class="mktFormReq mktField p-list__item">
                 <label for="email" class="mktoLabel">Email:</label>
-                <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,6}$" class="mktoField mktoEmailField mktoRequired" required="required" />
+                <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" class="mktoField mktoEmailField mktoRequired" required="required" />
               </li>
               <li class="mktFormReq mktField p-list__item">
                 <label for="phone" class="mktoLabel ">Mobile/cell phone number:</label>

--- a/templates/shared/forms/interactive/kubeflow.html
+++ b/templates/shared/forms/interactive/kubeflow.html
@@ -141,7 +141,7 @@
               </li>
               <li class="mktFormReq mktField p-list__item">
                 <label for="email" class="mktoLabel">Work email:</label>
-                <input required id="email" name="email" maxlength="255" type="email" class="mktoField mktoEmailField mktoRequired" required="required" />
+                <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,6}$" class="mktoField mktoEmailField mktoRequired" required="required" />
               </li>
               <li class="mktFormReq mktField p-list__item">
                 <label for="phone" class="mktoLabel ">Mobile/cell phone number:</label>

--- a/templates/shared/forms/interactive/kubeflow.html
+++ b/templates/shared/forms/interactive/kubeflow.html
@@ -141,7 +141,7 @@
               </li>
               <li class="mktFormReq mktField p-list__item">
                 <label for="email" class="mktoLabel">Work email:</label>
-                <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,6}$" class="mktoField mktoEmailField mktoRequired" required="required" />
+                <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" class="mktoField mktoEmailField mktoRequired" required="required" />
               </li>
               <li class="mktFormReq mktField p-list__item">
                 <label for="phone" class="mktoLabel ">Mobile/cell phone number:</label>

--- a/templates/shared/forms/interactive/kubernetes.html
+++ b/templates/shared/forms/interactive/kubernetes.html
@@ -24,7 +24,7 @@
               </li>
               <li class="mktFormReq mktField p-list__item">
                 <label for="email" class="mktoLabel">Work email:</label>
-                <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,6}$" class="mktoField mktoEmailField mktoRequired" required="required" />
+                <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" class="mktoField mktoEmailField mktoRequired" required="required" />
               </li>
               <li class="mktFormReq mktField p-list__item">
                 <label for="phone" class="mktoLabel ">Mobile/cell phone number:</label>

--- a/templates/shared/forms/interactive/kubernetes.html
+++ b/templates/shared/forms/interactive/kubernetes.html
@@ -24,7 +24,7 @@
               </li>
               <li class="mktFormReq mktField p-list__item">
                 <label for="email" class="mktoLabel">Work email:</label>
-                <input required id="email" name="email" maxlength="255" type="email" class="mktoField mktoEmailField mktoRequired" required="required" />
+                <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,6}$" class="mktoField mktoEmailField mktoRequired" required="required" />
               </li>
               <li class="mktFormReq mktField p-list__item">
                 <label for="phone" class="mktoLabel ">Mobile/cell phone number:</label>

--- a/templates/shared/forms/interactive/managed-apps.html
+++ b/templates/shared/forms/interactive/managed-apps.html
@@ -185,7 +185,7 @@
             </li>
             <li class="mktFormReq mktField p-list__item">
               <label for="email" class="mktoLabel">Work email:</label>
-              <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,6}$" class="mktoField mktoEmailField mktoRequired" required="required" />
+              <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" class="mktoField mktoEmailField mktoRequired" required="required" />
             </li>
             <li class="mktFormReq mktField p-list__item">
               <label for="phone" class="mktoLabel ">Mobile/cell phone number:</label>

--- a/templates/shared/forms/interactive/managed-apps.html
+++ b/templates/shared/forms/interactive/managed-apps.html
@@ -185,7 +185,7 @@
             </li>
             <li class="mktFormReq mktField p-list__item">
               <label for="email" class="mktoLabel">Work email:</label>
-              <input required id="email" name="email" maxlength="255" type="email" class="mktoField mktoEmailField mktoRequired" required="required" />
+              <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,6}$" class="mktoField mktoEmailField mktoRequired" required="required" />
             </li>
             <li class="mktFormReq mktField p-list__item">
               <label for="phone" class="mktoLabel ">Mobile/cell phone number:</label>

--- a/templates/shared/forms/interactive/managed-cassandra.html
+++ b/templates/shared/forms/interactive/managed-cassandra.html
@@ -225,7 +225,7 @@
               </li>
               <li class="mktFormReq mktField p-list__item">
                 <label for="email" class="mktoLabel">Work email:</label>
-                <input required id="email" name="email" maxlength="255" type="email" class="mktoField mktoEmailField mktoRequired" />
+                <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,6}$" class="mktoField mktoEmailField mktoRequired" />
               </li>
               <li class="mktField p-list__item">
                 <input class="mktoField" value="yes" id="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox" />

--- a/templates/shared/forms/interactive/managed-cassandra.html
+++ b/templates/shared/forms/interactive/managed-cassandra.html
@@ -225,7 +225,7 @@
               </li>
               <li class="mktFormReq mktField p-list__item">
                 <label for="email" class="mktoLabel">Work email:</label>
-                <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,6}$" class="mktoField mktoEmailField mktoRequired" />
+                <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" class="mktoField mktoEmailField mktoRequired" />
               </li>
               <li class="mktField p-list__item">
                 <input class="mktoField" value="yes" id="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox" />

--- a/templates/shared/forms/interactive/managed-kafka.html
+++ b/templates/shared/forms/interactive/managed-kafka.html
@@ -183,7 +183,7 @@
               </li>
               <li class="mktFormReq mktField p-list__item">
                 <label for="email" class="mktoLabel">Work email:</label>
-                <input required id="email" name="email" maxlength="255" type="email" class="mktoField mktoEmailField mktoRequired" />
+                <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,6}$" class="mktoField mktoEmailField mktoRequired" />
               </li>
               <li class="mktField p-list__item">
                 <input class="mktoField" value="yes" id="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox" />

--- a/templates/shared/forms/interactive/managed-kafka.html
+++ b/templates/shared/forms/interactive/managed-kafka.html
@@ -183,7 +183,7 @@
               </li>
               <li class="mktFormReq mktField p-list__item">
                 <label for="email" class="mktoLabel">Work email:</label>
-                <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,6}$" class="mktoField mktoEmailField mktoRequired" />
+                <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" class="mktoField mktoEmailField mktoRequired" />
               </li>
               <li class="mktField p-list__item">
                 <input class="mktoField" value="yes" id="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox" />

--- a/templates/shared/forms/interactive/managed-kubernetes.html
+++ b/templates/shared/forms/interactive/managed-kubernetes.html
@@ -24,7 +24,7 @@
               </li>
               <li class="mktFormReq mktField p-list__item">
                 <label for="email" class="mktoLabel">Work email:</label>
-                <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,6}$" class="mktoField mktoEmailField mktoRequired" required="required" />
+                <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" class="mktoField mktoEmailField mktoRequired" required="required" />
               </li>
               <li class="mktFormReq mktField p-list__item">
                 <label for="phone" class="mktoLabel ">Mobile/cell phone number:</label>

--- a/templates/shared/forms/interactive/managed-kubernetes.html
+++ b/templates/shared/forms/interactive/managed-kubernetes.html
@@ -24,7 +24,7 @@
               </li>
               <li class="mktFormReq mktField p-list__item">
                 <label for="email" class="mktoLabel">Work email:</label>
-                <input required id="email" name="email" maxlength="255" type="email" class="mktoField mktoEmailField mktoRequired" required="required" />
+                <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,6}$" class="mktoField mktoEmailField mktoRequired" required="required" />
               </li>
               <li class="mktFormReq mktField p-list__item">
                 <label for="phone" class="mktoLabel ">Mobile/cell phone number:</label>

--- a/templates/shared/forms/interactive/managed-services.html
+++ b/templates/shared/forms/interactive/managed-services.html
@@ -64,7 +64,7 @@
                 </li>
                 <li class="mktFormReq mktField p-list__item">
                   <label for="email" class="mktoLabel">Work email:</label>
-                  <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,6}$" class="mktoField mktoEmailField mktoRequired" required="required" />
+                  <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" class="mktoField mktoEmailField mktoRequired" required="required" />
                 </li>
                 <li class="mktFormReq mktField p-list__item">
                   <label for="phone" class="mktoLabel" >Mobile/cell phone number:</label >

--- a/templates/shared/forms/interactive/managed-services.html
+++ b/templates/shared/forms/interactive/managed-services.html
@@ -64,7 +64,7 @@
                 </li>
                 <li class="mktFormReq mktField p-list__item">
                   <label for="email" class="mktoLabel">Work email:</label>
-                  <input required id="email" name="email" maxlength="255" type="email" class="mktoField mktoEmailField mktoRequired" required="required" />
+                  <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,6}$" class="mktoField mktoEmailField mktoRequired" required="required" />
                 </li>
                 <li class="mktFormReq mktField p-list__item">
                   <label for="phone" class="mktoLabel" >Mobile/cell phone number:</label >

--- a/templates/shared/forms/interactive/masters-conference.html
+++ b/templates/shared/forms/interactive/masters-conference.html
@@ -13,7 +13,7 @@
             <ul class="p-list">
               <li class="mktFormReq mktField p-list__item">
                 <label for="email" class="mktoLabel">Email:</label>
-                <input required id="email" name="email" maxlength="255" type="email" class="mktoField mktoEmailField mktoRequired" required="required" />
+                <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,6}$" class="mktoField mktoEmailField mktoRequired" required="required" />
               </li>
               <li class="mktFormReq mktField p-list__item">
                 <label for="phone" class="mktoLabel ">Mobile/cell phone number:</label>

--- a/templates/shared/forms/interactive/masters-conference.html
+++ b/templates/shared/forms/interactive/masters-conference.html
@@ -13,7 +13,7 @@
             <ul class="p-list">
               <li class="mktFormReq mktField p-list__item">
                 <label for="email" class="mktoLabel">Email:</label>
-                <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,6}$" class="mktoField mktoEmailField mktoRequired" required="required" />
+                <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" class="mktoField mktoEmailField mktoRequired" required="required" />
               </li>
               <li class="mktFormReq mktField p-list__item">
                 <label for="phone" class="mktoLabel ">Mobile/cell phone number:</label>

--- a/templates/shared/forms/interactive/observability-contact-us.html
+++ b/templates/shared/forms/interactive/observability-contact-us.html
@@ -189,7 +189,7 @@
               </li>
               <li class="mktFormReq mktField p-list__item">
                 <label for="Email" class="mktoLabel">Email:</label>
-                <input required id="Email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,6}$" class="mktoField mktoEmailField mktoRequired" required="required" />
+                <input required id="Email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" class="mktoField mktoEmailField mktoRequired" required="required" />
               </li>
               <li class="mktFormReq mktField p-list__item">
                 <label for="Phone" class="mktoLabel ">Mobile/cell phone number:</label>

--- a/templates/shared/forms/interactive/observability-contact-us.html
+++ b/templates/shared/forms/interactive/observability-contact-us.html
@@ -189,7 +189,7 @@
               </li>
               <li class="mktFormReq mktField p-list__item">
                 <label for="Email" class="mktoLabel">Email:</label>
-                <input required id="Email" name="email" maxlength="255" type="email" class="mktoField mktoEmailField mktoRequired" required="required" />
+                <input required id="Email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,6}$" class="mktoField mktoEmailField mktoRequired" required="required" />
               </li>
               <li class="mktFormReq mktField p-list__item">
                 <label for="Phone" class="mktoLabel ">Mobile/cell phone number:</label>

--- a/templates/shared/forms/interactive/openstack-cost-calculator.html
+++ b/templates/shared/forms/interactive/openstack-cost-calculator.html
@@ -291,7 +291,7 @@
               </li>
               <li class="mktFormReq mktField p-list__item">
                 <label for="email" class="mktoLabel">Work email:</label>
-                <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,6}$" class="mktoField mktoEmailField mktoRequired" required="required" />
+                <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" class="mktoField mktoEmailField mktoRequired" required="required" />
               </li>
               <li class="mktFormReq mktField p-list__item">
                 <label for="phone" class="mktoLabel ">Mobile/cell phone number:</label>

--- a/templates/shared/forms/interactive/openstack-cost-calculator.html
+++ b/templates/shared/forms/interactive/openstack-cost-calculator.html
@@ -291,7 +291,7 @@
               </li>
               <li class="mktFormReq mktField p-list__item">
                 <label for="email" class="mktoLabel">Work email:</label>
-                <input required id="email" name="email" maxlength="255" type="email" class="mktoField mktoEmailField mktoRequired" required="required" />
+                <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,6}$" class="mktoField mktoEmailField mktoRequired" required="required" />
               </li>
               <li class="mktFormReq mktField p-list__item">
                 <label for="phone" class="mktoLabel ">Mobile/cell phone number:</label>

--- a/templates/shared/forms/interactive/openstack.html
+++ b/templates/shared/forms/interactive/openstack.html
@@ -298,7 +298,7 @@
               </li>
               <li class="mktFormReq mktField p-list__item">
                 <label for="email" class="mktoLabel">Work email:</label>
-                <input required id="email" name="email" maxlength="255" type="email" class="mktoField mktoEmailField mktoRequired" required="required" />
+                <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,6}$" class="mktoField mktoEmailField mktoRequired" required="required" />
               </li>
               <li class="mktFormReq mktField p-list__item">
                 <label for="phone" class="mktoLabel ">Mobile/cell phone number:</label>

--- a/templates/shared/forms/interactive/openstack.html
+++ b/templates/shared/forms/interactive/openstack.html
@@ -298,7 +298,7 @@
               </li>
               <li class="mktFormReq mktField p-list__item">
                 <label for="email" class="mktoLabel">Work email:</label>
-                <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,6}$" class="mktoField mktoEmailField mktoRequired" required="required" />
+                <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" class="mktoField mktoEmailField mktoRequired" required="required" />
               </li>
               <li class="mktFormReq mktField p-list__item">
                 <label for="phone" class="mktoLabel ">Mobile/cell phone number:</label>

--- a/templates/shared/forms/interactive/osm-contact-us.html
+++ b/templates/shared/forms/interactive/osm-contact-us.html
@@ -181,7 +181,7 @@
               </li>
               <li class="mktFormReq mktField p-list__item">
                 <label for="email" class="mktoLabel">Email:</label>
-                <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,6}$" class="mktoField mktoEmailField mktoRequired" required="required" />
+                <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" class="mktoField mktoEmailField mktoRequired" required="required" />
               </li>
               <li class="mktFormReq mktField p-list__item">
                 <label for="phone" class="mktoLabel ">Mobile/cell phone number:</label>

--- a/templates/shared/forms/interactive/osm-contact-us.html
+++ b/templates/shared/forms/interactive/osm-contact-us.html
@@ -181,7 +181,7 @@
               </li>
               <li class="mktFormReq mktField p-list__item">
                 <label for="email" class="mktoLabel">Email:</label>
-                <input required id="email" name="email" maxlength="255" type="email" class="mktoField mktoEmailField mktoRequired" required="required" />
+                <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,6}$" class="mktoField mktoEmailField mktoRequired" required="required" />
               </li>
               <li class="mktFormReq mktField p-list__item">
                 <label for="phone" class="mktoLabel ">Mobile/cell phone number:</label>

--- a/templates/shared/forms/interactive/partner-dell.html
+++ b/templates/shared/forms/interactive/partner-dell.html
@@ -207,7 +207,7 @@
               </li>
               <li class="mktFormReq mktField p-list__item">
                 <label for="email" class="mktoLabel">Work email:</label>
-                <input required id="email" name="email" maxlength="255" type="email" class="mktoField mktoEmailField mktoRequired" required="required" />
+                <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,6}$" class="mktoField mktoEmailField mktoRequired" required="required" />
               </li>
               <li class="mktFormReq mktField p-list__item">
                 <label for="phone" class="mktoLabel ">Mobile/cell phone number:</label>

--- a/templates/shared/forms/interactive/partner-dell.html
+++ b/templates/shared/forms/interactive/partner-dell.html
@@ -207,7 +207,7 @@
               </li>
               <li class="mktFormReq mktField p-list__item">
                 <label for="email" class="mktoLabel">Work email:</label>
-                <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,6}$" class="mktoField mktoEmailField mktoRequired" required="required" />
+                <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" class="mktoField mktoEmailField mktoRequired" required="required" />
               </li>
               <li class="mktFormReq mktField p-list__item">
                 <label for="phone" class="mktoLabel ">Mobile/cell phone number:</label>

--- a/templates/shared/forms/interactive/pricing-infra.html
+++ b/templates/shared/forms/interactive/pricing-infra.html
@@ -163,7 +163,7 @@
               </li>
               <li class="mktFormReq mktField p-list__item">
                 <label for="email" class="mktoLabel">Work email:</label>
-                <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,6}$" class="mktoField mktoEmailField mktoRequired" required="required" />
+                <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" class="mktoField mktoEmailField mktoRequired" required="required" />
               </li>
               <li class="mktFormReq mktField p-list__item">
                 <label for="phone" class="mktoLabel ">Mobile/cell phone number:</label>

--- a/templates/shared/forms/interactive/pricing-infra.html
+++ b/templates/shared/forms/interactive/pricing-infra.html
@@ -163,7 +163,7 @@
               </li>
               <li class="mktFormReq mktField p-list__item">
                 <label for="email" class="mktoLabel">Work email:</label>
-                <input required id="email" name="email" maxlength="255" type="email" class="mktoField mktoEmailField mktoRequired" required="required" />
+                <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,6}$" class="mktoField mktoEmailField mktoRequired" required="required" />
               </li>
               <li class="mktFormReq mktField p-list__item">
                 <label for="phone" class="mktoLabel ">Mobile/cell phone number:</label>

--- a/templates/shared/forms/interactive/robotics.html
+++ b/templates/shared/forms/interactive/robotics.html
@@ -175,7 +175,7 @@
               </li>
               <li class="mktFormReq mktField p-list__item">
                 <label for="email" class="mktoLabel">Work email:</label>
-                <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,6}$" class="mktoField mktoEmailField mktoRequired" required="required" />
+                <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" class="mktoField mktoEmailField mktoRequired" required="required" />
               </li>
               <li class="mktFormReq mktField p-list__item">
                 <label for="phone" class="mktoLabel ">Mobile/cell phone number:</label>

--- a/templates/shared/forms/interactive/robotics.html
+++ b/templates/shared/forms/interactive/robotics.html
@@ -175,7 +175,7 @@
               </li>
               <li class="mktFormReq mktField p-list__item">
                 <label for="email" class="mktoLabel">Work email:</label>
-                <input required id="email" name="email" maxlength="255" type="email" class="mktoField mktoEmailField mktoRequired" required="required" />
+                <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,6}$" class="mktoField mktoEmailField mktoRequired" required="required" />
               </li>
               <li class="mktFormReq mktField p-list__item">
                 <label for="phone" class="mktoLabel ">Mobile/cell phone number:</label>

--- a/templates/shared/forms/interactive/robotics_ros.html
+++ b/templates/shared/forms/interactive/robotics_ros.html
@@ -98,7 +98,7 @@
               </li>
               <li class="mktFormReq mktField p-list__item">
                 <label for="email" class="mktoLabel">Email address:</label>
-                <input required id="email" name="email" maxlength="255" type="email" class="mktoField mktoEmailField mktoRequired" />
+                <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,6}$" class="mktoField mktoEmailField mktoRequired" />
               </li>
               <li class="mktFormReq mktField p-list__item">
                 <label for="phone" class="mktoLabel">Phone number:</label>

--- a/templates/shared/forms/interactive/robotics_ros.html
+++ b/templates/shared/forms/interactive/robotics_ros.html
@@ -98,7 +98,7 @@
               </li>
               <li class="mktFormReq mktField p-list__item">
                 <label for="email" class="mktoLabel">Email address:</label>
-                <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,6}$" class="mktoField mktoEmailField mktoRequired" />
+                <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" class="mktoField mktoEmailField mktoRequired" />
               </li>
               <li class="mktFormReq mktField p-list__item">
                 <label for="phone" class="mktoLabel">Phone number:</label>

--- a/templates/shared/forms/interactive/smart-start.html
+++ b/templates/shared/forms/interactive/smart-start.html
@@ -191,7 +191,7 @@
               </li>
               <li class="mktFormReq mktField p-list__item">
                 <label for="email" class="mktoLabel">Work email:</label>
-                <input required id="email" name="email" maxlength="255" type="email" class="mktoField mktoEmailField mktoRequired" required="required" />
+                <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,6}$" class="mktoField mktoEmailField mktoRequired" required="required" />
               </li>
               <li class="mktFormReq mktField p-list__item">
                 <label for="phone" class="mktoLabel ">Mobile/cell phone number:</label>

--- a/templates/shared/forms/interactive/smart-start.html
+++ b/templates/shared/forms/interactive/smart-start.html
@@ -191,7 +191,7 @@
               </li>
               <li class="mktFormReq mktField p-list__item">
                 <label for="email" class="mktoLabel">Work email:</label>
-                <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,6}$" class="mktoField mktoEmailField mktoRequired" required="required" />
+                <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" class="mktoField mktoEmailField mktoRequired" required="required" />
               </li>
               <li class="mktFormReq mktField p-list__item">
                 <label for="phone" class="mktoLabel ">Mobile/cell phone number:</label>

--- a/templates/shared/forms/interactive/storage.html
+++ b/templates/shared/forms/interactive/storage.html
@@ -150,7 +150,7 @@
               </li>
               <li class="mktFormReq mktField p-list__item">
                 <label for="email" class="mktoLabel">Work email:</label>
-                <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,6}$" class="mktoField mktoEmailField mktoRequired" required="required" />
+                <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" class="mktoField mktoEmailField mktoRequired" required="required" />
               </li>
               <li class="mktFormReq mktField p-list__item">
                 <label for="phone" class="mktoLabel ">Mobile/cell phone number:</label>

--- a/templates/shared/forms/interactive/storage.html
+++ b/templates/shared/forms/interactive/storage.html
@@ -150,7 +150,7 @@
               </li>
               <li class="mktFormReq mktField p-list__item">
                 <label for="email" class="mktoLabel">Work email:</label>
-                <input required id="email" name="email" maxlength="255" type="email" class="mktoField mktoEmailField mktoRequired" required="required" />
+                <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,6}$" class="mktoField mktoEmailField mktoRequired" required="required" />
               </li>
               <li class="mktFormReq mktField p-list__item">
                 <label for="phone" class="mktoLabel ">Mobile/cell phone number:</label>

--- a/templates/shared/forms/interactive/support-openstack.html
+++ b/templates/shared/forms/interactive/support-openstack.html
@@ -539,7 +539,7 @@
                   id="email"
                   name="email"
                   maxlength="255"
-                  type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,6}$"
+                  type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$"
                   class="mktoField mktoEmailField mktoRequired"
                   required="required"
                 />

--- a/templates/shared/forms/interactive/support-openstack.html
+++ b/templates/shared/forms/interactive/support-openstack.html
@@ -539,7 +539,7 @@
                   id="email"
                   name="email"
                   maxlength="255"
-                  type="email"
+                  type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,6}$"
                   class="mktoField mktoEmailField mktoRequired"
                   required="required"
                 />

--- a/templates/shared/forms/interactive/support.html
+++ b/templates/shared/forms/interactive/support.html
@@ -161,7 +161,7 @@
               </li>
               <li class="mktFormReq mktField p-list__item">
                 <label for="email" class="mktoLabel">Work email:</label>
-                <input required id="email" name="email" maxlength="255" type="email" class="mktoField mktoEmailField mktoRequired" required="required" />
+                <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,6}$" class="mktoField mktoEmailField mktoRequired" required="required" />
               </li>
               <li class="mktFormReq mktField p-list__item">
                 <label for="phone" class="mktoLabel ">Mobile/cell phone number:</label>

--- a/templates/shared/forms/interactive/support.html
+++ b/templates/shared/forms/interactive/support.html
@@ -161,7 +161,7 @@
               </li>
               <li class="mktFormReq mktField p-list__item">
                 <label for="email" class="mktoLabel">Work email:</label>
-                <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,6}$" class="mktoField mktoEmailField mktoRequired" required="required" />
+                <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" class="mktoField mktoEmailField mktoRequired" required="required" />
               </li>
               <li class="mktFormReq mktField p-list__item">
                 <label for="phone" class="mktoLabel ">Mobile/cell phone number:</label>

--- a/templates/shared/forms/interactive/telco-networks.html
+++ b/templates/shared/forms/interactive/telco-networks.html
@@ -114,7 +114,7 @@
               </li>
               <li class="mktFormReq mktField p-list__item">
                 <label for="email" class="mktoLabel">Email:</label>
-                <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,6}$" class="mktoField mktoEmailField mktoRequired" required="required" />
+                <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" class="mktoField mktoEmailField mktoRequired" required="required" />
               </li>
               <li class="mktFormReq mktField p-list__item">
                 <label for="phone" class="mktoLabel ">Mobile/cell phone number:</label>

--- a/templates/shared/forms/interactive/telco-networks.html
+++ b/templates/shared/forms/interactive/telco-networks.html
@@ -114,7 +114,7 @@
               </li>
               <li class="mktFormReq mktField p-list__item">
                 <label for="email" class="mktoLabel">Email:</label>
-                <input required id="email" name="email" maxlength="255" type="email" class="mktoField mktoEmailField mktoRequired" required="required" />
+                <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,6}$" class="mktoField mktoEmailField mktoRequired" required="required" />
               </li>
               <li class="mktFormReq mktField p-list__item">
                 <label for="phone" class="mktoLabel ">Mobile/cell phone number:</label>

--- a/templates/shared/forms/interactive/telco.html
+++ b/templates/shared/forms/interactive/telco.html
@@ -255,7 +255,7 @@
               </li>
               <li class="mktFormReq mktField p-list__item">
                 <label for="email" class="mktoLabel">Work email:</label>
-                <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,6}$" class="mktoField mktoEmailField mktoRequired" />
+                <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" class="mktoField mktoEmailField mktoRequired" />
               </li>
               <li class="mktFormReq mktField p-list__item">
                 <label for="phone" class="mktoLabel ">Mobile/cell phone number:</label>

--- a/templates/shared/forms/interactive/telco.html
+++ b/templates/shared/forms/interactive/telco.html
@@ -255,7 +255,7 @@
               </li>
               <li class="mktFormReq mktField p-list__item">
                 <label for="email" class="mktoLabel">Work email:</label>
-                <input required id="email" name="email" maxlength="255" type="email" class="mktoField mktoEmailField mktoRequired" />
+                <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,6}$" class="mktoField mktoEmailField mktoRequired" />
               </li>
               <li class="mktFormReq mktField p-list__item">
                 <label for="phone" class="mktoLabel ">Mobile/cell phone number:</label>

--- a/templates/shared/forms/interactive/wsl.html
+++ b/templates/shared/forms/interactive/wsl.html
@@ -95,7 +95,7 @@
               </li>
               <li class="mktFormReq mktField p-list__item">
                 <label for="email" class="mktoLabel">Work email:</label>
-                <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,6}$" class="mktoField mktoEmailField mktoRequired" required="required" />
+                <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" class="mktoField mktoEmailField mktoRequired" required="required" />
               </li>
               <li class="mktFormReq mktField p-list__item">
                 <label for="phone" class="mktoLabel ">Mobile/cell phone number:</label>

--- a/templates/shared/forms/interactive/wsl.html
+++ b/templates/shared/forms/interactive/wsl.html
@@ -95,7 +95,7 @@
               </li>
               <li class="mktFormReq mktField p-list__item">
                 <label for="email" class="mktoLabel">Work email:</label>
-                <input required id="email" name="email" maxlength="255" type="email" class="mktoField mktoEmailField mktoRequired" required="required" />
+                <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,6}$" class="mktoField mktoEmailField mktoRequired" required="required" />
               </li>
               <li class="mktFormReq mktField p-list__item">
                 <label for="phone" class="mktoLabel ">Mobile/cell phone number:</label>


### PR DESCRIPTION
## Done

- There are many sentry errors caused by malformed or garbage email addresses
- I have added `pattern="^[^ ]+@[^ ]+\.[a-z]{2,6}$"` to all `type="email"` input fields to try to catch most of them before the user submits

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Go to any form and test some [valid and invalid emails](https://gist.github.com/cjaoude/fd9910626629b53c4d25) and see if it helps. Note, many do not work, but most are caught

