### PR TITLE
Redirect risc-v to wiki.ubuntu.com/RISC-V

### DIFF
--- a/redirects.yaml
+++ b/redirects.yaml
@@ -677,6 +677,7 @@ release-notes/oneiric-ocelot/?: "https://wiki.ubuntu.com/OneiricOcelot/ReleaseNo
 release-notes/precise-pangolin/?: "https://wiki.ubuntu.com/PrecisePangolin/ReleaseNotes"
 releases/?: "https://releases.ubuntu.com"
 releaseendoflife/?: "/about/release-cycle"
+risc-v/?: "https://wiki.ubuntu.com/RISC-V"
 robots.txt?: "/static/files/robots.txt"
 robotics/esm/?: "/robotics/ros-esm"
 rss\.xml/?: "/blog/feed"


### PR DESCRIPTION
## Done

- Redirect risc-v to wiki.ubuntu.com/RISC-V for the [video](https://docs.google.com/document/d/1vSMf_p1AXkPPzJhC-8pmceQSeyODGuWHuGcl6ROcxms/edit?disco=AAAAQ0sgz-8&usp_dm=true)

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/risc-v and see that it redirects to https://wiki.ubuntu.com/RISC-V
