### PR TITLE
Create ad hoc thank you page for pro beta contact form

### DIFF
--- a/templates/advantage/beta/thank-you.html
+++ b/templates/advantage/beta/thank-you.html
@@ -1,0 +1,18 @@
+{% extends "advantage/base_advantage.html" %}
+
+{% block title %}Join our free beta programme for Ubuntu Pro on prem&nbsp;&rsaquo;{% endblock %}
+{% block meta_description %}Ubuntu Advantage for Infrastructure offers a single, per-node packaging of the most comprehensive software, security and IaaS support in the industry, with OpenStack support, Kubernetes support included, and Livepatch, Landscape and Extended Security Maintenance to address security and compliance concerns.{% endblock %}
+
+{% block head_extra %}<meta name="robots" content="noindex" />{% endblock %}
+
+{% block content %}
+  <section class="p-strip--suru-topped">
+    <div class="row">
+      <div class="col-12 u-sv3">
+        <h1>Thank you for registering your interest.</h1>
+
+        <p> We will offer beta access to selected candidates and we will let everyone know once the service is generally available.</p>
+      </div>
+    </div>
+  </section>
+{% endblock %}

--- a/templates/shared/forms/interactive/advantage-beta.html
+++ b/templates/shared/forms/interactive/advantage-beta.html
@@ -138,7 +138,7 @@
                   <textarea id="Comments_from_lead__c" name="Comments_from_lead__c" rows="5" maxlength="2000"></textarea>
                 </li>
               </ul>
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="returnURL" value="/advantage" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="returnURL" value="/advantage/beta/thank-you" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formid" value="%% formid %%" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="Consent_to_Processing__c" value="yes" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" id="utm_campaign" value="" />


### PR DESCRIPTION

## Done

- Create a new page under /advantage/beta/thank-you

## QA

- go to https://ubuntu-com-10785.demos.haus/advantage
- click "Join our free beta programme for Ubuntu Pro on prem ›"
- fill in the form
- submit
- see that you land on https://ubuntu-com-10785.demos.haus/advantage/beta/thank-you

## Issue / Card

Fixes canonical-web-and-design/commercial-squad#352

## Screenshots

![image](https://user-images.githubusercontent.com/11927929/139905656-c057abc1-5c06-40a5-893b-e818ad754dd9.png)

