### PR TITLE
fix: accessibility for tutorial chapter menu button

### DIFF
--- a/static/js/src/tutorial.js
+++ b/static/js/src/tutorial.js
@@ -1,6 +1,13 @@
 function toggleTutorialNavigation() {
   const toggleButton = document.querySelector(".l-tutorial__nav-toggle");
-  const menu = document.querySelector(".l-tutorial__nav");
+  const menu = document.getElementById(toggleButton.getAttribute("aria-controls"));
+  const expanded = toggleButton.getAttribute("aria-expanded") === "true";
+
+  if (menu) {
+    toggleButton.setAttribute("aria-expanded", !expanded);
+    menu.setAttribute("aria-hidden", expanded);
+  }
+
   toggleButton.classList.toggle("p-icon--menu");
   toggleButton.classList.toggle("p-icon--close");
   menu.classList.toggle("u-hide--small");

--- a/static/js/src/tutorial.js
+++ b/static/js/src/tutorial.js
@@ -1,6 +1,8 @@
 function toggleTutorialNavigation() {
   const toggleButton = document.querySelector(".l-tutorial__nav-toggle");
-  const menu = document.getElementById(toggleButton.getAttribute("aria-controls"));
+  const menu = document.getElementById(
+    toggleButton.getAttribute("aria-controls")
+  );
   const expanded = toggleButton.getAttribute("aria-expanded") === "true";
 
   if (menu) {

--- a/static/js/src/tutorial.test.js
+++ b/static/js/src/tutorial.test.js
@@ -4,8 +4,8 @@ describe("toggleTutorialNavigation", () => {
   it("toggles menu classes`", () => {
     // Set up DOM elements
     document.body.innerHTML = `
-      <div class="l-tutorial__nav-toggle p-icon--menu">Toggle</div>
-      <div class="l-tutorial__nav u-hide--small">Nav</div>
+      <div class="l-tutorial__nav-toggle p-icon--menu" aria-controls="menu-tutorial">Toggle</div>
+      <div id="menu-tutorial" class="l-tutorial__nav u-hide--small">Nav</div>
     `;
 
     toggleTutorialNavigation();

--- a/static/sass/_layout-tutorial.scss
+++ b/static/sass/_layout-tutorial.scss
@@ -23,9 +23,14 @@
 
   .l-tutorial__nav-toggle {
     background-size: $sp-medium;
-    cursor: pointer;
     float: right;
     padding: $sp-large;
+    margin: 0;
+    border: 0;
+
+    &[aria-expanded=true] {
+      background-color: $color-x-light;
+    }
   }
 
   .l-tutorial__nav {

--- a/static/sass/_layout-tutorial.scss
+++ b/static/sass/_layout-tutorial.scss
@@ -23,12 +23,12 @@
 
   .l-tutorial__nav-toggle {
     background-size: $sp-medium;
-    float: right;
-    padding: $sp-large;
-    margin: 0;
     border: 0;
+    float: right;
+    margin: 0;
+    padding: $sp-large;
 
-    &[aria-expanded=true] {
+    &[aria-expanded="true"] {
       background-color: $color-x-light;
     }
   }

--- a/templates/tutorials/tutorial.html
+++ b/templates/tutorials/tutorial.html
@@ -29,8 +29,10 @@
 
 <div class="l-tutorial">
   <aside class="l-tutorial__sidebar">
-    <i class="l-tutorial__nav-toggle p-icon--menu u-hide u-show--small"></i>
-    <ol class="l-tutorial__nav p-stepped-list u-hide--small">
+    <button type="button" class="l-tutorial__nav-toggle p-icon--menu u-hide u-show--small" aria-controls="menu-tutorial" aria-expanded="false">
+      Toggle tutorial menu
+    </button>
+    <ol class="l-tutorial__nav p-stepped-list u-hide--small" id="menu-tutorial" aria-hidden="true">
       {% for section in document.sections %}
         <li class="p-stepped-list__item l-tutorial__nav-item">
           <p class="p-stepped-list__title l-tutorial__nav-title u-no-margin--bottom">


### PR DESCRIPTION
## Done

This fixes accessibility of the tutorial chapter menu button.

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- go to this example to test: http://127.0.0.1:8001/tutorials/setting-up-lxd-1604

## Issue / Card

Fixes #10867 

## Help

[QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html) - [Commit guidelines](https://canonical-web-and-design.github.io/practices/workflow/commit-messages.html)
