### PR TITLE
K8sdocs offline docs

### DIFF
--- a/navigation.yaml
+++ b/navigation.yaml
@@ -408,6 +408,9 @@ kubernetes:
         - title: IPv6
           path: /kubernetes/docs/ipv6
           hidden: True
+        - title: Ingress
+          path: /kubernetes/docs/ingress
+          hidden: True
         - title: Containerd and Docker
           path: /kubernetes/docs/container-runtime
           hidden: True

--- a/navigation.yaml
+++ b/navigation.yaml
@@ -363,6 +363,9 @@ kubernetes:
         - title: Install
           path: /kubernetes/docs/install-manual
           hidden: True
+        - title: Install Offline
+          path: /kubernetes/docs/install-offline
+          hidden: True
         - title: AWS integration
           path: /kubernetes/docs/aws-integration
           hidden: True
@@ -466,7 +469,7 @@ kubernetes:
           path: /kubernetes/docs/docker-registry
           hidden: True
         - title: Configuring proxies
-          path: /kubernetes/docs/proxy-settings
+          path: /kubernetes/docs/proxies
           hidden: True
         - title: Using GPU workers
           path: /kubernetes/docs/gpu-workers

--- a/templates/kubernetes/docs/1.20/charm-kubernetes-worker.md
+++ b/templates/kubernetes/docs/1.20/charm-kubernetes-worker.md
@@ -597,5 +597,5 @@ juju run-action kubernetes-worker ACTION [parameters] [--wait]
 
 
 <!-- LINKS -->
-[charm-kubernetes-master]: /charm-kubernetes-master
+[charm-kubernetes-master]: /kubernetes/docs/charm-kubernetes-master
 [kubelet-docs]: https://kubernetes.io/docs/reference/command-line-tools-reference/kubelet/

--- a/templates/kubernetes/docs/1.22/components.md
+++ b/templates/kubernetes/docs/1.22/components.md
@@ -14,7 +14,7 @@ layout:
     - base
     - ubuntu-com
 toc: false
-bundle_revision: '761'
+bundle_revision: '807'
 bundle_release: '1.22'
 ---
 
@@ -59,190 +59,170 @@ release. These charms are maintained by the Charmed Kubernetes team.
 <tr>
   <td> aws-iam </td>
   <td> A charm that enables using AWS IAM to authenticate with Kubernetes </td>
-  <td> <a href="/kubernetes/docs/1.22/charm-aws-iam">docs</a> </td>
-  <td> <a href="https://github.com/charmed-kubernetes/charm-aws-iam"> source </a> </td>
+  <td> <a href="/kubernetes/docs/1.22/charm-aws-iam">docs</a> </td> <td> <a href="https://github.com/charmed-kubernetes/charm-aws-iam"> source </a> </td>
   <td> <a href="https://bugs.launchpad.net/charmed-kubernetes"> bugs</a> </td>
-  <td> <a href="https://jaas.ai/u/containers/aws-iam/82"> 82 </a></td>
+  <td> <a href="https://jaas.ai/u/containers/aws-iam/91> 91 </td>
   <td> -- </td>
 </tr>
 <tr>
   <td> aws-integrator </td>
   <td> Charm to enable AWS integrations via Juju relations. </td>
-  <td> <a href="/kubernetes/docs/1.22/charm-aws-integrator">docs</a> </td>
-  <td> <a href="https://github.com/juju-solutions/charm-aws-integrator"> source </a> </td>
+  <td> <a href="/kubernetes/docs/1.22/charm-aws-integrator">docs</a> </td> <td> <a href="https://github.com/juju-solutions/charm-aws-integrator"> source </a> </td>
   <td> <a href="https://bugs.launchpad.net/charmed-kubernetes"> bugs</a> </td>
-  <td> <a href="https://jaas.ai/u/containers/aws-integrator/139"> 139 </a></td>
+  <td> <a href="https://jaas.ai/u/containers/aws-integrator/149> 149 </td>
   <td> -- </td>
 </tr>
 <tr>
   <td> azure-integrator </td>
   <td> Proxy charm to enable Azure integrations via Juju relations. </td>
-  <td> <a href="/kubernetes/docs/1.22/charm-azure-integrator">docs</a> </td>
-  <td> <a href="https://github.com/juju-solutions/charm-azure-integrator"> source </a> </td>
+  <td> <a href="/kubernetes/docs/1.22/charm-azure-integrator">docs</a> </td> <td> <a href="https://github.com/juju-solutions/charm-azure-integrator"> source </a> </td>
   <td> <a href="https://bugs.launchpad.net/charmed-kubernetes"> bugs</a> </td>
-  <td> <a href="https://jaas.ai/u/containers/azure-integrator/124"> 124 </a> </td>
+  <td> <a href="https://jaas.ai/u/containers/azure-integrator/134> 134 </td>
   <td> -- </td>
 </tr>
 <tr>
   <td> calico </td>
   <td> A robust Software Defined Network from Project Calico </td>
-  <td> <a href="/kubernetes/docs/1.22/charm-calico">docs</a> </td>
-  <td> <a href="https://github.com/juju-solutions/layer-calico"> source </a> </td>
+  <td> <a href="/kubernetes/docs/1.22/charm-calico">docs</a> </td> <td> <a href="https://github.com/juju-solutions/layer-calico"> source </a> </td>
   <td> <a href="https://bugs.launchpad.net/charmed-kubernetes"> bugs</a> </td>
-  <td> <a href="https://jaas.ai/u/containers/calico/826"> 826 </a> </td>
+  <td> <a href="https://jaas.ai/u/containers/calico/835> 835 </td>
   <td> -- </td>
 </tr>
 <tr>
   <td> canal </td>
   <td> A Software Defined Network based on Flannel and Calico </td>
-  <td> <a href="/kubernetes/docs/1.22/charm-canal">docs</a> </td>
-  <td> <a href="https://github.com/juju-solutions/layer-canal"> source </a> </td>
+  <td> <a href="/kubernetes/docs/1.22/charm-canal">docs</a> </td> <td> <a href="https://github.com/juju-solutions/layer-canal"> source </a> </td>
   <td> <a href="https://bugs.launchpad.net/charmed-kubernetes"> bugs</a> </td>
-  <td> <a href="https://jaas.ai/u/containers/canal/825"> 825</a> </td>
+  <td> <a href="https://jaas.ai/u/containers/canal/834> 834 </td>
   <td> -- </td>
 </tr>
 <tr>
   <td> containerd </td>
   <td> Containerd container runtime subordinate </td>
