### PR TITLE
Remove theme-color

### DIFF
--- a/templates/templates/base.html
+++ b/templates/templates/base.html
@@ -34,7 +34,6 @@
 
   <meta name="description" content="{% block meta_description %}Ubuntu is an open source software operating system that runs from the desktop, to the cloud, to all your internet connected things.{% endblock %}">
 
-  <meta name="theme-color" content="#E95420">
   <meta name="facebook-domain-verification" content="zxp9j79g1gy2xenbu9ll964pttk5hu">
   <meta name="twitter:account_id" content="4503599627481511">
   <meta name="twitter:site" content="@ubuntu">

--- a/templates/templates/base_no_nav.html
+++ b/templates/templates/base_no_nav.html
@@ -12,7 +12,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta property="twitter:account_id" content="4503599627481511" />
     <meta name="google-site-verification" content="ddh2iq7ZuKf1LpkL_gtM_T7DkKDVD7ibq6Ceue4a_3M" />
-    <meta name="theme-color" content="#E95420" />
     <meta name="copydoc" content="{% block meta_copydoc %}https://drive.google.com/drive/folders/0B4s80tIYQW4BMjNiMGFmNzQtNDkxZC00YmQ0LWJiZWUtNTk2YThlY2MzZmJh{% endblock %}" />
 
     <title>{% block title %}{% endblock %} | Ubuntu</title>


### PR DESCRIPTION
## Done

- Removed `meta` tag that had `theme-color` so the header can be default colour on safari. 

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Be sure to test on mobile, tablet and desktop screen sizes
- Check if the header colour turns to orange on safari. 

## Issue / Card

Fixes [#10540](https://github.com/canonical-web-and-design/ubuntu.com/issues/10540)
