### PR TITLE
K8sdocs 1.22+ck2 updates

### DIFF
--- a/templates/kubernetes/docs/1.22/components.md
+++ b/templates/kubernetes/docs/1.22/components.md
@@ -14,7 +14,7 @@ layout:
     - base
     - ubuntu-com
 toc: false
-bundle_revision: '807'
+bundle_revision: '814'
 bundle_release: '1.22'
 ---
 
@@ -59,181 +59,181 @@ release. These charms are maintained by the Charmed Kubernetes team.
 <tr>
   <td> aws-iam </td>
   <td> A charm that enables using AWS IAM to authenticate with Kubernetes </td>
-  <td> <a href="/kubernetes/docs/1.22/charm-aws-iam">docs</a> </td>
+  <td> <a href="/kubernetes/docs/1.22/charm-aws-iam">docs</a> </td> 
   <td> <a href="https://github.com/charmed-kubernetes/charm-aws-iam"> source </a> </td>
   <td> <a href="https://bugs.launchpad.net/charmed-kubernetes"> bugs</a> </td>
-  <td> <a href="https://jaas.ai/u/containers/aws-iam/91> 91 </a></td>
+  <td> <a href="https://jaas.ai/u/containers/aws-iam/94"> 94 </a> </td>
   <td> -- </td>
 </tr>
 <tr>
   <td> aws-integrator </td>
   <td> Charm to enable AWS integrations via Juju relations. </td>
-  <td> <a href="/kubernetes/docs/1.22/charm-aws-integrator">docs</a> </td>
+  <td> <a href="/kubernetes/docs/1.22/charm-aws-integrator">docs</a> </td> 
   <td> <a href="https://github.com/juju-solutions/charm-aws-integrator"> source </a> </td>
   <td> <a href="https://bugs.launchpad.net/charmed-kubernetes"> bugs</a> </td>
-  <td> <a href="https://jaas.ai/u/containers/aws-integrator/149> 149 </a></td>
+  <td> <a href="https://jaas.ai/u/containers/aws-integrator/153"> 153 </a> </td>
   <td> -- </td>
 </tr>
 <tr>
   <td> azure-integrator </td>
   <td> Proxy charm to enable Azure integrations via Juju relations. </td>
-  <td> <a href="/kubernetes/docs/1.22/charm-azure-integrator">docs</a> </td>
+  <td> <a href="/kubernetes/docs/1.22/charm-azure-integrator">docs</a> </td> 
   <td> <a href="https://github.com/juju-solutions/charm-azure-integrator"> source </a> </td>
   <td> <a href="https://bugs.launchpad.net/charmed-kubernetes"> bugs</a> </td>
-  <td> <a href="https://jaas.ai/u/containers/azure-integrator/134> 134 </a></td>
+  <td> <a href="https://jaas.ai/u/containers/azure-integrator/137"> 137 </a> </td>
   <td> -- </td>
 </tr>
 <tr>
   <td> calico </td>
   <td> A robust Software Defined Network from Project Calico </td>
-  <td> <a href="/kubernetes/docs/1.22/charm-calico">docs</a> </td>
+  <td> <a href="/kubernetes/docs/1.22/charm-calico">docs</a> </td> 
   <td> <a href="https://github.com/juju-solutions/layer-calico"> source </a> </td>
   <td> <a href="https://bugs.launchpad.net/charmed-kubernetes"> bugs</a> </td>
-  <td> <a href="https://jaas.ai/u/containers/calico/835> 835 </a></td>
+  <td> <a href="https://jaas.ai/u/containers/calico/838"> 838 </a> </td>
   <td> -- </td>
 </tr>
 <tr>
   <td> canal </td>
   <td> A Software Defined Network based on Flannel and Calico </td>
-  <td> <a href="/kubernetes/docs/1.22/charm-canal">docs</a> </td>
+  <td> <a href="/kubernetes/docs/1.22/charm-canal">docs</a> </td> 
   <td> <a href="https://github.com/juju-solutions/layer-canal"> source </a> </td>
   <td> <a href="https://bugs.launchpad.net/charmed-kubernetes"> bugs</a> </td>
-  <td> <a href="https://jaas.ai/u/containers/canal/834> 834 </a></td>
+  <td> <a href="https://jaas.ai/u/containers/canal/837"> 837 </a> </td>
   <td> -- </td>
 </tr>
 <tr>
   <td> containerd </td>
   <td> Containerd container runtime subordinate </td>