-  <td> <a href="/kubernetes/docs/1.22/charm-containerd">docs</a> </td>
-  <td> <a href=""> source </a> </td>
+  <td> <a href="/kubernetes/docs/1.22/charm-containerd">docs</a> </td> <td> <a href=""> source </a> </td>
   <td> <a href="https://bugs.launchpad.net/charmed-kubernetes"> bugs</a> </td>
-  <td> <a href="https://jaas.ai/u/containers/containerd/160"> 160</a> </td>
+  <td> <a href="https://jaas.ai/u/containers/containerd/175> 175 </td>
   <td> -- </td>
 </tr>
 <tr>
   <td> docker </td>
   <td> Docker container runtime subordinate </td>
-  <td> <a href="/kubernetes/docs/1.22/charm-docker">docs</a> </td>
-  <td> <a href=""> source </a> </td>
+  <td> <a href="/kubernetes/docs/1.22/charm-docker">docs</a> </td> <td> <a href=""> source </a> </td>
   <td> <a href="https://bugs.launchpad.net/charmed-kubernetes"> bugs</a> </td>
-  <td> <a href="https://jaas.ai/u/containers/docker/113"> 113</a> </td>
+  <td> <a href="https://jaas.ai/u/containers/docker/128> 128 </td>
   <td> -- </td>
 </tr>
 <tr>
   <td> docker-registry </td>
   <td> Registry for docker images </td>
-  <td> <a href="/kubernetes/docs/1.22/charm-docker-registry">docs</a> </td>
-  <td> <a href="https://github.com/CanonicalLtd/docker-registry-charm"> source </a> </td>
+  <td> <a href="/kubernetes/docs/1.22/charm-docker-registry">docs</a> </td> <td> <a href="https://github.com/CanonicalLtd/docker-registry-charm"> source </a> </td>
   <td> <a href="https://bugs.launchpad.net/charmed-kubernetes"> bugs</a> </td>
-  <td> <a href="https://jaas.ai/u/containers/docker-registry/201"> 201</a> </td>
+  <td> <a href="https://jaas.ai/u/containers/docker-registry/215> 215 </td>
   <td> -- </td>
 </tr>
 <tr>
   <td> easyrsa </td>
   <td> Delivers EasyRSA to create a Certificate Authority (CA). </td>
-  <td> <a href="/kubernetes/docs/1.22/charm-easyrsa">docs</a> </td>
-  <td> <a href="https://github.com/charmed-kubernetes/layer-easyrsa"> source </a> </td>
+  <td> <a href="/kubernetes/docs/1.22/charm-easyrsa">docs</a> </td> <td> <a href="https://github.com/charmed-kubernetes/layer-easyrsa"> source </a> </td>
   <td> <a href="https://bugs.launchpad.net/charmed-kubernetes"> bugs</a> </td>
-  <td> <a href="https://jaas.ai/u/containers/easyrsa/408"> 408</a> </td>
+  <td> <a href="https://jaas.ai/u/containers/easyrsa/417> 417 </td>
   <td> -- </td>
 </tr>
 <tr>
   <td> etcd </td>
   <td> Deploy a TLS terminated ETCD Cluster </td>
-  <td> <a href="/kubernetes/docs/1.22/charm-etcd">docs</a> </td>
-  <td> <a href="https://github.com/charmed-kubernetes/layer-etcd"> source </a> </td>
+  <td> <a href="/kubernetes/docs/1.22/charm-etcd">docs</a> </td> <td> <a href="https://github.com/charmed-kubernetes/layer-etcd"> source </a> </td>
   <td> <a href="https://bugs.launchpad.net/charmed-kubernetes"> bugs</a> </td>
-  <td> <a href="https://jaas.ai/u/containers/etcd/620"> 620</a> </td>
+  <td> <a href="https://jaas.ai/u/containers/etcd/630> 630 </td>
   <td> -- </td>
 </tr>
 <tr>
   <td> flannel </td>
   <td> A charm that provides a robust Software Defined Network </td>
-  <td> <a href="/kubernetes/docs/1.22/charm-flannel">docs</a> </td>
-  <td> <a href="https://github.com/coreos/flannel"> source </a> </td>
+  <td> <a href="/kubernetes/docs/1.22/charm-flannel">docs</a> </td> <td> <a href="https://github.com/coreos/flannel"> source </a> </td>
   <td> <a href="https://bugs.launchpad.net/charmed-kubernetes"> bugs</a> </td>
-  <td> <a href="https://jaas.ai/u/containers/flannel/584"> 584</a> </td>
+  <td> <a href="https://jaas.ai/u/containers/flannel/594> 594 </td>
   <td> -- </td>
 </tr>
 <tr>
   <td> gcp-integrator </td>
   <td> Charm to enable GCP integrations via Juju relations. </td>
-  <td> <a href="/kubernetes/docs/1.22/charm-gcp-integrator">docs</a> </td>
-  <td> <a href="https://github.com/juju-solutions/charm-gcp-integrator"> source </a> </td>
+  <td> <a href="/kubernetes/docs/1.22/charm-gcp-integrator">docs</a> </td> <td> <a href="https://github.com/juju-solutions/charm-gcp-integrator"> source </a> </td>
   <td> <a href="https://bugs.launchpad.net/charmed-kubernetes"> bugs</a> </td>
-  <td> <a href="https://jaas.ai/u/containers/gcp-integrator/131"> 131</a> </td>
+  <td> <a href="https://jaas.ai/u/containers/gcp-integrator/141> 141 </td>
   <td> -- </td>
 </tr>
 <tr>
   <td> kata </td>
   <td> Kata untrusted container runtime subordinate </td>
-  <td> <a href="/kubernetes/docs/1.22/charm-kata">docs</a> </td>
-  <td> <a href=""> source </a> </td>
+  <td> <a href="/kubernetes/docs/1.22/charm-kata">docs</a> </td> <td> <a href=""> source </a> </td>
   <td> <a href="https://bugs.launchpad.net/charmed-kubernetes"> bugs</a> </td>
-  <td> <a href="https://jaas.ai/u/containers/kata/121"> 121</a> </td>
+  <td> <a href="https://jaas.ai/u/containers/kata/135> 135 </td>
   <td> -- </td>
 </tr>
 <tr>
   <td> keepalived </td>
   <td> Failover and monitoring daemon for LVS clusters </td>
-  <td> <a href="/kubernetes/docs/1.22/charm-keepalived">docs</a> </td>
-  <td> <a href="https://github.com/juju-solutions/charm-keepalived"> source </a> </td>
+  <td> <a href="/kubernetes/docs/1.22/charm-keepalived">docs</a> </td> <td> <a href="https://github.com/juju-solutions/charm-keepalived"> source </a> </td>
   <td> <a href="https://bugs.launchpad.net/charmed-kubernetes"> bugs</a> </td>
