### PR TITLE
[OpenStack tutorials] Create /openstack/tutorials page

### DIFF
--- a/navigation.yaml
+++ b/navigation.yaml
@@ -173,6 +173,8 @@ openstack:
       path: /openstack/install
     - title: Docs
       path: /openstack/docs
+    - title: Tutorials
+      path: /openstack/tutorials
       persist: True
     - title: Thank you
       path: /openstack/newsletter-thank-you

--- a/templates/openstack/tutorials.html
+++ b/templates/openstack/tutorials.html
@@ -25,103 +25,187 @@
       <p>Get started with OpenStack on your workstation and familiarise yourself with basic OpenStack concepts.</p>
     </div>
   </div>
-  <div class="row u-equal-height">
-    <div class="p-card col-4">
-      <div class="p-card__title">
-        <h3>1. <a href="https://discourse.ubuntu.com/t/install-openstack-on-your-workstation-and-launch-your-first-instance/25065" class="p-link--external">Install</a></h3>
-      </div>
-      <div class="p-card__content">
-        <p>Install OpenStack on your workstation and launch your first instance</p>
-      </div>
-    </div>
-    <div class="p-card col-4">
-      <div class="p-card__title">
-        <h3>2. <a href="https://discourse.ubuntu.com/t/explore-openstack-components-and-set-up-an-openstack-client/25068" class="p-link--external">Components</a></h3>
-      </div>
-      <div class="p-card__content">
-        <p>Explore OpenStack components and set up an OpenStack client.</p>
-      </div>
-    </div>
-    <div class="p-card col-4">
-      <div class="p-card__title">
-        <h3>3. <a href="https://discourse.ubuntu.com/t/learn-about-openstack-services-and-their-functions/25069" class="p-link--external">Services</a></h3>
-      </div>
-      <div class="p-card__content">
-        <p>Learn about OpenStack services and their functions.</p>
+  <div class="row">
+    <div class="col-4 blog-p-card--post">
+      <header class="blog-p-card__header--tutorial">
+        <h5 class="p-muted-heading u-no-margin--bottom">
+          Openstack
+        </h5>
+      </header>
+      <div class="blog-p-card__content">
+        <h3 class="p-heading--three u-no-margin--top u-no-margin--bottom">1. 
+          <a class="p-link--soft" href="/tutorials/install-openstack-on-your-workstation-and-launch-your-first-instance#1-overview">
+            Install
+          </a>
+        </h3>
+        <p class="u-sv3">Install OpenStack on your workstation and launch your first instance</p>
       </div>
     </div>
-    <div class="p-card col-4">
-      <div class="p-card__title">
-        <h3>4. <a href="https://discourse.ubuntu.com/t/navigate-through-the-openstack-dashboard-menu/25070" class="p-link--external">Dashboard</a></h3>
-      </div>
-      <div class="p-card__content">
-        <p>Navigate through the OpenStack dashboard menu.</p>
-      </div>
-    </div>
-    <div class="p-card col-4">
-      <div class="p-card__title">
-        <h3>5. <a href="https://discourse.ubuntu.com/t/manage-instance-templates-including-images-and-flavors/25071" class="p-link--external">Templates</a></h3>
-      </div>
-      <div class="p-card__content">
-        <p>Manage instance templates, including images and flavors.</p>
-      </div>
-    </div>
-    <div class="p-card col-4">
-      <div class="p-card__title">
-        <h3>6. <a href="https://discourse.ubuntu.com/t/use-the-concept-of-domains-roles-users-and-groups-to-manage-identities/25072" class="p-link--external">Identities</a></h3>
-      </div>
-      <div class="p-card__content">
-        <p>Use the concept of domains, roles, users and groups to manage identities.</p>
+    <div class="col-4 blog-p-card--post">
+      <header class="blog-p-card__header--tutorial">
+        <h5 class="p-muted-heading u-no-margin--bottom">
+          Openstack
+        </h5>
+      </header>
+      <div class="blog-p-card__content">
+        <h3 class="p-heading--three u-no-margin--top u-no-margin--bottom">2. 
+          <a class="p-link--soft" href="/tutorials/explore-openstack-components-and-set-up-an-openstack-client">
+            Components
+          </a>
+        </h3>
+        <p class="u-sv3">Explore OpenStack components and set up an OpenStack client.</p>
       </div>
     </div>