-  <td> <a href="/kubernetes/docs/1.22/charm-containerd">docs</a> </td>
+  <td> <a href="/kubernetes/docs/1.22/charm-containerd">docs</a> </td> 
   <td> <a href="https://github.com/charmed-kubernetes/charm-containerd"> source </a> </td>
   <td> <a href="https://bugs.launchpad.net/charmed-kubernetes"> bugs</a> </td>
-  <td> <a href="https://jaas.ai/u/containers/containerd/175> 175 </a></td>
+  <td> <a href="https://jaas.ai/u/containers/containerd/178"> 178 </a> </td>
   <td> -- </td>
 </tr>
 <tr>
   <td> docker </td>
   <td> Docker container runtime subordinate </td>
-  <td> <a href="/kubernetes/docs/1.22/charm-docker">docs</a> </td>
+  <td> <a href="/kubernetes/docs/1.22/charm-docker">docs</a> </td> 
   <td> <a href="https://github.com/juju-solutions/layer-docker"> source </a> </td>
   <td> <a href="https://bugs.launchpad.net/charmed-kubernetes"> bugs</a> </td>
-  <td> <a href="https://jaas.ai/u/containers/docker/128> 128 </a></td>
+  <td> <a href="https://jaas.ai/u/containers/docker/131"> 131 </a> </td>
   <td> -- </td>
 </tr>
 <tr>
   <td> docker-registry </td>
   <td> Registry for docker images </td>
-  <td> <a href="/kubernetes/docs/1.22/charm-docker-registry">docs</a> </td>
+  <td> <a href="/kubernetes/docs/1.22/charm-docker-registry">docs</a> </td> 
   <td> <a href="https://github.com/CanonicalLtd/docker-registry-charm"> source </a> </td>
   <td> <a href="https://bugs.launchpad.net/charmed-kubernetes"> bugs</a> </td>
-  <td> <a href="https://jaas.ai/u/containers/docker-registry/215> 215 </a></td>
+  <td> <a href="https://jaas.ai/u/containers/docker-registry/218"> 218 </a> </td>
   <td> -- </td>
 </tr>
 <tr>
   <td> easyrsa </td>
   <td> Delivers EasyRSA to create a Certificate Authority (CA). </td>
-  <td> <a href="/kubernetes/docs/1.22/charm-easyrsa">docs</a> </td>
+  <td> <a href="/kubernetes/docs/1.22/charm-easyrsa">docs</a> </td> 
   <td> <a href="https://github.com/charmed-kubernetes/layer-easyrsa"> source </a> </td>
   <td> <a href="https://bugs.launchpad.net/charmed-kubernetes"> bugs</a> </td>
-  <td> <a href="https://jaas.ai/u/containers/easyrsa/417> 417 </a></td>
+  <td> <a href="https://jaas.ai/u/containers/easyrsa/420"> 420 </a> </td>
   <td> -- </td>
 </tr>
 <tr>
   <td> etcd </td>
   <td> Deploy a TLS terminated ETCD Cluster </td>
-  <td> <a href="/kubernetes/docs/1.22/charm-etcd">docs</a> </td>
+  <td> <a href="/kubernetes/docs/1.22/charm-etcd">docs</a> </td> 
   <td> <a href="https://github.com/charmed-kubernetes/layer-etcd"> source </a> </td>
   <td> <a href="https://bugs.launchpad.net/charmed-kubernetes"> bugs</a> </td>
-  <td> <a href="https://jaas.ai/u/containers/etcd/630> 630 </a></td>
+  <td> <a href="https://jaas.ai/u/containers/etcd/634"> 634 </a> </td>
   <td> -- </td>
 </tr>
 <tr>
   <td> flannel </td>
   <td> A charm that provides a robust Software Defined Network </td>
-  <td> <a href="/kubernetes/docs/1.22/charm-flannel">docs</a> </td>
+  <td> <a href="/kubernetes/docs/1.22/charm-flannel">docs</a> </td> 
   <td> <a href="https://github.com/coreos/flannel"> source </a> </td>
   <td> <a href="https://bugs.launchpad.net/charmed-kubernetes"> bugs</a> </td>
-  <td> <a href="https://jaas.ai/u/containers/flannel/594> 594 </a></td>
+  <td> <a href="https://jaas.ai/u/containers/flannel/597"> 597 </a> </td>
   <td> -- </td>
 </tr>
 <tr>
   <td> gcp-integrator </td>
   <td> Charm to enable GCP integrations via Juju relations. </td>
