### PR TITLE
Build what-are-containers

### DIFF
--- a/navigation.yaml
+++ b/navigation.yaml
@@ -331,6 +331,8 @@ kubernetes:
       path: /kubernetes
     - title: What is Kubernetes
       path: /kubernetes/what-is-kubernetes
+    - title: What are containers
+      path: /kubernetes/what-are-containers
     - title: Features
       path: /kubernetes/features
     - title: Managed

--- a/navigation.yaml
+++ b/navigation.yaml
@@ -292,6 +292,8 @@ containers:
   children:
     - title: Overview
       path: /containers
+    - title: What are containers
+      path: /containers/what-are-containers
     - title: Contact us
       path: /containers/contact-us
       hidden: True
@@ -331,8 +333,6 @@ kubernetes:
       path: /kubernetes
     - title: What is Kubernetes
       path: /kubernetes/what-is-kubernetes
-    - title: What are containers
-      path: /kubernetes/what-are-containers
     - title: Features
       path: /kubernetes/features
     - title: Managed

--- a/templates/containers/what-are-containers.html
+++ b/templates/containers/what-are-containers.html
@@ -1,10 +1,10 @@
-{% extends "kubernetes/base_kubernetes.html" %}
+{% extends "containers/base_containers.html" %}
 
 {% block title %}What are containers{% endblock %}
 
 {% block meta_description %}What are containers and how do containers enable fast-moving modern software, from the cloud to the edge? Learn how to use Ubuntu from the host kernel to container images running cloud applications to get a stable, secure, and consistent developer experience with Docker, Kubernetes, and LXD.{% endblock meta_description %}
 
-{% block meta_image %}{% endblock meta_image%}
+{% block meta_image %}https://assets.ubuntu.com/v1/fece8a11-container-in-the-cloud.svg{% endblock meta_image%}
 
 {% block meta_copydoc %}https://docs.google.com/document/d/1hStuIzY8dDdFEW4Q0TwboOx0_-SB5klk8zRuNIn3V4o/edit#{% endblock meta_copydoc %}
 
@@ -18,14 +18,13 @@
         <p>Containers are a virtualisation technology that isolates each process in a lightweight and standard environment. They allow users to package and quickly deploy entire applications parallel to each other on the same kernel and hardware, while maintaining isolation among the workloads.</p>
       </div>
       <div class="col-5 u-align--center u-vertically-center">
