### PR TITLE
Fix issue that caused renewal settings to be displayed empty

### DIFF
--- a/static/js/src/advantage/react/components/Subscriptions/SubscriptionList/SubscriptionList.test.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/SubscriptionList/SubscriptionList.test.tsx
@@ -124,7 +124,7 @@ describe("SubscriptionList", () => {
     ).toBe(true);
   });
 
-  it("shows the renewal settings if there are active subs", () => {
+  it("shows the renewal settings if there subscriptions for which we should present the auto-renewal option", () => {
     queryClient.setQueryData("userSubscriptions", [
       userSubscriptionFactory.build({
         period: UserSubscriptionPeriod.Yearly,
@@ -132,6 +132,7 @@ describe("SubscriptionList", () => {
         statuses: userSubscriptionStatusesFactory.build({
           is_subscription_active: false,
           is_subscription_auto_renewing: true,
+          should_present_auto_renewal: false,
         }),
       }),
       userSubscriptionFactory.build({
@@ -140,6 +141,7 @@ describe("SubscriptionList", () => {
         statuses: userSubscriptionStatusesFactory.build({
           is_subscription_active: true,
           is_subscription_auto_renewing: true,
+          should_present_auto_renewal: true,
         }),
       }),
     ]);
@@ -156,7 +158,7 @@ describe("SubscriptionList", () => {
     );
   });
 
-  it("does not show the renewal settings if there are no active subs", () => {
+  it("does not show the renewal settings if there are no subscriptions for which we should present the auto-renewal option", () => {
     queryClient.setQueryData("userSubscriptions", [
       userSubscriptionFactory.build({
         period: UserSubscriptionPeriod.Monthly,
@@ -164,14 +166,16 @@ describe("SubscriptionList", () => {
         statuses: userSubscriptionStatusesFactory.build({
           is_subscription_active: false,
           is_subscription_auto_renewing: true,
+          should_present_auto_renewal: false,
         }),
       }),
       userSubscriptionFactory.build({
         period: UserSubscriptionPeriod.Yearly,
         subscription_id: "ghi",
         statuses: userSubscriptionStatusesFactory.build({
-          is_subscription_active: false,
-          is_subscription_auto_renewing: true,
+          is_subscription_active: true,
+          is_subscription_auto_renewing: false,
+          should_present_auto_renewal: false,
         }),
       }),
     ]);

--- a/static/js/src/advantage/react/components/Subscriptions/SubscriptionList/SubscriptionList.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/SubscriptionList/SubscriptionList.tsx
@@ -4,7 +4,7 @@ import {
   selectFreeSubscription,
   selectUASubscriptions,
   selectBlenderSubscriptions,
-  selectActiveUASubscriptions,
+  selectPresentableRenewalSubscriptions,
 } from "advantage/react/hooks/useUserSubscriptions";
 import { sortSubscriptionsByStartDate } from "advantage/react/utils";
 import { sendAnalyticsEvent } from "advantage/react/utils/sendAnalyticsEvent";
@@ -40,16 +40,16 @@ const SubscriptionList = ({ selectedId, onSetActive }: Props) => {
   });
   const {
     data: activeUASubscriptions = [],
-    isLoading: isLoadingActiveUASubscriptions,
+    isLoading: isLoadingPresentableRenewalSubscriptions,
   } = useUserSubscriptions({
-    select: selectActiveUASubscriptions,
+    select: selectPresentableRenewalSubscriptions,
   });
 
   if (
     isLoadingFree ||
     isLoadingUA ||
     isLoadingBlender ||
-    isLoadingActiveUASubscriptions
+    isLoadingPresentableRenewalSubscriptions
   ) {
     return <Spinner />;
   }

--- a/static/js/src/advantage/react/hooks/useUserSubscriptions.ts
+++ b/static/js/src/advantage/react/hooks/useUserSubscriptions.ts
@@ -72,11 +72,13 @@ export const selectBlenderSubscriptions = (subscriptions: UserSubscription[]) =>
   );
 
 /**
- * Find the active UA subscriptions.
+ * Find the active UA subscriptions that should have their renewal options
+ * presented.
  */
-export const selectActiveUASubscriptions = (
+export const selectPresentableRenewalSubscriptions = (
   subscriptions: UserSubscription[]
-) => subscriptions.filter(({ statuses }) => statuses.is_subscription_active);
+) =>
+  subscriptions.filter(({ statuses }) => statuses.should_present_auto_renewal);
 
 /**
  * Find the subscriptions with for period.


### PR DESCRIPTION
This is fixing a small issue that caused the renewal settings button and menu to be displayed empty if the user had any active subscription (monthly/yearly), even if it was not time to display it yet (nothing was displayed though, the menu would be empty).

Tests were also updated to catch this.