### PR TITLE
Microcerts fix data inconsistencies across environments

### DIFF
--- a/konf/site.yaml
+++ b/konf/site.yaml
@@ -61,6 +61,11 @@ env:
       key: password
       name: badgr
 
+  - name: BADGR_QA_PASSWORD
+    secretKeyRef:
+      key: qa-password
+      name: badgr
+
   - name: CUBE_EDX_URL
     value: https://cube.ubuntu.com
 
@@ -72,6 +77,16 @@ env:
   - name: CUBE_EDX_CLIENT_SECRET
     secretKeyRef:
       key: client-secret
+      name: cube-edx
+  
+  - name: CUBE_EDX_QA_CLIENT_ID
+    secretKeyRef:
+      key: qa-client-id
+      name: cube-edx
+
+  - name: CUBE_EDX_CLIENT_QA_SECRET
+    secretKeyRef:
+      key: qa-client-secret
       name: cube-edx
 
   - name: MARKETO_API_CLIENT
@@ -167,6 +182,11 @@ production:
           secretKeyRef:
             key: password
             name: badgr
+        
+        - name: BADGR_QA_PASSWORD
+          secretKeyRef:
+            key: qa-password
+            name: badgr
 
         - name: CUBE_EDX_URL
           value: https://cube.ubuntu.com
@@ -179,6 +199,16 @@ production:
         - name: CUBE_EDX_CLIENT_SECRET
           secretKeyRef:
             key: client-secret
+            name: cube-edx
+        
+        - name: CUBE_EDX_QA_CLIENT_ID
+          secretKeyRef:
+            key: qa-client-id
+            name: cube-edx
+
+        - name: CUBE_EDX_CLIENT_QA_SECRET
+          secretKeyRef:
+            key: qa-client-secret
             name: cube-edx
 
     - paths: [/tutorials]
@@ -336,6 +366,11 @@ staging:
           secretKeyRef:
             key: password
             name: badgr
+        
+        - name: BADGR_QA_PASSWORD
+          secretKeyRef:
+            key: qa-password
+            name: badgr
 
         - name: CUBE_EDX_URL
           value: https://cube.ubuntu.com
@@ -348,6 +383,16 @@ staging:
         - name: CUBE_EDX_CLIENT_SECRET
           secretKeyRef:
             key: client-secret
+            name: cube-edx
+        
+        - name: CUBE_EDX_QA_CLIENT_ID
+          secretKeyRef:
+            key: qa-client-id
+            name: cube-edx
+
+        - name: CUBE_EDX_CLIENT_QA_SECRET
+          secretKeyRef:
+            key: qa-client-secret
             name: cube-edx
 
     - paths: [/tutorials]

--- a/webapp/advantage/decorators.py
+++ b/webapp/advantage/decorators.py
@@ -170,10 +170,10 @@ def cube_decorator(response="json"):
                     return flask.jsonify(message), 401
 
             badgr_issuer = (
-                BADGR_ISSUER if not test_backend else QA_BADGR_ISSUER
+                BADGR_ISSUER if not is_test_backend else QA_BADGR_ISSUER
             )
             certified_badge = (
-                CERTIFIED_BADGE if not test_backend else QA_CERTIFIED_BADGE,
+                CERTIFIED_BADGE if not is_test_backend else QA_CERTIFIED_BADGE,
             )
 
             # init API instance
@@ -186,24 +186,24 @@ def cube_decorator(response="json"):
 
             badgr_api = BadgrAPI(
                 "https://api.eu.badgr.io"
-                if not test_backend
+                if not is_test_backend
                 else "https://api.test.badgr.com",
                 os.getenv("BAGDR_USER"),
                 os.getenv("BADGR_PASSWORD")
-                if not test_backend
+                if not is_test_backend
                 else os.getenv("BADGR_QA_PASSWORD"),
                 badgr_session,
             )
 
             edx_api = EdxAPI(
                 "https://cube.ubuntu.com"
-                if not test_backend
+                if not is_test_backend
                 else "https://qa.cube.ubuntu.com",
                 os.getenv("CUBE_EDX_CLIENT_ID")
-                if not test_backend
+                if not is_test_backend
                 else os.getenv("CUBE_EDX_QA_CLIENT_ID"),
                 os.getenv("CUBE_EDX_CLIENT_SECRET")
-                if not test_backend
+                if not is_test_backend
                 else os.getenv("CUBE_EDX_CLIENT_QA_SECRET"),
                 edx_session,
             )