-        {{
-          image(
-          url="https://assets.ubuntu.com/v1/767f38a4-kubernetes-stacked-color.svg",
+        {{ image (
+          url="https://assets.ubuntu.com/v1/fece8a11-container-in-the-cloud.svg",
           alt="",
-          width="250",
-          height="195",
+          width="200",
+          height="163",
           hi_def=True,
-          loading="auto",
+          loading="auto"
           ) | safe
         }}
       </div>

--- a/templates/containers/what-are-containers.html
+++ b/templates/containers/what-are-containers.html
@@ -16,7 +16,7 @@
         <h1>What are containers?</h1>
         <p>Containers are a virtualisation technology that isolates each process in a lightweight and standard environment. They allow users to package and quickly deploy entire applications parallel to each other on the same kernel and hardware, while maintaining isolation among the workloads.</p>
       </div>
-      <div class="col-5 u-align--center u-vertically-center">
+      <div class="col-5 u-align--center u-vertically-center u-hide--small">
         {{ image (
           url="https://assets.ubuntu.com/v1/fece8a11-container-in-the-cloud.svg",
           alt="",
@@ -30,7 +30,7 @@
     </div>
 </section>
 
-<section class="p-strip">
+<section class="p-strip--light">
   <div class="u-fixed-width">
     <h2>Container virtualization</h2>
     <p>Containers are instantiated from container images, a layered packaging system, to distribute applications along with their configuration and runtime dependencies.</p>
@@ -39,28 +39,35 @@
   </div>
 </section>
 
-<section class="p-strip--light">
+<section class="p-strip">
   <div class="u-fixed-width">
     <h2>What is Docker?</h2>
-    <p><a href="https://www.docker.com/" class="p-link--external">Docker</a> is an open-source containerisation platform. It provides an easy way to build and deploy containers on the cloud or on-premises. Container technologies were not introduced by Docker, but they made the user experience of container technologies so easy for developers that Docker soon became shorthand for containers as well as the most popular container format. <a href="https://www.docker.com/" class="p-link--external">Docker Inc</a>, the company that supports the Docker project and community, also operates <a href="https://hub.docker.com/" class="p-link--external">Docker Hub</a>, a space for hosting container images.</p>
+    <p><a href="https://www.docker.com/" class="p-link--external">Docker</a>  is an open-source containerisation platform. It provides an easy way to build and deploy containers in the cloud or on-premises. Docker didn’t introduce container technologies, but they made the user experience of container technologies so easy for developers that Docker soon became shorthand for containers and the most popular container format. <a href="https://www.docker.com/" class="p-link--external">Docker Inc</a>, the company that supports the Docker project and community, also operates <a href="https://hub.docker.com/" class="p-link--external">Docker Hub</a>, a space for hosting container images.</p>
+  </div>
+</section>
+
+<section class="p-strip--light">
+  <div class="u-fixed-width">
+    <h2>Docker for beginners: docker-cli, containerd, and runc</h2>
+    <p>Docker is many things: a community, a company, and multiple software projects. The so-called “Docker developer experience” uses three projects: <a href="https://github.com/docker/cli" class="p-link--external">docker-cli</a>, <a href="https://containerd.io/" class="p-link--external">containerd</a>, and <a href="https://github.com/opencontainers/runc" class="p-link--external">runc</a>. The Docker command-line mostly interfaces with the containerd daemon to provide a great end-user experience. Containerd manages and supervises containers, images, storage, and networking. Finally, runc is the container runtime. It consists of all the code used to interact with container system features (think user namespaces, cgroups, and so on).</p>
   </div>
 </section>
 
 <section class="p-strip ">
   <div class="u-fixed-width">
     <h2>Kubernetes vs Docker: CRI-O and OCI</h2>
-    <p>With more and more applications deployed on containers, simple orchestration tools are not enough to support complex production environments. ‘<a href="/kubernetes/what-is-kubernetes#container-orchestration">Container orchestration</a>’ becomes a problem space of its own. The rise of <a href="/kubernetes">Kubernetes</a> is the industry's answer to the container orchestration problem, providing a way to manage containers at scale efficiently.</p>
+    <p>With more and more applications deployed on containers, simple orchestration tools are not enough to support complex production environments. '<a href="/kubernetes/what-is-kubernetes#container-orchestration">Container orchestration</a>'' becomes a problem space of its own. The rise of <a href="/kubernetes">Kubernetes</a> is the industry's answer to the container orchestration problem, providing a way to manage containers at scale efficiently.</p>
     <p>CRI (Container Runtime Interface) is a Kubernetes API to interface between Kubernetes orchestration features and container runtimes, such as containerd or CRI-O. The <a href="https://opencontainers.org/" class="p-link--external">Open Container Initiative</a> (OCI) defines a set of specifications to enable all these technologies to work together. Docker, runc, containerd, CRI-O are all OCI compatible.</p>
   </div>
 </section>
 
 <section class="p-strip--light">
   <div class="row">
-    <div class="col-6">
-      <p>Not clear on how Kubernetes vs Docker differ?</p>
-      <p><a href="/blog/kubernetes-versus-docker">Read the Kubernetes vs Docker blog&nbsp;&rsaquo;</a></p>
+    <div class="col-7">
+      <p>Not clear on how Kubernetes vs Docker differ?
+      <br><a href="/blog/kubernetes-versus-docker">Read the Kubernetes vs Docker blog&nbsp;&rsaquo;</a></p>
     </div>
-    <div class="col-6 u-align--center u-vertically-center">
+    <div class="col-5 u-align--center u-vertically-center u-hide--small">
       {{ image (
         url="https://assets.ubuntu.com/v1/cd384737-Kubernetes+v+Docker.svg",
         alt="",
@@ -79,10 +86,10 @@
   <div class="p-strip--suru-topped">
     <div class="row u-equal-height">
       <div class="col-7 u-vertically-center">
-        <p>Choosing the right Kubernetes distribution is crucial for your business.</p>
-        <p><a href="/engage/enterprise-kubernetes-comparison">Read the Kubernetes distribution comparison whitepaper&nbsp;&rsaquo;</a></p>
+        <p>Choosing the right Kubernetes distribution is crucial for your business.
+        <br><a href="/engage/enterprise-kubernetes-comparison">Read the Kubernetes distribution comparison whitepaper&nbsp;&rsaquo;</a></p>
       </div>
-      <div class="col-5 u-align--center u-vertically-center">
+      <div class="col-5 u-align--center u-vertically-center u-hide--small">
         {{ image (
           url="https://assets.ubuntu.com/v1/198b738b-Compare_Kubernetes-Openshift-Rancher.svg",
           alt="",
@@ -137,7 +144,7 @@
       <p>Canonical publishes a portfolio of base, runtime, and application images with an up to 10-year maintenance commitment. In collaboration with Docker, this content is publicly available on Docker Hub.</p>
       <p><a href="/security/docker-images">Secure your software supply chain with LTS Docker Images&nbsp;&rsaquo;</a></p>
     </div>
-    <div class="col-4 u-vertically-center u-align--center">
+    <div class="col-4 u-vertically-center u-align--center u-hide--small">
       {{ image (
         url="https://assets.ubuntu.com/v1/25c42877-simplified-software-management-2.svg",
         alt="",

--- a/templates/containers/what-are-containers.html
+++ b/templates/containers/what-are-containers.html
@@ -10,8 +10,7 @@
 
 {% block content %}
 
-<section class="p-strip u-no-padding--top u-no-padding--bottom is-bordered">
-  <div class="p-strip--suru-topped">
+<section class="p-strip--suru-bottomed">
     <div class="row u-equal-height">
       <div class="col-7">
         <h1>What are containers?</h1>
@@ -29,7 +28,6 @@
         }}
       </div>
     </div>
-  </div>
 </section>
 
 <section class="p-strip">
@@ -63,10 +61,10 @@
     </div>
     <div class="col-6 u-align--center u-vertically-center">
       {{ image (
-        url="https://assets.ubuntu.com/v1/ee9b80f7-Kubernetes+v+Docker.png",
+        url="https://assets.ubuntu.com/v1/cd384737-Kubernetes+v+Docker.svg",
         alt="",
-        width="200",
-        height="72",
+        width="300",
+        height="105",
         hi_def=True,
         loading="lazy"
         ) | safe
@@ -82,17 +80,18 @@
 </section>
 
 <section class="p-strip u-no-padding--top u-no-padding--bottom">
-  <div class="p-strip--suru-half-and-half">
+  <div class="p-strip--suru-topped">
     <div class="row u-equal-height">
-      <div class="col-7">
-        <p class="p-card__content">Choosing the right Kubernetes distribution is crucial for your business. <a href="/engage/enterprise-kubernetes-comparison">Read the Kubernetes distribution comparison whitepaper&nbsp;&rsaquo;</a></p>
+      <div class="col-7 u-vertically-center">
+        <p>Choosing the right Kubernetes distribution is crucial for your business.</p>
+        <p><a href="/engage/enterprise-kubernetes-comparison">Read the Kubernetes distribution comparison whitepaper&nbsp;&rsaquo;</a></p>
       </div>
       <div class="col-5 u-align--center u-vertically-center">
         {{ image (
-          url="https://assets.ubuntu.com/v1/4bf1d333-Compare_Kubernetes-Openshift-Rancher-WHT.svg",
+          url="https://assets.ubuntu.com/v1/198b738b-Compare_Kubernetes-Openshift-Rancher.svg",
           alt="",
-          width="200",
-          height="125",
+          width="240",
+          height="150",
           hi_def=True,
           loading="lazy"
           ) | safe

--- a/templates/containers/what-are-containers.html
+++ b/templates/containers/what-are-containers.html
@@ -48,16 +48,56 @@
   </div>
 </section>
 
-<section class="p-strip">
+<section class="p-strip ">
   <div class="u-fixed-width">
     <h2>Kubernetes vs Docker: CRI-O and OCI</h2>
-    <p>With more and more applications deployed on containers, simple orchestration tools provided by Docker are not enough to support complex production environments. ‘<a href="/kubernetes/what-is-kubernetes#container-orchestration">Container orchestration</a>’ becomes a problem space of its own. The rise of <a href="/kubernetes">Kubernetes</a> is the industry's answer to the container orchestration problem, providing a way to manage containers at scale efficiently.</p>
-    <div class="p-card">
-      <p class="p-card__content">Not clear on how Kubernetes vs Docker differ? <a href="/blog/kubernetes-versus-docker">Read the Kubernetes vs Docker blog&nbsp;&rsaquo;</a></p>
+    <p>With more and more applications deployed on containers, simple orchestration tools are not enough to support complex production environments. ‘<a href="/kubernetes/what-is-kubernetes#container-orchestration">Container orchestration</a>’ becomes a problem space of its own. The rise of <a href="/kubernetes">Kubernetes</a> is the industry's answer to the container orchestration problem, providing a way to manage containers at scale efficiently.</p>
+  </div>
+</section>
+
+<section class="p-strip--light">
+  <div class="row">
+    <div class="col-6">
+      <p>Not clear on how Kubernetes vs Docker differ?</p>
+      <p><a href="/blog/kubernetes-versus-docker">Read the Kubernetes vs Docker blog&nbsp;&rsaquo;</a></p>
     </div>
+    <div class="col-6 u-align--center u-vertically-center">
+      {{ image (
+        url="https://assets.ubuntu.com/v1/ee9b80f7-Kubernetes+v+Docker.png",
+        alt="",
+        width="200",
+        height="72",
+        hi_def=True,
+        loading="lazy"
+        ) | safe
+      }}
+    </div>
+  </div>
+</section>
+
+<section class="p-strip">
+  <div class="u-fixed-width">
     <p>CRI (Container Runtime Interface) is a Kubernetes API to interface between Kubernetes orchestration features and container runtimes, such as containerd or CRI-O. The <a href="https://opencontainers.org/" class="p-link--external">Open Container Initiative</a> (OCI) defines a set of specifications to enable all these technologies to work together. Docker, runc, containerd, CRI-O are all OCI compatible.</p>
-    <div class="p-card">
-      <p class="p-card__content">Choosing the right Kubernetes distribution is crucial for your business. <a href="/engage/enterprise-kubernetes-comparison">Read the Kubernetes distribution comparison whitepaper&nbsp;&rsaquo;</a></p>
+  </div>
+</section>
+
+<section class="p-strip u-no-padding--top u-no-padding--bottom">
+  <div class="p-strip--suru-half-and-half">
+    <div class="row u-equal-height">
+      <div class="col-7">
+        <p class="p-card__content">Choosing the right Kubernetes distribution is crucial for your business. <a href="/engage/enterprise-kubernetes-comparison">Read the Kubernetes distribution comparison whitepaper&nbsp;&rsaquo;</a></p>
+      </div>
+      <div class="col-5 u-align--center u-vertically-center">
+        {{ image (
+          url="https://assets.ubuntu.com/v1/4bf1d333-Compare_Kubernetes-Openshift-Rancher-WHT.svg",
+          alt="",
+          width="200",
+          height="125",
+          hi_def=True,
+          loading="lazy"
+          ) | safe
+        }}
+      </div>
     </div>
   </div>
 </section>

--- a/templates/containers/what-are-containers.html
+++ b/templates/containers/what-are-containers.html
@@ -50,6 +50,7 @@
   <div class="u-fixed-width">
     <h2>Kubernetes vs Docker: CRI-O and OCI</h2>
     <p>With more and more applications deployed on containers, simple orchestration tools are not enough to support complex production environments. ‘<a href="/kubernetes/what-is-kubernetes#container-orchestration">Container orchestration</a>’ becomes a problem space of its own. The rise of <a href="/kubernetes">Kubernetes</a> is the industry's answer to the container orchestration problem, providing a way to manage containers at scale efficiently.</p>
+    <p>CRI (Container Runtime Interface) is a Kubernetes API to interface between Kubernetes orchestration features and container runtimes, such as containerd or CRI-O. The <a href="https://opencontainers.org/" class="p-link--external">Open Container Initiative</a> (OCI) defines a set of specifications to enable all these technologies to work together. Docker, runc, containerd, CRI-O are all OCI compatible.</p>
   </div>
 </section>
 
@@ -73,11 +74,6 @@
   </div>
 </section>
 
-<section class="p-strip">
-  <div class="u-fixed-width">
-    <p>CRI (Container Runtime Interface) is a Kubernetes API to interface between Kubernetes orchestration features and container runtimes, such as containerd or CRI-O. The <a href="https://opencontainers.org/" class="p-link--external">Open Container Initiative</a> (OCI) defines a set of specifications to enable all these technologies to work together. Docker, runc, containerd, CRI-O are all OCI compatible.</p>
-  </div>
-</section>
 
 <section class="p-strip u-no-padding--top u-no-padding--bottom">
   <div class="p-strip--suru-topped">
@@ -155,12 +151,93 @@
   </div>
 </section>
 
-
-
-  <!-- Set default Marketo information for contact form below-->
-  <div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/kubernetes" data-form-id="3230" data-lp-id="6274" data-return-url="https://ubuntu.com/kubernetes/thank-you" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
+<section class="p-strip--suru">
+  <div class="row">
+    <h2>Further reading</h2>
   </div>
+  <div class="row p-divider is-dark">
+    <div class="col-4 p-divider__block">
+      <div class="p-heading-icon">
+        <div class="p-heading-icon__header">
+          {{
+            image(
+            url="https://assets.ubuntu.com/v1/271921af-Datasheet+-+white.svg",
+            alt="",
+            width="32",
+            height="28",
+            hi_def=True,
+            loading="lazy",
+            attrs={"class": "p-heading-icon__img p-heading-icon__img--small"},
+            ) | safe
+          }}
+          <h3 class="p-heading-icon__title p-heading--4 ">Data sheet</h3>
+        </div>
+      </div>
+      <p><a class="p-link--inverted p-link--external"href="https://assets.ubuntu.com/v1/b5f9ae49-Enterprise_Kubernetes_Datasheet.pdf">Kubernetes for the enterprise</a></p>
+    </div>
+    <div class="col-4 p-divider__block">
+      <div class="p-heading-icon">
+        <div class="p-heading-icon__header"> 
+          {{ 
+            image (
+            url="https://assets.ubuntu.com/v1/816ae23b-Webinar+-+white.svg",
+            alt="",
+            width="32",
+            height="28",
+            hi_def=True,
+            loading="lazy",
+            attrs={"class": "p-heading-icon__img p-heading-icon__img--small"},
+            ) | safe
+          }}
+          <h3 class="p-heading-icon__title p-heading--4">Webinar on demand</h3>
+        </div>
+      </div>
+      <p><a class="p-link--inverted" href="/engage/kubernetes-use-cases-webinar">Enterprise Kubernetes use cases: 4 real-world stories</a></p>
+    </div>
+    <div class="col-4 p-divider__block">
+      <div class="p-heading-icon">
+        <div class="p-heading-icon__header">
+          {{ 
+            image (
+            url="https://assets.ubuntu.com/v1/4ab8ff35-Whitepaper+-+white.svg",
+            alt="",
+            width="32",
+            height="28",
+            hi_def=True,
+            loading="lazy",
+            attrs={"class": "p-heading-icon__img p-heading-icon__img--small"},
+            ) | safe
+          }}
+          <h3 class="p-heading-icon__title p-heading--4">Whitepaper</h3>
+        </div>
+      </div>
+      <p><a href="/engage/kubernetes-deployment-enterprise-whitepaper" class="p-link--inverted">Five strategies to accelerate Kubernetes deployment in the enterprise</a></p>
+    </div>
+  </div>
+</section>
 
+<section class="p-strip">
+  <div class="row u-vertically-center">
+    <div class="col-8">
+      <h2 class="p-heading--3">Get your questions on containers answered today</h2>
+      <p>
+        <a class="p-button--positive js-invoke-modal" href="/containers/contact-us?product=containers-overview">Contact us</a>
+      </p>
+    </div>
+    <div class="col-4 u-hide--small">
+      {{
+        image(
+        url="https://assets.ubuntu.com/v1/24a03775-Contact+us.svg",
+        alt="",
+        width="240",
+        height="171",
+        hi_def=True,
+        loading="lazy",
+        attrs={"class": "p-inline-images__logos"},
+        ) | safe
+      }}
+    </div>
+  </div>
+</section>
 
-
-  {% endblock content %}
+{% endblock content %}

--- a/templates/kubernetes/what-are-containers.html
+++ b/templates/kubernetes/what-are-containers.html
@@ -1,0 +1,128 @@
+{% extends "kubernetes/base_kubernetes.html" %}
+
+{% block title %}What are containers{% endblock %}
+
+{% block meta_description %}What are containers and how do containers enable fast-moving modern software, from the cloud to the edge? Learn how to use Ubuntu from the host kernel to container images running cloud applications to get a stable, secure, and consistent developer experience with Docker, Kubernetes, and LXD.{% endblock meta_description %}
+
+{% block meta_image %}{% endblock meta_image%}
+
+{% block meta_copydoc %}https://docs.google.com/document/d/1hStuIzY8dDdFEW4Q0TwboOx0_-SB5klk8zRuNIn3V4o/edit#{% endblock meta_copydoc %}
+
+{% block content %}
+
+<section class="p-strip u-no-padding--top u-no-padding--bottom is-bordered">
+  <div class="p-strip--suru-topped">
+    <div class="row u-equal-height">
+      <div class="col-7">
+        <h1>What are containers?</h1>
+        <p>Containers are a virtualisation technology that isolates each process in a lightweight and standard environment. They allow users to package and quickly deploy entire applications parallel to each other on the same kernel and hardware, while maintaining isolation among the workloads.</p>
+      </div>
+      <div class="col-5 u-align--center u-vertically-center">
+        {{
+          image(
+          url="https://assets.ubuntu.com/v1/767f38a4-kubernetes-stacked-color.svg",
+          alt="",
+          width="250",
+          height="195",
+          hi_def=True,
+          loading="auto",
+          ) | safe
+        }}
+      </div>
+    </div>
+  </div>
+</section>
+
+<section class="p-strip">
+  <div class="u-fixed-width">
+    <h2>Container virtualization</h2>
+    <p>Containers are instantiated from container images, a layered packaging system, to distribute applications along with their configuration and runtime dependencies.</p>
+    <p>From development to production, containers power modern cloud applications as they allow developers to move fast between platforms and versions.</p>
+    <p>Inside Google alone, at least <a href="https://cloud.google.com/containers/" class="p-link--external">two billion containers are generated each week</a> to manage its vast operations. There are many tools to create, deploy and manage containers, including LXD, Docker and Kubernetes.</p>
+  </div>
+</section>
+
+<section class="p-strip--light">
+  <div class="u-fixed-width">
+    <h2>What is Docker?</h2>
+    <p><a href="https://www.docker.com/" class="p-link--external">Docker</a> is an open-source containerisation platform. It provides an easy way to build and deploy containers on the cloud or on-premises. Container technologies were not introduced by Docker, but they made the user experience of container technologies so easy for developers that Docker soon became shorthand for containers as well as the most popular container format. <a href="https://www.docker.com/" class="p-link--external">Docker Inc</a>, the company that supports the Docker project and community, also operates <a href="https://hub.docker.com/" class="p-link--external">Docker Hub</a>, a space for hosting container images.</p>
+  </div>
+</section>
+
+<section class="p-strip">
+  <div class="u-fixed-width">
+    <h2>Kubernetes vs Docker: CRI-O and OCI</h2>
+    <p>With more and more applications deployed on containers, simple orchestration tools provided by Docker are not enough to support complex production environments. ‘<a href="/kubernetes/what-is-kubernetes#container-orchestration">Container orchestration</a>’ becomes a problem space of its own. The rise of <a href="/kubernetes">Kubernetes</a> is the industry's answer to the container orchestration problem, providing a way to manage containers at scale efficiently.</p>
+    <div class="p-card">
+      <p class="p-card__content">Not clear on how Kubernetes vs Docker differ? <a href="/blog/kubernetes-versus-docker">Read the Kubernetes vs Docker blog&nbsp;&rsaquo;</a></p>
+    </div>
+    <p>CRI (Container Runtime Interface) is a Kubernetes API to interface between Kubernetes orchestration features and container runtimes, such as containerd or CRI-O. The <a href="https://opencontainers.org/" class="p-link--external">Open Container Initiative</a> (OCI) defines a set of specifications to enable all these technologies to work together. Docker, runc, containerd, CRI-O are all OCI compatible.</p>
+    <div class="p-card">
+      <p class="p-card__content">Choosing the right Kubernetes distribution is crucial for your business. <a href="/engage/enterprise-kubernetes-comparison">Read the Kubernetes distribution comparison whitepaper&nbsp;&rsaquo;</a></p>
+    </div>
+  </div>
+</section>
+
+<section class="p-strip--light">
+  <div class="u-fixed-width">
+    <h2>Containers vs virtual machines</h2>
+    <p>Containers are a modern way to virtualise infrastructure, more lightweight than traditional virtual machines: all containers on a single host OS share the kernel and other resources, require less memory space, ensure greater resource utilisation and shorter startup times by orders of magnitude.</p>
+    <p><a href="/containers/contact-us">Get a consultation on your container strategy&nbsp;&rsaquo;</a></p>
+    <div>
+      {{ image (
+        url="https://assets.ubuntu.com/v1/3d57842f-diagram-machine-virtualization-vs-containers.svg",
+        alt="",
+        width="681",
+        height="416",
+        hi_def=True,
+        loading="lazy"
+        ) | safe
+      }}
+    </div>
+  </div>
+</section>
+
+<section class="p-strip">
+  <div class="u-fixed-width">
+    <h2>Docker vs LXD: comparing container technologies</h2>
+    <p>Process containers (for example, Docker) and machine containers (traditional <a href="https://linuxcontainers.org/" class="p-link--external">linux containers</a>) are two types of container technologies that can address different use cases. Process containers typically contain a single application, while machine containers can contain one or more applications as well as their own operating system. Both container technologies share a kernel with the host operating system. </p>
+    <p>Docker is the most popular process container environment and allows for very small, immutable containers, containing only the application binaries and a minimal subset of libraries necessary for an application to run as a single process, requiring limited system resources.</p>
+    <p>LXD functions similarly to a traditional hypervisor and machine containers resemble virtual machines. Machine containers, also referred to as ‘system containers’ are larger compared to process containers, as well as stateful and mutable. They have an allocated filesystem, often containing a cut-down version of an operating system, which might include a shell and a limited number of daemons.</p>
+    <p>Docker is mostly used by developers making Platform-as-a-Service application instances more portable. LXD usage, on the other hand, is often driven by DevOps making Infrastructure-as-a-Service OS instances much faster.</p>
+    <p>Docker can run alongside LXD with both instances working together. Moreover, Docker can run inside of LXD with zero performance impact, allowing you to safely migrate your Docker containers between machines for easy scale-up and scale-down.</p>
+    <p><a href="/containers/lxd">Learn more about LXD&nbsp;&rsaquo;</a></p>
+  </div>
+</section>
+
+<section class="p-strip--light">
+  <div class="row">
+    <div class="col-8">
+      <h2>How to secure container images</h2>
+      <p>Canonical’s <a href="https://juju.is/cloud-native-kubernetes-usage-report-2021#selection-criteria-for-container-images" class="p-link--external">Kubernetes and cloud native operations report</a> showed that the best container images are secure, stable, and easy to use. While containerisation adds a layer of security by keeping workloads isolated from one another and the host system, it is not enough to secure an application.</p>
+      <p>Container images are made of software from many different projects and sources, not all equally well-maintained. Developers need to ask themselves what content can developers rely on today, tomorrow and for a long time thereafter. Particular attention should be paid to the base layer, specifically in selecting a frequently updated one with credible maintenance commitment, a large software ecosystem of well-maintained packages, and a great developer experience.</p>
+      <p>Canonical publishes a portfolio of base, runtime, and application images with an up to 10-year maintenance commitment. In collaboration with Docker, this content is publicly available on Docker Hub.</p>
+      <p><a href="/security/docker-images">Secure your software supply chain with LTS Docker Images&nbsp;&rsaquo;</a></p>
+    </div>
+    <div class="col-4 u-vertically-center u-align--center">
+      {{ image (
+        url="https://assets.ubuntu.com/v1/25c42877-simplified-software-management-2.svg",
+        alt="",
+        width="150",
+        height="150",
+        hi_def=True,
+        loading="lazy"
+        ) | safe
+      }}
+    </div>
+  </div>
+</section>
+
+
+
+  <!-- Set default Marketo information for contact form below-->
+  <div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/kubernetes" data-form-id="3230" data-lp-id="6274" data-return-url="https://ubuntu.com/kubernetes/thank-you" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
+  </div>
+
+
+
+  {% endblock content %}


### PR DESCRIPTION
## Done

- Builds what-are-containers as per [copydoc](https://docs.google.com/document/d/1hStuIzY8dDdFEW4Q0TwboOx0_-SB5klk8zRuNIn3V4o/edit#)

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/containers/what-are-containers or https://ubuntu-com-10761.demos.haus/containers/what-are-containers
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Compare against copydoc
- Check navigation works


## Issue / Card

Fixes https://github.com/canonical-web-and-design/web-squad/issues/4567