-  <td> <a href="/kubernetes/docs/1.22/charm-gcp-integrator">docs</a> </td>
+  <td> <a href="/kubernetes/docs/1.22/charm-gcp-integrator">docs</a> </td> 
   <td> <a href="https://github.com/juju-solutions/charm-gcp-integrator"> source </a> </td>
   <td> <a href="https://bugs.launchpad.net/charmed-kubernetes"> bugs</a> </td>
-  <td> <a href="https://jaas.ai/u/containers/gcp-integrator/141> 141 </a></td>
+  <td> <a href="https://jaas.ai/u/containers/gcp-integrator/145"> 145 </a> </td>
   <td> -- </td>
 </tr>
 <tr>
   <td> kata </td>
   <td> Kata untrusted container runtime subordinate </td>
-  <td> <a href="/kubernetes/docs/1.22/charm-kata">docs</a> </td>
+  <td> <a href="/kubernetes/docs/1.22/charm-kata">docs</a> </td> 
   <td> <a href="https://github.com/charmed-kubernetes/charm-kata"> source </a> </td>
   <td> <a href="https://bugs.launchpad.net/charmed-kubernetes"> bugs</a> </td>
-  <td> <a href="https://jaas.ai/u/containers/kata/135> 135 </a></td>
+  <td> <a href="https://jaas.ai/u/containers/kata/138"> 138 </a> </td>
   <td> -- </td>
 </tr>
 <tr>
   <td> keepalived </td>
   <td> Failover and monitoring daemon for LVS clusters </td>
-  <td> <a href="/kubernetes/docs/1.22/charm-keepalived">docs</a> </td>
+  <td> <a href="/kubernetes/docs/1.22/charm-keepalived">docs</a> </td> 
   <td> <a href="https://github.com/juju-solutions/charm-keepalived"> source </a> </td>
   <td> <a href="https://bugs.launchpad.net/charmed-kubernetes"> bugs</a> </td>
-  <td> <a href="https://jaas.ai/u/containers/keepalived/107> 107 </a></td>
+  <td> <a href="https://jaas.ai/u/containers/keepalived/110"> 110 </a> </td>
   <td> -- </td>
 </tr>
 <tr>
   <td> kubeapi-load-balancer </td>
   <td> Nginx Load Balancer </td>
-  <td> <a href="/kubernetes/docs/1.22/charm-kubeapi-load-balancer">docs</a> </td>
+  <td> <a href="/kubernetes/docs/1.22/charm-kubeapi-load-balancer">docs</a> </td> 
   <td> <a href="https://nginx.org/en/"> source </a> </td>
   <td> <a href="https://bugs.launchpad.net/charmed-kubernetes"> bugs</a> </td>
-  <td> <a href="https://jaas.ai/u/containers/kubeapi-load-balancer/841> 841 </a></td>
+  <td> <a href="https://jaas.ai/u/containers/kubeapi-load-balancer/844"> 844 </a> </td>
   <td> -- </td>
 </tr>
 <tr>
   <td> kubernetes-master </td>
   <td> The Kubernetes control plane. </td>
-  <td> <a href="/kubernetes/docs/1.22/charm-kubernetes-master">docs</a> </td>
+  <td> <a href="/kubernetes/docs/1.22/charm-kubernetes-master">docs</a> </td> 
   <td> <a href="https://github.com/charmed-kubernetes/charm-kubernetes-master"> source </a> </td>
   <td> <a href="https://bugs.launchpad.net/charmed-kubernetes"> bugs</a> </td>
-  <td> <a href="https://jaas.ai/u/containers/kubernetes-master/1074> 1074 </a></td>
+  <td> <a href="https://jaas.ai/u/containers/kubernetes-master/1078"> 1078 </a> </td>
   <td> -- </td>
 </tr>
 <tr>
   <td> kubernetes-worker </td>
   <td> The workload bearing units of a kubernetes cluster </td>
-  <td> <a href="/kubernetes/docs/1.22/charm-kubernetes-worker">docs</a> </td>
+  <td> <a href="/kubernetes/docs/1.22/charm-kubernetes-worker">docs</a> </td> 
   <td> <a href="https://github.com/charmed-kubernetes/charm-kubernetes-worker"> source </a> </td>
   <td> <a href="https://bugs.launchpad.net/charmed-kubernetes"> bugs</a> </td>
-  <td> <a href="https://jaas.ai/u/containers/kubernetes-worker/812> 812 </a></td>
+  <td> <a href="https://jaas.ai/u/containers/kubernetes-worker/816"> 816 </a> </td>
   <td> -- </td>
 </tr>
 <tr>
   <td> openstack-integrator </td>
   <td> Proxy charm to enable OpenStack integrations via Juju relations. </td>