-    <div class="p-card col-4">
-      <div class="p-card__title">
-        <h3>7. <a href="https://discourse.ubuntu.com/t/enable-multi-tenancy-and-manage-global-and-tenant-resources/25073" class="p-link--external">Multi-tenancy</a></h3>
-      </div>
-      <div class="p-card__content">
-        <p>Enable multi-tenancy and manage global, and tenant resources.</p>
-      </div>
-    </div>
-    <div class="p-card col-4">
-      <div class="p-card__title">
-        <h3>8. <a href="https://discourse.ubuntu.com/t/learn-how-openstack-manages-various-virtual-network-resources/25074" class="p-link--external">Network</a></h3>
-      </div>
-      <div class="p-card__content">
-        <p>Learn how OpenStack manages various virtual network resources.</p>
-      </div>
-    </div>
-    <div class="p-card col-4">
-      <div class="p-card__title">
-        <h3>9. <a href="https://discourse.ubuntu.com/t/launch-and-terminate-cloud-instances/25075" class="p-link--external">Instances</a></h3>
-      </div>
-      <div class="p-card__content">
-        <p>Launch and delete cloud instances.</p>
+    <div class="col-4 blog-p-card--post">
+      <header class="blog-p-card__header--tutorial">
+        <h5 class="p-muted-heading u-no-margin--bottom">
+          Openstack
+        </h5>
+      </header>
+      <div class="blog-p-card__content">
+        <h3 class="p-heading--three u-no-margin--top u-no-margin--bottom">3. 
+          <a class="p-link--soft" href="/tutorials/learn-about-openstack-services-and-their-functions">
+            Services
+          </a>
+        </h3>
+        <p class="u-sv3">Learn about OpenStack services and their functions.</p>
       </div>
     </div>
-    <div class="p-card col-4">
-      <div class="p-card__title">
-        <h3>10. <a href="https://discourse.ubuntu.com/t/learn-how-openstack-manages-different-types-of-storage/25076" class="p-link--external">Storage</a></h3>
-      </div>
-      <div class="p-card__content">
-        <p>Learn how OpenStack manages different types of storage.</p>
+    <div class="col-4 blog-p-card--post">
+      <header class="blog-p-card__header--tutorial">
+        <h5 class="p-muted-heading u-no-margin--bottom">
+          Openstack
+        </h5>
+      </header>
+      <div class="blog-p-card__content">
+        <h3 class="p-heading--three u-no-margin--top u-no-margin--bottom">4. 
+          <a class="p-link--soft" href="/tutorials/navigate-through-the-openstack-dashboard-menu">
+            Dashboard
+          </a>
+        </h3>
+        <p class="u-sv3">Navigate through the OpenStack dashboard menu.</p>
       </div>
     </div>
-    <div class="p-card col-4">
-      <div class="p-card__title">
-        <h3>11. <a href="https://discourse.ubuntu.com/t/limit-access-to-resources-by-applying-quotas/25077" class="p-link--external">Quotas</a></h3>
-      </div>
-      <div class="p-card__content">
-        <p>Limit access to resources by applying quotas.</p>
+    <div class="col-4 blog-p-card--post">
+      <header class="blog-p-card__header--tutorial">
+        <h5 class="p-muted-heading u-no-margin--bottom">
+          Openstack
+        </h5>
+      </header>
+      <div class="blog-p-card__content">
+        <h3 class="p-heading--three u-no-margin--top u-no-margin--bottom">5. 
+          <a class="p-link--soft" href="/tutorials/manage-instance-templates-including-images-and-flavors">
+            Templates
+          </a>
+        </h3>
+        <p class="u-sv3">Manage instance templates, including images and flavors.</p>
       </div>
     </div>
