### PR TITLE
Temporary fix for TOC not working properly in UASD

### DIFF
--- a/templates/legal/ubuntu-advantage-service-description/_base_legal_markdown.html
+++ b/templates/legal/ubuntu-advantage-service-description/_base_legal_markdown.html
@@ -12,7 +12,7 @@
           {{ content | safe }}
         </div>
 
-        <div class="col-4 p-sticky-toc">
+        <div class="col-4">
           <aside class="p-table-of-contents">
             {% include 'legal/ubuntu-advantage-service-description/_toc.html' %}
           </aside>


### PR DESCRIPTION
## Done

- Removes p-stick-toc class from contents in UASD as a temporary fix for the contents not fitting properly on the screen.

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- Check down [demo](https://ubuntu-com-10845.demos.haus/legal/ubuntu-advantage-service-description)

## Issue / Card

Fixes https://github.com/canonical-web-and-design/ubuntu.com/issues/10835


## Help

[QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html) - [Commit guidelines](https://canonical-web-and-design.github.io/practices/workflow/commit-messages.html)