-  <td> <a href="/kubernetes/docs/1.22/charm-openstack-integrator">docs</a> </td>
+  <td> <a href="/kubernetes/docs/1.22/charm-openstack-integrator">docs</a> </td> 
   <td> <a href="https://github.com/juju-solutions/charm-openstack-integrator"> source </a> </td>
-  <td> <a href="https://bugs.launchpad.net/charmed-kubernetes"> bugs</a> </a></td>
-  <td> <a href="https://jaas.ai/u/containers/openstack-integrator/178> 178 </a></td>
+  <td> <a href="https://bugs.launchpad.net/charmed-kubernetes"> bugs</a> </td>
+  <td> <a href="https://jaas.ai/u/containers/openstack-integrator/182"> 182 </a> </td>
   <td> -- </td>
 </tr>
 <tr>
   <td> tigera-secure-ee </td>
   <td> Tigera Secure Enterprise Edition </td>
-  <td> <a href="/kubernetes/docs/1.22/charm-tigera-secure-ee">docs</a> </td>
+  <td> <a href="/kubernetes/docs/1.22/charm-tigera-secure-ee">docs</a> </td> 
   <td> <a href="https://github.com/charmed-kubernetes/layer-tigera-secure-ee"> source </a> </td>
   <td> <a href="https://bugs.launchpad.net/charmed-kubernetes"> bugs</a> </td>
-  <td> <a href="https://jaas.ai/u/containers/tigera-secure-ee/227> 227 </a></td>
+  <td> <a href="https://jaas.ai/u/containers/tigera-secure-ee/230"> 230 </a> </td>
   <td> -- </td>
 </tr>
 <tr>
   <td> vsphere-integrator </td>
   <td> Proxy charm to enable VMware vSphere integrations via Juju relations. </td>
-  <td> <a href="/kubernetes/docs/1.22/charm-vsphere-integrator">docs</a> </td>
+  <td> <a href="/kubernetes/docs/1.22/charm-vsphere-integrator">docs</a> </td> 
   <td> <a href="https://github.com/juju-solutions/charm-vsphere-integrator"> source </a> </td>
   <td> <a href="https://bugs.launchpad.net/charmed-kubernetes"> bugs</a> </td>
-  <td> <a href="https://jaas.ai/u/containers/vsphere-integrator/120> 120 </a></td>
+  <td> <a href="https://jaas.ai/u/containers/vsphere-integrator/123"> 123 </a> </td>
   <td> -- </td>
 </tr>
 
@@ -385,7 +385,7 @@ These are the container images used by this release:
 -  sig-storage/csi-resizer:v1.1.0
 -  sig-storage/csi-snapshotter:v4.0.0
 -  sig-storage/livenessprobe:v2.2.0
--  sonatype/nexus3:latest 
+-  sonatype/nexus3:latest
 
 <!-- CONTAINER IMAGES END -->
 

--- a/templates/kubernetes/docs/1.22/components.md
+++ b/templates/kubernetes/docs/1.22/components.md
@@ -59,7 +59,7 @@ release. These charms are maintained by the Charmed Kubernetes team.
 <tr>
   <td> aws-iam </td>
   <td> A charm that enables using AWS IAM to authenticate with Kubernetes </td>
-  <td> <a href="/kubernetes/docs/1.22/charm-aws-iam">docs</a> </td> 
+  <td> <a href="/kubernetes/docs/1.22/charm-aws-iam">docs</a> </td>
   <td> <a href="https://github.com/charmed-kubernetes/charm-aws-iam"> source </a> </td>
   <td> <a href="https://bugs.launchpad.net/charmed-kubernetes"> bugs</a> </td>
   <td> <a href="https://jaas.ai/u/containers/aws-iam/94"> 94 </a> </td>
@@ -68,7 +68,7 @@ release. These charms are maintained by the Charmed Kubernetes team.
 <tr>
   <td> aws-integrator </td>
   <td> Charm to enable AWS integrations via Juju relations. </td>
-  <td> <a href="/kubernetes/docs/1.22/charm-aws-integrator">docs</a> </td> 
+  <td> <a href="/kubernetes/docs/1.22/charm-aws-integrator">docs</a> </td>
   <td> <a href="https://github.com/juju-solutions/charm-aws-integrator"> source </a> </td>
   <td> <a href="https://bugs.launchpad.net/charmed-kubernetes"> bugs</a> </td>
   <td> <a href="https://jaas.ai/u/containers/aws-integrator/153"> 153 </a> </td>
