### PR TITLE
Display blender subscriptions on /advantage

### DIFF
--- a/static/js/src/advantage/api/contracts.js
+++ b/static/js/src/advantage/api/contracts.js
@@ -213,7 +213,8 @@ export async function resizeContract(
   previousPurchaseId,
   productId,
   quantity,
-  period
+  period,
+  marketplace
 ) {
   const queryString = window.location.search; // Pass arguments to the flask backend eg. "test_backend=true"
   let response = await fetch(`/advantage/subscribe${queryString}`, {
@@ -235,6 +236,7 @@ export async function resizeContract(
         },
       ],
       resizing: true,
+      marketplace=marketplace,
     }),
   });
 

--- a/static/js/src/advantage/api/contracts.js
+++ b/static/js/src/advantage/api/contracts.js
@@ -236,7 +236,7 @@ export async function resizeContract(
         },
       ],
       resizing: true,
-      marketplace=marketplace,
+      marketplace: marketplace,
     }),
   });
 

--- a/static/js/src/advantage/react/components/Subscriptions/SubscriptionDetails/DetailsContent/DetailsContent.test.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/SubscriptionDetails/DetailsContent/DetailsContent.test.tsx
@@ -8,7 +8,10 @@ import {
   freeSubscriptionFactory,
   userSubscriptionFactory,
 } from "advantage/tests/factories/api";
-import { UserSubscriptionPeriod } from "advantage/api/enum";
+import {
+  UserSubscriptionPeriod,
+  UserSubscriptionMarketplace,
+} from "advantage/api/enum";
 import { CodeSnippet } from "@canonical/react-components";
 
 describe("DetailsContent", () => {
@@ -91,5 +94,19 @@ describe("DetailsContent", () => {
       </QueryClientProvider>
     );
     expect(wrapper.find("[data-test='cost-col']").exists()).toBe(false);
+  });
+
+  it("displays correctly for blender subscription", () => {
+    const contract = userSubscriptionFactory.build({
+      marketplace: UserSubscriptionMarketplace.Blender,
+    });
+    queryClient.setQueryData("userSubscriptions", [contract]);
+    const wrapper = mount(
+      <QueryClientProvider client={queryClient}>
+        <DetailsContent selectedId={contract.id} />
+      </QueryClientProvider>
+    );
+    expect(wrapper.find("[data-test='machine-type-col']").exists()).toBe(false);
+    expect(wrapper.find("CodeSnippet").exists()).toBe(false);
   });
 });

--- a/static/js/src/advantage/react/components/Subscriptions/SubscriptionDetails/DetailsContent/DetailsContent.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/SubscriptionDetails/DetailsContent/DetailsContent.tsx
@@ -15,15 +15,13 @@ import {
   getPeriodDisplay,
   getSubscriptionCost,
   isFreeSubscription,
+  isBlenderSubscription,
 } from "advantage/react/utils";
 import React, { ReactNode } from "react";
 
 import DetailsTabs from "../DetailsTabs";
 import { SelectedId } from "../../Content/types";
