### PR TITLE
Fixed link and formatting issue in '/openstack/install"

### DIFF
--- a/templates/openstack/install.html
+++ b/templates/openstack/install.html
@@ -166,21 +166,29 @@
 </section>
 
 <section class="p-strip--light">
-  <div class="u-fixed-width">
-    <div class="col-4 u-align--center u-hide--small u-vertically-center">
-
+  <div class="row">
+    <div class="col-5 u-align--center u-hide--small u-vertically-center">
+      {{ image (
+        url="https://assets.ubuntu.com/v1/ada1d5b5-operate.svg",
+        alt="",
+        width="228",
+        height="150",
+        hi_def=True,
+        loading="lazy"
+        ) | safe
+      }}
     </div>
-    <div class="col-6 col-start-large-6 u-vertically-center">
+    <div class="col-7 u-vertically-center">
       <h2>OpenStack tutorials</h2>
       <p>Learn OpenStack through a series of tutorials.</p>
-      <p><a class="p-button--positive js-invoke-modal" href="/openstack/tutorials">Explore tutorials</a></p>
+      <p><a class="p-button--positive" href="/openstack/tutorials">Explore tutorials</a></p>
     </div>
   </div>
 </section>
 
 <section class="p-strip--light">
-  <div class="u-fixed-width">
-    <div class="col-4 u-align--center u-hide--small u-vertically-center">
+  <div class="row">
+    <div class="col-5 u-align--center u-hide--small u-vertically-center">
       {{
         image(
         url="https://assets.ubuntu.com/v1/0e5f4269-questions.svg",
@@ -192,7 +200,7 @@
         ) | safe
       }}
     </div>
-    <div class="col-6 col-start-large-6 u-vertically-center">
+    <div class="col-7 u-vertically-center">
       <h2>Got stuck with OpenStack installation?</h2>
       <p>Let our cloud experts help you take the next step.</p>
       <p><a class="p-button--positive js-invoke-modal" href="/openstack/contact-us?product=openstack">Talk to a Canonical expert</a></p>

--- a/templates/openstack/install.html
+++ b/templates/openstack/install.html
@@ -154,7 +154,7 @@
       <p>
         These instructions use <a href="https://docs.openstack.org/charm-guide/latest/">OpenStack Charms</a>. OpenStack Charms are the foundation of Canonical’s <a href="https://ubuntu.com/openstack">Charmed OpenStack</a> distribution which is an enterprise private cloud, designed to run mission-critical workloads.
       </p>
-      <p class="u-sv3">Find the documentation for "Installation" of<a href="https://docs.openstack.org/project-deploy-guide/charm-deployment-guide/latest/" class="p-link--external">OpenStack Charms Deployment Guide here</a>.</p>
+      <p class="u-sv3">Find the documentation for "Installation" of <a href="https://docs.openstack.org/project-deploy-guide/charm-deployment-guide/latest/" class="p-link--external">OpenStack Charms Deployment Guide here</a>.</p>
       <div class="p-notification">
         <p class="p-notification__response">
           <span class="p-notification__status">NOTE:</span> In order to qualify for the <a href="https://assets.ubuntu.com/v1/d4766546-Private-Cloud-Build_Datasheet.pdf" class="p-link--external">Private Cloud Build (PCB)</a> service, <a href="https://assets.ubuntu.com/v1/1a8fb1b3-UA-I_datasheet_2019-Oct.pdf" class="p-link--external">Ubuntu Advantage for Infrastructure (UA-I)</a> support subscription and <a href="https://assets.ubuntu.com/v1/a797f6f9-Datasheet_Openstack_05.10.20+%281%29.pdf" class="p-link--external">Managed OpenStack</a>, at least 12 nodes are required for Charmed OpenStack. Please contact your Canonical sales representative for detailed information on minimum hardware requirements
@@ -165,7 +165,7 @@
   </div>
 </section>
 
-<section class="p-strip--light">
+<section class="p-strip--light is-bordered">
   <div class="row">
     <div class="col-5 u-align--center u-hide--small u-vertically-center">
       {{ image (
@@ -186,7 +186,7 @@
   </div>
 </section>
 
-<section class="p-strip--light">
+<section class="p-strip">
   <div class="row">
     <div class="col-5 u-align--center u-hide--small u-vertically-center">
       {{

--- a/templates/shared/contextual_footers/_openstack_install.html
+++ b/templates/shared/contextual_footers/_openstack_install.html
@@ -1,5 +1,5 @@
 <div class="col-4 p-divider__block">
     <h3 class="p-heading--four">How about Managed OpenStack?</h3>
     <p>No need to design and install OpenStack. Canonical can build and operate the cloud for you.</p>
-    <p><a class="p-button--positive" href="/openstack/contact-us?product=openstack">Contact us</a></p>
+    <p><a class="p-button" href="/openstack/contact-us?product=openstack">Contact us</a></p>
 </div>

--- a/templates/shared/contextual_footers/_openstack_install_documentation.html
+++ b/templates/shared/contextual_footers/_openstack_install_documentation.html
@@ -19,7 +19,6 @@
         </li>
         <li class="p-list__item"><a
             href="/openstack/tutorials"
-            class="p-link--external"
             onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'openstack documentation', 'eventLabel' : 'OpenStack tutorials', 'eventValue' : undefined });">OpenStack tutorials</a>
         </li>        
     </ul>


### PR DESCRIPTION
## Done

- Updates links to point to /openstack/tutorials
- Updates to correct asset and fixes formatting

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/openstack/install
    - Be sure to test on mobile, tablet and desktop screen sizes
- Compare against [copydoc](https://docs.google.com/document/d/1eQ16jzv6YRGzG_k_C-tUnhM06k6_Ic6fZM-x_ARMzuc/edit)


## Help

[QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html) - [Commit guidelines](https://canonical-web-and-design.github.io/practices/workflow/commit-messages.html)
