### PR TITLE
Update raspberry-pi page 

### DIFF
--- a/templates/download/raspberry-pi/index.html
+++ b/templates/download/raspberry-pi/index.html
@@ -22,7 +22,7 @@
         First time installing Ubuntu on Raspberry Pi?
       </p>
       <p>
-        Follow our <a href="/tutorials/how-to-install-ubuntu-desktop-on-raspberry-pi-4">desktop</a> or <a href="/tutorials/how-to-install-ubuntu-on-your-raspberry-pi">server</a> tutorials.
+        Follow our <a href="/tutorials/how-to-install-ubuntu-desktop-on-raspberry-pi-4">desktop</a>, <a href="/tutorials/how-to-install-ubuntu-on-your-raspberry-pi">server</a> and <a href="/download/raspberry-pi-core">core</a> tutorials.
       </p>
     </div>
     <div class="col-5 u-align--center u-hide--small">
@@ -36,6 +36,136 @@
         loading="auto"
         ) | safe
       }}
+    </div>
+  </div>
+</section>
+
+{# desktop latest #}
+<section class="p-strip--light {% if releases.latest.short_version < releases.lts.short_version %}is-bordered{% endif %}">
+  <div class="row">
+    <div class="col-6">
+      <h2 class="u-sv2">
+        Download Ubuntu Desktop
+      </h2>
+      <p class="p-muted-heading">
+        Recommended desktop
+      </p>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-6">
+      <h3>
+        Ubuntu Desktop {{ releases.latest.full_version }}
+      </h3>
+      <p>
+        The latest development release of Ubuntu with nine months of support, until {{ releases.latest.eol }}.
+      </p>
+      <p>
+        <a
+        class="p-button--positive"
+        href="/download/raspberry-pi/thank-you?version={{ releases.latest.full_version }}&amp;architecture=desktop-arm64+raspi"
+        onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'Raspberry Pi 64-bit - desktop', 'eventLabel' : '{{ releases.latest.short_version }}', 'eventValue' : undefined });">
+          Download 64-bit
+        </a>
+      </p>
+    </div>
+
+    <div class="col-6">
+      <h3>
+        Ubuntu Desktop {{ releases.lts.short_version }} LTS
+      </h3>
+      <p>
+        The latest development release of Ubuntu with nine months of support, until {{ releases.lts.eol }}.
+      </p>
+      <p>
+        <a class="p-button--positive" href="/download/raspberry-pi/thank-you?version={{ releases.lts.full_version }}&amp;architecture=server-arm64+raspi" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'Raspberry Pi 64-bit - server', 'eventLabel' : '{{ releases.lts.short_version }}', 'eventValue' : undefined });">
+          Download 64-bit
+        </a>
+      </p>
+    </div>
+  </div>
+
+  <div class="row u-hide--medium u-hide--large">
+    <div class="col-6">
+      <p>Works on:</p>
+      <ul class="p-list">
+        <li class="p-list__item is-ticked">Raspberry Pi 4 - <em>At least 4 GB RAM required.</em></li>
+        <li class="p-list__item is-ticked">Raspberry Pi 400</li>
+        <li class="p-list__item is-ticked">Raspberry Pi CM4 - <em>At least 4 GB RAM required.</em></li>
+      </ul>
+    </div>
+  </div>
+
+  <div class="u-fixed-width u-hide--small">
+    <h4>
+      Works on:
+    </h4>
+  </div>
+  <div class="row u-hide--small">
+    <div class="col-2">
+      <p class="u-no-padding--top" style="margin-bottom: .5rem;">
+        Raspberry Pi 4
+      </p>
+      <hr>
+      <div>
+        {{
+          image(
+          url="https://assets.ubuntu.com/v1/a999bb5f-Raspberry+Pi+4.png",
+          alt="",
+          height="48",
+          width="75",
+          hi_def=True,
+          attrs={"class": "u-align--left", "style": "margin-top: 1rem;"},
+          loading="auto"
+          ) | safe
+        }}
+      </div>
+      <h6 class="u-text-light">
+        <em>
+          * At least 4 GB RAM required
+        </em>
+      </h6>
+    </div>
+    <div class="col-2">
+      <p class="u-no-padding--top" style="margin-bottom: .5rem;">
+        Raspberry Pi 400
+      </p>
+      <hr>
+      <div>
+        {{ image (
+          url="https://assets.ubuntu.com/v1/cfdcd6c7-Raspberry-Pi-400-back--1536x1097.png",
+          alt="",
+          height="48",
+          width="93",
+          hi_def=True,
+          attrs={"class": "u-align--left", "style": "margin-top: 1rem;"},
+          loading="lazy"
+          ) | safe
+        }}
+      </div>      
+    </div>
+    <div class="col-2">
+      <p class="u-no-padding--top" style="margin-bottom: .5rem;">
+        Raspberry Pi CM4
+      </p>
+      <hr>
+      <div>
+        {{ image (
+          url="https://assets.ubuntu.com/v1/3be8f179-Raspberry-Pi-CM4.png",
+          alt="",
+          height="48",
+          width="68",
+          hi_def=True,
+          attrs={"class": "u-align--left", "style": "margin-top: 1rem;"},
+          loading="lazy"
+          ) | safe
+        }}
+      </div>
+      <h6 class="u-text-light">
+        <em>
+          * At least 4 GB RAM required
+        </em>
+      </h6>  
     </div>
   </div>
 </section>