-  <td> <a href="https://jaas.ai/u/containers/keepalived/98"> 98</a> </td>
+  <td> <a href="https://jaas.ai/u/containers/keepalived/107> 107 </td>
   <td> -- </td>
 </tr>
 <tr>
   <td> kubeapi-load-balancer </td>
   <td> Nginx Load Balancer </td>
-  <td> <a href="/kubernetes/docs/1.22/charm-kubeapi-load-balancer">docs</a> </td>
-  <td> <a href="https://nginx.org/en/"> source </a> </td>
+  <td> <a href="/kubernetes/docs/1.22/charm-kubeapi-load-balancer">docs</a> </td> <td> <a href="https://nginx.org/en/"> source </a> </td>
   <td> <a href="https://bugs.launchpad.net/charmed-kubernetes"> bugs</a> </td>
-  <td> <a href="https://jaas.ai/u/containers/kubeapi-load-balancer/827"> 827</a> </td>
+  <td> <a href="https://jaas.ai/u/containers/kubeapi-load-balancer/841> 841 </td>
   <td> -- </td>
 </tr>
 <tr>
   <td> kubernetes-master </td>
   <td> The Kubernetes control plane. </td>
-  <td> <a href="/kubernetes/docs/1.22/charm-kubernetes-master">docs</a> </td>
-  <td> <a href="https://github.com/charmed-kubernetes/charm-kubernetes-master"> source </a> </td>
+  <td> <a href="/kubernetes/docs/1.22/charm-kubernetes-master">docs</a> </td> <td> <a href="https://github.com/charmed-kubernetes/charm-kubernetes-master"> source </a> </td>
   <td> <a href="https://bugs.launchpad.net/charmed-kubernetes"> bugs</a> </td>
-  <td> <a href="https://jaas.ai/u/containers/kubernetes-master/1051"> 1051</a> </td>
+  <td> <a href="https://jaas.ai/u/containers/kubernetes-master/1074> 1074 </td>
   <td> -- </td>
 </tr>
 <tr>
   <td> kubernetes-worker </td>
   <td> The workload bearing units of a kubernetes cluster </td>
-  <td> <a href="/kubernetes/docs/1.22/charm-kubernetes-worker">docs</a> </td>
-  <td> <a href="https://github.com/charmed-kubernetes/charm-kubernetes-worker"> source </a> </td>
+  <td> <a href="/kubernetes/docs/1.22/charm-kubernetes-worker">docs</a> </td> <td> <a href="https://github.com/charmed-kubernetes/charm-kubernetes-worker"> source </a> </td>
   <td> <a href="https://bugs.launchpad.net/charmed-kubernetes"> bugs</a> </td>
-  <td> <a href="https://jaas.ai/u/containers/kubernetes-worker/801"> 801</a> </td>
+  <td> <a href="https://jaas.ai/u/containers/kubernetes-worker/812> 812 </td>
   <td> -- </td>
 </tr>
 <tr>
   <td> openstack-integrator </td>
   <td> Proxy charm to enable OpenStack integrations via Juju relations. </td>
-  <td> <a href="/kubernetes/docs/1.22/charm-openstack-integrator">docs</a> </td>
-  <td> <a href="https://github.com/juju-solutions/charm-openstack-integrator"> source </a> </td>
+  <td> <a href="/kubernetes/docs/1.22/charm-openstack-integrator">docs</a> </td> <td> <a href="https://github.com/juju-solutions/charm-openstack-integrator"> source </a> </td>
   <td> <a href="https://bugs.launchpad.net/charmed-kubernetes"> bugs</a> </td>
-  <td> <a href="https://jaas.ai/u/containers/openstack-integrator/166"> 166</a> </td>
+  <td> <a href="https://jaas.ai/u/containers/openstack-integrator/178> 178 </td>
   <td> -- </td>
 </tr>
 <tr>
   <td> tigera-secure-ee </td>
   <td> Tigera Secure Enterprise Edition </td>
-  <td> <a href="/kubernetes/docs/1.22/charm-tigera-secure-ee">docs</a> </td>
-  <td> <a href=""> source </a> </td>
+  <td> <a href="/kubernetes/docs/1.22/charm-tigera-secure-ee">docs</a> </td> <td> <a href=""> source </a> </td>
   <td> <a href="https://bugs.launchpad.net/charmed-kubernetes"> bugs</a> </td>
-  <td> <a href="https://jaas.ai/u/containers/tigera-secure-ee/218"> 218</a> </td>
+  <td> <a href="https://jaas.ai/u/containers/tigera-secure-ee/227> 227 </td>
   <td> -- </td>
 </tr>
 <tr>
   <td> vsphere-integrator </td>
   <td> Proxy charm to enable VMware vSphere integrations via Juju relations. </td>
-  <td> <a href="/kubernetes/docs/1.22/charm-vsphere-integrator">docs</a> </td>
-  <td> <a href="https://github.com/juju-solutions/charm-vsphere-integrator"> source </a> </td>
+  <td> <a href="/kubernetes/docs/1.22/charm-vsphere-integrator">docs</a> </td> <td> <a href="https://github.com/juju-solutions/charm-vsphere-integrator"> source </a> </td>
   <td> <a href="https://bugs.launchpad.net/charmed-kubernetes"> bugs</a> </td>
-  <td> <a href="https://jaas.ai/u/containers/vsphere-integrator/111"> 111</a> </td>
+  <td> <a href="https://jaas.ai/u/containers/vsphere-integrator/120> 120 </td>
   <td> -- </td>
 </tr>
-</tbody>
-</table>
+
+ </tbody>
+ </table>
 
 ## Compatible Charms
 
 These charms are frequently used with Charmed Kubernetes.
-
 
 <table class ="u-table-layout--auto">
   <thead>
@@ -338,8 +318,9 @@ These charms are frequently used with Charmed Kubernetes.
   <td> <a href="https://jaas.ai/vault">docs</a> </td>
   <td>  </td>
 </tr>
-</tbody>
-</table>
+
+ </tbody>
+ </table>
 
 
 ## Images
@@ -349,42 +330,42 @@ These are the container images used by this release:
 
 <!-- GENERATED CONTAINER IMAGES -->
  
