### PR TITLE
Update kernel-eol graph data

### DIFF
--- a/static/js/src/chart-data.js
+++ b/static/js/src/chart-data.js
@@ -258,7 +258,7 @@ export var kernelReleases = [
   },
   {
     startDate: new Date("2021-04-30T00:00:00"),
-    endDate: new Date("2024-04-29T00:00:00"),
+    endDate: new Date("2026-04-29T00:00:00"),
     taskName: "Ubuntu 16.04.5 LTS",
     taskVersion: "",
     status: "ESM",
@@ -300,7 +300,7 @@ export var kernelReleases = [
   },
   {
     startDate: new Date("2019-04-30T00:00:00"),
-    endDate: new Date("2022-04-29T00:00:00"),
+    endDate: new Date("2024-04-29T00:00:00"),
     taskName: "Ubuntu 14.04.5 LTS",
     taskVersion: "",
     status: "ESM",
@@ -314,7 +314,7 @@ export var kernelReleases = [
   },
   {
     startDate: new Date("2021-04-30T00:00:00"),
-    endDate: new Date("2024-04-29T00:00:00"),
+    endDate: new Date("2026-04-29T00:00:00"),
     taskName: "Ubuntu 16.04.1 LTS",
     taskVersion: "4.4 kernel",
     status: "ESM",
@@ -328,7 +328,7 @@ export var kernelReleases = [
   },
   {
     startDate: new Date("2021-04-30T00:00:00"),
-    endDate: new Date("2024-04-29T00:00:00"),
+    endDate: new Date("2026-04-29T00:00:00"),
     taskName: "Ubuntu 16.04.0 LTS",
     taskVersion: "",
     status: "ESM",
@@ -342,7 +342,7 @@ export var kernelReleases = [
   },
   {
     startDate: new Date("2019-04-30T00:00:00"),
-    endDate: new Date("2022-04-29T00:00:00"),
+    endDate: new Date("2024-04-29T00:00:00"),
     taskName: "Ubuntu 14.04.1 LTS",
     taskVersion: "",
     status: "ESM",
@@ -356,7 +356,7 @@ export var kernelReleases = [
   },
   {
     startDate: new Date("2019-04-30T00:00:00"),
-    endDate: new Date("2022-04-29T00:00:00"),
+    endDate: new Date("2024-04-29T00:00:00"),
     taskName: "Ubuntu 14.04.0 LTS",
     taskVersion: "3.13 kernel",
     status: "ESM",


### PR DESCRIPTION
## Done

- Update kernel-eol graph data to have the correct dates as per spreadsheet data

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- Compare against [copydoc](https://docs.google.com/document/d/1-l3B7AoyDoETaL80UhlfEWCVKmMWPdy3zoF5LpsGcYQ/edit) and spreadsheet

## Issue / Card

Fixes https://github.com/canonical-web-and-design/ubuntu.com/issues/10834


## Help

[QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html) - [Commit guidelines](https://canonical-web-and-design.github.io/practices/workflow/commit-messages.html)
