### PR TITLE
Fix ua permissions

### DIFF
--- a/navigation.yaml
+++ b/navigation.yaml
@@ -1243,9 +1243,6 @@ support:
     - title: Your subscriptions
       path: /advantage
       persist: True
-    - title: Account users
-      path: /advantage/users
-      persist: True
 
     - title: Community support
       path: /support/community-support

--- a/navigation.yaml
+++ b/navigation.yaml
@@ -1243,6 +1243,9 @@ support:
     - title: Your subscriptions
       path: /advantage
       persist: True
+    - title: Account users
+      path: /advantage/users
+      persist: True
 
     - title: Community support
       path: /support/community-support

--- a/static/js/src/advantage/api/types.ts
+++ b/static/js/src/advantage/api/types.ts
@@ -39,6 +39,8 @@ export type UserSubscriptionStatuses = {
   is_subscription_active: boolean;
   is_subscription_auto_renewing: boolean;
   should_present_auto_renewal: boolean;
+  has_access_to_support: boolean;
+  has_access_to_token: boolean;
 };
 
 export type UserSubscription = {

--- a/static/js/src/advantage/react/components/Subscriptions/SubscriptionDetails/DetailsContent/DetailsContent.test.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/SubscriptionDetails/DetailsContent/DetailsContent.test.tsx
@@ -7,6 +7,7 @@ import {
   contractTokenFactory,
   freeSubscriptionFactory,
   userSubscriptionFactory,
+  userSubscriptionStatusesFactory,
 } from "advantage/tests/factories/api";
 import {
   UserSubscriptionPeriod,
@@ -62,6 +63,24 @@ describe("DetailsContent", () => {
     );
     expect(wrapper.find("[data-test='token-spinner'] Spinner").exists()).toBe(
       true
+    );
+  });
+
+  it("displays no contract token for billing users", () => {
+    const contract = userSubscriptionFactory.build({
+      statuses: userSubscriptionStatusesFactory.build({
+        has_access_to_token: false,
+      }),
+    });
+
+    queryClient.setQueryData("userSubscriptions", [contract]);
+    const wrapper = mount(
+      <QueryClientProvider client={queryClient}>
+        <DetailsContent selectedId={contract.id} />
+      </QueryClientProvider>
+    );
+    expect(wrapper.find("[data-test='token-spinner'] Spinner").exists()).toBe(
+      false
     );
   });
 

--- a/static/js/src/advantage/react/components/Subscriptions/SubscriptionDetails/DetailsContent/DetailsContent.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/SubscriptionDetails/DetailsContent/DetailsContent.tsx
@@ -51,10 +51,14 @@ const DetailsContent = ({ selectedId }: Props) => {
   const { data: subscription, isLoading } = useUserSubscriptions({
     select: selectSubscriptionById(selectedId),
   });
-  const { data: token, isLoading: isLoadingToken } = useContractToken(
-    subscription?.contract_id
-  );
+  const hasAccessToToken = subscription?.statuses.has_access_to_token;
   const isBlender = isBlenderSubscription(subscription);
+  const showToken = hasAccessToToken && !isBlender;
+
+  const { data: token, isLoading: isLoadingToken } = useContractToken(
+    subscription?.contract_id,
+    showToken
+  );
 
   const SubscriptionToken = () => {
     return (
@@ -141,7 +145,7 @@ const DetailsContent = ({ selectedId }: Props) => {
           },
         ])}
       </Row>
-      {isBlender ? null : <SubscriptionToken />}
+      {showToken ? <SubscriptionToken /> : null}
       <DetailsTabs subscription={subscription} token={token} />
     </div>
   );

--- a/static/js/src/advantage/react/components/Subscriptions/SubscriptionDetails/DetailsContent/DetailsContent.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/SubscriptionDetails/DetailsContent/DetailsContent.tsx
@@ -53,11 +53,11 @@ const DetailsContent = ({ selectedId }: Props) => {
   });
   const hasAccessToToken = subscription?.statuses.has_access_to_token;
   const isBlender = isBlenderSubscription(subscription);