@@ -77,7 +77,7 @@ release. These charms are maintained by the Charmed Kubernetes team.
 <tr>
   <td> azure-integrator </td>
   <td> Proxy charm to enable Azure integrations via Juju relations. </td>
-  <td> <a href="/kubernetes/docs/1.22/charm-azure-integrator">docs</a> </td> 
+  <td> <a href="/kubernetes/docs/1.22/charm-azure-integrator">docs</a> </td>
   <td> <a href="https://github.com/juju-solutions/charm-azure-integrator"> source </a> </td>
   <td> <a href="https://bugs.launchpad.net/charmed-kubernetes"> bugs</a> </td>
   <td> <a href="https://jaas.ai/u/containers/azure-integrator/137"> 137 </a> </td>
@@ -86,7 +86,7 @@ release. These charms are maintained by the Charmed Kubernetes team.
 <tr>
   <td> calico </td>
   <td> A robust Software Defined Network from Project Calico </td>
-  <td> <a href="/kubernetes/docs/1.22/charm-calico">docs</a> </td> 
+  <td> <a href="/kubernetes/docs/1.22/charm-calico">docs</a> </td>
   <td> <a href="https://github.com/juju-solutions/layer-calico"> source </a> </td>
   <td> <a href="https://bugs.launchpad.net/charmed-kubernetes"> bugs</a> </td>
   <td> <a href="https://jaas.ai/u/containers/calico/838"> 838 </a> </td>
@@ -95,7 +95,7 @@ release. These charms are maintained by the Charmed Kubernetes team.
 <tr>
   <td> canal </td>
   <td> A Software Defined Network based on Flannel and Calico </td>
-  <td> <a href="/kubernetes/docs/1.22/charm-canal">docs</a> </td> 
+  <td> <a href="/kubernetes/docs/1.22/charm-canal">docs</a> </td>
   <td> <a href="https://github.com/juju-solutions/layer-canal"> source </a> </td>
   <td> <a href="https://bugs.launchpad.net/charmed-kubernetes"> bugs</a> </td>
   <td> <a href="https://jaas.ai/u/containers/canal/837"> 837 </a> </td>
@@ -104,7 +104,7 @@ release. These charms are maintained by the Charmed Kubernetes team.
 <tr>
   <td> containerd </td>
   <td> Containerd container runtime subordinate </td>
-  <td> <a href="/kubernetes/docs/1.22/charm-containerd">docs</a> </td> 
+  <td> <a href="/kubernetes/docs/1.22/charm-containerd">docs</a> </td>
   <td> <a href="https://github.com/charmed-kubernetes/charm-containerd"> source </a> </td>
   <td> <a href="https://bugs.launchpad.net/charmed-kubernetes"> bugs</a> </td>
   <td> <a href="https://jaas.ai/u/containers/containerd/178"> 178 </a> </td>
@@ -113,7 +113,7 @@ release. These charms are maintained by the Charmed Kubernetes team.
 <tr>
   <td> docker </td>
   <td> Docker container runtime subordinate </td>
-  <td> <a href="/kubernetes/docs/1.22/charm-docker">docs</a> </td> 
+  <td> <a href="/kubernetes/docs/1.22/charm-docker">docs</a> </td>
   <td> <a href="https://github.com/juju-solutions/layer-docker"> source </a> </td>
   <td> <a href="https://bugs.launchpad.net/charmed-kubernetes"> bugs</a> </td>
   <td> <a href="https://jaas.ai/u/containers/docker/131"> 131 </a> </td>
@@ -122,7 +122,7 @@ release. These charms are maintained by the Charmed Kubernetes team.
 <tr>
   <td> docker-registry </td>
   <td> Registry for docker images </td>
-  <td> <a href="/kubernetes/docs/1.22/charm-docker-registry">docs</a> </td> 
+  <td> <a href="/kubernetes/docs/1.22/charm-docker-registry">docs</a> </td>
   <td> <a href="https://github.com/CanonicalLtd/docker-registry-charm"> source </a> </td>
   <td> <a href="https://bugs.launchpad.net/charmed-kubernetes"> bugs</a> </td>
   <td> <a href="https://jaas.ai/u/containers/docker-registry/218"> 218 </a> </td>
@@ -131,7 +131,7 @@ release. These charms are maintained by the Charmed Kubernetes team.
 <tr>
   <td> easyrsa </td>
   <td> Delivers EasyRSA to create a Certificate Authority (CA). </td>
