### PR TITLE
Update Enterprise and Developer mega menus

### DIFF
--- a/templates/templates/navigation-developer-h.html
+++ b/templates/templates/navigation-developer-h.html
@@ -125,7 +125,7 @@
           <p class="p-p--small">Fun guides and HOWTOs covering Ubuntu cloud, desktop, server, community, IoT, packaging and more.</p>
           <div>
             <ul class="p-text-list--small is-bordered">
-              <li class="p-list__item"><a href="/tutorials/tutorial-guidelines">How to write a tutorial</a></li>
+              <li class="p-list__item"><a href="/tutorials/tutorial-guidelines#1-overview">How to write a tutorial</a></li>
             </ul>
           </div>
         </div>
@@ -155,11 +155,12 @@
       <div class="col-9">
         <ul class="p-inline-list--middot is-x-dense">
           <li class="p-inline-list__item"><a href="https://docs.ubuntu.com">Docs</a></li>
+          <li class="p-inline-list__item"><a href="https://discourse.ubuntu.com">Ubuntu Discourse</a></li>
           <li class="p-inline-list__item"><a href="https://ubuntuforums.org">Forum</a></li>
           <li class="p-inline-list__item"><a href="/tutorials">Tutorials</a></li>
           <li class="p-inline-list__item"><a href="https://www.youtube.com/user/celebrateubuntu">Videos</a></li>
-          <li class="p-inline-list__item"><a href="https://www.brighttalk.com/search?q=Canonical">Webinars</a></li>
-          <li class="p-inline-list__item"><a href="/blog?category=white-papers#posts-list">Whitepapers</a></li>
+          <li class="p-inline-list__item"><a href="/engage?resource=webinar">Webinars</a></li>
+          <li class="p-inline-list__item"><a href="/engage?resource=whitepaper">Whitepapers</a></li>
           <li class="p-inline-list__item"><a href="/blog">Blog</a></li>
         </ul>
       </div>
@@ -203,7 +204,8 @@
         <div class="col-9">
           <ul class="p-inline-list--middot is-x-dense">
             <li class="p-inline-list__item"><a href="https://cloud-init.io">cloud-init</a></li>
-            <li class="p-inline-list__item"><a href="https://charmhub.io">Juju</a></li>
+            <li class="p-inline-list__item"><a href="https://netplan.io">netplan</a></li>
+            <li class="p-inline-list__item"><a href="https://juju.is">Juju</a></li>
             <li class="p-inline-list__item"><a href="https://snapcraft.io">Snapcraft</a></li>
             <li class="p-inline-list__item"><a href="http://linuxcontainers.org">LXD</a></li>
             <li class="p-inline-list__item"><a href="https://multipass.run">Multipass</a></li>

--- a/templates/templates/navigation-enterprise-h.html
+++ b/templates/templates/navigation-enterprise-h.html
@@ -149,7 +149,7 @@
         <h4 class="p-muted-heading"><a href="/server">Data centre&nbsp;&rsaquo;</a></h4>
         <ul class="p-text-list--small is-bordered">
           <li class="p-list__item"><a href="https://maas.io" title="Visit Metal as a Service - external site">MAAS - fast server provisioning</a></li>
-          <li class="p-list__item"><a href="https://jaas.ai" title="Visit jaas.ai - external site">Multi cloud operations with Juju</a></li>
+          <li class="p-list__item"><a href="https://juju.is" title="Visit juju.is - external site">Multi cloud operations with Juju</a></li>
           <li class="p-list__item"><a href="/ceph" title="Visit Ceph storage on Ubuntu">Ceph storage on Ubuntu</a></li>
           <li class="p-list__item"><a href="/certified/server" title="Visit certification - external site">Certified hardware</a></li>
           <li class="p-list__item"><a href="/server/docs" title="Get the Ubuntu server documentation">Ubuntu Server docs</a></li>
@@ -215,11 +215,11 @@
       </div>
       <div class="col-9">
         <ul class="p-inline-list--middot is-x-dense">
-          <li class="p-inline-list__item"><a href="/blog?category=webinars#posts-list">Webinars</a></li>
+          <li class="p-inline-list__item"><a href="/engage?resource=webinar">Webinars</a></li>
           <li class="p-inline-list__item"><a href="/tutorials" title="Visit our tutorials">Tutorials</a></li>
           <li class="p-inline-list__item"><a href="https://www.youtube.com/user/celebrateubuntu" title="Visit the Videos - external site">Videos</a></li>
-          <li class="p-inline-list__item"><a href="/blog?category=case-studies#posts-list">Case studies</a></li>
-          <li class="p-inline-list__item"><a href="/blog?category=white-papers#posts-list">White papers</a></li>
+          <li class="p-inline-list__item"><a href="/engage?resource=case+study">Case studies</a></li>
+          <li class="p-inline-list__item"><a href="/engage?resource=whitepaper">Whitepapers</a></li>
           <li class="p-inline-list__item"><a href="https://docs.ubuntu.com" title="Visit the Docs - external site">Docs</a></li>
           <li class="p-inline-list__item"><a href="/training">Training</a></li>
           <li class="p-inline-list__item"><a href="/blog" title="Visit the Blog">Blog</a></li>


### PR DESCRIPTION
## Done

- Update Enterprise and Developer mega menus with new and updated urls

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/#enterprise and http://0.0.0.0:8001/#developer
    - Be sure to test on mobile, tablet and desktop screen sizes
- Compare ENTERPRISE to the [copy doc](https://docs.google.com/document/d/1YBdQvLuqEpEQr_QqyycxMhZr4OaLapMlNJyYKCmPJsQ/edit?usp=drivesdk)
- Compare DEVELOPERS to the  [copy doc] and resolve comments(https://docs.google.com/document/d/1JzZPBydcdyV96Hu4xRpa7VDU_WREr6gb05bL7GlQaYY/edit?disco=AAAAQvhOfSo&usp_dm=true) and resolve comments

## Issue / Card

Fixes #10797

