### PR TITLE
Adjust CVE references links

### DIFF
--- a/templates/security/notices/lsn.html
+++ b/templates/security/notices/lsn.html
@@ -80,7 +80,7 @@
       <ul class="p-list">
         {% if notice.cves %}
           {% for cve in notice.cves %}
-            <li class="p-list__item"><a href="https://people.canonical.com/~ubuntu-security/cve/{{ cve.id }}">{{ cve.id }}</a></li>
+            <li class="p-list__item"><a href="/security/{{ cve.id }}">{{ cve.id }}</a></li>
           {% endfor %}
         {% endif %}
 

--- a/templates/security/notices/usn.html
+++ b/templates/security/notices/usn.html
@@ -86,7 +86,7 @@
       <ul class="p-list">
         {% if notice.cves %}
           {% for cve in notice.cves %}
-            <li class="p-list__item"><a href="https://people.canonical.com/~ubuntu-security/cve/{{ cve.id }}">{{ cve.id }}</a></li>
+            <li class="p-list__item"><a href="/security/{{ cve.id }}">{{ cve.id }}</a></li>
           {% endfor %}
         {% endif %}
 


### PR DESCRIPTION
## Done

- Adjust CVE references links

## QA

What happens now:
- Go to https://ubuntu.com/security/notices/USN-5114-1
- Scroll down to the **References** section you will see a list of CVE ids
- If you take a look at the URL of the CVE ids, it will use our old people.canonical.com url. Which will make the redirect to ubuntu.com, but ideally we should just use the ubuntu.com url

QA the new behaviour:
- Fetch the branch changes locally
- Ask @albertkol for the email of how to set up the CVE database locally.
- Go to a notice page: https://0.0.0.0:8001/security/notices/USN-4414-1 
- Scroll down to the **References** section you will see a list of CVE ids
- Check the links of the CVE ids, the new link will be to <localhost_url>/security/<cve_id> (which on prod is ubuntu.com)

## Issue / Card

Fixes #https://github.com/canonical-web-and-design/ubuntu.com/issues/10709