-    <div class="p-card col-4">
-      <div class="p-card__title">
-        <h3>12. <a href="https://discourse.ubuntu.com/t/tear-down-your-openstack-lab-environment/25078" class="p-link--external">Teardown</a></h3>
+    <div class="col-4 blog-p-card--post">
+      <header class="blog-p-card__header--tutorial">
+        <h5 class="p-muted-heading u-no-margin--bottom">
+          Openstack
+        </h5>
+      </header>
+      <div class="blog-p-card__content">
+        <h3 class="p-heading--three u-no-margin--top u-no-margin--bottom">6. 
+          <a class="p-link--soft" href="/tutorials/use-the-concept-of-domains-roles-users-and-groups-to-manage-identities">
+            Identities
+          </a>
+        </h3>
+        <p class="u-sv3">Use the concept of domains, roles, users and groups to manage identities.</p>
       </div>
-      <div class="p-card__content">
-        <p>Tear down your OpenStack lab environment.</p>
+    </div>
+    <div class="col-4 blog-p-card--post">
+      <header class="blog-p-card__header--tutorial">
+        <h5 class="p-muted-heading u-no-margin--bottom">
+          Openstack
+        </h5>
+      </header>
+      <div class="blog-p-card__content">
+        <h3 class="p-heading--three u-no-margin--top u-no-margin--bottom">7. 
+          <a class="p-link--soft" href="/tutorials/enable-multi-tenancy-and-manage-global-and-tenant-resources">
+            Multi-tenancy
+          </a>
+        </h3>
+        <p class="u-sv3">Enable multi-tenancy and manage global, and tenant resources.</p>
       </div>
-    </div>                                            
+    </div>
+    <div class="col-4 blog-p-card--post">
+      <header class="blog-p-card__header--tutorial">
+        <h5 class="p-muted-heading u-no-margin--bottom">
+          Openstack
+        </h5>
+      </header>
+      <div class="blog-p-card__content">
+        <h3 class="p-heading--three u-no-margin--top u-no-margin--bottom">8. 
+          <a class="p-link--soft" href="/tutorials/learn-how-openstack-manages-various-virtual-network-resources">
+            Network
+          </a>
+        </h3>
+        <p class="u-sv3">Learn how OpenStack manages various virtual network resources.</p>
+      </div>
+    </div>
+    <div class="col-4 blog-p-card--post">
+      <header class="blog-p-card__header--tutorial">
+        <h5 class="p-muted-heading u-no-margin--bottom">
+          Openstack
+        </h5>
+      </header>
+      <div class="blog-p-card__content">
+        <h3 class="p-heading--three u-no-margin--top u-no-margin--bottom">9. 
+          <a class="p-link--soft" href="/tutorials/launch-and-terminate-cloud-instances">
+            Instances
+          </a>
+        </h3>
+        <p class="u-sv3">Launch and delete cloud instances.</p>
+      </div>
+    </div>
+    <div class="col-4 blog-p-card--post">
+      <header class="blog-p-card__header--tutorial">
+        <h5 class="p-muted-heading u-no-margin--bottom">
+          Openstack
+        </h5>
+      </header>
+      <div class="blog-p-card__content">
+        <h3 class="p-heading--three u-no-margin--top u-no-margin--bottom">10. 
+          <a class="p-link--soft" href="/tutorials/learn-how-openstack-manages-different-types-of-storage">
+            Storage
+          </a>
+        </h3>
+        <p class="u-sv3">Learn how OpenStack manages different types of storage.</p>
+      </div>
+    </div>
+    <div class="col-4 blog-p-card--post">
+      <header class="blog-p-card__header--tutorial">
+        <h5 class="p-muted-heading u-no-margin--bottom">
+          Openstack
+        </h5>
+      </header>
+      <div class="blog-p-card__content">
+        <h3 class="p-heading--three u-no-margin--top u-no-margin--bottom">11. 
+          <a class="p-link--soft" href="/tutorials/limit-access-to-resources-by-applying-quotas">
+            Quotas
+          </a>
+        </h3>
+        <p class="u-sv3">Limit access to resources by applying quotas.</p>
+      </div>
+    </div>
+    <div class="col-4 blog-p-card--post">
+      <header class="blog-p-card__header--tutorial">
+        <h5 class="p-muted-heading u-no-margin--bottom">
+          Openstack
+        </h5>
+      </header>
+      <div class="blog-p-card__content">
+        <h3 class="p-heading--three u-no-margin--top u-no-margin--bottom">12. 
+          <a class="p-link--soft" href="/tutorials/tear-down-your-openstack-lab-environment">
+            Teardown
+          </a>
+        </h3>
+        <p class="u-sv3">Tear down your OpenStack lab environment.</p>
+      </div>
+    </div>                                          
   </div>
 </section>
 

