### PR TITLE
Added link to /what-are-containers inside glossary

### DIFF
--- a/templates/kubernetes/what-is-kubernetes.html
+++ b/templates/kubernetes/what-is-kubernetes.html
@@ -449,7 +449,7 @@
             </div>
             <section class="p-accordion__panel" id="tab3-section" aria-hidden="true" aria-labelledby="tab3">
               <p>
-                A standard unit of software that packages up code and all its dependencies, making it portable across different compute environments.
+                A standard unit of software that packages up code and all its dependencies, making it portable across different compute environments. <a href="/containers/what-are-containers">Learn more about containers&nbsp;&rsaquo;</a>
               </p>
             </section>
           </li>


### PR DESCRIPTION
## Done

- Added link to glossary section as per [copy doc](https://docs.google.com/document/d/19ZAsyujRHjOBIKP15F-4Z9L24KpfoYrx0YpL-0gO6sE/edit#)

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: https://ubuntu-com-10822.demos.haus/kubernetes/what-is-kubernetes#tab3
- See that the update has been made and that the link works

## Issue / Card

Fixes https://github.com/canonical-web-and-design/ubuntu.com/issues/10821
