### PR TITLE
Add function that HTML encodes

### DIFF
--- a/webapp/views.py
+++ b/webapp/views.py
@@ -619,11 +619,6 @@ def sitemap_index():
     return response
 
 
-def encode_comment(encodedText):
-    encodedText = html.escape(encodedText)
-    return encodedText
-
-
 def marketo_submit():
     form_fields = {}
     for key, value in flask.request.form.items():
@@ -652,7 +647,7 @@ def marketo_submit():
     form_fields.pop("g-recaptcha-response", None)
     return_url = form_fields.pop("returnURL", None)
 
-    encoded_comment = encode_comment(form_fields["Comments_from_lead__c"])
+    encoded_comment = html.escape(form_fields["Comments_from_lead__c"])
     form_fields["Comments_from_lead__c"] = encoded_comment
 
     visitor_data = {

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -2,6 +2,7 @@
 import math
 import os
 import re
+import html
 
 # Packages
 import dateutil
@@ -618,6 +619,11 @@ def sitemap_index():
     return response
 
 
+def encode_comment(encodedText):
+    encodedText = html.escape(encodedText)
+    return encodedText
+
+
 def marketo_submit():
     form_fields = {}
     for key, value in flask.request.form.items():
@@ -645,6 +651,9 @@ def marketo_submit():
     form_fields.pop("thankyoumessage", None)
     form_fields.pop("g-recaptcha-response", None)
     return_url = form_fields.pop("returnURL", None)
+
+    encoded_comment = encode_comment(form_fields["Comments_from_lead__c"])
+    form_fields["Comments_from_lead__c"] = encoded_comment
 
     visitor_data = {
         "userAgentString": flask.request.headers.get("User-Agent"),


### PR DESCRIPTION
## Done

- Add a function that HTML encodes. 
- Encode `Comments_from_lead__c` in `form_fields` before submitting.

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Check if `Comments_from_lead__c`  in `form_fields` is html encoded before submitting.
- Please check if this PR resolves this [issue](https://github.com/canonical-web-and-design/ubuntu.com/issues/10394) 

## Issue / Card

Fixes[#10394](https://github.com/canonical-web-and-design/ubuntu.com/issues/10394)
