### PR TITLE
add extra purchase metadata for marketing purposes

### DIFF
--- a/webapp/advantage/decorators.py
+++ b/webapp/advantage/decorators.py
@@ -24,6 +24,7 @@ RESPONSE_LIST = {
 
 MARKETING_FLAGS = {
     "utm_campaign": "salesforce-campaign-id",
+    "utm_source": "ad_source",
     "gclid": "google-click-id",
     "gbraid": "google-gbraid-id",
     "wbraid": "google-wbraid-id",

--- a/webapp/advantage/views.py
+++ b/webapp/advantage/views.py
@@ -371,11 +371,12 @@ def post_advantage_subscriptions(preview, **kwargs):
     # marketing parameters
 
     metadata_keys = [
-        "salesforce-campaign-id",
+        "ad_source",
         "google-click-id",
         "google-gbraid-id",
         "google-wbraid-id",
         "facebook-click-id",
+        "salesforce-campaign-id",
     ]
 
     metadata = [

--- a/webapp/login.py
+++ b/webapp/login.py
@@ -43,6 +43,7 @@ def empty_session(user_session):
     user_session.pop("authentication_token", None)
     user_session.pop("openid", None)
     user_session.pop("salesforce-campaign-id", None)
+    user_session.pop("ad_source", None)
     user_session.pop("google-click-id", None)
     user_session.pop("google-gbraid-id", None)
     user_session.pop("google-wbraid-id", None)


### PR DESCRIPTION
## Done

- added extra metadata needed for marketing campaigns. On further discussion with marketing, we need to pay attention to `utm_source` when adding metadata for marketing-triggered purchase.

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- go to http://0.0.0.0:8001/support?utm_source=google_ad&utm_medium=search&utm_campaign=7014K000000gaQfQAI&gclid=this-is-a-click-id

## Issue / Card
this extends the work on the linked 
Fixes https://github.com/canonical-web-and-design/ubuntu.com/issues/10696

## Screenshots

[If relevant, please include a screenshot.]


## Help

[QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html) - [Commit guidelines](https://canonical-web-and-design.github.io/practices/workflow/commit-messages.html)
