### PR TITLE
Replace machine with user for blender subs

### DIFF
--- a/static/js/src/advantage/react/components/Subscriptions/SubscriptionEdit/SubscriptionEdit.test.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/SubscriptionEdit/SubscriptionEdit.test.tsx
@@ -318,7 +318,9 @@ describe("SubscriptionEdit", () => {
           is_downsizeable: true,
         }),
       });
-      const isValid = await generateSchema(subscription).isValid({ size: 4 });
+      const isValid = await generateSchema(subscription, "machine").isValid({
+        size: 4,
+      });
       expect(isValid).toBe(true);
     });
 
@@ -329,7 +331,9 @@ describe("SubscriptionEdit", () => {
           is_downsizeable: true,
         }),
       });
-      const isValid = await generateSchema(subscription).isValid({ size: 0 });
+      const isValid = await generateSchema(subscription, "machine").isValid({
+        size: 0,
+      });
       expect(isValid).toBe(false);
     });
 
@@ -340,7 +344,9 @@ describe("SubscriptionEdit", () => {
           is_downsizeable: false,
         }),
       });
-      const isValid = await generateSchema(subscription).isValid({ size: 4 });
+      const isValid = await generateSchema(subscription, "machine").isValid({
+        size: 4,
+      });
       expect(isValid).toBe(false);
     });
 
@@ -351,7 +357,9 @@ describe("SubscriptionEdit", () => {
           is_upsizeable: true,
         }),
       });
-      const isValid = await generateSchema(subscription).isValid({ size: 6 });
+      const isValid = await generateSchema(subscription, "machine").isValid({
+        size: 6,
+      });
       expect(isValid).toBe(true);
     });
 
@@ -362,7 +370,9 @@ describe("SubscriptionEdit", () => {
           is_upsizeable: false,
         }),
       });
-      const isValid = await generateSchema(subscription).isValid({ size: 6 });
+      const isValid = await generateSchema(subscription, "machine").isValid({
+        size: 6,
+      });
       expect(isValid).toBe(false);
     });
   });

--- a/static/js/src/advantage/react/components/Subscriptions/SubscriptionEdit/SubscriptionEdit.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/SubscriptionEdit/SubscriptionEdit.tsx
@@ -15,6 +15,7 @@ import { SelectedId } from "../Content/types";
 import { useResizeContract, useUserSubscriptions } from "advantage/react/hooks";
 import { selectSubscriptionById } from "advantage/react/hooks/useUserSubscriptions";
 import { sendAnalyticsEvent } from "advantage/react/utils/sendAnalyticsEvent";
+import { isBlenderSubscription } from "advantage/react/utils";
 import usePendingPurchase from "advantage/subscribe/react/hooks/usePendingPurchase";
 import { ResizeContractResponse } from "advantage/react/hooks/useResizeContract";
 import { useQueryClient } from "react-query";
@@ -27,9 +28,11 @@ type Props = {
   setShowingCancel: (showingCancel: boolean) => void;
 };
 
-const sizeMessage = "You must have at least one machine.";
-
-export const generateSchema = (subscription: UserSubscription) => {
+export const generateSchema = (
+  subscription: UserSubscription,
+  unitName: string
+) => {
+  const sizeMessage = `You must have at least one ${unitName}`;
   let min = 1;
   let minMessage = sizeMessage;
   let max = Infinity;
@@ -101,6 +104,10 @@ const SubscriptionEdit = ({
     select: selectSubscriptionById(selectedId),
   });
   const resizeContract = useResizeContract(subscription);
+  const isBlender = isBlenderSubscription(subscription);
+
+  const unitName = isBlender ? "user" : "machine";
+
   const {
     setPendingPurchaseID,
     error: pendingPurchaseError,
@@ -146,7 +153,7 @@ const SubscriptionEdit = ({
   if (isSubscriptionLoading || !subscription) {
     return <Spinner />;
   }
-  const ResizeSchema = generateSchema(subscription);
+  const ResizeSchema = generateSchema(subscription, unitName);
   return (
     <>
       <Formik
@@ -181,14 +188,14 @@ const SubscriptionEdit = ({
                   error={errors.size || generateError(error)}
                   help={
                     <>
-                      You can resize your subscriptions to as many machines as
-                      needed.
+                      You can resize your subscriptions to as many {unitName}s
+                      as needed.
                       <br />
                       Your next billing period will reflect the changes
                       accordingly.
                     </>
                   }
-                  label="Number of machines"
+                  label={`Number of ${unitName}s`}
                   min={
                     subscription.statuses.is_downsizeable
                       ? 1


### PR DESCRIPTION
## Done

- [List of work items including drive-bys - remember to add the why and what of this work.]

## QA

- go to https://ubuntu-com-10861.demos.haus/advantage?test_backend=true
- log in with an account that has a blender subscription
- click edit subscription on the side panel and see that every mention of machine has been replace by "user"

## Issue / Card

Fixes canonical-web-and-design/commercial-squad#397

## Screenshots

![image](https://user-images.githubusercontent.com/11927929/141818424-f00c3747-e961-49c6-8d40-514e8a31fa69.png)
