### PR TITLE
Prevent invoices page to break on payment without invoice

### DIFF
--- a/webapp/advantage/views.py
+++ b/webapp/advantage/views.py
@@ -823,7 +823,7 @@ def invoices_view(**kwargs):
 
             total = None
             invoice = raw_payment.get("invoice")
-            status = invoice.get("status")
+            status = invoice.get("status") if invoice else "Missing"
             if invoice and invoice.get("total"):
                 cost = invoice.get("total") / 100
                 currency = invoice.get("currency")

--- a/webapp/advantage/views.py
+++ b/webapp/advantage/views.py
@@ -823,7 +823,7 @@ def invoices_view(**kwargs):
 
             total = None
             invoice = raw_payment.get("invoice")
-            status = invoice.get("status") if invoice else "Missing"
+            status = invoice.get("status") if invoice else "Pending"
             if invoice and invoice.get("total"):
                 cost = invoice.get("total") / 100
                 currency = invoice.get("currency")


### PR DESCRIPTION
## Done

- If for some reason the payment gets stuck with the status `started` and no invoice is attached to the payment, the /invoices breaks.

## QA

- Go to https://ubuntu-com-10748.demos.haus/account/invoices?test_backend=true&email=albert.kolozsvari@canonical.com
- Can you see the missing invoice?

## Issue / Card

Fixes #https://github.com/canonical-web-and-design/commercial-squad/issues/353