### PR TITLE
[Certified] - Add website link on model details page

### DIFF
--- a/templates/certified/model-details.html
+++ b/templates/certified/model-details.html
@@ -11,6 +11,9 @@
     <div class="col-7">
       <h1>{{ vendor }} {{ name }}</h1>
       <p class="p-heading--4"> {{ form_factor }} system certified with Ubuntu</p>
+      {% if hardware_website %}
+      <a href="{{ hardware_website }}" class="p-link--external" target="blank">Visit the website</a>
+      {% endif %}
     </div>
     <div class="col-5 u-vertically-center u-align--center u-hide--small">
       {% if category == "Desktop" or category == "Laptop" %}

--- a/webapp/certified/views.py
+++ b/webapp/certified/views.py
@@ -191,6 +191,7 @@ def certified_model_details(canonical_id):
         release_details=release_details,
         has_enabled_releases=has_enabled_releases,
         components=component_summaries,
+        hardware_website=model_release["hardware_website"],
     )
 
 


### PR DESCRIPTION
## Done

- Add `hardware_website=model_release["hardware_website"]` to view
- For most models this is empty so add conditional render of website link to model_details page. 

## QA

- View page at: https://ubuntu-com-10774.demos.haus/certified/202105-29115
- Check the website link is available under the header
- Check on another model with no website link the page doesn't break i.e. https://ubuntu-com-10774.demos.haus/certified/202012-28554


## Issue / Card

Fixes #10723 

## Screenshots

![Screenshot 2021-11-01 at 14 45 48](https://user-images.githubusercontent.com/58959073/139690329-e966f306-6f4b-4853-955e-0e44f1217ef8.png)