-  const showToken = hasAccessToToken && !isBlender;
+  const isTokenVisible = hasAccessToToken && !isBlender;
 
   const { data: token, isLoading: isLoadingToken } = useContractToken(
     subscription?.contract_id,
-    showToken
+    isTokenVisible
   );
 
   const SubscriptionToken = () => {
@@ -145,7 +145,7 @@ const DetailsContent = ({ selectedId }: Props) => {
           },
         ])}
       </Row>
-      {showToken ? <SubscriptionToken /> : null}
+      {isTokenVisible ? <SubscriptionToken /> : null}
       <DetailsTabs subscription={subscription} token={token} />
     </div>
   );

--- a/static/js/src/advantage/react/components/Subscriptions/SubscriptionDetails/SubscriptionDetails.test.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/SubscriptionDetails/SubscriptionDetails.test.tsx
@@ -62,6 +62,42 @@ describe("SubscriptionDetails", () => {
     expect(wrapper.find("DetailsContent").exists()).toBe(false);
   });
 
+  it("can show the support button", () => {
+    const wrapper = mount(
+      <QueryClientProvider client={queryClient}>
+        <SubscriptionDetails
+          onCloseModal={jest.fn()}
+          selectedId={contract.id}
+        />
+      </QueryClientProvider>
+    );
+    expect(wrapper.find("Button[data-test='support-button']").exists()).toBe(
+      true
+    );
+  });
+
+  it("cannot show the support button", () => {
+    const contract = userSubscriptionFactory.build({
+      statuses: userSubscriptionStatusesFactory.build({
+        has_access_to_support: false,
+      }),
+    });
+
+    queryClient.setQueryData("userSubscriptions", [contract]);
+
+    const wrapper = mount(
+      <QueryClientProvider client={queryClient}>
+        <SubscriptionDetails
+          onCloseModal={jest.fn()}
+          selectedId={contract.id}
+        />
+      </QueryClientProvider>
+    );
+    expect(wrapper.find("Button[data-test='support-button']").exists()).toBe(
+      false
+    );
+  });
+
   it("closes the edit form when closing the modal", () => {
     // Create a wrapping component to pass props to the inner
     // SubscriptionDetails component. This is needed so that setProps will

--- a/static/js/src/advantage/react/components/Subscriptions/SubscriptionDetails/SubscriptionDetails.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/SubscriptionDetails/SubscriptionDetails.tsx
@@ -36,8 +36,6 @@ export const SubscriptionDetails = forwardRef<HTMLDivElement, Props>(
       select: selectSubscriptionById(selectedId),
     });
     const isFree = isFreeSubscription(subscription);
-    const hasAccessToSupport = subscription?.statuses.has_access_to_support;
-    const hideSupportPortal = !hasAccessToSupport || isFree;
     const isResizable =
       subscription?.statuses.is_upsizeable ||
       subscription?.statuses.is_downsizeable;
@@ -89,18 +87,20 @@ export const SubscriptionDetails = forwardRef<HTMLDivElement, Props>(
               statuses={subscription.statuses}
             />
             {notification ? <Notification {...notification} /> : null}
-            {hideSupportPortal ? null : (
+            {isFree ? null : (
               <>
-                <Button
-                  appearance="positive"
-                  className="p-subscriptions__details-action"
-                  data-test="support-button"
-                  disabled={editing}
-                  element="a"
-                  href="https://support.canonical.com/"
-                >
-                  Support portal
-                </Button>
+                {subscription.statuses.has_access_to_support ? (
+                  <Button
+                    appearance="positive"
+                    className="p-subscriptions__details-action"
+                    data-test="support-button"
+                    disabled={editing}
+                    element="a"
+                    href="https://support.canonical.com/"
+                  >
+                    Support portal
+                  </Button>
+                ) : null}
                 {subscription.statuses.is_renewable ? (
                   <Button
                     appearance="neutral"

--- a/static/js/src/advantage/react/components/Subscriptions/SubscriptionDetails/SubscriptionDetails.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/SubscriptionDetails/SubscriptionDetails.tsx
@@ -36,6 +36,8 @@ export const SubscriptionDetails = forwardRef<HTMLDivElement, Props>(
       select: selectSubscriptionById(selectedId),
     });
     const isFree = isFreeSubscription(subscription);
+    const hasAccessToSupport = subscription?.statuses.has_access_to_support;
+    const hideSupportPortal = !hasAccessToSupport || isFree;
     const isResizable =
       subscription?.statuses.is_upsizeable ||
       subscription?.statuses.is_downsizeable;
@@ -87,7 +89,7 @@ export const SubscriptionDetails = forwardRef<HTMLDivElement, Props>(
               statuses={subscription.statuses}
             />
             {notification ? <Notification {...notification} /> : null}
-            {isFree ? null : (
+            {hideSupportPortal ? null : (
               <>
                 <Button
                   appearance="positive"

--- a/static/js/src/advantage/react/hooks/useContractToken.test.tsx
+++ b/static/js/src/advantage/react/hooks/useContractToken.test.tsx
@@ -37,6 +37,4 @@ describe("useContractToken", () => {
     await waitForNextUpdate();
     expect(result.current.data).toStrictEqual(contractToken);
   });
-
-  // write test for not returning token
 });

--- a/static/js/src/advantage/react/hooks/useContractToken.test.tsx
+++ b/static/js/src/advantage/react/hooks/useContractToken.test.tsx
@@ -37,4 +37,6 @@ describe("useContractToken", () => {
     await waitForNextUpdate();
     expect(result.current.data).toStrictEqual(contractToken);
   });
+
+  // write test for not returning token
 });

--- a/static/js/src/advantage/react/hooks/useContractToken.ts
+++ b/static/js/src/advantage/react/hooks/useContractToken.ts
@@ -4,13 +4,13 @@ import { useQuery } from "react-query";
 
 export const useContractToken = (
   contractId?: UserSubscription["contract_id"] | null,
-  showToken?: boolean | false
+  isTokenVisible?: boolean | false
 ) => {
   const query = useQuery<ContractToken>(
     ["contractToken", contractId],
     async () => await getContractToken(contractId),
     {
-      enabled: !!contractId && showToken,
+      enabled: !!contractId && isTokenVisible,
     }
   );
   return query;

--- a/static/js/src/advantage/react/hooks/useContractToken.ts
+++ b/static/js/src/advantage/react/hooks/useContractToken.ts
@@ -3,13 +3,14 @@ import { ContractToken, UserSubscription } from "advantage/api/types";
 import { useQuery } from "react-query";
 
 export const useContractToken = (
-  contractId?: UserSubscription["contract_id"] | null
+  contractId?: UserSubscription["contract_id"] | null,
+  showToken?: boolean | false
 ) => {
   const query = useQuery<ContractToken>(
     ["contractToken", contractId],
     async () => await getContractToken(contractId),
     {
-      enabled: !!contractId,
+      enabled: !!contractId && showToken,
     }
   );
   return query;

--- a/static/js/src/advantage/react/hooks/useUserSubscriptions.test.tsx
+++ b/static/js/src/advantage/react/hooks/useUserSubscriptions.test.tsx
@@ -98,6 +98,8 @@ describe("useUserSubscriptions", () => {
       is_subscription_active: false,
       is_subscription_auto_renewing: false,
       should_present_auto_renewal: false,
+      has_access_to_support: true,
+      has_access_to_token: true,
     });
   });
 

--- a/static/js/src/advantage/react/hooks/useUserSubscriptions.ts
+++ b/static/js/src/advantage/react/hooks/useUserSubscriptions.ts
@@ -59,6 +59,8 @@ export const selectStatusesSummary = (
     subscriptions,
     "should_present_auto_renewal"
   ),
+  has_access_to_support: hasStatus(subscriptions, "has_access_to_support"),
+  has_access_to_token: hasStatus(subscriptions, "has_access_to_token"),
 });
 
 export const selectUASubscriptions = (subscriptions: UserSubscription[]) =>

--- a/static/js/src/advantage/tests/factories/api.ts
+++ b/static/js/src/advantage/tests/factories/api.ts
@@ -48,6 +48,8 @@ export const userSubscriptionStatusesFactory = Factory.define<UserSubscriptionSt
     is_subscription_active: false,
     is_subscription_auto_renewing: false,
     should_present_auto_renewal: false,
+    has_access_to_support: true,
+    has_access_to_token: true,
   })
 );
 

--- a/templates/account/forbidden.html
+++ b/templates/account/forbidden.html
@@ -1,0 +1,20 @@
+{% extends "templates/base.html" %}
+
+{% block title %}Your account{% endblock %}
+
+{% block head_extra %}
+  <meta name="robots" content="noindex, nofollow">
+{% endblock %}
+
+{% block outer_content %}
+
+  <section class="p-strip--suru-topped p-strip-account-page">
+    <div class="row">
+      <div class="col-12">
+        <h1>Access Forbidden</h1>
+        <p>You cannot perform that action. Contact your account administrator for more information.</p>
+      </div>
+    </div>
+  </section>
+
+{% endblock %}

--- a/tests/advantage/fixtures/account.json
+++ b/tests/advantage/fixtures/account.json
@@ -15,5 +15,6 @@
     }
   ],
   "id": "aAbBcCdDeEfFgGhHiIjJkKlLmMnNoOpP",
-  "name": "Account Name"
+  "name": "Account Name",
+  "userRoleOnAccount": "admin"
 }