-  <td> <a href="/kubernetes/docs/1.22/charm-easyrsa">docs</a> </td> 
+  <td> <a href="/kubernetes/docs/1.22/charm-easyrsa">docs</a> </td>
   <td> <a href="https://github.com/charmed-kubernetes/layer-easyrsa"> source </a> </td>
   <td> <a href="https://bugs.launchpad.net/charmed-kubernetes"> bugs</a> </td>
   <td> <a href="https://jaas.ai/u/containers/easyrsa/420"> 420 </a> </td>
@@ -140,7 +140,7 @@ release. These charms are maintained by the Charmed Kubernetes team.
 <tr>
   <td> etcd </td>
   <td> Deploy a TLS terminated ETCD Cluster </td>
-  <td> <a href="/kubernetes/docs/1.22/charm-etcd">docs</a> </td> 
+  <td> <a href="/kubernetes/docs/1.22/charm-etcd">docs</a> </td>
   <td> <a href="https://github.com/charmed-kubernetes/layer-etcd"> source </a> </td>
   <td> <a href="https://bugs.launchpad.net/charmed-kubernetes"> bugs</a> </td>
   <td> <a href="https://jaas.ai/u/containers/etcd/634"> 634 </a> </td>
@@ -149,7 +149,7 @@ release. These charms are maintained by the Charmed Kubernetes team.
 <tr>
   <td> flannel </td>
   <td> A charm that provides a robust Software Defined Network </td>
-  <td> <a href="/kubernetes/docs/1.22/charm-flannel">docs</a> </td> 
+  <td> <a href="/kubernetes/docs/1.22/charm-flannel">docs</a> </td>
   <td> <a href="https://github.com/coreos/flannel"> source </a> </td>
   <td> <a href="https://bugs.launchpad.net/charmed-kubernetes"> bugs</a> </td>
   <td> <a href="https://jaas.ai/u/containers/flannel/597"> 597 </a> </td>
@@ -158,7 +158,7 @@ release. These charms are maintained by the Charmed Kubernetes team.
 <tr>
   <td> gcp-integrator </td>
   <td> Charm to enable GCP integrations via Juju relations. </td>
-  <td> <a href="/kubernetes/docs/1.22/charm-gcp-integrator">docs</a> </td> 
+  <td> <a href="/kubernetes/docs/1.22/charm-gcp-integrator">docs</a> </td>
   <td> <a href="https://github.com/juju-solutions/charm-gcp-integrator"> source </a> </td>
   <td> <a href="https://bugs.launchpad.net/charmed-kubernetes"> bugs</a> </td>
   <td> <a href="https://jaas.ai/u/containers/gcp-integrator/145"> 145 </a> </td>
@@ -167,7 +167,7 @@ release. These charms are maintained by the Charmed Kubernetes team.
 <tr>
   <td> kata </td>
   <td> Kata untrusted container runtime subordinate </td>
-  <td> <a href="/kubernetes/docs/1.22/charm-kata">docs</a> </td> 
+  <td> <a href="/kubernetes/docs/1.22/charm-kata">docs</a> </td>
   <td> <a href="https://github.com/charmed-kubernetes/charm-kata"> source </a> </td>
   <td> <a href="https://bugs.launchpad.net/charmed-kubernetes"> bugs</a> </td>
   <td> <a href="https://jaas.ai/u/containers/kata/138"> 138 </a> </td>
@@ -176,7 +176,7 @@ release. These charms are maintained by the Charmed Kubernetes team.
 <tr>
   <td> keepalived </td>
   <td> Failover and monitoring daemon for LVS clusters </td>
-  <td> <a href="/kubernetes/docs/1.22/charm-keepalived">docs</a> </td> 
+  <td> <a href="/kubernetes/docs/1.22/charm-keepalived">docs</a> </td>
   <td> <a href="https://github.com/juju-solutions/charm-keepalived"> source </a> </td>
   <td> <a href="https://bugs.launchpad.net/charmed-kubernetes"> bugs</a> </td>
   <td> <a href="https://jaas.ai/u/containers/keepalived/110"> 110 </a> </td>
@@ -185,7 +185,7 @@ release. These charms are maintained by the Charmed Kubernetes team.
 <tr>
   <td> kubeapi-load-balancer </td>
   <td> Nginx Load Balancer </td>