@@ -94,12 +224,13 @@
   <div class="row u-hide--medium u-hide--large">
     <div class="col-6">
       <p>Works on:</p>
-      <ul class="p-list is-split">
+      <ul class="p-list">
         <li class="p-list__item is-ticked">Raspberry Pi 2 - <em>32-bit only</em></li>
         <li class="p-list__item is-ticked">Raspberry Pi 3</li>
         <li class="p-list__item is-ticked">Raspberry Pi 4</li>
         <li class="p-list__item is-ticked">Raspberry Pi 400</li>
         <li class="p-list__item is-ticked">Raspberry Pi CM4</li>
+        <li class="p-list__item is-ticked">Raspberry Pi Zero 2</li>
       </ul>
     </div>
   </div>
@@ -207,131 +338,208 @@
           ) | safe
         }}
       </div>
-    </div>
+    </div> 
+    <div class="col-2">
+      <p class="u-no-padding--top" style="margin-bottom: .5rem;">
+        Raspberry Pi Zero 2
+      </p>
+      <hr>
+      <div>
+        {{ image (
+          url="https://assets.ubuntu.com/v1/c9ded07a-Raspberry-Pi-Zero-2_7b29629e-7f4c-4869-8002-22cc6487aa20_400x.jpg",
+          alt="",
+          width="60",
+          height="60",
+          hi_def=True,
+          loading="lazy"
+          ) | safe
+        }}
+      </div>
+    <div> 
   </div>
 </section>
 
