### PR TITLE
persist embedded and automotive to show the subnav in both pages

### DIFF
--- a/navigation.yaml
+++ b/navigation.yaml
@@ -1208,8 +1208,10 @@ iot:
       path: /internet-of-things/appstore
     - title: Embedded Linux
       path: /embedded
+      persist: True
     - title: Automotive
       path: /automotive
+      persist: True
     - title: EdgeX
       path: /internet-of-things/edgex
     - title: Networking


### PR DESCRIPTION
## Done

- fix the missing subnav in /embedded and /automotive

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/internet-of-things or https://ubuntu-com-10800.demos.haus/internet-of-things
- Click on the subnav `embedded` and `automotive`
- Make sure that both pages have the subnav
![image](https://user-images.githubusercontent.com/36013798/140303998-8dde923c-84c2-4380-bed4-667b0d800663.png)

## Issue / Card

Fixes #10427 

## Help

[QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html) - [Commit guidelines](https://canonical-web-and-design.github.io/practices/workflow/commit-messages.html)