--  cdk/addon-resizer-{{ arch }}:1.8.9
--  cephcsi/cephcsi:v3.3.1 
--  coredns/coredns:1.8.3 
--  coreos/kube-state-metrics:v1.9.8 
--  k8s-dns-dnsmasq-nanny:1.17.3 
--  k8s-dns-kube-dns:1.17.3 
--  k8s-dns-sidecar:1.17.3 
--  k8scloudprovider/cinder-csi-plugin:v1.20.0 
--  k8scloudprovider/k8s-keystone-auth:v1.20.0 
--  k8scloudprovider/openstack-cloud-controller-manager:v1.20.0 
--  kubernetesui/dashboard:v2.2.0 
--  kubernetesui/metrics-scraper:v1.0.6 
--  metrics-server/metrics-server:v0.5.0 
--  nvidia/k8s-device-plugin:v0.9.0 
--  sig-storage/csi-attacher:v2.2.1 
--  sig-storage/csi-attacher:v3.0.2 
--  sig-storage/csi-node-driver-registrar:v1.3.0 
--  sig-storage/csi-node-driver-registrar:v2.0.1 
--  sig-storage/csi-provisioner:v1.6.1 
--  sig-storage/csi-provisioner:v2.0.4 
--  sig-storage/csi-resizer:v0.5.1 
--  sig-storage/csi-resizer:v1.0.1 
--  sig-storage/csi-snapshotter:v2.1.3 
--  sig-storage/csi-snapshotter:v4.0.0 
--  sig-storage/livenessprobe:v2.1.0 
-
-This is a list of the images which have been added or updated since the previous release:
-
--  cephcsi/cephcsi:v3.3.1 
--  k8s-dns-dnsmasq-nanny:1.17.3 
--  k8s-dns-kube-dns:1.17.3 
--  k8s-dns-sidecar:1.17.3 
--  metrics-server:v0.5.0 
--  sig-storage/csi-snapshotter:v4.0.0 
-
-
+-  cdkbot/microbot-amd64:latest
+-  cdkbot/microbot-arm64:latest
+-  cdkbot/microbot-s390x:latest
+-  cephcsi/cephcsi:v3.3.1
+-  coredns/coredns:1.8.3
+-  coreos/kube-state-metrics:v1.9.8
+-  defaultbackend-amd64:1.5
+-  defaultbackend-arm64:1.5
+-  defaultbackend-ppc64le:1.5
+-  defaultbackend-s390x:1.4
+-  dns/k8s-dns-dnsmasq-nanny:1.17.3
+-  dns/k8s-dns-kube-dns:1.17.3
+-  dns/k8s-dns-sidecar:1.17.3
+-  external_storage/nfs-client-provisioner:v3.1.0-k8s1.11
+-  k8s-artifacts-prod/ingress-nginx/controller:v1.0.0-beta.3
+-  k8scloudprovider/cinder-csi-plugin:v1.22.0
+-  k8scloudprovider/k8s-keystone-auth:v1.22.0
+-  k8scloudprovider/openstack-cloud-controller-manager:v1.22.0
+-  kubernetes-ingress-controller/nginx-ingress-controller-ppc64le:0.20.0
+-  kubernetesui/dashboard:v2.2.0
+-  kubernetesui/metrics-scraper:v1.0.6
+-  metrics-server/metrics-server:v0.5.0
+-  nvidia/k8s-device-plugin:v0.9.0
+-  pause:3.4.1
+-  rancher/rancher:latest
+-  sig-storage/csi-attacher:v3.0.2
+-  sig-storage/csi-attacher:v3.1.0
+-  sig-storage/csi-node-driver-registrar:v2.0.1
+-  sig-storage/csi-node-driver-registrar:v2.1.0
+-  sig-storage/csi-provisioner:v2.0.4
+-  sig-storage/csi-provisioner:v2.2.0
+-  sig-storage/csi-resizer:v1.0.1
+-  sig-storage/csi-resizer:v1.1.0
+-  sig-storage/csi-snapshotter:v4.0.0
+-  sig-storage/livenessprobe:v2.2.0
+-  sonatype/nexus3:latest 
 
 <!-- CONTAINER IMAGES END -->
 