-
-{# desktop latest #}
-<section class="p-strip">
-  <div class="u-fixed-width">
-    <h2>
-      Download Ubuntu Desktop
-    </h2>
+{# core #}
+<section class="p-strip--light {% if releases.latest.short_version < releases.lts.short_version %}is-bordered{% endif %}">
+  <div class="row">
+    <div class="col-6">
+      <h2 class="u-sv2">
+        Download Ubuntu Core
+      </h2>
+      <p class="p-muted-heading">
+        Recommended core
+      </p>
+    </div>
   </div>
   <div class="row">
     <div class="col-6">
       <h3>
-        Ubuntu Desktop {{ releases.latest.full_version }}
+        Ubuntu Core 20 arm64
       </h3>
       <p>
-        The latest development release of Ubuntu with nine months of support, until {{ releases.latest.eol }}.
+        Ubuntu Core 20 comes with 10 years of support, until 2030.
       </p>
       <p>
-        <a
-        class="p-button--positive"
-        href="/download/raspberry-pi/thank-you?version={{ releases.latest.full_version }}&amp;architecture=desktop-arm64+raspi"
-        onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'Raspberry Pi 64-bit - desktop', 'eventLabel' : '{{ releases.latest.short_version }}', 'eventValue' : undefined });">
-        Download 64-bit
-      </a>
-    </p>
-    <div class="u-hide--medium u-hide--large">
+        <a class="p-button--positive p-link--external" href="https://cdimage.ubuntu.com/ubuntu-core/20/stable/current/ubuntu-core-20-arm64+raspi.img.xz " onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'Raspberry Pi 64-bit - core', 'eventLabel' : '20 arm64', 'eventValue' : undefined });">
+          Download 64-bit
+        </a>
+        <a class="p-button" href=" https://cdimage.ubuntu.com/ubuntu-core/20/stable/current/ubuntu-core-20-armhf+raspi.img.xz" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'Raspberry Pi 32-bit - server', 'eventLabel' : '20 armhf', 'eventValue' : undefined });">
+          Download 32-bit
+        </a>
+      </p>
+    </div>
+  </div>
+
+  <div class="row u-hide--medium u-hide--large">
+    <div class="col-6">
       <p>Works on:</p>
-      <ul class="p-list is-split">
+      <ul class="p-list">
+        <li class="p-list__item is-ticked">Raspberry Pi 2 - <em>32-bit only</em></li>
+        <li class="p-list__item is-ticked">Raspberry Pi 3</li>
         <li class="p-list__item is-ticked">Raspberry Pi 4</li>
         <li class="p-list__item is-ticked">Raspberry Pi 400</li>
         <li class="p-list__item is-ticked">Raspberry Pi CM4</li>
+        <li class="p-list__item is-ticked">Raspberry Pi Zero 2</li>
       </ul>
     </div>
   </div>
-</div>
 
-<div class="u-fixed-width u-hide--small">
-  <h4>
-    Works on:
-  </h4>
-</div>
-<div class="row u-hide--small">
-  <div class="col-2">
-    <p class="u-no-padding--top" style="margin-bottom: .5rem;">
-      Raspberry Pi 4
-    </p>
-    <hr>
-    <div>
-      {{
-        image(
-        url="https://assets.ubuntu.com/v1/a999bb5f-Raspberry+Pi+4.png",
-        alt="",
-        height="48",
-        width="75",
-        hi_def=True,
-        attrs={"class": "u-align--left", "style": "margin-top: 1rem;"},
-        loading="auto"
-        ) | safe
-      }}
-    </div>
-    <h6 class="u-text-light">
-      <em>
-        * At least 4 GB RAM required
-      </em>
-    </h6>
+  <div class="u-fixed-width u-hide--small">
+    <h4>
+      Works on:
+    </h4>
   </div>
-  <div class="col-2">
-    <p class="u-no-padding--top" style="margin-bottom: .5rem;">
-      Raspberry Pi 400
-    </p>
-    <hr>
-    <div>
-      {{ image (
-        url="https://assets.ubuntu.com/v1/cfdcd6c7-Raspberry-Pi-400-back--1536x1097.png",
-        alt="",
-        height="48",
-        width="93",
-        hi_def=True,
-        attrs={"class": "u-align--left", "style": "margin-top: 1rem;"},
-        loading="lazy"
-        ) | safe
-      }}
+  <div class="row u-hide--small">
+    <div class="col-2">
+      <p class="u-no-padding--top" style="margin-bottom: .5rem;">
+        Raspberry Pi 2
+      </p>
+      <hr>
+      <div>
+        {{
+          image(
+          url="https://assets.ubuntu.com/v1/8542c958-Raspberry+Pi+2.png",
+          alt="",
+          height="48",
+          width="72",
+          hi_def=True,
+          attrs={"class": "u-align--left", "style": "margin-top: 1rem;"},
+          loading="auto"
+          ) | safe
+        }}
+      </div>
+      <h6 class="u-text-light">
+        <em>
+          * 32-bit only
+        </em>
+      </h6>
     </div>
