### PR TITLE
Update download megamenu remove up2

### DIFF
--- a/templates/download/iot/index.html
+++ b/templates/download/iot/index.html
@@ -83,7 +83,7 @@
           ) | safe
         }}
         <p>
-          <a href="/download/intel-nuc-desktop">Install Ubuntu Server&nbsp;&rsaquo;</a>
+          <a href="/download/up-squared-iot-grove-server">Install Ubuntu Server&nbsp;&rsaquo;</a>
         </p>
       </div>
       <div class="col-3">

--- a/templates/templates/navigation-download-h.html
+++ b/templates/templates/navigation-download-h.html
@@ -43,9 +43,6 @@
             <li class='p-list__item'><a class='p-link' href='/download/qualcomm-dragonboard-410c'>
               Qualcomm Dragonboard 410c
             </a></li>
-            <li class='p-list__item'><a class='p-link' href='/download/up-squared-iot-grove-server'>
-              UP<sup>2</sup> IoT Grove
-            </a></li>
             <li class='p-list__item'><a class='p-link' href='/download/intel-iei-tank-870'>
               Intel IEI TANK 870
             </a></li>

--- a/templates/templates/navigation-download-h.html
+++ b/templates/templates/navigation-download-h.html
@@ -32,7 +32,7 @@
           <p class="p-p--small">Are you a developer who wants to try snappy Ubuntu Core or classic Ubuntu on an IoT board?</p>
           <ul class='p-text-list--small is-bordered'>
             <li class='p-list__item'><a class='p-link' href='/download/raspberry-pi'>
-              Raspberry Pi 2, 3 or 4
+              Raspberry Pi
             </a></li>
             <li class='p-list__item'><a class='p-link' href='/download/intel-nuc'>
               Intel NUC


### PR DESCRIPTION
## Done

- Removed up2 from the download mega menu
- Removed numbers from Raspberry Pi models from the download mega menu
- Fixed the link to Up2 on /download/iot

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/#download and http://0.0.0.0:8001/download/iot
- Compare to the [copy doc](https://docs.google.com/document/d/11pX5gxOE6UWljIGRBZdwuCL1MHzs4pNgxJpK0mcIqdQ/edit#) and resolve comments


## Issue / Card

Fixes #10780
