### PR TITLE
Update openstack-eol chart

### DIFF
--- a/static/js/src/chart-data.js
+++ b/static/js/src/chart-data.js
@@ -1090,7 +1090,7 @@ export var openStackReleases = [
   {
     startDate: new Date("2022-04-01T00:00:00"),
     endDate: new Date("2025-04-01T00:00:00"),
-    taskName: "OpenStack Y",
+    taskName: "OpenStack Yoga",
     status: "MATCHING_OPENSTACK_RELEASE_SUPPORT",
   },
   {
@@ -1200,12 +1200,6 @@ export var openStackReleases = [
     endDate: new Date("2028-04-01T00:00:00"),
     taskName: "Ubuntu 18.04 LTS",
     status: "ESM",
-  },
-  {
-    startDate: new Date("2018-02-01T00:00:00"),
-    endDate: new Date("2021-04-01T00:00:00"),
-    taskName: "OpenStack Queens",
-    status: "MATCHING_OPENSTACK_RELEASE_SUPPORT",
   },
   {
     startDate: new Date("2016-04-01T00:00:00"),
@@ -1482,7 +1476,7 @@ export var kernelReleaseNamesLTS = [
 export var openStackReleaseNames = [
   "OpenStack Y LTS",
   "Ubuntu 22.04 LTS",
-  "OpenStack Y",
+  "OpenStack Yoga",
   "OpenStack Xena",
   "OpenStack Wallaby",
   "OpenStack Victoria",
@@ -1494,7 +1488,6 @@ export var openStackReleaseNames = [
   "OpenStack Rocky",
   "OpenStack Queens LTS",
   "Ubuntu 18.04 LTS",
-  "OpenStack Queens",
   "OpenStack Mitaka LTS",
   "Ubuntu 16.04 LTS",
 ];

--- a/templates/about/release-cycle.html
+++ b/templates/about/release-cycle.html
@@ -451,7 +451,7 @@
               <td>Apr 2032</td>
             </tr>
             <tr>
-              <td>OpenStack Y</td>
+              <td>OpenStack Yoga</td>
               <td>&nbsp;</td>
               <td>Apr 2022</td>
               <td>Apr 2025</td>
@@ -545,14 +545,6 @@
               <td>Apr 2023</td>
               <td>&nbsp;</td>
               <td>Apr 2028</td>
-            </tr>
-            <tr>
-              <td>OpenStack Queens</td>
-              <td>&nbsp;</td>
-              <td>Feb 2018</td>
-              <td>Apr 2021</td>
-              <td>&nbsp;</td>
-              <td>&nbsp;</td>
             </tr>
             <tr>
               <td>OpenStack Mitaka LTS</td>


### PR DESCRIPTION
## Done

- Update openstack-eol chart to changes 'Openstack Y' to 'Openstack Yoga' and removes the row 'Openstack Queens'.

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- |Compare against [copydoc](https://docs.google.com/document/d/1-l3B7AoyDoETaL80UhlfEWCVKmMWPdy3zoF5LpsGcYQ/edit)

## Issue / Card

Fixes https://github.com/canonical-web-and-design/ubuntu.com/issues/10817


## Help

[QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html) - [Commit guidelines](https://canonical-web-and-design.github.io/practices/workflow/commit-messages.html)