--- a/webapp/cube/api.py
+++ b/webapp/cube/api.py
@@ -41,8 +41,6 @@ class BadgrAPI:
         data = {"username": self.username, "password": self.password}
 
         response = self.session.post(uri, data=data).json()
-        print("Over here")
-        print(response)
         self.token = response["access_token"]
 
     def get_assertions(self, issuer: str, email: str):
@@ -99,8 +97,6 @@ class EdxAPI:
             method="POST", path="/oauth2/access_token", data=data, retry=False
         ).json()
 
-        print("Over here")
-        print(response)
         self.token = response["access_token"]
 
     def get_course_attempts(self, course_id: str, username: str):

--- a/webapp/cube/api.py
+++ b/webapp/cube/api.py
@@ -41,6 +41,8 @@ class BadgrAPI:
         data = {"username": self.username, "password": self.password}
 
         response = self.session.post(uri, data=data).json()
+        print("Over here")
+        print(response)
         self.token = response["access_token"]
 
     def get_assertions(self, issuer: str, email: str):
@@ -97,6 +99,8 @@ class EdxAPI:
             method="POST", path="/oauth2/access_token", data=data, retry=False
         ).json()
 
+        print("Over here")
+        print(response)
         self.token = response["access_token"]
 
     def get_course_attempts(self, course_id: str, username: str):

--- a/webapp/cube/api.py
+++ b/webapp/cube/api.py
@@ -101,14 +101,28 @@ class EdxAPI:
 
     def get_course_attempts(self, course_id: str, username: str):
         uri = (
-            "/api/edx_proctoring/v1/proctored_exam/attempt/course_id/"
+            "/api/edx_proctoring/v1/proctored_exam/attempt/grouped/course_id/"
             f"{course_id}/search/{username}"
             "?page_size=100"
         )
-        return self.make_request(
+        result = self.make_request(
             "GET",
             uri,
-        ).json()
+        )
+
+        # TODO: Remove after upgrading to Lilac
+        if result.status_code == 404:
+            uri = (
+                "/api/edx_proctoring/v1/proctored_exam/attempt/course_id/"
+                f"{course_id}/search/{username}"
+                "?page_size=100"
+            )
+            result = self.make_request(
+                "GET",
+                uri,
+            )
+
+        return result.json()
 
     def get_enrollments(self, username: str):
         uri = (


### PR DESCRIPTION
## Done

- Fix issues between environments mentioned in https://github.com/canonical-web-and-design/commercial-squad/issues/366 that manifest in https://github.com/canonical-web-and-design/ubuntu.com/pull/10743#issuecomment-957316184
- Refactored API classes into CUBE decorator function and removed reliance on `flask.g` global store
- Removed some variables unused by front-end in the `microcerts.json` endpoint

## QA

- I believe best way to QA this is to use [Morgan's PR](https://github.com/canonical-web-and-design/ubuntu.com/pull/10743#issuecomment-957316184)
- One way to do this, would be to:
```
# Create a new branch for viewing only
git checkout -b carkod-microcerts-fix-envs main
git pull https://github.com/mrgnr/ubuntu.com.git cube-purchase-study-labs
# Pulled Morgan's PR and resolve the conflicts (only 2)
git pull https://github.com/carkod/ubuntu.com.git microcerts-fix-envs
# Pulled this PR
```
- Purchase a course and make sure that the buttons change to "Enrolled" and "Take" now
- Fail a course and check that it's not accessible anymore (Purchase button reappears) issue 359
- Header should activate the correct course you are taking (same as current ubuntu.com)

## Before merging into main branch
Update k8s secrets in prod-comms and demo cluster:
- `BADGR_QA_PASSWORD`
- `CUBE_EDX_QA_CLIENT_ID`
- `CUBE_EDX_CLIENT_QA_SECRET`

Additionally, you can check that passwords have been encoded correctly:
- Connect to VPN
- Get your K8s credentials for demo and prod-comms if you don't have them.
- Do the following commands in demo, prod-comms `--namespace staging` and `--namespace production`
```
kubectl describe secret badgr
kubectl describe secret cube-edx
```
They should include a new `qa-password`, `qa-client-id`, `qa-client-secret` encoded in base64

## Issue / Card

Fixes https://github.com/canonical-web-and-design/commercial-squad/issues/366
Fixes https://github.com/canonical-web-and-design/commercial-squad/issues/359
Fixes https://github.com/canonical-web-and-design/commercial-squad/issues/367
Fixes https://github.com/canonical-web-and-design/commercial-squad/issues/403
Fixes https://github.com/canonical-web-and-design/commercial-squad/issues/410