### PR TITLE
Update copy on raspberry-pi-core

### DIFF
--- a/templates/download/raspberry-pi-core.html
+++ b/templates/download/raspberry-pi-core.html
@@ -1,6 +1,8 @@
 {% extends "download/_base_download.html" %}
 
 {% block title %}Install Ubuntu Core on a Raspberry Pi{% endblock %}}
+
+{% block meta_description %}Ubuntu is an open-source operating system for cross platform development, there’s no better place to get started than with Ubuntu on a Raspberry Pi{% endblock meta_description %}
 {% block meta_copydoc %}https://docs.google.com/document/d/1Ig906jbgB39QHw61uHMvIsRbSBUjchJBDkMZl0WzlWM/edit{% endblock meta_copydoc %}
 
 {% block content %}

--- a/templates/download/raspberry-pi-core.html
+++ b/templates/download/raspberry-pi-core.html
@@ -15,7 +15,7 @@
       <div class="u-equal-height row p-divider">
         <div class="col-6 p-divider__block">
           <h2>Install Ubuntu Core</h2>
-          <p>We will walk you through the steps of flashing Ubuntu Core on a Raspberry Pi 2, 3, 4 or CM3. At the end of this process, you will have a board ready for production or testing snaps.</p>
+          <p>We will walk you through the steps of flashing Ubuntu Core on a Raspberry Pi 2, 3, 4 or CM4. At the end of this process, you will have a board ready for production or testing snaps.</p>
         </div>
         <div class="col-6 p-divider__block">
           <h3>Minimum requirements</h3>
@@ -44,7 +44,7 @@
           Download Ubuntu Core
         </h3>
         <div class="p-stepped-list__content">
-          <p>Download <a class="p-link--external" href="https://cdimage.ubuntu.com/ubuntu-core/20/stable/current/ubuntu-core-20-armhf+raspi.img.xz">Ubuntu Core 20 image for Raspberry Pi</a>.</p>
+          <p>Download <a class="p-link--external" href="https://ubuntu.com/download/raspberry-pi">Ubuntu Core 20 image for Raspberry Pi</a>.</p>
           <p>You can verify the integrity of the files using the <a class="p-link--external" href="https://cdimage.ubuntu.com/ubuntu-core/20/stable/current/SHA256SUMS">SHA256SUM</a> and <a class="p-link--external" href="https://cdimage.ubuntu.com/ubuntu-core/20/stable/current/SHA256SUMS.gpg">SHA256SUM.gpg</a> files.</p>
         </div>
       </li>


### PR DESCRIPTION
## Done

- Updates copy on raspberry-pi-core as per [copydoc](https://docs.google.com/document/d/1Ig906jbgB39QHw61uHMvIsRbSBUjchJBDkMZl0WzlWM/edit#)

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Compare against copydoc


## Issue / Card

Fixes https://github.com/canonical-web-and-design/ubuntu.com/issues/10710