--- a/templates/openstack/tutorials.html
+++ b/templates/openstack/tutorials.html
@@ -1,0 +1,191 @@
+{% extends "openstack/_base_openstack.html" %}
+
+{% block title %}OpenStack tutorials on Ubuntu | OpenStack{% endblock %}
+{% block meta_description %}Free Openstack tutorials for beginners. No infrastructure needed. Get started on your workstation in 20 minutes!{% endblock meta_description %}
+{% block meta_copydoc %}https://docs.google.com/document/d/1_4EJlX-fbcQBVC9Ojhjdbls6kbmITGvHKi5IEqw-HAA/edit#{% endblock meta_copydoc %}
+
+{% block content %}
+
+<section class="p-strip is-bordered u-no-padding--top u-no-padding--bottom">
+  <div class="p-strip--suru-topped">
+    <div class="row">
+      <div class="col-8">
+        <h1>OpenStack tutorials</h1>
+        <h2 class="p-heading--three">Learn OpenStack through a series of tutorials</h2>
+        <p>Starting with just your workstation, learn how to use OpenStack for cloud infrastructure implementation purposes, from a single-node installation to large-scale clusters.</p>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section class="p-strip is-bordered">
+  <div class="row">
+    <div class="col-8">
+      <h2>Phase I - Single node OpenStack on your workstation</h2>
+      <p>Get started with OpenStack on your workstation and familiarise yourself with basic OpenStack concepts.</p>
+    </div>
+  </div>
+  <div class="row u-equal-height">
+    <div class="p-card col-4">
+      <div class="p-card__title">
+        <h3>1. <a href="https://discourse.ubuntu.com/t/install-openstack-on-your-workstation-and-launch-your-first-instance/25065" class="p-link--external">Install</a></h3>
+      </div>
+      <div class="p-card__content">
+        <p>Install OpenStack on your workstation and launch your first instance</p>
+      </div>
+    </div>
+    <div class="p-card col-4">
+      <div class="p-card__title">
+        <h3>2. <a href="https://discourse.ubuntu.com/t/explore-openstack-components-and-set-up-an-openstack-client/25068" class="p-link--external">Components</a></h3>
+      </div>
+      <div class="p-card__content">
+        <p>Explore OpenStack components and set up an OpenStack client.</p>
+      </div>
+    </div>
+    <div class="p-card col-4">
+      <div class="p-card__title">
+        <h3>3. <a href="https://discourse.ubuntu.com/t/learn-about-openstack-services-and-their-functions/25069" class="p-link--external">Services</a></h3>
+      </div>
+      <div class="p-card__content">
+        <p>Learn about OpenStack services and their functions.</p>
+      </div>
+    </div>
+    <div class="p-card col-4">
+      <div class="p-card__title">
+        <h3>4. <a href="https://discourse.ubuntu.com/t/navigate-through-the-openstack-dashboard-menu/25070" class="p-link--external">Dashboard</a></h3>
+      </div>
+      <div class="p-card__content">
+        <p>Navigate through the OpenStack dashboard menu.</p>
+      </div>
+    </div>
+    <div class="p-card col-4">
+      <div class="p-card__title">
+        <h3>5. <a href="https://discourse.ubuntu.com/t/manage-instance-templates-including-images-and-flavors/25071" class="p-link--external">Templates</a></h3>
+      </div>
+      <div class="p-card__content">
+        <p>Manage instance templates, including images and flavors.</p>
+      </div>
+    </div>
+    <div class="p-card col-4">
+      <div class="p-card__title">
+        <h3>6. <a href="https://discourse.ubuntu.com/t/use-the-concept-of-domains-roles-users-and-groups-to-manage-identities/25072" class="p-link--external">Identities</a></h3>
+      </div>
+      <div class="p-card__content">
+        <p>Use the concept of domains, roles, users and groups to manage identities.</p>
+      </div>
+    </div>
+    <div class="p-card col-4">
+      <div class="p-card__title">
+        <h3>7. <a href="https://discourse.ubuntu.com/t/enable-multi-tenancy-and-manage-global-and-tenant-resources/25073" class="p-link--external">Multi-tenancy</a></h3>
+      </div>
+      <div class="p-card__content">
+        <p>Enable multi-tenancy and manage global, and tenant resources.</p>
+      </div>
+    </div>
+    <div class="p-card col-4">
+      <div class="p-card__title">
+        <h3>8. <a href="https://discourse.ubuntu.com/t/learn-how-openstack-manages-various-virtual-network-resources/25074" class="p-link--external">Network</a></h3>
+      </div>
+      <div class="p-card__content">
+        <p>Learn how OpenStack manages various virtual network resources.</p>
+      </div>
+    </div>
+    <div class="p-card col-4">
+      <div class="p-card__title">
+        <h3>9. <a href="https://discourse.ubuntu.com/t/launch-and-terminate-cloud-instances/25075" class="p-link--external">Instances</a></h3>
+      </div>
+      <div class="p-card__content">
+        <p>Launch and delete cloud instances.</p>
+      </div>
+    </div>
+    <div class="p-card col-4">
+      <div class="p-card__title">
+        <h3>10. <a href="https://discourse.ubuntu.com/t/learn-how-openstack-manages-different-types-of-storage/25076" class="p-link--external">Storage</a></h3>
+      </div>
+      <div class="p-card__content">
+        <p>Learn how OpenStack manages different types of storage.</p>
+      </div>
+    </div>
+    <div class="p-card col-4">
+      <div class="p-card__title">
+        <h3>11. <a href="https://discourse.ubuntu.com/t/limit-access-to-resources-by-applying-quotas/25077" class="p-link--external">Quotas</a></h3>
+      </div>
+      <div class="p-card__content">
+        <p>Limit access to resources by applying quotas.</p>
+      </div>
+    </div>
+    <div class="p-card col-4">
+      <div class="p-card__title">
+        <h3>12. <a href="https://discourse.ubuntu.com/t/tear-down-your-openstack-lab-environment/25078" class="p-link--external">Teardown</a></h3>
+      </div>
+      <div class="p-card__content">
+        <p>Tear down your OpenStack lab environment.</p>
+      </div>
+    </div>                                            
+  </div>
+</section>
+
+<section class="p-strip is-deep is-bordered">
+  <div class="u-fixed-width">
+    <h2>Additional resources</h2>
+    <div class="p-divider row">
+      <div class="col-4 p-divider__block">
+        <div class="p-heading-icon--muted">
+          <div class="p-heading-icon__header">
+            {{ image (
+              url="https://assets.ubuntu.com/v1/b061c401-White+paper.svg",
+              alt="",
+              width="32",
+              height="28",
+              hi_def=True,
+              attrs={"class": "p-heading-icon__img p-heading-icon__img--small"},
+              loading="lazy"
+              ) | safe
+            }}
+            <h4 class="p-heading-icon__title">Whitepaper</h4>
+          </div>
+          <h3 class="p-heading--four"><a href="/engage/openstack-deployment-guide">OpenStack Deployment Guide</a></h3>
+        </div>
+      </div>
+      <div class="col-4 p-divider__block">
+        <div class="p-heading-icon--muted">
+          <div class="p-heading-icon__header">
+            {{
+              image(
+                url="https://assets.ubuntu.com/v1/6e184942-Webinar.svg",
+                alt="",
+                height="28",
+                width="32",
+                hi_def=True,
+                attrs={"class": "p-heading-icon__img p-heading-icon__img--small"},
+                loading="lazy",
+              ) | safe
+            }}
+            <h4 class="p-heading-icon__title">Webinar</h4>
+          </div>
+          <h3 class="p-heading--four"><a class="p-link--external" href="https://pages.ubuntu.com/stuckstack_webinar_upgrades_register.html?utm_source=Insights&utm_medium=link&utm_campaign=FY18_Cloud_StuckStack_WBN&_ga=2.77897687.2138546849.1632943896-403880216.1621244507">OpenStack Upgrades</a></h3>
+        </div>
+      </div>
+      <div class="col-4 p-divider__block">
+        <div class="p-heading-icon--muted">
+          <div class="p-heading-icon__header">
+            {{ image (
+              url="https://assets.ubuntu.com/v1/3e9e430a-icon-documentation.svg",
+              alt="",
+              width="28",
+              height="32",
+              hi_def=True,
+              attrs={"class": "p-heading-icon__img p-heading-icon__img--small"},              
+              loading="lazy"
+              ) | safe
+            }}
+            <h4 class="p-heading-icon__title">Documentation</h4>
+          </div>
+          <h3 class="p-heading--four"><a href="/openstack/docs">Charmed OpenStack Documentation</a></h3>
+        </div>
+      </div>            
+    </div>
+  </div>
+</section>
+
+{% endblock content %}

