### PR TITLE
Use the new GetAccountForMarketplace endpoint from ua-contracts

### DIFF
--- a/tests/advantage/test_api.py
+++ b/tests/advantage/test_api.py
@@ -1002,7 +1002,7 @@ class TestGetPurchaseAccount(unittest.TestCase):
             client = make_client(session, is_for_view=is_for_view)
 
             with self.assertRaises(expected_error) as error:
-                client.get_purchase_account()
+                client.get_purchase_account("canonical-ua")
 
             self.assertEqual(error.exception.response.json(), response_content)
 
@@ -1016,14 +1016,14 @@ class TestGetPurchaseAccount(unittest.TestCase):
         )
         client = make_client(session)
 
-        response = client.get_purchase_account()
+        response = client.get_purchase_account("canonical-ua")
 
         expected_args = {
             "headers": {"Authorization": "Macaroon secret-token"},
             "json": None,
             "method": "get",
             "params": None,
-            "url": "https://1.2.3.4/v1/purchase-account",
+            "url": "https://1.2.3.4/v1/marketplace/canonical-ua/account",
         }
 
         self.assertEqual(response, json_account)
@@ -1039,14 +1039,14 @@ class TestGetPurchaseAccount(unittest.TestCase):
         )
         client = make_client(session, convert_response=True)
 
-        response = client.get_purchase_account()
+        response = client.get_purchase_account("canonical-ua")
 
         expected_args = {
             "headers": {"Authorization": "Macaroon secret-token"},
             "json": None,
             "method": "get",
             "params": None,
-            "url": "https://1.2.3.4/v1/purchase-account",
+            "url": "https://1.2.3.4/v1/marketplace/canonical-ua/account",
         }
 
         self.assertIsInstance(response, Account)

--- a/webapp/advantage/ua_contracts/api.py
+++ b/webapp/advantage/ua_contracts/api.py
@@ -311,10 +311,10 @@ class UAContractsAPI:
 
         return response.json()
 
-    def get_purchase_account(self):
+    def get_purchase_account(self, marketplace: str = ""):
         response = self._request(
             method="get",
-            path="v1/purchase-account",
+            path=f"v1/marketplace/{marketplace}/account",
             error_rules=["default", "no-found"],
         )
 

--- a/webapp/advantage/views.py
+++ b/webapp/advantage/views.py
@@ -130,7 +130,7 @@ def get_account_users():
     g.api.set_convert_response(True)
 
     try:
-        account = g.api.get_purchase_account()
+        account = g.api.get_purchase_account("canonical-ua")
     except UAContractsUserHasNoAccount as error:
         # if no account throw 404
         raise UAContractsAPIError(error)
@@ -209,7 +209,7 @@ def get_user_info():
     g.api.set_convert_response(True)
 
     try:
-        account = g.api.get_purchase_account()
+        account = g.api.get_purchase_account("canonical-ua")
     except UAContractsUserHasNoAccount as error:
         # if no account throw 404
         raise UAContractsAPIError(error)
@@ -245,7 +245,7 @@ def advantage_shop_view():
     account = None
     if user_info(flask.session):
         try:
-            account = g.api.get_purchase_account()
+            account = g.api.get_purchase_account("canonical-ua")
         except UAContractsUserHasNoAccount:
             # There is no purchase account yet for this user.
             # One will need to be created later; expected condition.
@@ -297,7 +297,7 @@ def payment_methods_view():
     pending_purchase_id = ""
 
     try:
-        account = g.api.get_purchase_account()
+        account = g.api.get_purchase_account("canonical-ua")
     except UAContractsUserHasNoAccount:
         # No Stripe account
 
@@ -880,7 +880,7 @@ def blender_shop_view():
     account = None
     if user_info(flask.session):
         try:
-            account = g.api.get_purchase_account()
+            account = g.api.get_purchase_account("blender")
         except UAContractsUserHasNoAccount:
             # There is no purchase account yet for this user.
             # One will need to be created later; expected condition.

--- a/webapp/cube/views.py
+++ b/webapp/cube/views.py
@@ -74,7 +74,7 @@ def cube_microcerts():
 
     if sso_user:
         try:
-            account = g.api.get_purchase_account()
+            account = g.api.get_purchase_account("canonical-cube")
         except UAContractsUserHasNoAccount:
             # There is no purchase account yet for this user.
             # One will need to be created later; expected condition.
@@ -227,7 +227,7 @@ def get_microcerts():
 
     if sso_user:
         try:
-            account = g.api.get_purchase_account()
+            account = g.api.get_purchase_account("canonical-cube")
         except UAContractsUserHasNoAccount:
             # There is no purchase account yet for this user.
             # One will need to be created later; expected condition.


### PR DESCRIPTION
This new endpoint behaves exactly like the old one, it's just a different path. The change in ua-contracts happened because of early account management developments, and some requirements we anticipate will arrive in the future.

The same migration was done to the new `EnsureAccountForMarketplace` last week, when the captcha for guest purchases was introduced. This PR is just finishing the work.

To test it, go to https://ubuntu-com-10763.demos.haus/advantage/subscribe?test_backend=true and view your payment methods. If it works, it works :)