-import {
-  UserSubscriptionType,
-  UserSubscriptionMarketplace,
-} from "advantage/api/enum";
+import { UserSubscriptionType } from "advantage/api/enum";
 
 type Props = {
   selectedId?: SelectedId;
@@ -56,8 +54,7 @@ const DetailsContent = ({ selectedId }: Props) => {
   const { data: token, isLoading: isLoadingToken } = useContractToken(
     subscription?.contract_id
   );
-  const isBlender =
-    subscription?.marketplace === UserSubscriptionMarketplace.Blender;
+  const isBlender = isBlenderSubscription(subscription);
 
   const SubscriptionToken = () => {
     return (

--- a/static/js/src/advantage/react/components/Subscriptions/SubscriptionDetails/DetailsContent/DetailsContent.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/SubscriptionDetails/DetailsContent/DetailsContent.tsx
@@ -20,7 +20,10 @@ import React, { ReactNode } from "react";
 
 import DetailsTabs from "../DetailsTabs";
 import { SelectedId } from "../../Content/types";
-import { UserSubscriptionType } from "advantage/api/enum";
+import {
+  UserSubscriptionType,
+  UserSubscriptionMarketplace,
+} from "advantage/api/enum";
 
 type Props = {
   selectedId?: SelectedId;
@@ -53,6 +56,26 @@ const DetailsContent = ({ selectedId }: Props) => {
   const { data: token, isLoading: isLoadingToken } = useContractToken(
     subscription?.contract_id
   );
+  const isBlender =
+    subscription?.marketplace === UserSubscriptionMarketplace.Blender;
+
+  const SubscriptionToken = () => {
+    return (
+      <>
+        <h5 className="u-no-padding--top p-subscriptions__details-small-title">
+          Subscription
+        </h5>
+        {isLoadingToken ? (
+          <div className="u-sv4" data-test="token-spinner">
+            <Spinner />
+          </div>
+        ) : (
+          tokenBlock
+        )}
+      </>
+    );
+  };
+
   const isFree = isFreeSubscription(subscription);
   if (isLoading || !subscription) {
     return <Spinner />;
@@ -106,26 +129,22 @@ const DetailsContent = ({ selectedId }: Props) => {
             ? // Don't show the cost column if it's empty.
               [costCol]
             : []),
+          ...(isBlender
+            ? // Don't show the column for Blender subscriptions.
+              []
+            : [
+                {
+                  title: "Machine type",
+                  value: getMachineTypeDisplay(subscription.machine_type),
+                },
+              ]),
           {
-            title: "Machine type",
-            value: getMachineTypeDisplay(subscription.machine_type),
-          },
-          {
-            title: "Machines",
+            title: isBlender ? "Users" : "Machines",
             value: subscription.number_of_machines,
           },
         ])}
       </Row>
-      <h5 className="u-no-padding--top p-subscriptions__details-small-title">
-        Subscription
-      </h5>
-      {isLoadingToken ? (
-        <div className="u-sv4" data-test="token-spinner">
-          <Spinner />
-        </div>
-      ) : (
-        tokenBlock
-      )}
+      {isBlender ? null : <SubscriptionToken />}
       <DetailsTabs subscription={subscription} token={token} />
     </div>
   );

--- a/static/js/src/advantage/react/components/Subscriptions/SubscriptionDetails/DetailsTabs/DetailsTabs.test.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/SubscriptionDetails/DetailsTabs/DetailsTabs.test.tsx
@@ -21,13 +21,28 @@ describe("DetailsTabs", () => {
   let subscription: UserSubscription;
 
   beforeEach(async () => {
-    subscription = userSubscriptionFactory.build();
+    subscription = userSubscriptionFactory.build({
+      entitlements: [
+        userSubscriptionEntitlementFactory.build({
+          enabled_by_default: true,
+          type: EntitlementType.Livepatch,
+        }),
+      ],
+    });
   });
 
-  it("defaults to the features tab", () => {
+  it("defaults to the features tab if there are entitlements", () => {
     const wrapper = mount(<DetailsTabs subscription={subscription} />);
     expect(wrapper.find("[data-testid='features-content']").exists()).toBe(
       true
+    );
+  });
+
+  it("hides the feature content tab is there are not entitlements", () => {
+    subscription = userSubscriptionFactory.build();
+    const wrapper = mount(<DetailsTabs subscription={subscription} />);
+    expect(wrapper.find("[data-testid='features-content']").exists()).toBe(
+      false
     );
   });
 

--- a/static/js/src/advantage/react/components/Subscriptions/SubscriptionDetails/DetailsTabs/DetailsTabs.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/SubscriptionDetails/DetailsTabs/DetailsTabs.tsx
@@ -7,11 +7,11 @@ import {
   UserSubscriptionEntitlement,
 } from "advantage/api/types";
 import { filterAndFormatEntitlements } from "advantage/react/utils/filterAndFormatEntitlements";
-import { isFreeSubscription } from "advantage/react/utils";
 import {
-  EntitlementType,
-  UserSubscriptionMarketplace,
-} from "advantage/api/enum";
+  isBlenderSubscription,
+  isFreeSubscription,
+} from "advantage/react/utils";
+import { EntitlementType } from "advantage/api/enum";
 import { sendAnalyticsEvent } from "advantage/react/utils/sendAnalyticsEvent";
 import FeaturesTab from "./components/FeaturesTab";
 
@@ -146,8 +146,7 @@ const DetailsTabs = ({ subscription, token, ...wrapperProps }: Props) => {
   );
   let content: ReactNode | null;
 
-  const isBlender =
-    subscription?.marketplace === UserSubscriptionMarketplace.Blender;
+  const isBlender = isBlenderSubscription(subscription);
 
   const isFree = isFreeSubscription(subscription);
   // Don't display any docs links for the free subscription.

--- a/static/js/src/advantage/react/components/Subscriptions/SubscriptionDetails/DetailsTabs/DetailsTabs.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/SubscriptionDetails/DetailsTabs/DetailsTabs.tsx
@@ -6,8 +6,12 @@ import {
   UserSubscription,
   UserSubscriptionEntitlement,
 } from "advantage/api/types";
+import { filterAndFormatEntitlements } from "advantage/react/utils/filterAndFormatEntitlements";
 import { isFreeSubscription } from "advantage/react/utils";
-import { EntitlementType } from "advantage/api/enum";
+import {
+  EntitlementType,
+  UserSubscriptionMarketplace,
+} from "advantage/api/enum";
 import { sendAnalyticsEvent } from "advantage/react/utils/sendAnalyticsEvent";
 import FeaturesTab from "./components/FeaturesTab";
 
@@ -132,8 +136,19 @@ const generateDocLinks = (
   );
 
 const DetailsTabs = ({ subscription, token, ...wrapperProps }: Props) => {
-  const [activeTab, setActiveTab] = useState<ActiveTab>(ActiveTab.FEATURES);
+  const featuresDisplay = filterAndFormatEntitlements(
+    subscription.entitlements
+  );
+  const [activeTab, setActiveTab] = useState<ActiveTab>(
+    featuresDisplay.included.length > 0
+      ? ActiveTab.FEATURES
+      : ActiveTab.DOCUMENTATION
+  );
   let content: ReactNode | null;
+
+  const isBlender =
+    subscription?.marketplace === UserSubscriptionMarketplace.Blender;
+
   const isFree = isFreeSubscription(subscription);
   // Don't display any docs links for the free subscription.
   const docs = isFree ? [] : generateDocLinks(subscription.entitlements);
@@ -145,37 +160,53 @@ const DetailsTabs = ({ subscription, token, ...wrapperProps }: Props) => {
       eventLabel: `subscription ${tab} tab clicked`,
     });
   };
+
+  const generateUADocs = () => {
+    return generateList(
+      "Documentation & tutorials",
+      docs
+        .map((doc) => ({
+          label: (
+            <a data-test="doc-link" href={doc.url}>
+              {doc.label}
+            </a>
+          ),
+        }))
+        .concat(
+          token
+            ? [
+                {
+                  label: (
+                    <>
+                      To attach a machine:{" "}
+                      <code data-test="contract-token">
+                        sudo ua attach {token?.contract_token}
+                      </code>
+                    </>
+                  ),
+                },
+              ]
+            : []
+        )
+    );
+  };
+
+  const blenderDocs = (
+    <>
+      <h5 className="u-no-padding--top p-subscriptions__details-small-title">
+        Documentation & tutorials
+      </h5>
+      <a data-test="doc-link" href="https://blender.stackexchange.com/">
+        Blender StackExchange
+      </a>
+    </>
+  );
+
   switch (activeTab) {
     case ActiveTab.DOCUMENTATION:
       content = (
         <div data-test="docs-content">
-          {generateList(
-            "Documentation & tutorials",
-            docs
-              .map((doc) => ({
-                label: (
-                  <a data-test="doc-link" href={doc.url}>
-                    {doc.label}
-                  </a>
-                ),
-              }))
-              .concat(
-                token
-                  ? [
-                      {
-                        label: (
-                          <>
-                            To attach a machine:{" "}
-                            <code data-test="contract-token">
-                              sudo ua attach {token?.contract_token}
-                            </code>
-                          </>
-                        ),
-                      },
-                    ]
-                  : []
-              )
-          )}
+          {isBlender ? blenderDocs : generateUADocs()}
         </div>
       );
       break;
@@ -189,12 +220,17 @@ const DetailsTabs = ({ subscription, token, ...wrapperProps }: Props) => {
       <Tabs
         className="p-tabs--brand"
         links={[
-          {
-            active: activeTab === ActiveTab.FEATURES,
-            "data-test": "features-tab",
-            label: "Features",
-            onClick: () => setTab(ActiveTab.FEATURES),
-          },
+          ...(featuresDisplay.included.length > 0
+            ? // Don't show the Features tab if there are no included features.
+              [
+                {
+                  active: activeTab === ActiveTab.FEATURES,
+                  "data-test": "features-tab",
+                  label: "Features",
+                  onClick: () => setTab(ActiveTab.FEATURES),
+                },
+              ]
+            : []),
           {
             active: activeTab === ActiveTab.DOCUMENTATION,
             "data-test": "docs-tab",

--- a/static/js/src/advantage/react/components/Subscriptions/SubscriptionDetails/DetailsTabs/components/FeaturesTab/FeaturesTab.test.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/SubscriptionDetails/DetailsTabs/components/FeaturesTab/FeaturesTab.test.tsx
@@ -39,3 +39,16 @@ it("displays feature categories with content", () => {
   expect(screen.queryByText("ESM Apps")).not.toBeInTheDocument();
   within(screen.getByTestId("always-available-features")).getByLabelText("CIS");
 });
+
+it("hides feature tab when no features are available", () => {
+  const subscription = userSubscriptionFactory.build({
+    entitlements: [
+      userSubscriptionEntitlementFactory.build({
+        enabled_by_default: false,
+        type: EntitlementType.EsmApps,
+      }),
+    ],
+  });
+  renderWithQueryClient(<FeaturesTab subscription={subscription} />);
+  expect(screen.queryByText("Features")).not.toBeInTheDocument();
+});

--- a/static/js/src/advantage/react/components/Subscriptions/SubscriptionList/ListCard/ListCard.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/SubscriptionList/ListCard/ListCard.tsx
@@ -4,6 +4,7 @@ import classNames from "classnames";
 import {
   formatDate,
   getFeaturesDisplay,
+  isBlenderSubscription,
   isFreeSubscription,
   makeInteractiveProps,
 } from "advantage/react/utils";
@@ -13,10 +14,7 @@ import {
   ExpiryNotificationSize,
   ORDERED_STATUS_KEYS,
 } from "../../ExpiryNotification/ExpiryNotification";
-import {
-  UserSubscriptionType,
-  UserSubscriptionMarketplace,
-} from "advantage/api/enum";
+import { UserSubscriptionType } from "advantage/api/enum";
 
 type Props = {
   isSelected?: boolean;
@@ -30,8 +28,7 @@ const ListCard = ({
   subscription,
 }: Props): JSX.Element => {
   const isFree = isFreeSubscription(subscription);
-  const isBlender =
-    subscription?.marketplace === UserSubscriptionMarketplace.Blender;
+  const isBlender = isBlenderSubscription(subscription);
   // If the subscription statuses is true for any of the expiry status keys then
   // a notification will be displayed.
   const hasExpiryNotification = !!ORDERED_STATUS_KEYS.find(

--- a/static/js/src/advantage/react/components/Subscriptions/SubscriptionList/ListCard/ListCard.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/SubscriptionList/ListCard/ListCard.tsx
@@ -13,7 +13,10 @@ import {
   ExpiryNotificationSize,
   ORDERED_STATUS_KEYS,
 } from "../../ExpiryNotification/ExpiryNotification";
-import { UserSubscriptionType } from "advantage/api/enum";
+import {
+  UserSubscriptionType,
+  UserSubscriptionMarketplace,
+} from "advantage/api/enum";
 
 type Props = {
   isSelected?: boolean;
@@ -27,6 +30,8 @@ const ListCard = ({
   subscription,
 }: Props): JSX.Element => {
   const isFree = isFreeSubscription(subscription);
+  const isBlender =
+    subscription?.marketplace === UserSubscriptionMarketplace.Blender;
   // If the subscription statuses is true for any of the expiry status keys then
   // a notification will be displayed.
   const hasExpiryNotification = !!ORDERED_STATUS_KEYS.find(
@@ -79,7 +84,9 @@ const ListCard = ({
         </div>
         <Row>
           <Col medium={3} size={3} small={1}>
-            <p className="u-text--muted u-no-margin--bottom">Machines</p>
+            <p className="u-text--muted u-no-margin--bottom">
+              {isBlender ? "Users" : "Machines"}
+            </p>
             <span data-test="card-machines">
               {subscription.number_of_machines}
             </span>
@@ -99,12 +106,14 @@ const ListCard = ({
             </span>
           </Col>
         </Row>
-        <List
-          className="p-subscriptions__list-card-features p-text--x-small-capitalised u-text--muted u-no-margin--bottom"
-          data-test="card-entitlements"
-          inline
-          items={getFeaturesDisplay(subscription.entitlements).included}
-        />
+        {getFeaturesDisplay(subscription.entitlements).included.length > 0 ? (
+          <List
+            className="p-subscriptions__list-card-features p-text--x-small-capitalised u-text--muted u-no-margin--bottom"
+            data-test="card-entitlements"
+            inline
+            items={getFeaturesDisplay(subscription.entitlements).included}
+          />
+        ) : null}
       </div>
     </Card>
   );

--- a/static/js/src/advantage/react/components/Subscriptions/SubscriptionList/SubscriptionList.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/SubscriptionList/SubscriptionList.tsx
@@ -3,6 +3,7 @@ import { useUserInfo, useUserSubscriptions } from "advantage/react/hooks";
 import {
   selectFreeSubscription,
   selectUASubscriptions,
+  selectBlenderSubscriptions,
 } from "advantage/react/hooks/useUserSubscriptions";
 import { sortSubscriptionsByStartDate } from "advantage/react/utils";
 import { sendAnalyticsEvent } from "advantage/react/utils/sendAnalyticsEvent";
@@ -30,8 +31,14 @@ const SubscriptionList = ({ selectedId, onSetActive }: Props) => {
   } = useUserSubscriptions({
     select: selectUASubscriptions,
   });
+  const {
+    data: blenderSubscriptionsData = [],
+    isLoading: isLoadingBlender,
+  } = useUserSubscriptions({
+    select: selectBlenderSubscriptions,
+  });
   const { data: userInfo, isLoading: isLoadingUserInfo } = useUserInfo();
-  if (isLoadingFree || isLoadingUA || isLoadingUserInfo) {
+  if (isLoadingFree || isLoadingUA || isLoadingBlender || isLoadingUserInfo) {
     return <Spinner />;
   }
   // Sort the subscriptions so that the most recently started subscription is first.
@@ -55,6 +62,29 @@ const SubscriptionList = ({ selectedId, onSetActive }: Props) => {
     />
   ));
 
+  const sortedBlenderSubscriptions = sortSubscriptionsByStartDate(
+    blenderSubscriptionsData
+  );
+
+  const blenderSubscriptions = sortedBlenderSubscriptions.map(
+    (subscription, i) => (
+      <ListCard
+        data-test="blender-subscription"
+        isSelected={selectedId === subscription.id}
+        key={i}
+        onClick={() => {
+          sendAnalyticsEvent({
+            eventCategory: "Advantage",
+            eventAction: "subscription-change",
+            eventLabel: "blender subscription clicked",
+          });
+          onSetActive(subscription.id);
+        }}
+        subscription={subscription}
+      />
+    )
+  );
+
   return (
     <div className="p-subscriptions__list">
       <div className="p-subscriptions__list-scroll">
@@ -65,6 +95,12 @@ const SubscriptionList = ({ selectedId, onSetActive }: Props) => {
             showRenewalSettings={userInfo?.has_monthly_subscription}
           >
             {uaSubscriptions}
+          </ListGroup>
+        ) : null}
+
+        {sortedBlenderSubscriptions.length ? (
+          <ListGroup data-test="blender-subscriptions-group" title="Blender">
+            {blenderSubscriptions}
           </ListGroup>
         ) : null}
 

--- a/static/js/src/advantage/react/components/Subscriptions/SubscriptionList/SubscriptionList.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/SubscriptionList/SubscriptionList.tsx
@@ -45,7 +45,7 @@ const SubscriptionList = ({ selectedId, onSetActive }: Props) => {
   const sortedUASubscriptions = sortSubscriptionsByStartDate(
     uaSubscriptionsData
   );
-  const uaSubscriptions = sortedUASubscriptions.map((subscription, i) => (
+  const uaSubscriptions = sortedUASubscriptions.map((subscription) => (
     <ListCard
       data-test="ua-subscription"
       isSelected={selectedId === subscription.id}
@@ -67,7 +67,7 @@ const SubscriptionList = ({ selectedId, onSetActive }: Props) => {
   );
 
   const blenderSubscriptions = sortedBlenderSubscriptions.map(
-    (subscription, i) => (
+    (subscription) => (
       <ListCard
         data-test="blender-subscription"
         isSelected={selectedId === subscription.id}

--- a/static/js/src/advantage/react/components/Subscriptions/SubscriptionList/SubscriptionList.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/SubscriptionList/SubscriptionList.tsx
@@ -49,7 +49,7 @@ const SubscriptionList = ({ selectedId, onSetActive }: Props) => {
     <ListCard
       data-test="ua-subscription"
       isSelected={selectedId === subscription.id}
-      key={i}
+      key={subscription.id}
       onClick={() => {
         sendAnalyticsEvent({
           eventCategory: "Advantage",
@@ -71,7 +71,7 @@ const SubscriptionList = ({ selectedId, onSetActive }: Props) => {
       <ListCard
         data-test="blender-subscription"
         isSelected={selectedId === subscription.id}
-        key={i}
+        key={subscription.id}
         onClick={() => {
           sendAnalyticsEvent({
             eventCategory: "Advantage",

--- a/static/js/src/advantage/react/hooks/useResizeContract.test.tsx
+++ b/static/js/src/advantage/react/hooks/useResizeContract.test.tsx
@@ -55,7 +55,8 @@ describe("useResizeContract", () => {
       ],
       subscription.listing_id,
       2,
-      UserSubscriptionPeriod.Yearly
+      UserSubscriptionPeriod.Yearly,
+      UserSubscriptionMarketplace.CanonicalUA
     );
   });
 

--- a/static/js/src/advantage/react/hooks/useResizeContract.ts
+++ b/static/js/src/advantage/react/hooks/useResizeContract.ts
@@ -25,7 +25,8 @@ export const useResizeContract = (subscription?: UserSubscription) => {
         lastPurchaseId,
         subscription?.listing_id,
         quantity,
-        subscription?.period
+        subscription?.period,
+        subscription?.marketplace
       ).then((response) => {
         if (response.errors) {
           // Sometimes the request fails because the previous purchase id

--- a/static/js/src/advantage/react/hooks/useUserSubscriptions.ts
+++ b/static/js/src/advantage/react/hooks/useUserSubscriptions.ts
@@ -52,33 +52,21 @@ export const selectStatusesSummary = (
   is_upsizeable: hasStatus(subscriptions, "is_upsizeable"),
 });
 
-/**
- * Find the UA subscriptions.
- */
 export const selectUASubscriptions = (subscriptions: UserSubscription[]) =>
   subscriptions.filter(
     ({ marketplace }) => marketplace === UserSubscriptionMarketplace.CanonicalUA
   );
 
-/**
- * Find the Blender subscriptions.
- */
 export const selectBlenderSubscriptions = (subscriptions: UserSubscription[]) =>
   subscriptions.filter(
     ({ marketplace }) => marketplace === UserSubscriptionMarketplace.Blender
   );
 
-/**
- * Find the subscriptions with for period.
- */
 export const selectSubscriptionsForPeriod = (
   period: UserSubscriptionPeriod
 ) => (subscriptions: UserSubscription[]) =>
   subscriptions.filter((subscription) => subscription.period === period);
 
-/**
- * Find the auto renewable subscriptions.
- */
 export const selectAutoRenewableUASubscriptions = (
   subscriptions: UserSubscription[]
 ) =>

--- a/static/js/src/advantage/react/hooks/useUserSubscriptions.ts
+++ b/static/js/src/advantage/react/hooks/useUserSubscriptions.ts
@@ -61,6 +61,14 @@ export const selectUASubscriptions = (subscriptions: UserSubscription[]) =>
   );
 
 /**
+ * Find the Blender subscriptions.
+ */
+export const selectBlenderSubscriptions = (subscriptions: UserSubscription[]) =>
+  subscriptions.filter(
+    ({ marketplace }) => marketplace === UserSubscriptionMarketplace.Blender
+  );
+
+/**
  * Find the subscriptions with for period.
  */
 export const selectSubscriptionsForPeriod = (

--- a/static/js/src/advantage/react/utils/index.ts
+++ b/static/js/src/advantage/react/utils/index.ts
@@ -6,6 +6,7 @@ export { getMachineTypeDisplay } from "./getMachineTypeDisplay";
 export { getPeriodDisplay } from "./getPeriodDisplay";
 export { getSubscriptionCost } from "./getSubscriptionCost";
 export { isFreeSubscription } from "./isFreeSubscription";
+export { isBlenderSubscription } from "./isBlenderSubscription";
 export { makeInteractiveProps } from "./makeInteractiveProps";
 export { removeFalsy } from "./removeFalsy";
 export { sortSubscriptionsByStartDate } from "./sortSubscriptionsByStartDate";

--- a/static/js/src/advantage/react/utils/isBlenderSubscription.test.ts
+++ b/static/js/src/advantage/react/utils/isBlenderSubscription.test.ts
@@ -1,0 +1,25 @@
+import { UserSubscriptionMarketplace } from "advantage/api/enum";
+import { userSubscriptionFactory } from "advantage/tests/factories/api";
+import { isBlenderSubscription } from "./isBlenderSubscription";
+
+describe("isBlenderSubscription", () => {
+  it("can identify blender subscriptions", () => {
+    expect(
+      isBlenderSubscription(
+        userSubscriptionFactory.build({
+          marketplace: UserSubscriptionMarketplace.Blender,
+        })
+      )
+    ).toBe(true);
+  });
+
+  it("can identify non-blender subscriptions", () => {
+    expect(
+      isBlenderSubscription(
+        userSubscriptionFactory.build({
+          marketplace: UserSubscriptionMarketplace.CanonicalUA,
+        })
+      )
+    ).toBe(false);
+  });
+});

--- a/static/js/src/advantage/react/utils/isBlenderSubscription.ts
+++ b/static/js/src/advantage/react/utils/isBlenderSubscription.ts
@@ -1,0 +1,5 @@
+import { UserSubscriptionMarketplace } from "advantage/api/enum";
+import { UserSubscription } from "advantage/api/types";
+
+export const isBlenderSubscription = (subscription?: UserSubscription | null) =>
+  subscription?.marketplace === UserSubscriptionMarketplace.Blender;

--- a/webapp/advantage/ua_contracts/builders.py
+++ b/webapp/advantage/ua_contracts/builders.py
@@ -214,11 +214,17 @@ def build_final_user_subscriptions(
             account, type, contract, renewal, subscription_id, item_id
         )
 
+        entitlements = (
+            apply_entitlement_rules(contract.entitlements)
+            if marketplace == "canonical-ua"
+            else []
+        )
+
         user_subscription = UserSubscription(
             id=id,
             type=type,
             account_id=account.id,
-            entitlements=apply_entitlement_rules(contract.entitlements),
+            entitlements=entitlements,
             start_date=aggregated_values.get("start_date"),
             end_date=end_date,
             number_of_machines=number_of_machines,


### PR DESCRIPTION
## Done

- Added blender subscriptions to /advantage
- Made adjustments to components to display blender infos correctly

## QA

- Go to https://ubuntu-com-10724.demos.haus/advantage?test_backend=true with a blender subscription (you can buy one here https://ubuntu-com-10711.demos.haus/advantage/subscribe/blender?test_backend=true )
- Check that it displays correctly


## Issue / Card

Fixes 
https://github.com/canonical-web-and-design/commercial-squad/issues/341
https://github.com/canonical-web-and-design/commercial-squad/issues/342

## Screenshots

![image](https://user-images.githubusercontent.com/11927929/138901047-4eae4d15-fd49-466c-89f1-3a3ce861628f.png)
