### PR TITLE
release-cycle: updated text

### DIFF
--- a/templates/about/release-cycle.html
+++ b/templates/about/release-cycle.html
@@ -68,8 +68,8 @@
           <tr>
             <td>&nbsp;</td>
             <th scope="col">Released</th>
+            <th scope="col">End of Standard Support</th>
             <th scope="col">End of Life</th>
-            <th scope="col">Extended security maintenance</th>
           </tr>
           <tbody>
             <tr>


### PR DESCRIPTION
## Done

- Updated text not in copy doc

The text replaced (end-of-life) was picked by google when searching for "ubuntu 16.04 lifecycle", but it was incorrect. It is not visible in the page itself. If the text is coming from a supported spreadsheet let me know, but the spreadsheet I checked did not use these terms for LTS releases, so I'm updating the page directly.