--- a/tests/advantage/fixtures/accounts.json
+++ b/tests/advantage/fixtures/accounts.json
@@ -2,7 +2,8 @@
   {
     "createdAt": "2010-01-01T10:00:00Z",
     "id": "a123AbBcCdDeEfFgGhHiIjJkKlLmMnNoOpP",
-    "name": "Free"
+    "name": "Free",
+    "userRoleOnAccount": "admin"
   },
   {
     "createdAt": "2011-01-01T10:00:00Z",
@@ -21,6 +22,7 @@
       }
     ],
     "id": "aAbBcCdDeEfFgGhHiIjJkKlLmMnNoOpP",
-    "name": "Account Name"
+    "name": "Account Name",
+    "userRoleOnAccount": "admin"
   }
 ]

--- a/tests/advantage/helpers.py
+++ b/tests/advantage/helpers.py
@@ -12,6 +12,7 @@ from webapp.advantage.ua_contracts.primitives import (
     ContractItem,
     Contract,
     Renewal,
+    Account,
 )
 
 
@@ -220,6 +221,7 @@ def make_legacy_contract_item(
 
 
 def make_purchase_contract_item(
+    id: int = None,
     contract_id: str = None,
     created_at: str = None,
     start_date: str = None,
@@ -229,6 +231,7 @@ def make_purchase_contract_item(
     purchase_id: str = None,
 ) -> ContractItem:
     return ContractItem(
+        id=id or 123,
         contract_id=contract_id or "cAaBbCcDdEeFfGg",
         created_at=created_at or "2020-01-01T00:00:00Z",
         start_date=start_date or "2020-01-01T00:00:00Z",
@@ -343,4 +346,16 @@ def make_shop_contract(
         product_id=product_id or "product-name",
         entitlements=entitlements or default_entitlements,
         items=items or default_items,
+    )
+
+
+def make_account(
+    id: str = None,
+    name: str = None,
+    role: str = None,
+):
+    return Account(
+        id=id or "aAbBcCdDeE",
+        name=name or "Account name",
+        role=role or "admin",
     )

--- a/tests/advantage/test_api.py
+++ b/tests/advantage/test_api.py
@@ -8,6 +8,7 @@ from webapp.advantage.ua_contracts.api import (
     UAContractsUserHasNoAccount,
     CannotCancelLastContractError,
     UnauthorizedError,
+    AccessForbiddenError,
 )
 from webapp.advantage.models import Listing
 from webapp.advantage.ua_contracts.primitives import (
@@ -987,16 +988,28 @@ class TestGetPurchase(unittest.TestCase):
 class TestGetPurchaseAccount(unittest.TestCase):
     def test_errors(self):
         cases = [
-            (401, False, UAContractsAPIError),
-            (401, True, UAContractsAPIErrorView),
-            (404, False, UAContractsUserHasNoAccount),
-            (404, True, UAContractsUserHasNoAccount),
-            (500, False, UAContractsAPIError),
-            (500, True, UAContractsAPIErrorView),
+            (
+                401,
+                False,
+                AccessForbiddenError,
+                "user not allowed to purchase on account",
+            ),
+            (
+                401,
+                False,
+                AccessForbiddenError,
+                "user not allowed to purchase on account",
+            ),
+            (401, False, UAContractsAPIError, "Error message"),
+            (401, True, UAContractsAPIErrorView, "Error message"),
+            (404, False, UAContractsUserHasNoAccount, "Error message"),
+            (404, True, UAContractsUserHasNoAccount, "Error message"),
+            (500, False, UAContractsAPIError, "Error message"),
+            (500, True, UAContractsAPIErrorView, "Error message"),
         ]
 
-        for code, is_for_view, expected_error in cases:
-            response_content = {"code": "expected error"}
+        for code, is_for_view, expected_error, message in cases:
+            response_content = {"code": "expected error", "message": message}
             response = Response(status_code=code, content=response_content)
             session = Session(response=response)
             client = make_client(session, is_for_view=is_for_view)

--- a/tests/advantage/test_api.py
+++ b/tests/advantage/test_api.py
@@ -988,28 +988,18 @@ class TestGetPurchase(unittest.TestCase):
 class TestGetPurchaseAccount(unittest.TestCase):
     def test_errors(self):
         cases = [
-            (
-                401,
-                False,
-                AccessForbiddenError,
-                "user not allowed to purchase on account",
-            ),
-            (
-                401,
-                False,
-                AccessForbiddenError,
-                "user not allowed to purchase on account",
-            ),
-            (401, False, UAContractsAPIError, "Error message"),
-            (401, True, UAContractsAPIErrorView, "Error message"),
-            (404, False, UAContractsUserHasNoAccount, "Error message"),
-            (404, True, UAContractsUserHasNoAccount, "Error message"),
-            (500, False, UAContractsAPIError, "Error message"),
-            (500, True, UAContractsAPIErrorView, "Error message"),
+            (403, False, AccessForbiddenError),
+            (403, False, AccessForbiddenError),
+            (401, False, UAContractsAPIError),
+            (401, True, UAContractsAPIErrorView),
+            (404, False, UAContractsUserHasNoAccount),
+            (404, True, UAContractsUserHasNoAccount),
+            (500, False, UAContractsAPIError),
+            (500, True, UAContractsAPIErrorView),
         ]
 
-        for code, is_for_view, expected_error, message in cases:
-            response_content = {"code": "expected error", "message": message}
+        for code, is_for_view, expected_error in cases:
+            response_content = {"code": "expected error"}
             response = Response(status_code=code, content=response_content)
             session = Session(response=response)
             client = make_client(session, is_for_view=is_for_view)

--- a/tests/advantage/test_helpers.py
+++ b/tests/advantage/test_helpers.py
@@ -11,6 +11,7 @@ from tests.advantage.helpers import (
     make_subscription_item,
     make_legacy_contract_item,
     make_renewal,
+    make_account,
 )
 from webapp.advantage.models import Entitlement
 from webapp.advantage.ua_contracts.helpers import (
@@ -469,6 +470,7 @@ class TestHelpers(unittest.TestCase):
         scenarios = {
             "test_free_user_subscription": {
                 "parameters": {
+                    "account": make_account(),
                     "type": "free",
                     "end_date": "2020-08-31T23:59:59Z",
                     "subscriptions": None,
@@ -489,10 +491,13 @@ class TestHelpers(unittest.TestCase):
                     "is_subscription_active": False,
                     "is_subscription_auto_renewing": False,
                     "should_present_auto_renewal": False,
+                    "has_access_to_support": True,
+                    "has_access_to_token": True,
                 },
             },
             "test_yearly_user_subscription_just_started": {
                 "parameters": {
+                    "account": make_account(),
                     "type": "yearly",
                     "end_date": "2021-08-31T23:59:59Z",
                     "subscriptions": [
@@ -518,10 +523,13 @@ class TestHelpers(unittest.TestCase):
                     "is_subscription_active": True,
                     "is_subscription_auto_renewing": False,
                     "should_present_auto_renewal": False,
+                    "has_access_to_support": True,
+                    "has_access_to_token": True,
                 },
             },
             "test_yearly_user_subscription_expiring": {
                 "parameters": {
+                    "account": make_account(),
                     "type": "yearly",
                     "end_date": "2020-09-30T23:59:59Z",
                     "subscriptions": [
@@ -547,10 +555,13 @@ class TestHelpers(unittest.TestCase):
                     "is_subscription_active": True,
                     "is_subscription_auto_renewing": False,
                     "should_present_auto_renewal": True,
+                    "has_access_to_support": True,
+                    "has_access_to_token": True,
                 },
             },
             "test_yearly_user_subscription_expiring_but_auto_renewing": {
                 "parameters": {
+                    "account": make_account(),
                     "type": "yearly",
                     "end_date": "2020-09-30T23:59:59Z",
                     "subscriptions": [
@@ -579,10 +590,13 @@ class TestHelpers(unittest.TestCase):
                     "is_subscription_active": True,
                     "is_subscription_auto_renewing": True,
                     "should_present_auto_renewal": True,
+                    "has_access_to_support": True,
+                    "has_access_to_token": True,
                 },
             },
             "test_yearly_user_subscription_grace_period": {
                 "parameters": {
+                    "account": make_account(),
                     "type": "yearly",
                     "end_date": "2020-08-31T23:59:59Z",
                     "subscriptions": None,
@@ -603,10 +617,13 @@ class TestHelpers(unittest.TestCase):
                     "is_subscription_active": False,
                     "is_subscription_auto_renewing": False,
                     "should_present_auto_renewal": False,
+                    "has_access_to_support": True,
+                    "has_access_to_token": True,
                 },
             },
             "test_monthly_user_subscription": {
                 "parameters": {
+                    "account": make_account(),
                     "type": "monthly",
                     "end_date": "2020-09-01T00:00:00Z",
                     "subscription_id": "sub-id-1",
@@ -639,10 +656,13 @@ class TestHelpers(unittest.TestCase):
                     "is_subscription_active": True,
                     "is_subscription_auto_renewing": True,
                     "should_present_auto_renewal": True,
+                    "has_access_to_support": True,
+                    "has_access_to_token": True,
                 },
             },
             "test_cancelled_user_subscription": {
                 "parameters": {
+                    "account": make_account(),
                     "type": "monthly",
                     "end_date": "2020-09-05T00:00:00Z",
                     "subscription_id": "sub-id-1",
@@ -674,10 +694,13 @@ class TestHelpers(unittest.TestCase):
                     "is_subscription_active": False,
                     "is_subscription_auto_renewing": False,
                     "should_present_auto_renewal": False,
+                    "has_access_to_support": True,
+                    "has_access_to_token": True,
                 },
             },
             "test_expired_user_subscription": {
                 "parameters": {
+                    "account": make_account(),
                     "type": "monthly",
                     "end_date": "2020-08-01T00:00:00Z",
                     "subscriptions": None,
@@ -698,10 +721,13 @@ class TestHelpers(unittest.TestCase):
                     "is_subscription_active": False,
                     "is_subscription_auto_renewing": False,
                     "should_present_auto_renewal": False,
+                    "has_access_to_support": True,
+                    "has_access_to_token": True,
                 },
             },
             "test_trial_user_subscription": {
                 "parameters": {
+                    "account": make_account(),
                     "type": "trial",
                     "end_date": "2020-08-18T00:00:00Z",
                     "subscriptions": [
@@ -728,10 +754,13 @@ class TestHelpers(unittest.TestCase):
                     "is_subscription_active": False,
                     "is_subscription_auto_renewing": False,
                     "should_present_auto_renewal": False,
+                    "has_access_to_support": True,
+                    "has_access_to_token": True,
                 },
             },
             "test_pending_purchases_user_subscription": {
                 "parameters": {
+                    "account": make_account(),
                     "type": "trial",
                     "end_date": "2020-09-07T23:59:59Z",
                     "subscriptions": [
@@ -756,10 +785,13 @@ class TestHelpers(unittest.TestCase):
                     "is_subscription_active": False,
                     "is_subscription_auto_renewing": False,
                     "should_present_auto_renewal": False,
+                    "has_access_to_support": True,
+                    "has_access_to_token": True,
                 },
             },
             "test_legacy_user_subscription": {
                 "parameters": {
+                    "account": make_account(),
                     "type": "legacy",
                     "end_date": "2020-10-01T10:00:00Z",
                     "renewal": make_renewal(
@@ -784,10 +816,13 @@ class TestHelpers(unittest.TestCase):
                     "is_subscription_active": False,
                     "is_subscription_auto_renewing": False,
                     "should_present_auto_renewal": False,
+                    "has_access_to_support": True,
+                    "has_access_to_token": True,
                 },
             },
             "test_non_actionable_legacy_user_subscription": {
                 "parameters": {
+                    "account": make_account(),
                     "type": "legacy",
                     "end_date": "2020-10-01T10:00:00Z",
                     "renewal": make_renewal(actionable=False),
@@ -807,6 +842,45 @@ class TestHelpers(unittest.TestCase):
                     "is_subscription_active": False,
                     "is_subscription_auto_renewing": False,
                     "should_present_auto_renewal": False,
+                    "has_access_to_support": True,
+                    "has_access_to_token": True,
+                },
+            },
+            "test_billing_user_subscription": {
+                "parameters": {
+                    "account": make_account(role="billing"),
+                    "type": "monthly",
+                    "end_date": "2021-01-01T00:00:00Z",
+                    "subscription_id": "sub-id-1",
+                    "subscriptions": [
+                        make_subscription(
+                            id="sub-id-1",
+                            items=[
+                                make_subscription_item(
+                                    product_listing_id="listing-id"
+                                )
+                            ],
+                        )
+                    ],
+                    "listing": make_listing(id="listing-id"),
+                },
+                "expectations": {
+                    "is_upsizeable": True,
+                    "is_downsizeable": True,
+                    "is_cancellable": True,
+                    "is_cancelled": False,
+                    "is_expiring": False,
+                    "is_in_grace_period": False,
+                    "is_expired": False,
+                    "is_trialled": False,
+                    "is_renewable": False,
+                    "is_renewal_actionable": False,
+                    "has_pending_purchases": False,
+                    "is_subscription_active": True,
+                    "is_subscription_auto_renewing": False,
+                    "should_present_auto_renewal": True,
+                    "has_access_to_support": False,
+                    "has_access_to_token": False,
                 },
             },
         }
@@ -816,6 +890,7 @@ class TestHelpers(unittest.TestCase):
                 with self.subTest(msg=f"{case}", scenario=scenario):
                     parameters = scenario["parameters"]
                     statuses = get_user_subscription_statuses(
+                        account=parameters.get("account"),
                         type=parameters.get("type"),
                         end_date=parameters.get("end_date"),
                         renewal=parameters.get("renewal"),

--- a/tests/advantage/test_parsers.py
+++ b/tests/advantage/test_parsers.py
@@ -40,6 +40,7 @@ class TestParsers(unittest.TestCase):
         expectation = Account(
             id="aAbBcCdDeEfFgGhHiIjJkKlLmMnNoOpP",
             name="Account Name",
+            role="admin",
         )
 
         self.assertIsInstance(parsed_account, Account)
@@ -53,10 +54,12 @@ class TestParsers(unittest.TestCase):
             Account(
                 id="a123AbBcCdDeEfFgGhHiIjJkKlLmMnNoOpP",
                 name="Free",
+                role="admin",
             ),
             Account(
                 id="aAbBcCdDeEfFgGhHiIjJkKlLmMnNoOpP",
                 name="Account Name",
+                role="admin",
             ),
         ]
 

--- a/webapp/advantage/schemas.py
+++ b/webapp/advantage/schemas.py
@@ -93,7 +93,6 @@ invoice_view = {
             ["", "canonical-ua", "canonical-cube", "blender"]
         )
     ),
-    "email": String(),
 }
 
 post_account_user_role = {

--- a/webapp/advantage/ua_contracts/api.py
+++ b/webapp/advantage/ua_contracts/api.py
@@ -389,10 +389,8 @@ class UAContractsAPI:
         status_code = error.response.status_code
         message = error.response.json().get("message")
 
-        # the status code is at the moment 401 will be changed later to 403
-        if "user-role" in error_rules:
-            if "user not allowed to purchase on account" in message:
-                raise AccessForbiddenError(error)
+        if "user-role" in error_rules and status_code == 403:
+            raise AccessForbiddenError(error)
 
         if "cancel-subscription" in error_rules and status_code == 400:
             if "cannot remove all subscription items" in message:

--- a/webapp/advantage/ua_contracts/builders.py
+++ b/webapp/advantage/ua_contracts/builders.py
@@ -202,6 +202,7 @@ def build_final_user_subscriptions(
             contract.name if type != "free" else "Free Personal Token"
         )
         statuses = get_user_subscription_statuses(
+            account=account,
             type=type,
             end_date=end_date,
             renewal=renewal,

--- a/webapp/advantage/ua_contracts/helpers.py
+++ b/webapp/advantage/ua_contracts/helpers.py
@@ -113,6 +113,7 @@ def is_trialling_user_subscription(items: List[ContractItem]) -> bool:
 
 
 def get_user_subscription_statuses(
+    account: Account,
     type: str,
     end_date: str = None,
     renewal: Renewal = None,
@@ -148,7 +149,7 @@ def get_user_subscription_statuses(
         "is_expiring": False,
         # is_in_grace_period describes whether this user subscription is in
         # its grace period, meaning it's past its end, but it still gives
-        # access to the pproduct.
+        # access to the product.
         "is_in_grace_period": False,
         # is_expired describes whether this user subscription is completely
         # expired, past its end date and its grace period.
@@ -182,7 +183,18 @@ def get_user_subscription_statuses(
         # belongs to a billing subscription that should have its auto-renewal
         # option displayed to the user at the current time.
         "should_present_auto_renewal": False,
+        # has_access_to_support describes whether this user subscription
+        # displays the Support portal button. At the moment `billing` users
+        # do not have access
+        "has_access_to_support": False,
+        # has_access_to_token describes whether this user subscription displays
+        # the token or not. At the moment `billing` users do not have access
+        "has_access_to_token": False,
     }
+
+    if account.role != "billing":
+        statuses["has_access_to_support"] = True
+        statuses["has_access_to_token"] = True
 
     if type == "free":
         return statuses

--- a/webapp/advantage/ua_contracts/parsers.py
+++ b/webapp/advantage/ua_contracts/parsers.py
@@ -61,6 +61,7 @@ def parse_account(raw_account: Dict) -> Account:
     return Account(
         id=raw_account.get("id"),
         name=raw_account.get("name"),
+        role=raw_account.get("userRoleOnAccount"),
     )
 
 

--- a/webapp/advantage/ua_contracts/primitives.py
+++ b/webapp/advantage/ua_contracts/primitives.py
@@ -120,9 +120,11 @@ class Account:
         self,
         id: str,
         name: str,
+        role: str,
     ):
         self.id = id
         self.name = name
+        self.role = role
 
 
 class User:

--- a/webapp/advantage/views.py
+++ b/webapp/advantage/views.py
@@ -250,6 +250,20 @@ def advantage_shop_view():
 
 @advantage_decorator(permission="user", response="html")
 def advantage_account_users_view():
+    g.api.set_convert_response(True)
+
+    account = None
+
+    try:
+        account = g.api.get_purchase_account("canonical-ua")
+    except UAContractsUserHasNoAccount:
+        pass
+    except AccessForbiddenError:
+        return flask.render_template("account/forbidden.html")
+
+    if account is None or account.role != "admin":
+        return flask.render_template("account/forbidden.html")
+
     return flask.render_template("advantage/users/index.html")
 
 

--- a/webapp/advantage/views.py
+++ b/webapp/advantage/views.py
@@ -264,7 +264,7 @@ def advantage_account_users_view():
     if account is None or account.role != "admin":
         return flask.render_template("account/forbidden.html")
 
-    return flask.render_template("advantage/users/index.html")
+    return flask.render_template("advantage/maintenance.html")
 
 
 @advantage_decorator(permission="user", response="html")


### PR DESCRIPTION
## Done

- Implement user roles rules:
  - `technical`: Cannot access /invoices and /payment-methods
  - `billing`: Cannot see Support portal button and token

## QA

Test billing user:
- Go to https://ubuntu-com-10819.demos.haus/advantage?test_backend=true&email=albert.kolozsvari%2Btester7%40canonical.com
- Check the support button is not there on any of the user subscriptions while Edit subscription is there
- Check the token never shows up

Test billing user:
- Go to https://ubuntu-com-10819.demos.haus/advantage?test_backend=true&email=albert.kolozsvari%2Btester3%40canonical.com
- Check the support button is there on any of the user subscriptions
- Check that no edit subscription buttons are there
- Check the token shows up

Test admin user (with your own account):
- can do all

## Issue / Card

Fixes #https://github.com/canonical-web-and-design/commercial-squad/issues/379

Screenshots:
