### PR TITLE
Use original Flask-OpenID instead of FlaskOpenID-Stateless

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ canonicalwebteam.discourse==4.0.4
 python-dateutil==2.8.1
 pytz==2020.5
 maxminddb-geolite2==2018.703
-Flask-OpenID-Stateless==1.2.6
+Flask-OpenID==1.3.0
 feedgen==0.9.0
 feedparser==6.0.2
 pymacaroons==0.13.0

--- a/webapp/login.py
+++ b/webapp/login.py
@@ -13,7 +13,9 @@ from webapp.macaroons import (
 
 
 open_id = flask_openid.OpenID(
-    stateless=True, safe_roots=[], extension_responses=[MacaroonResponse]
+    store_factory=lambda: None,
+    safe_roots=[],
+    extension_responses=[MacaroonResponse],
 )
 session = talisker.requests.get_session()
 


### PR DESCRIPTION
## Done

- This is a copy of this PR for snapcraft.io: https://github.com/canonical-web-and-design/snapcraft.io/pull/3740
- Stop using our own fork FlaskOpenID-Stateless to use the original module.

## QA

- Check the authentication is working as usual.