-  </div>
-  <div class="col-2">
-    <p class="u-no-padding--top" style="margin-bottom: .5rem;">
-      Raspberry Pi CM4
-    </p>
-    <hr>
-    <div>
-      {{ image (
-        url="https://assets.ubuntu.com/v1/3be8f179-Raspberry-Pi-CM4.png",
-        alt="",
-        height="48",
-        width="68",
-        hi_def=True,
-        attrs={"class": "u-align--left", "style": "margin-top: 1rem;"},
-        loading="lazy"
-        ) | safe
-      }}
+    <div class="col-2">
+      <p class="u-no-padding--top" style="margin-bottom: .5rem;">
+        Raspberry Pi 3
+      </p>
+      <hr>
+      <div>
+        {{
+          image(
+          url="https://assets.ubuntu.com/v1/c4a007b6-Raspberry+Pi+3.png",
+          alt="",
+          height="48",
+          width="75",
+          hi_def=True,
+          attrs={"class": "u-align--left", "style": "margin-top: 1rem;"},
+          loading="auto"
+          ) | safe
+        }}
+      </div>
     </div>
-    <h6 class="u-text-light">
-      <em>
-        * At least 4 GB RAM required
-      </em>
-    </h6>
+    <div class="col-2">
+      <p class="u-no-padding--top" style="margin-bottom: .5rem;">
+        Raspberry Pi 4
+      </p>
+      <hr>
+      <div>
+        {{
+          image(
+          url="https://assets.ubuntu.com/v1/a999bb5f-Raspberry+Pi+4.png",
+          alt="",
+          height="48",
+          width="75",
+          hi_def=True,
+          attrs={"class": "u-align--left", "style": "margin-top: 1rem;"},
+          loading="auto"
+          ) | safe
+        }}
+      </div>
+    </div>
+    <div class="col-2">
+      <p class="u-no-padding--top" style="margin-bottom: .5rem;">
+        Raspberry Pi 400
+      </p>
+      <hr>
+      <div>
+        {{ image (
+          url="https://assets.ubuntu.com/v1/cfdcd6c7-Raspberry-Pi-400-back--1536x1097.png",
+          alt="",
+          height="48",
+          width="93",
+          hi_def=True,
+          attrs={"class": "u-align--left", "style": "margin-top: 1rem;"},
+          loading="lazy"
+          ) | safe
+        }}
+      </div>
+    </div>
+    <div class="col-2">
+      <p class="u-no-padding--top" style="margin-bottom: .5rem;">
+        Raspberry Pi CM4
+      </p>
+      <hr>
+      <div>
+        {{ image (
+          url="https://assets.ubuntu.com/v1/3be8f179-Raspberry-Pi-CM4.png",
+          alt="",
+          height="48",
+          width="68",
+          hi_def=True,
+          attrs={"class": "u-align--left", "style": "margin-top: 1rem;"},
+          loading="lazy"
+          ) | safe
+        }}
+      </div>
+    </div> 
+    <div class="col-2">
+      <p class="u-no-padding--top" style="margin-bottom: .5rem;">
+        Raspberry Pi Zero 2
+      </p>
+      <hr>
+      <div>
+        {{ image (
+          url="https://assets.ubuntu.com/v1/c9ded07a-Raspberry-Pi-Zero-2_7b29629e-7f4c-4869-8002-22cc6487aa20_400x.jpg",
+          alt="",
+          width="60",
+          height="60",
+          hi_def=True,
+          loading="lazy"
+          ) | safe
+        }}
+      </div>
+    <div> 
   </div>
-</div>
 </section>
 
 <section class="p-strip--light">
   <div class="row">
     <div class="col-6">
