### PR TITLE
Explicitly reference documentation in certifications

### DIFF
--- a/navigation.yaml
+++ b/navigation.yaml
@@ -1589,6 +1589,8 @@ security:
           path: /security/disa-stig
         - title: CIS
           path: /security/cis
+        - title: Docs
+          path: /security/certifications/docs
 
     - title: CVEs
       path: /security/cve


### PR DESCRIPTION
## Done

- This introduces a direct link to documentation from the certifications page. The documentation has been improved significantly and it can be directly linked to.

