### PR TITLE
Fix blender cancel subscription

### DIFF
--- a/static/js/src/advantage/api/contracts.js
+++ b/static/js/src/advantage/api/contracts.js
@@ -186,7 +186,12 @@ export async function postPurchaseData(
   return data;
 }
 
-export async function cancelContract(accountId, previousPurchaseId, productId) {
+export async function cancelContract(
+  accountId,
+  previousPurchaseId,
+  productId,
+  marketplace
+) {
   const queryString = window.location.search; // Pass arguments to the flask backend eg. "test_backend=true"
 
   let response = await fetch(`/advantage/subscribe${queryString}`, {
@@ -201,6 +206,7 @@ export async function cancelContract(accountId, previousPurchaseId, productId) {
       account_id: accountId,
       previous_purchase_id: previousPurchaseId,
       product_listing_id: productId,
+      marketplace: marketplace,
     }),
   });
 

--- a/static/js/src/advantage/react/hooks/useCancelContract.test.tsx
+++ b/static/js/src/advantage/react/hooks/useCancelContract.test.tsx
@@ -55,7 +55,8 @@ describe("useCancelContract", () => {
       lastPurchaseIds?.[UserSubscriptionMarketplace.CanonicalUA]?.[
         UserSubscriptionPeriod.Monthly
       ],
-      subscription.listing_id
+      subscription.listing_id,
+      subscription.marketplace
     );
   });
 

--- a/static/js/src/advantage/react/hooks/useCancelContract.ts
+++ b/static/js/src/advantage/react/hooks/useCancelContract.ts
@@ -20,7 +20,8 @@ export const useCancelContract = (subscription?: UserSubscription) => {
       cancelContract(
         subscription?.account_id,
         lastPurchaseId,
-        subscription?.listing_id
+        subscription?.listing_id,
+        subscription?.marketplace
       ).then((response) => {
         if (response.errors) {
           throw new Error(response.errors);

--- a/webapp/advantage/schemas.py
+++ b/webapp/advantage/schemas.py
@@ -49,6 +49,10 @@ cancel_advantage_subscriptions = {
     "account_id": String(required=True),
     "previous_purchase_id": String(required=True),
     "product_listing_id": String(required=True),
+    "marketplace": String(
+        validate=validate.OneOf(["canonical-ua", "canonical-cube", "blender"]),
+        required=True,
+    ),
 }
 
 post_anonymised_customer_info = {
@@ -80,7 +84,9 @@ ensure_purchase_account = {
 
 invoice_view = {
     "marketplace": String(
-        validate=validate.OneOf(["", "canonical-ua", "canonical-cube"])
+        validate=validate.OneOf(
+            ["", "canonical-ua", "canonical-cube", "blender"]
+        )
     ),
     "email": String(),
 }

--- a/webapp/advantage/views.py
+++ b/webapp/advantage/views.py
@@ -449,10 +449,11 @@ def cancel_advantage_subscriptions(**kwargs):
     account_id = kwargs.get("account_id")
     previous_purchase_id = kwargs.get("previous_purchase_id")
     product_listing_id = kwargs.get("product_listing_id")
+    marketplace = kwargs.get("marketplace")
 
     monthly_subscriptions = g.api.get_account_subscriptions(
         account_id=account_id,
-        marketplace="canonical-ua",
+        marketplace=marketplace,
         filters={"status": "active", "period": "monthly"},
     )
 
@@ -476,7 +477,7 @@ def cancel_advantage_subscriptions(**kwargs):
 
     try:
         purchase = g.api.purchase_from_marketplace(
-            marketplace="canonical-ua", purchase_request=purchase_request
+            marketplace=marketplace, purchase_request=purchase_request
         )
     except CannotCancelLastContractError:
         g.api.cancel_subscription(


### PR DESCRIPTION
## Done

- Add marketplace parameter to the cancel subscription endpoint

## QA

- Have a monthly blender purchase
- If you do not have one use this demo and purchase one: https://ubuntu-com-10711.demos.haus/advantage/subscribe/blender?test_backend=true
- After you finished purchasing the blender product go to this demo: https://ubuntu-com-10787.demos.haus/advantage?test_backend=true
- You will see you blender subscription you purchased
- Hit edit subscription and then try to cancel the subscription
- It should work and after that the edit subscription button will disappear because the status of the subscription is `is_cancelled`. You can confirm that by checking the raw data ttps://ubuntu-com-10787.demos.haus/advantage/user-subscriptions?test_backend=true

## Issue / Card

Fixes #https://github.com/canonical-web-and-design/commercial-squad/issues/378