-  <td> <a href="/kubernetes/docs/1.22/charm-kubeapi-load-balancer">docs</a> </td> 
+  <td> <a href="/kubernetes/docs/1.22/charm-kubeapi-load-balancer">docs</a> </td>
   <td> <a href="https://nginx.org/en/"> source </a> </td>
   <td> <a href="https://bugs.launchpad.net/charmed-kubernetes"> bugs</a> </td>
   <td> <a href="https://jaas.ai/u/containers/kubeapi-load-balancer/844"> 844 </a> </td>
@@ -194,7 +194,7 @@ release. These charms are maintained by the Charmed Kubernetes team.
 <tr>
   <td> kubernetes-master </td>
   <td> The Kubernetes control plane. </td>
-  <td> <a href="/kubernetes/docs/1.22/charm-kubernetes-master">docs</a> </td> 
+  <td> <a href="/kubernetes/docs/1.22/charm-kubernetes-master">docs</a> </td>
   <td> <a href="https://github.com/charmed-kubernetes/charm-kubernetes-master"> source </a> </td>
   <td> <a href="https://bugs.launchpad.net/charmed-kubernetes"> bugs</a> </td>
   <td> <a href="https://jaas.ai/u/containers/kubernetes-master/1078"> 1078 </a> </td>
@@ -203,7 +203,7 @@ release. These charms are maintained by the Charmed Kubernetes team.
 <tr>
   <td> kubernetes-worker </td>
   <td> The workload bearing units of a kubernetes cluster </td>
-  <td> <a href="/kubernetes/docs/1.22/charm-kubernetes-worker">docs</a> </td> 
+  <td> <a href="/kubernetes/docs/1.22/charm-kubernetes-worker">docs</a> </td>
   <td> <a href="https://github.com/charmed-kubernetes/charm-kubernetes-worker"> source </a> </td>
   <td> <a href="https://bugs.launchpad.net/charmed-kubernetes"> bugs</a> </td>
   <td> <a href="https://jaas.ai/u/containers/kubernetes-worker/816"> 816 </a> </td>
@@ -212,7 +212,7 @@ release. These charms are maintained by the Charmed Kubernetes team.
 <tr>
   <td> openstack-integrator </td>
   <td> Proxy charm to enable OpenStack integrations via Juju relations. </td>
-  <td> <a href="/kubernetes/docs/1.22/charm-openstack-integrator">docs</a> </td> 
+  <td> <a href="/kubernetes/docs/1.22/charm-openstack-integrator">docs</a> </td>
   <td> <a href="https://github.com/juju-solutions/charm-openstack-integrator"> source </a> </td>
   <td> <a href="https://bugs.launchpad.net/charmed-kubernetes"> bugs</a> </td>
   <td> <a href="https://jaas.ai/u/containers/openstack-integrator/182"> 182 </a> </td>
@@ -221,7 +221,7 @@ release. These charms are maintained by the Charmed Kubernetes team.
 <tr>
   <td> tigera-secure-ee </td>
   <td> Tigera Secure Enterprise Edition </td>
-  <td> <a href="/kubernetes/docs/1.22/charm-tigera-secure-ee">docs</a> </td> 
+  <td> <a href="/kubernetes/docs/1.22/charm-tigera-secure-ee">docs</a> </td>
   <td> <a href="https://github.com/charmed-kubernetes/layer-tigera-secure-ee"> source </a> </td>
   <td> <a href="https://bugs.launchpad.net/charmed-kubernetes"> bugs</a> </td>
   <td> <a href="https://jaas.ai/u/containers/tigera-secure-ee/230"> 230 </a> </td>
@@ -230,7 +230,7 @@ release. These charms are maintained by the Charmed Kubernetes team.
 <tr>
   <td> vsphere-integrator </td>
   <td> Proxy charm to enable VMware vSphere integrations via Juju relations. </td>
-  <td> <a href="/kubernetes/docs/1.22/charm-vsphere-integrator">docs</a> </td> 
+  <td> <a href="/kubernetes/docs/1.22/charm-vsphere-integrator">docs</a> </td>
   <td> <a href="https://github.com/juju-solutions/charm-vsphere-integrator"> source </a> </td>
   <td> <a href="https://bugs.launchpad.net/charmed-kubernetes"> bugs</a> </td>
   <td> <a href="https://jaas.ai/u/containers/vsphere-integrator/123"> 123 </a> </td>

--- a/templates/kubernetes/docs/1.22/release-notes.md
+++ b/templates/kubernetes/docs/1.22/release-notes.md
@@ -13,6 +13,15 @@ layout: [base, ubuntu-com]
 toc: False
 ---
 
