### PR TITLE
add Intel IoT platforms link to download nav

### DIFF
--- a/templates/templates/navigation-download-h.html
+++ b/templates/templates/navigation-download-h.html
@@ -34,6 +34,9 @@
             <li class='p-list__item'><a class='p-link' href='/download/raspberry-pi'>
               Raspberry Pi
             </a></li>
+            <li class='p-list__item'><a class='p-link' href='/download/iot/intel-iotg'>
+              Intel IoT platforms
+            </a></li>
             <li class='p-list__item'><a class='p-link' href='/download/intel-nuc'>
               Intel NUC
             </a></li>


### PR DESCRIPTION
## Done

- Added "Intel IoT platforms" link to Download dropdown nav, per [copy doc](https://docs.google.com/document/d/11pX5gxOE6UWljIGRBZdwuCL1MHzs4pNgxJpK0mcIqdQ/edit)

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/ or visit https://ubuntu-com-10830.demos.haus
- Click the "Download" nav item, and see that "Intel IoT platforms" appears as the second link below Ubuntu for IoT
- Click the link, it should take you to https://ubuntu-com-10830.demos.haus/download/iot/intel-iotg

## Issue / Card

Fixes #10820 

## Screenshots
![Screenshot from 2021-11-09 17-05-25](https://user-images.githubusercontent.com/2376968/140971180-e1b1b198-7abf-458a-b73e-3901d532c64a.png)


## Help

[QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html) - [Commit guidelines](https://canonical-web-and-design.github.io/practices/workflow/commit-messages.html)