-      <h2>Which image should I pick?</h2>
+      <h3>Which image should I pick?</h3>
       <p>If you are wondering which download to pick, here are a few pointers on the options.</p>
     </div>
   </div>
   <div class="row u-equal-height">
     <div class="col-6 p-card">
-      <h3>Desktop vs Server</h3>
+      <h3><a href="/desktop">Ubuntu Desktop</a></h3>
       <hr class="u-sv1">
-      <p>The full Ubuntu Desktop image is large but it contains everything you need to turn a Raspberry Pi into your main PC. Surf the web, watch videos, write some documents, do some shopping &mdash; whatever you like. However, because of its size it only works on the Raspberry Pi 4 models with 4GB or 8GB of RAM. The Ubuntu Server image is much smaller, you can install flavours of the Ubuntu Desktop on top of it, it gives you access to the Ubuntu CLI and by extension, all of the latest open source. Ubuntu Server works on the Raspberry Pi 2, 3 and 4.</p>
+      <p>The full Ubuntu Desktop image contains everything you need to turn a Raspberry Pi into your main PC, from surfing the web and writing documents to developing software. Because of its size, it only works on the Raspberry Pi 4 models with 4GB or 8GB of RAM.</p>
     </div>
     <div class="col-6 p-card">
       <h3>32 bit vs 64 bit</h3>

--- a/templates/download/raspberry-pi/index.html
+++ b/templates/download/raspberry-pi/index.html
@@ -546,6 +546,16 @@
       <hr class="u-sv1">
       <p>The Raspberry Pi 2 only supports 32 bits, so that's an easy choice. However the Raspberry Pi 3 and 4 are 64 bit boards. According to the Raspberry Pi foundation, there are limited benefits to using the 64 bit version for the Pi 3 due to the fact that it only supports 1GB of memory; however, with the Pi 4, the 64 bit version should be faster.</p>
     </div>
+        <div class="col-6 p-card">
+      <h3><a href="/server">Ubuntu Server</a></h3>
+      <hr class="u-sv1">
+      <p>The Ubuntu Server image is much smaller than the Desktop version, although you can install flavours of the Ubuntu Desktop on top of it. It gives you access to the Ubuntu CLI and by extension, all of the latest open source. Ubuntu Server works on the Raspberry Pi 2, 3 and 4. </p>
+    </div>
+    <div class="col-6 p-card">
+      <h3><a href="/core">Ubuntu Core</a></h3>
+      <hr class="u-sv1">
+      <p>Ubuntu Core is a leaner, containerised operating system built on snaps, our universal packaging format. It supports Secure Boot and Full Disk Encryption for added security as well as OTA updates. Develop your IoT software on your Ubuntu Desktop and deploy it to an Ubuntu Core device with ease, even at scale.</p>
+    </div>
   </div>
 </section>
 

