### PR TITLE
Show ESM Apps only if it's included

### DIFF
--- a/static/js/src/advantage/react/utils/filterAndFormatEntitlements.test.ts
+++ b/static/js/src/advantage/react/utils/filterAndFormatEntitlements.test.ts
@@ -43,6 +43,13 @@ it("returns entitlements with labels as keys", () => {
       support_level: "advanced",
       type: "support",
     },
+    "ESM Apps": {
+      enabled_by_default: false,
+      is_available: false,
+      is_editable: false,
+      support_level: null,
+      type: "esm-apps",
+    },
     "ESM Infra": {
       enabled_by_default: false,
       is_available: true,
@@ -95,6 +102,7 @@ it("ignores some labels", () => {
     }),
   ];
   expect(filterAndFormatEntitlements(entitlements).included).toStrictEqual([
+    EntitlementLabel.EsmApps,
     EntitlementLabel.EsmInfra,
   ]);
   expect(filterAndFormatEntitlements(entitlements).excluded).toHaveLength(0);

--- a/static/js/src/advantage/react/utils/filterAndFormatEntitlements.ts
+++ b/static/js/src/advantage/react/utils/filterAndFormatEntitlements.ts
@@ -5,6 +5,7 @@ export enum EntitlementLabel {
   Cis = "CIS",
   Blender = "Blender",
   EsmInfra = "ESM Infra",
+  EsmApps = "ESM Apps",
   FipsUpdates = "FIPS-Updates",
   Fips = "FIPS",
   Livepatch = "Livepatch",
@@ -21,7 +22,7 @@ const alwaysAvailableLabels: Record<string, EntitlementLabel> = {
 const labels: Record<string, EntitlementLabel | null> = {
   [EntitlementType.Blender]: EntitlementLabel.Blender,
   [EntitlementType.CcEal]: null,
-  [EntitlementType.EsmApps]: null,
+  [EntitlementType.EsmApps]: EntitlementLabel.EsmApps,
   [EntitlementType.EsmInfra]: EntitlementLabel.EsmInfra,
   [EntitlementType.Livepatch]: EntitlementLabel.Livepatch,
   [EntitlementType.LivepatchOnprem]: EntitlementLabel.Livepatch,
@@ -98,7 +99,10 @@ export const groupEntitlements = (
       } else if (entitlement.is_available) {
         included.push(label);
       } else if (!entitlement.is_available && !entitlement.is_editable) {
-        excluded.push(label);
+        // we hide ESM Apps from the excluded list until the proper release
+        if (entitlement.type !== EntitlementType.EsmApps) {
+          excluded.push(label);
+        }
       }
     }
   });

--- a/static/js/src/advantage/react/utils/getFeaturesDisplay.test.ts
+++ b/static/js/src/advantage/react/utils/getFeaturesDisplay.test.ts
@@ -26,7 +26,7 @@ describe("getFeaturesDisplay", () => {
       }),
     ];
     expect(getFeaturesDisplay(entitlements)).toStrictEqual({
-      excluded: ["Blender", "ESM Infra"],
+      excluded: ["Blender", "ESM Apps", "ESM Infra"],
       included: ["Livepatch", "24/7 Support"],
     });
   });

--- a/static/js/src/advantage/react/utils/getFeaturesDisplay.ts
+++ b/static/js/src/advantage/react/utils/getFeaturesDisplay.ts
@@ -5,7 +5,7 @@ const labels: Record<string, string | null> = {
   [EntitlementType.Blender]: "Blender",
   [EntitlementType.CcEal]: null,
   [EntitlementType.Cis]: null,
-  [EntitlementType.EsmApps]: null,
+  [EntitlementType.EsmApps]: "ESM Apps",
   [EntitlementType.EsmInfra]: "ESM Infra",
   [EntitlementType.FipsUpdates]: null,
   [EntitlementType.Fips]: null,


### PR DESCRIPTION
## Done

- Changed the logic to only display ESM Apps if it's included in the conctract

## QA

- go to [/advantage?test_backend=true](https://ubuntu-com-10803.demos.haus/advantage?test_backend=true) with an ESM Apps contract (you can buy one at [/advantage/subscribe?test_backend=true](https://ubuntu-com-10803.demos.haus/advantage/subscribe?test_backend=true) )
- Check that the badge and the toggle for ESM Apps display correctly for this subscription
- Check that no mention of ESM apps appear on infra only subscriptions

## Issue / Card

Fixes https://github.com/canonical-web-and-design/web-squad/issues/4569

## Screenshots

![image](https://user-images.githubusercontent.com/11927929/140386418-a7496746-4e20-4002-82d9-dcb8f199f47f.png)

![image](https://user-images.githubusercontent.com/11927929/140386505-fb14de8c-f6bd-44b9-a9e8-701153b25f20.png)