+# 1.22+ck2 Bugfix release
+
+### October 27, 2021 - [charmed-kubernetes-814](https://api.jujucharms.com/charmstore/v5/charmed-kubernetes-814/archive/bundle.yaml)
+
+## Fixes
+
+A list of bug fixes and other minor feature updates in this release can be found at
+[the launchpad milestone page for 1.22+ck2](https://launchpad.net/charmed-kubernetes/+milestone/1.22+ck2).
+
 # 1.22+ck1 Bugfix release
 
 ### October 21, 2021 - [charmed-kubernetes-807](https://api.jujucharms.com/charmstore/v5/charmed-kubernetes-807/archive/bundle.yaml)

--- a/templates/kubernetes/docs/install-manual.md
+++ b/templates/kubernetes/docs/install-manual.md
@@ -232,7 +232,7 @@ versions of the **Charmed Kubernetes** bundle are shown in the table below:
 
 | Kubernetes version | Charmed Kubernetes bundle |
 | --- | --- |
-| 1.22.x    | [charmed-kubernetes-807](https://api.jujucharms.com/charmstore/v5/charmed-kubernetes-807/archive/bundle.yaml) |
+| 1.22.x    | [charmed-kubernetes-814](https://api.jujucharms.com/charmstore/v5/charmed-kubernetes-814/archive/bundle.yaml) |
 | 1.21.x    | [charmed-kubernetes-733](https://api.jujucharms.com/charmstore/v5/charmed-kubernetes-733/archive/bundle.yaml) |
 | 1.20.x    | [charmed-kubernetes-596](https://api.jujucharms.com/charmstore/v5/charmed-kubernetes-596/archive/bundle.yaml) |
 | 1.19.x    | [charmed-kubernetes-545](https://api.jujucharms.com/charmstore/v5/charmed-kubernetes-545/archive/bundle.yaml) |

--- a/templates/kubernetes/docs/release-notes.md
+++ b/templates/kubernetes/docs/release-notes.md
@@ -13,6 +13,16 @@ layout: [base, ubuntu-com]
 toc: False
 ---
 
+# 1.22+ck2 Bugfix release
+
+### October 27, 2021 - [charmed-kubernetes-814](https://api.jujucharms.com/charmstore/v5/charmed-kubernetes-814/archive/bundle.yaml)
+
+## Fixes
+
+A list of bug fixes and other minor feature updates in this release can be found at
+[the launchpad milestone page for 1.22+ck2](https://launchpad.net/charmed-kubernetes/+milestone/1.22+ck2).
+
+
 # 1.22+ck1 Bugfix release
 
 ### October 21, 2021 - [charmed-kubernetes-807](https://api.jujucharms.com/charmstore/v5/charmed-kubernetes-807/archive/bundle.yaml)

--- a/templates/kubernetes/docs/shared/_side-navigation.md
+++ b/templates/kubernetes/docs/shared/_side-navigation.md
@@ -33,6 +33,7 @@
 - [SR-IOV](/kubernetes/docs/cni-sriov)
 - [Using multiple networks](/kubernetes/docs/multiple-networks)
 - [IPv6](/kubernetes/docs/ipv6)
+- [Ingress](/kubernetes/docs/ingress)
 
 ## Container Runtimes
 - [Containerd & Docker](/kubernetes/docs/container-runtime)

--- a/templates/kubernetes/docs/supported-versions.md
+++ b/templates/kubernetes/docs/supported-versions.md
@@ -57,7 +57,7 @@ versions of the **Charmed Kubernetes** bundle are shown in the table below:
 
 | Kubernetes version | Charmed Kubernetes bundle |
 | --- | --- |
-| 1.22.x    | [charmed-kubernetes-807](https://api.jujucharms.com/charmstore/v5/charmed-kubernetes-807/archive/bundle.yaml) |
+| 1.22.x    | [charmed-kubernetes-814](https://api.jujucharms.com/charmstore/v5/charmed-kubernetes-814/archive/bundle.yaml) |
 | 1.21.x    | [charmed-kubernetes-733](https://api.jujucharms.com/charmstore/v5/charmed-kubernetes-733/archive/bundle.yaml) |
 | 1.20.x    | [charmed-kubernetes-596](https://api.jujucharms.com/charmstore/v5/charmed-kubernetes-596/archive/bundle.yaml) |
 | 1.19.x    | [charmed-kubernetes-545](https://api.jujucharms.com/charmstore/v5/charmed-kubernetes-545/archive/bundle.yaml) |


### PR DESCRIPTION
## Done

- Update release notes
- Update and fix components page
- Add ingress page to navigation


## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