--- a/templates/openstack/tutorials.html
+++ b/templates/openstack/tutorials.html
@@ -211,7 +211,7 @@
 
 <section class="p-strip is-deep is-bordered">
   <div class="u-fixed-width">
-    <h2>Additional resources</h2>
+    <h2>Learn more</h2>
     <div class="p-divider row">
       <div class="col-4 p-divider__block">
         <div class="p-heading-icon--muted">
@@ -247,7 +247,7 @@
             }}
             <h4 class="p-heading-icon__title">Webinar</h4>
           </div>
-          <h3 class="p-heading--four"><a class="p-link--external" href="https://pages.ubuntu.com/stuckstack_webinar_upgrades_register.html?utm_source=Insights&utm_medium=link&utm_campaign=FY18_Cloud_StuckStack_WBN&_ga=2.77897687.2138546849.1632943896-403880216.1621244507">OpenStack Upgrades</a></h3>
+          <h3 class="p-heading--four"><a class="p-link--external" href="https://ubuntu.com/engage/openstack-upgrades-webinar">OpenStack Upgrades</a></h3>
         </div>
       </div>
       <div class="col-4 p-divider__block">


### PR DESCRIPTION
## Done

- Create /openstack/tutorials page

**NOTE**: Waiting for tutorials to be uploaded to discourse

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/openstack/tutorials or https://ubuntu-com-10687.demos.haus/openstack/tutorials
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Compare page against [copydoc](https://docs.google.com/document/d/1_4EJlX-fbcQBVC9Ojhjdbls6kbmITGvHKi5IEqw-HAA/edit#)
- Check tutorials appear in navigation of openstack and are accessible through /openstack/install 


## Issue / Card

Fixes https://github.com/canonical-web-and-design/web-squad/issues/4586