@@ -397,7 +378,6 @@ The following snaps are used by this release of Charmed Kubernetes:
 |aws-cli| classic | Resource to side-load aws-cli snap in network-restricted deployments. | [store page](https://snapcraft.io/aws-cli) |
 |core| strict | core snap | [store page](https://snapcraft.io/core) |
 |etcd| classic | Snap package of etcd | [store page](https://snapcraft.io/etcd) |
-|gcloud| ? | Resource to side-load gcloud snap in network-restricted deployments. | ? |
 |cdk-addons| strict | CDK addons snap | [store page](https://snapcraft.io/cdk-addons) |
 |kube-apiserver| strict | kube-apiserver snap | [store page](https://snapcraft.io/kube-apiserver) |
 |kube-controller-manager| strict | kube-controller-manager snap | [store page](https://snapcraft.io/kube-controller-manager) |

--- a/templates/kubernetes/docs/1.22/release-notes.md
+++ b/templates/kubernetes/docs/1.22/release-notes.md
@@ -13,6 +13,39 @@ layout: [base, ubuntu-com]
 toc: False
 ---
 
+# 1.22+ck1 Bugfix release
+
+### October 21, 2021 - [charmed-kubernetes-807](https://api.jujucharms.com/charmstore/v5/charmed-kubernetes-807/archive/bundle.yaml)
+
+## What's new
+
+- Configurable default PodSecurityPolicy
+
+A new `pod-security-policy` config option has been added to the
+kubernetes-master charm. This option allows you to override the default
+PodSecurityPolicy that is created by the charm.
+
+- Configurable Nvidia APT sources
+
+New config options have been added to the containerd charm:
+`nvidia_apt_key_urls`, `nvidia_apt_sources`, and `nvidia_apt_packages`. These
+provide better support for Nvidia GPUs in air gapped deployments by allowing
+you to specify where the Nvidia Container Runtime and CUDA packages are pulled
+from.
+
+- Better OpenStack credential handling
+
+The openstack-integrator charm now checks for updated cloud credentials from
+Juju every time its update-status hook runs, ensuring that cloud credentials
+are properly detected a short time after they change. To expedite this process,
+you can use the new openstack-integrator charm's new `refresh-credentials`
+action to force a recheck immediately.
+
+## Fixes
+
+A list of bug fixes and other minor feature updates in this release can be found at
+[the launchpad milestone page](https://launchpad.net/charmed-kubernetes/+milestone/1.22+ck1).
+
 # 1.22
 
 ### September 1, 2021 - [charmed-kubernetes-761](https://api.jujucharms.com/charmstore/v5/charmed-kubernetes-761/archive/bundle.yaml)

--- a/templates/kubernetes/docs/charm-etcd.md
+++ b/templates/kubernetes/docs/charm-etcd.md
@@ -121,7 +121,7 @@ juju expose etcd
 export ETCDCTL_KEY=$(pwd)/client.key
 export ETCDCTL_CERT=$(pwd)/client.crt
 export ETCDCTL_CACERT=$(pwd)/ca.crt
-export ETCDCTL_ENDPOINT=https://{ip of etcd host}:2379
+export ETCDCTL_ENDPOINTS=https://{ip of etcd host}:2379
 etcdctl member list
 ```
 

--- a/templates/kubernetes/docs/docker-registry.md
+++ b/templates/kubernetes/docs/docker-registry.md
@@ -122,7 +122,8 @@ Login Succeeded
 
 Relate the deployed registry to the appropriate
 [container runtime][container-runtime] for your cluster. This configures
-the runtime with authentication, proxy, and/or TLS data from the registry.
+the runtime with authentication, proxy, and/or TLS data from the registry,
+and allows your registry to be used by the cluster to pull images for pods.
 
 ### Containerd
 
@@ -169,11 +170,11 @@ juju run-action docker-registry/0 \
 
 The above procedure should be repeated for all required images.
 
-## Using hosted images
+## Using the registry for cluster components
 
-The image registry used by **Charmed Kubernetes** is controlled by a
-`kubernetes-master` config option. Configure `kubernetes-master` to use your
-private registry as follows:
+The image registry used by **Charmed Kubernetes** for images used in managing
+or supporting components of the cluster itself is controlled by a `kubernetes-master`
+config option. Configure `kubernetes-master` to use your private registry as follows:
 
 ```bash
 juju config kubernetes-master image-registry=$REGISTRY

--- a/templates/kubernetes/docs/ingress.md
+++ b/templates/kubernetes/docs/ingress.md
@@ -1,0 +1,87 @@
+---
+wrapper_template: "templates/docs/markdown.html"
+markdown_includes:
+  nav: "kubernetes/docs/shared/_side-navigation.md" # Fix syntax highlighting: _.
+context:
+  title: "Ingress"
+  description: Using Ingress with Charmed Kubernetes.
+keywords: juju, network, networking
+tags: [operating]
+sidebar: k8smain-sidebar
+permalink: ingress.html
+layout: [base, ubuntu-com]
+toc: False
+---
+
+Applications in Kubernetes can be exposed outside of the cluster in several ways, such
+as via `NodePort` or `LoadBalancer` type services, or via ingress controllers or
+gateways.
+
+`NodePort` services expose the service directly via a port on each of the nodes, which
+can then be manually managed by firewall rules or external load balancers.
+
+`LoadBalancer` services require something that can provide indvidual load balancers for
+each service, which could be native load balancers provided by the underlying cloud
+(see the relevant Cloud Integration section of the docs) or something like [MetalLB][].
+
+Ingress controllers provide a single point of entry instead of needing to deal with
+multiple individual service addresses, and then use rules or path matching to direct
+traffic appropriately. The ingress endpoint itself still needs to be exposed via one
+of the above methods but can provide feature-rich management of traffic routing into
+the cluster.
+
+
+## NGINX Ingress
+
+By default, **Charmed Kubernetes** sets up the [NGINX Ingress Controller][ingress-nginx],
+which can be customized via the config options on the [worker charm][].
+[`Ingress` resources][ingress-resources] can then be used to configure routes for specific
+applications.
+
+## Istio Ingress
+
+By deploying the [Istio bundle][] into your cluster, you can use the
+[Istio traffic management features][istio-traffic]. You can then relate Kubernetes
+charms which support the `ingress` relation to automatically manage [`VirtualServices`][virt-svc],
+manually manage [`VirtualServices`][virt-svc] for your applications, or even use
+[`Ingress` resources][istio-ingress].
+
+<div class="p-notification--positive">
+<p markdown="1" class="p-notification__response">
+<span class="p-notification__status">Note:</span>
+The Istio bundle requires a load balancer provider. If you're not using a cloud
+integrator which provides this, [MetalLB][] can be used.
+</p></div>
+
+
+## Multiple Ingress Controllers
+
+Multiple ingress controllers or gateways can be used at the same time, typically with
+different configuration or exposure. The `networking.k8s.io/v1` defines an
+[`IngressClass` resource][ingress-class] to select between controllers, but some
+controllers may rely on annotations, such as Istio's
+[`kubernetes.io/ingress.class` annotation][istio-annotation].
+
+<!-- LINKS -->
+
+[ingress-nginx]: https://kubernetes.github.io/ingress-nginx/
+[MetalLB]: metallb
+[worker charm]: charm-kubernetes-worker
+[ingress-resources]: https://kubernetes.io/docs/concepts/services-networking/ingress/
+[Istio bundle]: https://jaas.ai/istio
+[istio-traffic]: https://istio.io/latest/docs/concepts/traffic-management/
+[virt-svc]: https://istio.io/latest/docs/concepts/traffic-management/#virtual-services
+[istio-ingress]: https://istio.io/latest/docs/tasks/traffic-management/ingress/kubernetes-ingress/
+[ingress-class]: https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-class
+[istio-annotation]: https://istio.io/latest/docs/tasks/traffic-management/ingress/kubernetes-ingress/#configuring-ingress-using-an-ingress-resource
+
+<!-- FEEDBACK -->
+<div class="p-notification--information">
+  <p class="p-notification__response">
+    We appreciate your feedback on the documentation. You can
+    <a href="https://github.com/charmed-kubernetes/kubernetes-docs/edit/master/pages/k8s/ingress.md" class="p-notification__action">edit this page</a>
+    or
+    <a href="https://github.com/charmed-kubernetes/kubernetes-docs/issues/new" class="p-notification__action">file a bug here</a>.
+  </p>
+</div>
+

--- a/templates/kubernetes/docs/ingress.md
+++ b/templates/kubernetes/docs/ingress.md
@@ -50,7 +50,7 @@ manually manage [`VirtualServices`][virt-svc] for your applications, or even use
 <p markdown="1" class="p-notification__response">
 <span class="p-notification__status">Note:</span>
 The Istio bundle requires a load balancer provider. If you're not using a cloud
-integrator which provides this, [MetalLB][] can be used.
+  integrator which provides this, <a href="metallb">MetalLB</a> can be used.
 </p></div>
 
 

--- a/templates/kubernetes/docs/install-manual.md
+++ b/templates/kubernetes/docs/install-manual.md
@@ -232,7 +232,7 @@ versions of the **Charmed Kubernetes** bundle are shown in the table below:
 
 | Kubernetes version | Charmed Kubernetes bundle |
 | --- | --- |
-| 1.22.x    | [charmed-kubernetes-761](https://api.jujucharms.com/charmstore/v5/charmed-kubernetes-761/archive/bundle.yaml) |
+| 1.22.x    | [charmed-kubernetes-807](https://api.jujucharms.com/charmstore/v5/charmed-kubernetes-807/archive/bundle.yaml) |
 | 1.21.x    | [charmed-kubernetes-733](https://api.jujucharms.com/charmstore/v5/charmed-kubernetes-733/archive/bundle.yaml) |
 | 1.20.x    | [charmed-kubernetes-596](https://api.jujucharms.com/charmstore/v5/charmed-kubernetes-596/archive/bundle.yaml) |
 | 1.19.x    | [charmed-kubernetes-545](https://api.jujucharms.com/charmstore/v5/charmed-kubernetes-545/archive/bundle.yaml) |

--- a/templates/kubernetes/docs/install-offline.md
+++ b/templates/kubernetes/docs/install-offline.md
@@ -1,0 +1,290 @@
+---
+wrapper_template: "templates/docs/markdown.html"
+markdown_includes:
+  nav: "kubernetes/docs/shared/_side-navigation.md"
+context:
+  title: "Installing Charmed Kubernetes offline"
+  description: How to install Charmed Kubernetes in a restricted network
+keywords: lxd, requirements, developer
+tags: [install]
+sidebar: k8smain-sidebar
+permalink: install-offline.html
+layout: [base, ubuntu-com]
+toc: False
+---
+
+There are many reasons why it may be desirable to install Charmed Kubernetes
+on a system which does not have unfettered access to the internet. To make
+this possible, it is necessary to prepare the required resources, and configure
+Charmed Kubernetes to make use of them.
+
+As user needs may vary, this documentation does not present a prescriptive 
+recipe, but outlines the types of resources which are required and some 
+recommendations on how to provide them. If you are already installing 
+services in a restricted environment you may already have some 'air-gap'
+resources available, and may only need to configure Charmed Kubernetes to
+make use of them.
+
+<div class="p-notification--positive"><p markdown="1" class="p-notification__response">
+<span class="p-notification__status">Shrinkwrap</span>
+A simple tool for collecting the bundle and charm files, as well as automating some of 
+the work required to install offline is available. 
+The <a href="https://github.com/charmed-kubernetes/cdk-shrinkwrap"> shrinkwrap repository</a>
+contains the latest version and docs.
+</p></div>
+
+
+## APT package repository
+
+Access to a repository is required for installing software which is not yet available
+as snap packages, as well as receiving updates for the underlying operating system.
+In normal use this requires network access to  `http://archive.ubuntu.com/` or one
+of its localised mirrors.
+
+In order to access the APT package repository, it is common to set up a local
+mirror or allow traffic through a proxy to the main archive.
+
+There are many ways of setting up a local mirror. The repository is essentially just
+a directory of files and some means of serving them (http, ftp, etc). It is common to
+use tools such as **rsync**, **apt-mirror** or **aptly** to create the mirror.
+
+### Series and architectures
+
+Note that the mirror should contain packages for the required series (e.g. focal 
+(Ubuntu 20.04), bionic) and architectures (e.g. `amd64`, `i386`) expected to be used
+in the deployment. The core Charmed Kubernetes components all use the `focal` series,
+but some additional charms may be based on other series.
+
+### Setting up a proxy
+
+- Tutorial on setting up a mirror with Rsync from [ubuntu community docs][rsync].
+- Tutorial on setting up a mirror with apt-mirror from [HowtoForge][apt-mirror].
+- Using aptly to mirror APT repositories from the [aptly documentation][aptly].
+
+## Snap packages
+
+<div class="p-notification--positive"><p markdown="1" class="p-notification__response">
+<span class="p-notification__status">Snap resources</span>
+Many current charms include snaps as bundled resources. The inclusion of
+snaps as charm resources is deprecated, and these will be removed in future
+versions of these charms. Deployments will need to be able to access the
+official Snap Store or use the Snap Store Proxy to gain access to the required
+snaps.
+</p></div>
+
+The majority of charms, including all the core Charmed Kubernetes charms, rely on
+[snap][] packages to deliver applications. Snaps are packages for desktop, cloud and
+IoT that are easy to install, secure, cross‐platform and dependency‐free.
+
+The list of snaps required by Charmed Kubernetes is detailed in the "components"
+page for each release. For example, for 1.22, the
+[snaps are listed here][1.22-components].
+
+While it is _possible_ to download a snap package from the store, each snap will then
+need to be authenticated, and subsequent updates, even in the case of security
+updates, will require manual intervention. To avoid this, the recommended
+solution is to use the [Snap Store Proxy][] software.
+
+The Snap Store Proxy can also be configured to run in an "air-gap" mode, which
+disconnects it from the upstream store and allows snaps to be "sideloaded" into
+the local store. Information on how to do this is in the
+[Snap Store Proxy documentation][sideload].
+
+
+Note: Running the Snap Store Proxy also requires access to a PostgreSQL database,
+and an Ubuntu SSO account.
+
+## Juju 
+
+Since `Charmed Kubernetes` requires Juju, the Juju environment will also
+need to be deployed in an offline-mode. Details of how to install and run Juju
+are in the relevant section of the [Juju documentation][offline-mode].
+
+## Container images
+
+`Charmed Kubernetes` relies on container images for many of its components. To
+run an air-gap or offline installation, it will be necessary to make these
+images through Juju configuration or a Juju deployed registry.
+
+### Creating a private registry
+
+The registry is simply a store for managing and serving up the requested images.
+Many public clouds (Azure, AWS, Google etc) also have registry components which
+could be used, but for the small number of images required for Charmed Kubernetes
+it is sufficient to run a local repository using Docker.
+
+The recommended method is to use Juju to deploy a Docker registry and use that to
+serve the required images. See the [Docker registry documentation][registry] for more
+details.
+
+Note that if you wish to deploy the registry in the same Juju model (recommended) as
+Charmed Kubernetes, you should populate the registry with the images before
+deploying the rest of Charmed Kubernetes.
+
+### Fetching the required images
+
+A list of the required images for each supported release is made available as part of
+the Charmed Kubernetes bundle repository on github. You can inspect or download the
+lists from the [container images][] directory. 
+
+Using this list, it is possible to fetch the desired images locally on a system which
+has access to public repositories. The shrinkwrap tool also gathers all the necessary
+images for a specific release into one "containers" folder of the resulting tar.gz 
+ready for installation.
+
+When using the Juju docker-registry charm, the image archives can be copied to the running unit
+added to the registry. Note that if the `docker-registry` charm itself has been deployed offline,
+you will also need to fetch the registry image:
+
+```bash
+docker pull registry
+docker save registry | gzip > registry.tgz
+```
+
+The local image files can then be copied to the unit running the docker-registry and loaded:
+
+```bash
+juju scp *.tgz docker-registry/0:
+juju ssh docker-registry/0
+ls -1 *.tgz | xargs --no-run-if-empty -L 1 docker load -i
+rm -rf *.tgz
+exit
+```
+
+You can confirm the images are present by running the action:
+
+```bash
+juju run-action --wait docker-registry/0 images
+```
+
+## OS images
+
+Juju will require access to OS images to install on machines. This is usually handled
+by Juju in conjunction with the underlying cloud, and has no need of any user
+interaction. If you are using a private cloud which has not yet been configured for use
+with Juju or Ubuntu images, the following documentation may be useful.
+
+-  OpenStack image metadata [from Juju docs][simplestreams]
+-  Image metadata for MAAS [from the MAAS docs][maas-images]
+
+### LXD
+
+[LXD][] is a special case, as not only can Charmed Kubernetes be deployed entirely
+on LXD containers (See the [localhost documentation][local-install]), but LXD is also used in other
+clouds to co-locate applications on a single machine. In both cases, the OS images need
+to be fetched from somewhere. 
+
+This can be configured in various ways using LXD, either 
+by pre-caching image files or pointing to an accessible repository. This is covered
+in detail in the [LXD image documentation][LXD-image].
+
+## Python packages and PyPI
+
+**Charmed Kubernetes** base charms all come with the necessary pip wheels.
+Other charms (e.g. those used to monitor or provide metric data) may require
+additional packages which aren't bundled as wheels, and expect to install those
+dependencies from PyPI. Any charm attempting to do so, will need to handle pip installing
+from a different pypi-server using the `extra-index-url` argument and charm configuration.
+Check the documentation of any additional charms.
+
+## Livepatch Proxy
+
+The Linux Kernel supports realtime updates to the running kernel without restarting
+the existing kernel. In normal use this requires network access to pull the kernel
+patches and apply to the running kernel. However, with [On Prem Livepatch][on-prem-livepatch],
+patches can be published to a locally available livepatch hosting server.
+
+
+## Charmed Kubernetes 
+
+### Bundle and charms
+
+The specific bundle and charms which are required by those bundles must first be retrieved,
+then locally installed with Juju. The [bundles][], [overlays][], and charms to install
+can be retrieved using the [Shrinkwrap][cdk-shrinkwrap] tool.   
+
+from an internet connected machine:
+
+1. Download the installable bundles, charms, snaps, and containers using [Shrinkwrap][cdk-shrinkwrap]
+1. Pull the archive for the deployment
+
+```bash
+git clone https://github.com/charmed-kubernetes/cdk-shrinkwrap.git /tmp/.shrinkwrap
+cd /tmp/.shrinkwrap
+BUNDLE=cs:charmed-kubernetes-733       # Choose a deployment bundle (example is 1.21.x)
+./shrinkwrap-lxc.sh $BUNDLE 
+ls /tmp/.shrinkwrap/build/
+```
+
+In air-gapped environment with access to the Juju controller, 
+1. Extract the tar.gz file
+1. Print Available instructions from the deploy.sh
+   1. Push the snaps to the snap-store-proxy
+   1. Push the container images to your offline container registry
+1. Ensure the Juju environment is configured to pull from the snap-store-proxy and container registry
+   1. This will require configuration changes on the `containerd` application and `kubernetes-master` application in the `./bundle.yaml`
+   1. Ensure `applcations.containerd.options` includes `custom_registries` settings
+1. Finally, deploy the Juju charms and resources from the provided local bundle.
+```bash
+tar -xvf cs:charmed-kubernetes-733-stable-*.tar.gz --force-local
+cd cs:charmed-kubernetes-733-stable-*/
+./deploy.sh
+# examine provided instructions
+# ensure necessary modifications are considered
+juju deploy ...
+```
+
+
+### Configuring Charmed Kubernetes to work with proxies
+
+Whether you decide to proxy any or all of the above services, the only extra configuration required
+is for Juju to route the traffic to the relevant proxies. Proxy configuration for Charmed Kubernetes
+is covered in the [proxy documentation][].
+
+
+
+<!-- IMAGES -->
+
+
+
+<!-- LINKS -->
+[LXD-image]: https://linuxcontainers.org/lxd/docs/master/image-handling
+[maas-images]: https://maas.io/docs/snap/3.1/ui/using-image-streams
+[simplestreams]: https://juju.is/docs/olm/cloud-image-metadata
+[bundles]: /kubernetes/docs/supported-versions
+[containerd]: https://ubuntu.com/kubernetes/docs/1.21/charm-containerd
+[1.22-components]: https://ubuntu.com/kubernetes/docs/1.22/components#snaps
+[cdk-shrinkwrap]: https://github.com/charmed-kubernetes/cdk-shrinkwrap
+[controller-config]: https://juju.is/docs/olm/controllers
+[credentials]: https://juju.is/docs/olm/credentials
+[customize-bundle]: /kubernetes/docs/install-manual#customising-the-bundle-install
+[container images]: https://github.com/charmed-kubernetes/bundle/tree/master/container-images
+[juju-bundle]: https://juju.is/docs/sdk/bundles
+[juju-constraints]: https://juju.is/docs/olm/constraints
+[juju-docs]: https://juju.is/docs/olm/installing-juju
+[juju-gui]: https://juju.is/docs/olm/accessing-juju%E2%80%99s-web-interface
+[offline-mode]: https://juju.is/docs/t/offline-mode-strategies/1071
+[on-prem-livepatch]: https://ubuntu.com/security/livepatch/docs/on_prem
+[overlays]: /kubernetes/docs/install-manual#overlay
+[quickstart]: /kubernetes/docs/quickstart
+[snap]: https://snapcraft.io
+[snaps]: https://docs.snapcraft.io/snap-documentation
+[Snap Store Proxy]: https://docs.ubuntu.com/snap-store-proxy
+[rsync]: https://help.ubuntu.com/community/Rsyncmirror
+[apt-mirror]: https://www.howtoforge.com/local_debian_ubuntu_mirror
+[aptly]: https://www.aptly.info/doc/overview/
+[sideload]: https://docs.ubuntu.com/snap-store-proxy/en/airgap#usage
+[proxy documentation]: /kubernetes/docs/proxies
+[registry]: /kubernetes/docs/docker-registry
+[LXD]: https://linuxcontainers.org/lxd/introduction/
+[local-install]: /kubernetes/docs/install-local
+
+<!-- FEEDBACK -->
+<div class="p-notification--information">
+  <p class="p-notification__response">
+    We appreciate your feedback on the documentation. You can
+    <a href="https://github.com/charmed-kubernetes/kubernetes-docs/edit/master/pages/k8s/install-offline.md" class="p-notification__action">edit this page</a>
+    or
+    <a href="https://github.com/charmed-kubernetes/kubernetes-docs/issues/new" class="p-notification__action">file a bug here</a>.
+  </p>
+</div>

--- a/templates/kubernetes/docs/proxies.md
+++ b/templates/kubernetes/docs/proxies.md
@@ -8,7 +8,7 @@ context:
 keywords: oflline, proxy, configuration
 tags: [configure]
 sidebar: k8smain-sidebar
-permalink: proxy-settings.html
+permalink: proxies.html
 layout: [base, ubuntu-com]
 toc: False
 ---
@@ -24,7 +24,7 @@ configurations required for individual services or charms.
 
 A Juju model can define proxies for the resources Charmed Kubernetes will need:
 
-- A snap proxy, for installing software from snap packages
+- A snap proxy, for installing software from snap packages ([see below](#snap-store-proxy))
 - An apt proxy, for software installed via apt packages.
 - A Juju proxy, which exposes proxy settings to Juju itself, and to deployed
    charms.
@@ -74,9 +74,28 @@ The relevant options for setting proxies for Charmed Kubernetes are:
 For more extensive documentation on configuring proxies with Juju, please
 refer to the [Juju proxy documentation][]
 
+## Snap Store Proxy
+
+The majority of charms, including all the core Charmed Kubernetes charms, rely on
+[snap][] packages to deliver applications. Snaps are packages for desktop, cloud and
+IoT that are easy to install, secure, cross‐platform and dependency‐free.
+
+The list of snaps required by Charmed Kubernetes is detailed in the "components"
+page for each release. For example, for 1.22, the 
+[snaps are listed here][1.22-components].
+
+If your installation needs to proxy the connection to the Snap Store for any reason,
+the recommended solution is to use the [Snap Store Proxyy][] software. This can 
+also be configured for offline use (see the 
+[Charmed Kubernetes offline documentation][offline]).
+
 <!-- LINKS -->
 
 [Juju proxy documentation]: https://juju.is/docs/t/offline-mode-strategies/1071
+[1.22-components]: 1.22/components
+[offline]: install-offline
+[snap]: https://snapcraft.io
+[Snap Store Proxy]: https://docs.ubuntu.com/snap-store-proxy/en/
 
 <!-- FEEDBACK -->
 <div class="p-notification--information">

--- a/templates/kubernetes/docs/release-notes.md
+++ b/templates/kubernetes/docs/release-notes.md
@@ -13,6 +13,40 @@ layout: [base, ubuntu-com]
 toc: False
 ---
 
+# 1.22+ck1 Bugfix release
+
+### October 21, 2021 - [charmed-kubernetes-807](https://api.jujucharms.com/charmstore/v5/charmed-kubernetes-807/archive/bundle.yaml)
+
+## What's new
+
+- Configurable default PodSecurityPolicy
+
+A new `pod-security-policy` config option has been added to the
+kubernetes-master charm. This option allows you to override the default
+PodSecurityPolicy that is created by the charm.
+
+- Configurable Nvidia APT sources
+
+New config options have been added to the containerd charm:
+`nvidia_apt_key_urls`, `nvidia_apt_sources`, and `nvidia_apt_packages`. These
+provide better support for Nvidia GPUs in air gapped deployments by allowing
+you to specify where the Nvidia Container Runtime and CUDA packages are pulled
+from.
+
+- Better OpenStack credential handling
+
+The openstack-integrator charm now checks for updated cloud credentials from
+Juju every time its update-status hook runs, ensuring that cloud credentials
+are properly detected a short time after they change. To expedite this process,
+you can use the new openstack-integrator charm's new `refresh-credentials`
+action to force a recheck immediately.
+
+## Fixes
+
+A list of bug fixes and other minor feature updates in this release can be found at
+[the launchpad milestone page](https://launchpad.net/charmed-kubernetes/+milestone/1.22+ck1).
+
+
 # 1.22
 
 ### September 1, 2021 - [charmed-kubernetes-761](https://api.jujucharms.com/charmstore/v5/charmed-kubernetes-761/archive/bundle.yaml)

--- a/templates/kubernetes/docs/shared/_side-navigation.md
+++ b/templates/kubernetes/docs/shared/_side-navigation.md
@@ -12,6 +12,7 @@
 - [Quickstart](/kubernetes/docs/quickstart)
 - [Install](/kubernetes/docs/install-manual)
 - [Local install](/kubernetes/docs/install-local)
+- [Offline install](/kubernetes/docs/install-offline)
 
 ## Cloud Integration
 - [AWS integration](/kubernetes/docs/aws-integration)
@@ -51,7 +52,7 @@
 - [Security](/kubernetes/docs/security)
 - [Authentication with LDAP](/kubernetes/docs/ldap)
 - [Private Docker Registry](/kubernetes/docs/docker-registry)
-- [Configuring proxies](/kubernetes/docs/proxy-settings)
+- [Configuring proxies](/kubernetes/docs/proxies)
 - [Using GPU workers](/kubernetes/docs/gpu-workers)
 - [Audit Logging](/kubernetes/docs/audit-logging)
 - [Troubleshooting](/kubernetes/docs/troubleshooting)

--- a/templates/kubernetes/docs/supported-versions.md
+++ b/templates/kubernetes/docs/supported-versions.md
@@ -57,7 +57,7 @@ versions of the **Charmed Kubernetes** bundle are shown in the table below:
 
 | Kubernetes version | Charmed Kubernetes bundle |
 | --- | --- |
-| 1.22.x    | [charmed-kubernetes-761](https://api.jujucharms.com/charmstore/v5/charmed-kubernetes-761/archive/bundle.yaml) |
+| 1.22.x    | [charmed-kubernetes-807](https://api.jujucharms.com/charmstore/v5/charmed-kubernetes-807/archive/bundle.yaml) |
 | 1.21.x    | [charmed-kubernetes-733](https://api.jujucharms.com/charmstore/v5/charmed-kubernetes-733/archive/bundle.yaml) |
 | 1.20.x    | [charmed-kubernetes-596](https://api.jujucharms.com/charmstore/v5/charmed-kubernetes-596/archive/bundle.yaml) |
 | 1.19.x    | [charmed-kubernetes-545](https://api.jujucharms.com/charmstore/v5/charmed-kubernetes-545/archive/bundle.yaml) |


### PR DESCRIPTION
## Done

- Adds a page for offline install
-  Adds Ingress page
- Updates to the proxy page
- minor correction to etcd docs

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)