--- a/templates/download/raspberry-pi/index.html
+++ b/templates/download/raspberry-pi/index.html
@@ -346,10 +346,10 @@
       <hr>
       <div>
         {{ image (
-          url="https://assets.ubuntu.com/v1/c9ded07a-Raspberry-Pi-Zero-2_7b29629e-7f4c-4869-8002-22cc6487aa20_400x.jpg",
+          url="https://assets.ubuntu.com/v1/a79a3cee-raspberry-pi-z-2.png",
           alt="",
-          width="60",
-          height="60",
+          width="70",
+          height="46",
           hi_def=True,
           loading="lazy"
           ) | safe
@@ -515,10 +515,10 @@
       <hr>
       <div>
         {{ image (
-          url="https://assets.ubuntu.com/v1/c9ded07a-Raspberry-Pi-Zero-2_7b29629e-7f4c-4869-8002-22cc6487aa20_400x.jpg",
+          url="https://assets.ubuntu.com/v1/a79a3cee-raspberry-pi-z-2.png",
           alt="",
-          width="60",
-          height="60",
+          width="70",
+          height="46",
           hi_def=True,
           loading="lazy"
           ) | safe

--- a/templates/download/raspberry-pi/index.html
+++ b/templates/download/raspberry-pi/index.html
@@ -230,7 +230,7 @@
         <li class="p-list__item is-ticked">Raspberry Pi 4</li>
         <li class="p-list__item is-ticked">Raspberry Pi 400</li>
         <li class="p-list__item is-ticked">Raspberry Pi CM4</li>
-        <li class="p-list__item is-ticked">Raspberry Pi Zero 2</li>
+        <li class="p-list__item is-ticked">Raspberry Pi Zero 2 - <em>32-bit only</em></li>
       </ul>
     </div>
   </div>
@@ -355,6 +355,11 @@
           ) | safe
         }}
       </div>
+      <h6 class="u-text-light">
+        <em>
+          * 32-bit only
+        </em>
+      </h6>
     <div> 
   </div>
 </section>
@@ -399,7 +404,7 @@
         <li class="p-list__item is-ticked">Raspberry Pi 4</li>
         <li class="p-list__item is-ticked">Raspberry Pi 400</li>
         <li class="p-list__item is-ticked">Raspberry Pi CM4</li>
-        <li class="p-list__item is-ticked">Raspberry Pi Zero 2</li>
+        <li class="p-list__item is-ticked">Raspberry Pi Zero 2 - <em>32-bit only</em></li>
       </ul>
     </div>
   </div>
@@ -524,6 +529,11 @@
           ) | safe
         }}
       </div>
+      <h6 class="u-text-light">
+        <em>
+          * 32-bit only
+        </em>
+      </h6>      
     <div> 
   </div>
 </section>
@@ -545,6 +555,7 @@
       <h3>32 bit vs 64 bit</h3>
       <hr class="u-sv1">
       <p>The Raspberry Pi 2 only supports 32 bits, so that's an easy choice. However the Raspberry Pi 3 and 4 are 64 bit boards. According to the Raspberry Pi foundation, there are limited benefits to using the 64 bit version for the Pi 3 due to the fact that it only supports 1GB of memory; however, with the Pi 4, the 64 bit version should be faster.</p>
+      <p><strong>Note:</strong> Raspberry Pi Zero 2 supports both 32 bit and 64 bit images. Currently only 32 bit images work out of the box, however you can also use 64 bit images with a workaround detailed <a href="/blog/raspberry-pi-zero-2-w-with-ubuntu-server-support-is-here">here</a>.</p>
     </div>
         <div class="col-6 p-card">
       <h3><a href="/server">Ubuntu Server</a></h3>

--- a/templates/download/raspberry-pi/thank-you.html
+++ b/templates/download/raspberry-pi/thank-you.html
@@ -13,12 +13,13 @@
 {% block content %}
 
 {% if version %}
-<meta http-equiv="refresh" content="3;url=https://cdimage.ubuntu.com/releases/{{ version }}/release/ubuntu-{{ version }}-preinstalled-{{ architecture }}.img.xz">
+  <meta http-equiv="refresh" content="3;url=https://cdimage.ubuntu.com/releases/{{ version }}/release/ubuntu-{{ version }}-preinstalled-{{ architecture }}.img.xz">
 {% endif %}
 
 <section class="p-strip--suru-topped" style="overflow: visible;">
   <div class="row u-vertically-center">
     <div class="col-7">
+    <h1>{{ version }}</h1>
       {% if version %}
       <h1>Thank you for downloading<br />
         Ubuntu {{ version }}<br />


### PR DESCRIPTION
## Done

- Updates /raspberry-pi as per [copydoc](https://docs.google.com/document/d/1KgnSBa8mbR7qwlxxtqbE5a1wXh5GjtVums8TIB7IGVw/edit#heading=h.pcvvnawhd192)


## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: https://ubuntu-com-10754.demos.haus/download/raspberry-pi
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Compare against copydoc


## Issue / Card

Fixes https://github.com/canonical-web-and-design/ubuntu.com/issues/9722
