### PR TITLE
Add CUBE dashboard POC

### DIFF
--- a/build.js
+++ b/build.js
@@ -18,6 +18,7 @@ let entries = {
   cve: "./static/js/src/cve/cve.js",
   productSelector: "./static/js/src/advantage/subscribe/product-selector.js",
   advantageAccountUsers: "./static/js/src/advantage/users/app.jsx",
+  cubeDashboard: "./static/js/src/cube/dashboard/app.tsx",
   openstackChart: "./static/js/src/openstack-chart.js",
   uaSubscribe: "./static/js/src/advantage/subscribe/react/app.jsx",
   uaSubscriptions: "./static/js/src/advantage/react/app.tsx",

--- a/package.json
+++ b/package.json
@@ -102,6 +102,7 @@
     "react-google-recaptcha": "^2.1.0",
     "react-query": "3.16.0",
     "react-useportal": "1.0.14",
+    "recharts": "^2.1.6",
     "sass": "1.27.0",
     "smartquotes": "2.3.2",
     "typescript": "4.3.5",

--- a/static/js/src/cube/dashboard/app.tsx
+++ b/static/js/src/cube/dashboard/app.tsx
@@ -1,0 +1,27 @@
+import React, { useEffect, useState } from "react";
+import ReactDOM from "react-dom";
+import { QueryClient, QueryClientProvider } from "react-query";
+import Dashboard from "./components/Dashboard";
+
+const oneHour = 1000 * 60 * 60;
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      refetchOnWindowFocus: false,
+      refetchOnMount: false,
+      refetchOnReconnect: false,
+      staleTime: oneHour,
+      retryOnMount: false,
+    },
+  },
+});
+
+const App = () => {
+  return (
+    <QueryClientProvider client={queryClient}>
+      <Dashboard />
+    </QueryClientProvider>
+  );
+};
+
+ReactDOM.render(<App />, document.getElementById("react-root"));

--- a/static/js/src/cube/dashboard/components/CertificationsTable/CertificationsTable.tsx
+++ b/static/js/src/cube/dashboard/components/CertificationsTable/CertificationsTable.tsx
@@ -1,41 +1,39 @@
 import React from "react";
 import { Card, MainTable } from "@canonical/react-components";
 import DownloadCSVButton from "../DownloadCSVButton";
-import useExamAttempts from "../../hooks/useExamAttempts";
+import useCertifications from "../../hooks/useCertifications";
 
-type Props = {
-  courses: string[];
-};
-
-const ExamAttemptsTable = ({ courses }: Props) => {
-  const { examAttempts, isLoading } = useExamAttempts({ courses });
-  const rows = examAttempts ? examAttempts : [];
+const CertificationsTable = () => {
+  const { certifications, isLoading } = useCertifications({
+    usernames: ["mrgnr", "krenshaw", "LexJoy", "crenguta", "albertkoltester2"],
+  });
+  const rows = certifications ? certifications : [];
 
   return (
-    <Card title="Exam attempts">
+    <Card title="Certifications">
       <DownloadCSVButton data={rows} />
       <MainTable
         headers={[
           { content: "Course ID", sortKey: "course_id" },
-          { content: "Start", sortKey: "started_at" },
-          { content: "End", sortKey: "completed_at" },
-          { content: "Status", sortKey: "status" },
+          { content: "Created", sortKey: "created" },
+          { content: "Passing", sortKey: "is_passing" },
+          { content: "Grade", sortKey: "grade" },
           { content: "Username", sortKey: "username" },
         ]}
         rows={rows.map(
-          ({ course_id, started_at, completed_at, status, username }) => ({
+          ({ course_id, created, is_passing, grade, username }) => ({
             columns: [
               { content: course_id },
-              { content: started_at },
-              { content: completed_at },
-              { content: status },
+              { content: created },
+              { content: String(is_passing) },
+              { content: grade },
               { content: username },
             ],
             sortData: {
               course_id: course_id,
-              started_at: new Date(started_at),
-              completed_at: new Date(completed_at),
-              status: status,
+              created: new Date(created),
+              is_passing: Boolean(is_passing),
+              grade: grade,
               username: username,
             },
           })
@@ -54,4 +52,4 @@ const ExamAttemptsTable = ({ courses }: Props) => {
   );
 };
 
-export default ExamAttemptsTable;
+export default CertificationsTable;

--- a/static/js/src/cube/dashboard/components/CertificationsTable/index.ts
+++ b/static/js/src/cube/dashboard/components/CertificationsTable/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./CertificationsTable";

--- a/static/js/src/cube/dashboard/components/Dashboard/Dashboard.tsx
+++ b/static/js/src/cube/dashboard/components/Dashboard/Dashboard.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { Col, Row } from "@canonical/react-components";
 import { useQuery } from "react-query";
 import EnrollmentsChart from "../EnrollmentsChart";
+import ExamAttemptsChart from "../ExamAttemptsChart";
 
 const Dashboard = () => {
   const { data } = useQuery("courses", async () => {
@@ -24,6 +25,7 @@ const Dashboard = () => {
           <>
             <h1>CUBE Dashboard</h1>
             <EnrollmentsChart courses={courses} />
+            <ExamAttemptsChart courses={courses} />
           </>
         </Col>
       </Row>

--- a/static/js/src/cube/dashboard/components/Dashboard/Dashboard.tsx
+++ b/static/js/src/cube/dashboard/components/Dashboard/Dashboard.tsx
@@ -1,0 +1,34 @@
+import React from "react";
+import { Col, Row } from "@canonical/react-components";
+import { useQuery } from "react-query";
+import EnrollmentsChart from "../EnrollmentsChart";
+
+const Dashboard = () => {
+  const { data } = useQuery("courses", async () => {
+    const response = await fetch("/cube/courses.json");
+    const responseData = await response.json();
+
+    if (responseData.errors) {
+      throw new Error(responseData.errors);
+    }
+
+    return responseData;
+  });
+
+  const courses = data ? data.map((course) => course["id"]) : [];
+
+  return (
+    <section className="p-strip">
+      <Row>
+        <Col size={12}>
+          <>
+            <h1>CUBE Dashboard</h1>
+            <EnrollmentsChart courses={courses} />
+          </>
+        </Col>
+      </Row>
+    </section>
+  );
+};
+
+export default Dashboard;

--- a/static/js/src/cube/dashboard/components/Dashboard/Dashboard.tsx
+++ b/static/js/src/cube/dashboard/components/Dashboard/Dashboard.tsx
@@ -2,7 +2,8 @@ import React from "react";
 import { Col, Row } from "@canonical/react-components";
 import { useQuery } from "react-query";
 import EnrollmentsChart from "../EnrollmentsChart";
-import ExamAttemptsChart from "../ExamAttemptsChart";
+import EnrollmentsTable from "../EnrollmentsTable";
+import ExamAttemptsTable from "../ExamAttemptsTable";
 
 const Dashboard = () => {
   const { data } = useQuery("courses", async () => {
@@ -25,7 +26,8 @@ const Dashboard = () => {
           <>
             <h1>CUBE Dashboard</h1>
             <EnrollmentsChart courses={courses} />
-            <ExamAttemptsChart courses={courses} />
+            <EnrollmentsTable courses={courses} />
+            <ExamAttemptsTable courses={courses} />
           </>
         </Col>
       </Row>

--- a/static/js/src/cube/dashboard/components/Dashboard/Dashboard.tsx
+++ b/static/js/src/cube/dashboard/components/Dashboard/Dashboard.tsx
@@ -1,26 +1,14 @@
 import React from "react";
 import { Col, Row } from "@canonical/react-components";
-import { useQuery } from "react-query";
+import CertificationsTable from "../CertificationsTable";
 import EnrollmentsChart from "../EnrollmentsChart";
 import EnrollmentsTable from "../EnrollmentsTable";
 import ExamAttemptsTable from "../ExamAttemptsTable";
 import GradesTable from "../GradesTable";
+import useCourses from "../../hooks/useCourses";
 
 const Dashboard = () => {
-  const { data } = useQuery("courses", async () => {
-    const response = await fetch("/cube/courses.json");
-    const responseData = await response.json();
-
-    if (responseData.errors) {
-      throw new Error(responseData.errors);
-    }
-
-    return responseData;
-  });
-
-  const courses = data ? data.map((course) => course["id"]) : [];
-
-  console.log("!!! courses: ", courses);
+  const { courses } = useCourses();
 
   return (
     <section className="p-strip">
@@ -32,6 +20,7 @@ const Dashboard = () => {
             <EnrollmentsTable courses={courses} />
             <ExamAttemptsTable courses={courses} />
             <GradesTable courses={courses} />
+            <CertificationsTable />
           </>
         </Col>
       </Row>

--- a/static/js/src/cube/dashboard/components/Dashboard/Dashboard.tsx
+++ b/static/js/src/cube/dashboard/components/Dashboard/Dashboard.tsx
@@ -4,6 +4,7 @@ import { useQuery } from "react-query";
 import EnrollmentsChart from "../EnrollmentsChart";
 import EnrollmentsTable from "../EnrollmentsTable";
 import ExamAttemptsTable from "../ExamAttemptsTable";
+import GradesTable from "../GradesTable";
 
 const Dashboard = () => {
   const { data } = useQuery("courses", async () => {
@@ -19,6 +20,8 @@ const Dashboard = () => {
 
   const courses = data ? data.map((course) => course["id"]) : [];
 
+  console.log("!!! courses: ", courses);
+
   return (
     <section className="p-strip">
       <Row>
@@ -28,6 +31,7 @@ const Dashboard = () => {
             <EnrollmentsChart courses={courses} />
             <EnrollmentsTable courses={courses} />
             <ExamAttemptsTable courses={courses} />
+            <GradesTable courses={courses} />
           </>
         </Col>
       </Row>

--- a/static/js/src/cube/dashboard/components/Dashboard/index.ts
+++ b/static/js/src/cube/dashboard/components/Dashboard/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./Dashboard";

--- a/static/js/src/cube/dashboard/components/DownloadCSVButton/DownloadCSVButton.tsx
+++ b/static/js/src/cube/dashboard/components/DownloadCSVButton/DownloadCSVButton.tsx
@@ -1,0 +1,19 @@
+import React from "react";
+import { Button } from "@canonical/react-components";
+import generateCSV from "../../../utils/generateCSV";
+
+type Props = {
+  data: Record<string, unknown>[];
+};
+
+const DownloadCSVButton = ({ data }: Props) => {
+  const onClick = () => {
+    const csv = generateCSV(data);
+    const encodedCSV = encodeURI(csv);
+    window.open(encodedCSV);
+  };
+
+  return <Button onClick={onClick}>Download CSV</Button>;
+};
+
+export default DownloadCSVButton;

--- a/static/js/src/cube/dashboard/components/DownloadCSVButton/index.ts
+++ b/static/js/src/cube/dashboard/components/DownloadCSVButton/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./DownloadCSVButton";

--- a/static/js/src/cube/dashboard/components/EnrollmentsChart/EnrollmentsChart.tsx
+++ b/static/js/src/cube/dashboard/components/EnrollmentsChart/EnrollmentsChart.tsx
@@ -85,8 +85,6 @@ const groupByMonth = (enrollments) => {
 
     const previousDate = new Date(combined.at(-1)["date"]);
     const currentDate = new Date(current["date"]);
-    console.log("!!! previousDate: ", previousDate);
-    console.log("!!! currentDate: ", currentDate);
 
     if (
       previousDate.getFullYear() === currentDate.getFullYear() &&
@@ -94,8 +92,6 @@ const groupByMonth = (enrollments) => {
     ) {
       const previous = combined.pop();
       const merged = addCounts(previous, current);
-      console.log("!!! previous: ", previous);
-      console.log("!!! merged: ", merged);
       return [...combined, merged];
     }
 

--- a/static/js/src/cube/dashboard/components/EnrollmentsChart/EnrollmentsChart.tsx
+++ b/static/js/src/cube/dashboard/components/EnrollmentsChart/EnrollmentsChart.tsx
@@ -40,16 +40,16 @@ const groupByDay = (enrollments) => {
     const currentDate = new Date(current["date"]);
     const oneDay = 86400000; // milliseconds in a day
     const difference = (currentDate - lastDate) / oneDay;
-    let emptyDates = [];
+    const emptyDates = [];
 
     // Fill in missing dates with empty data
-    // for (let i = 1; i < difference; i++) {
-    //   const emptyDate = addDay(lastDate, i);
-    //   const emptyDateString = `${emptyDate.getFullYear()}-${
-    //     emptyDate.getMonth() + 1
-    //   }-${emptyDate.getDate()}`;
-    //   emptyDates.push({ date: emptyDateString });
-    // }
+    for (let i = 1; i < difference; i++) {
+      const emptyDate = addDay(lastDate, i);
+      const emptyDateString = `${emptyDate.getFullYear()}-${
+        emptyDate.getMonth() + 1
+      }-${emptyDate.getDate()}`;
+      emptyDates.push({ date: emptyDateString });
+    }
 
     return [...combined, ...emptyDates, current];
   }, []);

--- a/static/js/src/cube/dashboard/components/EnrollmentsChart/EnrollmentsChart.tsx
+++ b/static/js/src/cube/dashboard/components/EnrollmentsChart/EnrollmentsChart.tsx
@@ -1,4 +1,4 @@
-import React, { ChangeEventHandler, useEffect, useState } from "react";
+import React, { useState } from "react";
 import {
   Card,
   Col,
@@ -129,10 +129,15 @@ const EnrollmentsChart = ({ courses }: Props) => {
   const [selectedFilters, setSelectedFilters] = useState<string[]>([]);
   const [selectedGrouping, setSelectedGrouping] = useState("daily");
 
+  const params = new URLSearchParams(window.location.search);
+  const testBackend = params.get("test_backend") === "true";
+
   const { isLoading, isError, data: enrollments } = useQuery(
     "enrollments",
     async () => {
-      const response = await fetch("/cube/enrollments.json");
+      const response = await fetch(
+        "/cube/enrollments.json" + (testBackend ? "?test_backend=true" : "")
+      );
       const responseData = await response.json();
 
       if (responseData.errors) {

--- a/static/js/src/cube/dashboard/components/EnrollmentsChart/EnrollmentsChart.tsx
+++ b/static/js/src/cube/dashboard/components/EnrollmentsChart/EnrollmentsChart.tsx
@@ -1,0 +1,258 @@
+import React, { ChangeEventHandler, useEffect, useState } from "react";
+import {
+  Card,
+  Col,
+  Row,
+  SearchAndFilter,
+  Select,
+} from "@canonical/react-components";
+import {
+  SearchAndFilterChip,
+  SearchAndFilterData,
+} from "@canonical/react-components/dist/components/SearchAndFilter/types";
+
+import { useQuery } from "react-query";
+import {
+  Bar,
+  BarChart,
+  CartesianGrid,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
+
+type Props = {
+  courses: string[];
+};
+
+const addDay = (date, days) => {
+  let result = new Date(date);
+  result.setDate(result.getDate() + days);
+  return result;
+};
+
+const groupByDay = (enrollments) => {
+  return enrollments.reduce((combined, current) => {
+    if (!combined.length) return [current];
+
+    const lastDate = new Date(combined.at(-1)["date"]);
+    const currentDate = new Date(current["date"]);
+    const oneDay = 86400000; // milliseconds in a day
+    const difference = (currentDate - lastDate) / oneDay;
+    let emptyDates = [];
+
+    // Fill in missing dates with empty data
+    // for (let i = 1; i < difference; i++) {
+    //   const emptyDate = addDay(lastDate, i);
+    //   const emptyDateString = `${emptyDate.getFullYear()}-${
+    //     emptyDate.getMonth() + 1
+    //   }-${emptyDate.getDate()}`;
+    //   emptyDates.push({ date: emptyDateString });
+    // }
+
+    return [...combined, ...emptyDates, current];
+  }, []);
+};
+
+const addCounts = (counts1, counts2) => {
+  const result = {};
+  for (const key in counts1) {
+    if (key === "date") continue;
+    if (key in counts2) {
+      result[key] = counts1[key] + counts2[key];
+    } else {
+      result[key] = counts1[key];
+    }
+  }
+
+  for (const key in counts2) {
+    if (key === "date") continue;
+    if (!(key in counts1)) {
+      result[key] = counts2[key];
+    }
+  }
+
+  const dateString = counts1["date"];
+  result["date"] = dateString.substring(0, 7);
+
+  return result;
+};
+
+const groupByMonth = (enrollments) => {
+  return enrollments.reduce((combined, current) => {
+    if (!combined.length) return [current];
+
+    const previousDate = new Date(combined.at(-1)["date"]);
+    const currentDate = new Date(current["date"]);
+    console.log("!!! previousDate: ", previousDate);
+    console.log("!!! currentDate: ", currentDate);
+
+    if (
+      previousDate.getFullYear() === currentDate.getFullYear() &&
+      previousDate.getMonth() === currentDate.getMonth()
+    ) {
+      const previous = combined.pop();
+      const merged = addCounts(previous, current);
+      console.log("!!! previous: ", previous);
+      console.log("!!! merged: ", merged);
+      return [...combined, merged];
+    }
+
+    return [...combined, current];
+  }, []);
+};
+
+const colors = [
+  "#D32F2F",
+  "#C2185B",
+  "#7B1FA2",
+  "#512DA8",
+  "#303F9F",
+  "#1976D2",
+  "#0288D1",
+  "#0097A7",
+  "#00796B",
+  "#388E3C",
+  "#689F38",
+  "#AFB42B",
+  "#FBC02D",
+  "#FFA000",
+  "#F57C00",
+  "#E64A19",
+  "#5D4037",
+  "#616161",
+  "#455A64",
+];
+
+const EnrollmentsChart = ({ courses }: Props) => {
+  const [selectedFilters, setSelectedFilters] = useState<string[]>([]);
+  const [selectedGrouping, setSelectedGrouping] = useState("daily");
+
+  const { isLoading, isError, data: enrollments } = useQuery(
+    "enrollments",
+    async () => {
+      const response = await fetch("/cube/enrollments.json");
+      const responseData = await response.json();
+
+      if (responseData.errors) {
+        throw new Error(responseData.errors);
+      }
+
+      return responseData;
+    }
+  );
+
+  console.log("!!! enrollments: ", enrollments);
+
+  let filteredData = enrollments
+    ? enrollments.map((enrollment) => {
+        const filters = selectedFilters.length ? selectedFilters : courses;
+        const counts = Object.keys(enrollment)
+          .filter((key) => filters.includes(key))
+          .reduce((obj, key) => ({ ...obj, [key]: enrollment[key] }), {});
+        const date = enrollment["date"];
+        return { date, ...counts };
+      })
+    : [];
+
+  switch (selectedGrouping) {
+    case "daily":
+      filteredData = groupByDay(filteredData);
+      break;
+    case "monthly":
+      filteredData = groupByMonth(filteredData);
+      break;
+  }
+
+  const onSelectGrouping = (event: React.ChangeEvent<HTMLSelectElement>) => {
+    setSelectedGrouping(event.target.value);
+  };
+
+  console.log("!!! filteredData: ", filteredData);
+
+  const searchAndFilterChips: SearchAndFilterChip[] = courses.map((course) => ({
+    value: course,
+  }));
+  console.log("!!! courses: ", courses);
+
+  const updateFilter = (selectedChips: SearchAndFilterChip[]) => {
+    const sortedNewFilters = selectedChips.map((chip) => chip.value).sort();
+    const sortedOldFilters = selectedFilters.sort();
+    const isFilterUnchanged =
+      sortedNewFilters.length === sortedOldFilters.length &&
+      sortedNewFilters.every(
+        (value, index) => value === sortedOldFilters[index]
+      );
+
+    if (!isFilterUnchanged) {
+      const filters = selectedChips.map((chip) => chip.value);
+      setSelectedFilters(filters);
+    }
+  };
+
+  return (
+    <Card title="Enrollments">
+      <Row>
+        <Row>
+          <Col size={6}>
+            <SearchAndFilter
+              filterPanelData={[{ id: 0, chips: searchAndFilterChips }]}
+              returnSearchData={updateFilter}
+            />
+          </Col>
+          <Col size={6}>
+            <Select
+              options={[
+                {
+                  label: "Daily",
+                  value: "daily",
+                },
+                {
+                  label: "Monthly",
+                  value: "monthly",
+                },
+              ]}
+              onChange={onSelectGrouping}
+            />
+          </Col>
+        </Row>
+        <Col size={12}>
+          {isLoading ? (
+            <i className="p-icon--spinner u-animation--spin"></i>
+          ) : isError ? (
+            <i>An error occurred while fetching the data</i>
+          ) : (
+            <ResponsiveContainer minHeight={600}>
+              <BarChart
+                data={filteredData}
+                margin={{
+                  top: 20,
+                  bottom: 65,
+                  left: 0,
+                  right: 50,
+                }}
+              >
+                <CartesianGrid stroke={"#E4E4E4"} />
+                <XAxis dataKey="date" angle={60} textAnchor="start" />
+                <YAxis />
+                {courses &&
+                  courses.map((course, i) => (
+                    <Bar
+                      key={course}
+                      dataKey={course}
+                      stackId="a"
+                      fill={colors[i]}
+                    />
+                  ))}
+                <Tooltip />
+              </BarChart>
+            </ResponsiveContainer>
+          )}
+        </Col>
+      </Row>
+    </Card>
+  );
+};
+
+export default EnrollmentsChart;

--- a/static/js/src/cube/dashboard/components/EnrollmentsChart/EnrollmentsChart.tsx
+++ b/static/js/src/cube/dashboard/components/EnrollmentsChart/EnrollmentsChart.tsx
@@ -131,12 +131,18 @@ const EnrollmentsChart = ({ courses }: Props) => {
 
   const params = new URLSearchParams(window.location.search);
   const testBackend = params.get("test_backend") === "true";
+  const encodedCoursesParam = courses
+    .map((course) => encodeURIComponent(course))
+    .join(",");
 
   const { isLoading, isError, data: enrollments } = useQuery(
-    "enrollments",
+    "dailyEnrollments",
     async () => {
       const response = await fetch(
-        "/cube/enrollments.json" + (testBackend ? "?test_backend=true" : "")
+        encodeURI(
+          `/cube/daily-enrollments.json?course_id=${encodedCoursesParam}` +
+            (testBackend ? "&test_backend=true" : "")
+        )
       );
       const responseData = await response.json();
 
@@ -145,7 +151,8 @@ const EnrollmentsChart = ({ courses }: Props) => {
       }
 
       return responseData;
-    }
+    },
+    { enabled: courses && courses.length > 0 }
   );
 
   console.log("!!! enrollments: ", enrollments);

--- a/static/js/src/cube/dashboard/components/EnrollmentsChart/index.ts
+++ b/static/js/src/cube/dashboard/components/EnrollmentsChart/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./EnrollmentsChart";

--- a/static/js/src/cube/dashboard/components/EnrollmentsTable/EnrollmentsTable.tsx
+++ b/static/js/src/cube/dashboard/components/EnrollmentsTable/EnrollmentsTable.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { Card, MainTable } from "@canonical/react-components";
 import { useQuery } from "react-query";
+import DownloadCSVButton from "../DownloadCSVButton";
 
 type Props = {
   courses: string[];
@@ -13,7 +14,7 @@ const EnrollmentsTable = ({ courses }: Props) => {
     .map((course) => encodeURIComponent(course))
     .join(",");
 
-  const { data: enrollments } = useQuery(
+  const { data: enrollments, isLoading } = useQuery(
     "enrollments",
     async () => {
       const response = await fetch(
@@ -33,31 +34,39 @@ const EnrollmentsTable = ({ courses }: Props) => {
     { enabled: courses && courses.length > 0 }
   );
 
+  const rows = enrollments ? enrollments : [];
+
   return (
     <Card title="Enrollments">
-      {enrollments && (
-        <MainTable
-          headers={[
-            { content: "Course ID", sortKey: "course_id" },
-            { content: "Created", sortKey: "created" },
-            { content: "Active", sortKey: "is_active" },
-          ]}
-          rows={enrollments.map(({ course_id, created, is_active }) => ({
-            columns: [
-              { content: course_id },
-              { content: created },
-              { content: is_active ? "Yes" : "No" },
-            ],
-            sortData: {
-              course_id: course_id,
-              created: new Date(created),
-              is_active: is_active,
-            },
-          }))}
-          sortable
-          paginate={20}
-        />
-      )}
+      <DownloadCSVButton data={rows} />
+      <MainTable
+        headers={[
+          { content: "Course ID", sortKey: "course_id" },
+          { content: "Created", sortKey: "created" },
+          { content: "Active", sortKey: "is_active" },
+        ]}
+        rows={rows.map(({ course_id, created, is_active }) => ({
+          columns: [
+            { content: course_id },
+            { content: created },
+            { content: is_active ? "Yes" : "No" },
+          ],
+          sortData: {
+            course_id: course_id,
+            created: new Date(created),
+            is_active: is_active,
+          },
+        }))}
+        sortable
+        paginate={20}
+        emptyStateMsg={
+          isLoading ? (
+            <i className="p-icon--spinner u-animation--spin"></i>
+          ) : (
+            <i>No data could be fetched</i>
+          )
+        }
+      />
     </Card>
   );
 };

--- a/static/js/src/cube/dashboard/components/EnrollmentsTable/EnrollmentsTable.tsx
+++ b/static/js/src/cube/dashboard/components/EnrollmentsTable/EnrollmentsTable.tsx
@@ -1,0 +1,65 @@
+import React from "react";
+import { Card, MainTable } from "@canonical/react-components";
+import { useQuery } from "react-query";
+
+type Props = {
+  courses: string[];
+};
+
+const EnrollmentsTable = ({ courses }: Props) => {
+  const params = new URLSearchParams(window.location.search);
+  const testBackend = params.get("test_backend") === "true";
+  const encodedCoursesParam = courses
+    .map((course) => encodeURIComponent(course))
+    .join(",");
+
+  const { data: enrollments } = useQuery(
+    "enrollments",
+    async () => {
+      const response = await fetch(
+        encodeURI(
+          `/cube/enrollments.json?course_id=${encodedCoursesParam}` +
+            (testBackend ? "&test_backend=true" : "")
+        )
+      );
+      const responseData = await response.json();
+
+      if (responseData.errors) {
+        throw new Error(responseData.errors);
+      }
+
+      return responseData;
+    },
+    { enabled: courses && courses.length > 0 }
+  );
+
+  return (
+    <Card title="Enrollments">
+      {enrollments && (
+        <MainTable
+          headers={[
+            { content: "Course ID", sortKey: "course_id" },
+            { content: "Created", sortKey: "created" },
+            { content: "Active", sortKey: "is_active" },
+          ]}
+          rows={enrollments.map(({ course_id, created, is_active }) => ({
+            columns: [
+              { content: course_id },
+              { content: created },
+              { content: is_active ? "Yes" : "No" },
+            ],
+            sortData: {
+              course_id: course_id,
+              created: new Date(created),
+              is_active: is_active,
+            },
+          }))}
+          sortable
+          paginate={20}
+        />
+      )}
+    </Card>
+  );
+};
+
+export default EnrollmentsTable;

--- a/static/js/src/cube/dashboard/components/EnrollmentsTable/EnrollmentsTable.tsx
+++ b/static/js/src/cube/dashboard/components/EnrollmentsTable/EnrollmentsTable.tsx
@@ -2,38 +2,14 @@ import React from "react";
 import { Card, MainTable } from "@canonical/react-components";
 import { useQuery } from "react-query";
 import DownloadCSVButton from "../DownloadCSVButton";
+import useEnrollments from "../../hooks/useEnrollments";
 
 type Props = {
   courses: string[];
 };
 
 const EnrollmentsTable = ({ courses }: Props) => {
-  const params = new URLSearchParams(window.location.search);
-  const testBackend = params.get("test_backend") === "true";
-  const encodedCoursesParam = courses
-    .map((course) => encodeURIComponent(course))
-    .join(",");
-
-  const { data: enrollments, isLoading } = useQuery(
-    "enrollments",
-    async () => {
-      const response = await fetch(
-        encodeURI(
-          `/cube/enrollments.json?course_id=${encodedCoursesParam}` +
-            (testBackend ? "&test_backend=true" : "")
-        )
-      );
-      const responseData = await response.json();
-
-      if (responseData.errors) {
-        throw new Error(responseData.errors);
-      }
-
-      return responseData;
-    },
-    { enabled: courses && courses.length > 0 }
-  );
-
+  const { enrollments, isLoading } = useEnrollments({ courses });
   const rows = enrollments ? enrollments : [];
 
   return (

--- a/static/js/src/cube/dashboard/components/EnrollmentsTable/index.ts
+++ b/static/js/src/cube/dashboard/components/EnrollmentsTable/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./EnrollmentsTable";

--- a/static/js/src/cube/dashboard/components/ExamAttemptsTable/ExamAttemptsTable.tsx
+++ b/static/js/src/cube/dashboard/components/ExamAttemptsTable/ExamAttemptsTable.tsx
@@ -1,0 +1,67 @@
+import React from "react";
+import { Card, MainTable } from "@canonical/react-components";
+import { useQuery } from "react-query";
+
+type Props = {
+  courses: string[];
+};
+
+const ExamAttemptsTable = ({ courses }: Props) => {
+  const params = new URLSearchParams(window.location.search);
+  const testBackend = params.get("test_backend") === "true";
+
+  const { data: attempts } = useQuery(
+    "attempts",
+    async () => {
+      const response = await fetch(
+        `/cube/exam-attempts.json?course_id=${courses.join(",")}` +
+          (testBackend ? "&test_backend=true" : "")
+      );
+      const responseData = await response.json();
+
+      if (responseData.errors) {
+        throw new Error(responseData.errors);
+      }
+
+      return responseData;
+    },
+    { enabled: courses && courses.length > 0 }
+  );
+
+  console.log("!!! attempts: ", attempts);
+
+  return (
+    <Card title="Exam attempts">
+      {attempts && (
+        <MainTable
+          headers={[
+            { content: "Course ID", sortKey: "course_id" },
+            { content: "Start", sortKey: "started_at" },
+            { content: "End", sortKey: "completed_at" },
+            { content: "Status", sortKey: "status" },
+          ]}
+          rows={attempts.map(
+            ({ course_id, started_at, completed_at, status }) => ({
+              columns: [
+                { content: course_id },
+                { content: started_at },
+                { content: completed_at },
+                { content: status },
+              ],
+              sortData: {
+                course_id: course_id,
+                started_at: new Date(started_at),
+                completed_at: new Date(completed_at),
+                status: status,
+              },
+            })
+          )}
+          sortable
+          paginate={20}
+        />
+      )}
+    </Card>
+  );
+};
+
+export default ExamAttemptsTable;

--- a/static/js/src/cube/dashboard/components/ExamAttemptsTable/ExamAttemptsTable.tsx
+++ b/static/js/src/cube/dashboard/components/ExamAttemptsTable/ExamAttemptsTable.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { Card, MainTable } from "@canonical/react-components";
 import { useQuery } from "react-query";
+import DownloadCSVButton from "../DownloadCSVButton";
 
 type Props = {
   courses: string[];
@@ -10,7 +11,7 @@ const ExamAttemptsTable = ({ courses }: Props) => {
   const params = new URLSearchParams(window.location.search);
   const testBackend = params.get("test_backend") === "true";
 
-  const { data: attempts } = useQuery(
+  const { data: attempts, isLoading } = useQuery(
     "attempts",
     async () => {
       const response = await fetch(
@@ -30,36 +31,42 @@ const ExamAttemptsTable = ({ courses }: Props) => {
 
   console.log("!!! attempts: ", attempts);
 
+  const rows = attempts ? attempts : [];
+
   return (
     <Card title="Exam attempts">
-      {attempts && (
-        <MainTable
-          headers={[
-            { content: "Course ID", sortKey: "course_id" },
-            { content: "Start", sortKey: "started_at" },
-            { content: "End", sortKey: "completed_at" },
-            { content: "Status", sortKey: "status" },
-          ]}
-          rows={attempts.map(
-            ({ course_id, started_at, completed_at, status }) => ({
-              columns: [
-                { content: course_id },
-                { content: started_at },
-                { content: completed_at },
-                { content: status },
-              ],
-              sortData: {
-                course_id: course_id,
-                started_at: new Date(started_at),
-                completed_at: new Date(completed_at),
-                status: status,
-              },
-            })
-          )}
-          sortable
-          paginate={20}
-        />
-      )}
+      <DownloadCSVButton data={rows} />
+      <MainTable
+        headers={[
+          { content: "Course ID", sortKey: "course_id" },
+          { content: "Start", sortKey: "started_at" },
+          { content: "End", sortKey: "completed_at" },
+          { content: "Status", sortKey: "status" },
+        ]}
+        rows={rows.map(({ course_id, started_at, completed_at, status }) => ({
+          columns: [
+            { content: course_id },
+            { content: started_at },
+            { content: completed_at },
+            { content: status },
+          ],
+          sortData: {
+            course_id: course_id,
+            started_at: new Date(started_at),
+            completed_at: new Date(completed_at),
+            status: status,
+          },
+        }))}
+        sortable
+        paginate={20}
+        emptyStateMsg={
+          isLoading ? (
+            <i className="p-icon--spinner u-animation--spin"></i>
+          ) : (
+            <i>No data could be fetched</i>
+          )
+        }
+      />
     </Card>
   );
 };

--- a/static/js/src/cube/dashboard/components/ExamAttemptsTable/index.ts
+++ b/static/js/src/cube/dashboard/components/ExamAttemptsTable/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./ExamAttemptsTable";

--- a/static/js/src/cube/dashboard/components/GradesTable/GradesTable.tsx
+++ b/static/js/src/cube/dashboard/components/GradesTable/GradesTable.tsx
@@ -37,7 +37,9 @@ const GradesTable = ({ courses }: Props) => {
     { enabled: courses && courses.length > 0 }
   );
 
-  console.log("!!! grades: ", grades);
+  if (grades) {
+    console.log("!!! grades: ", grades);
+  }
 
   const rows = grades ? grades : [];
 
@@ -51,17 +53,15 @@ const GradesTable = ({ courses }: Props) => {
           { content: "Percent", sortKey: "percent" },
           { content: "Letter grade", sortKey: "letter_grade" },
           { content: "Username", sortKey: "username" },
-          { content: "Email", sortKey: "email" },
         ]}
         rows={rows.map(
-          ({ course_id, passed, percent, letter_grade, username, email }) => ({
+          ({ course_id, passed, percent, letter_grade, username }) => ({
             columns: [
               { content: course_id },
               { content: passed ? "Yes" : "No" },
               { content: percent },
               { content: letter_grade },
               { content: username },
-              { content: email },
             ],
             sortData: {
               course_id: course_id,
@@ -69,7 +69,6 @@ const GradesTable = ({ courses }: Props) => {
               percent: percent,
               letter_grade: letter_grade,
               username: username,
-              email: email,
             },
           })
         )}

--- a/static/js/src/cube/dashboard/components/GradesTable/GradesTable.tsx
+++ b/static/js/src/cube/dashboard/components/GradesTable/GradesTable.tsx
@@ -1,0 +1,90 @@
+import React from "react";
+import { Card, MainTable } from "@canonical/react-components";
+import { useQuery } from "react-query";
+import DownloadCSVButton from "../DownloadCSVButton";
+
+type Props = {
+  courses: string[];
+};
+
+const GradesTable = ({ courses }: Props) => {
+  const params = new URLSearchParams(window.location.search);
+  const testBackend = params.get("test_backend") === "true";
+  const encodedCoursesParam = courses
+    .map((course) => encodeURIComponent(course))
+    .join(",");
+
+  //const encodedCoursesParam = encodeURIComponent(courses[0]);
+  //const encodedCoursesParam = encodeURIComponent("course-v1:CUBE+sysarch+2020");
+
+  const { data: grades, isLoading } = useQuery(
+    "grades",
+    async () => {
+      const response = await fetch(
+        encodeURI(
+          `/cube/grades.json?course_id=${encodedCoursesParam}` +
+            (testBackend ? "&test_backend=true" : "")
+        )
+      );
+      const responseData = await response.json();
+
+      if (responseData.errors) {
+        throw new Error(responseData.errors);
+      }
+
+      return responseData;
+    },
+    { enabled: courses && courses.length > 0 }
+  );
+
+  console.log("!!! grades: ", grades);
+
+  const rows = grades ? grades : [];
+
+  return (
+    <Card title="Grades">
+      <DownloadCSVButton data={rows} />
+      <MainTable
+        headers={[
+          { content: "Course ID", sortKey: "course_id" },
+          { content: "Passed", sortKey: "passed" },
+          { content: "Percent", sortKey: "percent" },
+          { content: "Letter grade", sortKey: "letter_grade" },
+          { content: "Username", sortKey: "username" },
+          { content: "Email", sortKey: "email" },
+        ]}
+        rows={rows.map(
+          ({ course_id, passed, percent, letter_grade, username, email }) => ({
+            columns: [
+              { content: course_id },
+              { content: passed ? "Yes" : "No" },
+              { content: percent },
+              { content: letter_grade },
+              { content: username },
+              { content: email },
+            ],
+            sortData: {
+              course_id: course_id,
+              passed: passed,
+              percent: percent,
+              letter_grade: letter_grade,
+              username: username,
+              email: email,
+            },
+          })
+        )}
+        sortable
+        paginate={20}
+        emptyStateMsg={
+          isLoading ? (
+            <i className="p-icon--spinner u-animation--spin"></i>
+          ) : (
+            <i>No data could be fetched</i>
+          )
+        }
+      />
+    </Card>
+  );
+};
+
+export default GradesTable;

--- a/static/js/src/cube/dashboard/components/GradesTable/index.ts
+++ b/static/js/src/cube/dashboard/components/GradesTable/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./GradesTable";

--- a/static/js/src/cube/dashboard/hooks/useCertifications.ts
+++ b/static/js/src/cube/dashboard/hooks/useCertifications.ts
@@ -1,0 +1,44 @@
+import { useState } from "react";
+import { useQuery } from "react-query";
+
+type Props = {
+  usernames: string[];
+};
+
+const useCertifications = ({ usernames }: Props) => {
+  const [certifications, setCertifications] = useState();
+
+  const params = new URLSearchParams(window.location.search);
+  const testBackend = params.get("test_backend") === "true";
+
+  const { isLoading, isSuccess, isError, error } = useQuery(
+    "certifications" + usernames.join(","),
+    async () => {
+      console.log("!!! fetch certifications");
+      const response = await fetch(
+        `/cube/certifications.json?username=${usernames.join(",")}` +
+          (testBackend ? "&test_backend=true" : "")
+      );
+      const responseData = await response.json();
+
+      if (responseData.errors) {
+        throw new Error(responseData.errors);
+      }
+
+      const certifications = responseData;
+      console.log("!!! certifications: ", certifications);
+      setCertifications(certifications);
+    },
+    { enabled: usernames && usernames.length > 0 }
+  );
+
+  return {
+    certifications,
+    isLoading,
+    isSuccess,
+    isError,
+    error,
+  };
+};
+
+export default useCertifications;

--- a/static/js/src/cube/dashboard/hooks/useCourses.ts
+++ b/static/js/src/cube/dashboard/hooks/useCourses.ts
@@ -1,0 +1,32 @@
+import { useState } from "react";
+import { useQuery } from "react-query";
+
+const useCourses = () => {
+  const [courses, setCourses] = useState<string[]>([]);
+
+  const { isLoading, isSuccess, isError, error } = useQuery(
+    "courses",
+    async () => {
+      const response = await fetch("/cube/courses.json");
+      const responseData = await response.json();
+
+      if (responseData.errors) {
+        throw new Error(responseData.errors);
+      }
+
+      const courses = responseData.map((course) => course["id"]);
+      console.log("!!! courses: ", courses);
+      setCourses(courses);
+    }
+  );
+
+  return {
+    courses,
+    isLoading,
+    isSuccess,
+    isError,
+    error,
+  };
+};
+
+export default useCourses;

--- a/static/js/src/cube/dashboard/hooks/useEnrollments.ts
+++ b/static/js/src/cube/dashboard/hooks/useEnrollments.ts
@@ -1,0 +1,49 @@
+import { useState } from "react";
+import { useQuery } from "react-query";
+
+type Props = {
+  courses: string[];
+};
+
+const useEnrollments = ({ courses }: Props) => {
+  const [enrollments, setEnrollments] = useState();
+
+  const params = new URLSearchParams(window.location.search);
+  const testBackend = params.get("test_backend") === "true";
+  const encodedCoursesParam = courses
+    .map((course) => encodeURIComponent(course))
+    .join(",");
+
+  const { isLoading, isSuccess, isError, error } = useQuery(
+    "enrollments" + courses.join(","),
+    async () => {
+      console.log("!!! fetch enrollments");
+      const response = await fetch(
+        encodeURI(
+          `/cube/enrollments.json?course_id=${encodedCoursesParam}` +
+            (testBackend ? "&test_backend=true" : "")
+        )
+      );
+      const responseData = await response.json();
+
+      if (responseData.errors) {
+        throw new Error(responseData.errors);
+      }
+
+      const enrollments = responseData;
+      console.log("!!! enrollments: ", enrollments);
+      setEnrollments(enrollments);
+    },
+    { enabled: courses && courses.length > 0 }
+  );
+
+  return {
+    enrollments,
+    isLoading,
+    isSuccess,
+    isError,
+    error,
+  };
+};
+
+export default useEnrollments;

--- a/static/js/src/cube/dashboard/hooks/useExamAttempts.ts
+++ b/static/js/src/cube/dashboard/hooks/useExamAttempts.ts
@@ -1,0 +1,47 @@
+import { useState } from "react";
+import { useQuery } from "react-query";
+
+type Props = {
+  courses: string[];
+};
+
+const useExamAttempts = ({ courses }: Props) => {
+  const [examAttempts, setExamAttempts] = useState();
+
+  const params = new URLSearchParams(window.location.search);
+  const testBackend = params.get("test_backend") === "true";
+
+  const { isLoading, isSuccess, isError, error } = useQuery(
+    "examAttempts" + courses.join(","),
+    async () => {
+      console.log("!!! fetch exam attempts");
+      const response = await fetch(
+        `/cube/exam-attempts.json?course_id=${courses.join(",")}` +
+          (testBackend ? "&test_backend=true" : "")
+      );
+      const responseData = await response.json();
+
+      if (responseData.errors) {
+        throw new Error(responseData.errors);
+      }
+
+      const examAttempts = responseData;
+      console.log("!!! examAttempts: ", examAttempts);
+      setExamAttempts(examAttempts);
+    },
+    { enabled: courses && courses.length > 0 }
+  );
+
+  if (examAttempts) {
+  }
+
+  return {
+    examAttempts,
+    isLoading,
+    isSuccess,
+    isError,
+    error,
+  };
+};
+
+export default useExamAttempts;

--- a/static/js/src/cube/utils/generateCSV.ts
+++ b/static/js/src/cube/utils/generateCSV.ts
@@ -1,0 +1,18 @@
+const generateCSV = (records: Record<string, unknown>[]) => {
+  if (!records.length) {
+    return "data:text/csv;charset=utf-8,";
+  }
+
+  const headers = Object.keys(records[0]);
+
+  const rows: string[] = records.map((record) => {
+    const fields = headers.map((header) => String(record[header]));
+    return fields.join(",");
+  });
+
+  let csvContent = "data:text/csv;charset=utf-8,";
+  csvContent += headers.join(",") + "\n" + rows.join("\n");
+  return csvContent;
+};
+
+export default generateCSV;

--- a/static/sass/_pattern_recharts.scss
+++ b/static/sass/_pattern_recharts.scss
@@ -1,0 +1,3 @@
+.recharts-responsive-container {
+  overflow: hidden;
+}

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -67,6 +67,7 @@ $color-shadow: rgba(0, 0, 0, 0.5) !default;
 @import "pattern_navigation";
 @import "pattern_pie_chart";
 @import "pattern_ratings";
+@import "pattern_recharts";
 @import "pattern_renewal-modal";
 @import "pattern_security-certs-table";
 @import "pattern_shop-cart";

--- a/templates/cube/dashboard.html
+++ b/templates/cube/dashboard.html
@@ -1,0 +1,13 @@
+{% extends "cube/base_cube.html" %}
+
+{% block title %} Dashboard | CUBE {% endblock %}
+
+{% block meta_description %}Follow the path to certification - complete the 15 microcerts to attain CUBE.{% endblock meta_description %}
+
+{% block content %}
+
+<div id="react-root"></div>
+
+<script src="/static/js/dist/cubeDashboard.js" type="module"></script>
+
+{% endblock content %}

--- a/webapp/advantage/decorators.py
+++ b/webapp/advantage/decorators.py
@@ -158,10 +158,10 @@ def cube_decorator(response="json"):
                     if is_test_backend:
                         return flask.redirect(
                             "/login?test_backend=true&"
-                            "next=/cube/microcerts?test_backend=true"
+                            "next=/cube/dashboard?test_backend=true"
                         )
 
-                    return flask.redirect("/login?next=/cube/microcerts")
+                    return flask.redirect("/login?next=/cube/dashboard")
 
             elif response == "json":
                 if not user_info(flask.session):

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -51,6 +51,7 @@ from webapp.cube.views import (
     get_daily_enrollments,
     get_enrollments,
     get_exam_attempts,
+    get_course_grades,
 )
 
 from webapp.views import (
@@ -816,6 +817,7 @@ app.add_url_rule("/cube/courses.json", view_func=get_courses)
 app.add_url_rule("/cube/daily-enrollments.json", view_func=get_daily_enrollments)
 app.add_url_rule("/cube/enrollments.json", view_func=get_enrollments)
 app.add_url_rule("/cube/exam-attempts.json", view_func=get_exam_attempts)
+app.add_url_rule("/cube/grades.json", view_func=get_course_grades)
 
 # Charmed OpenStack docs
 openstack_docs = Docs(

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -49,6 +49,7 @@ from webapp.cube.views import (
     cube_dashboard,
     get_courses,
     get_daily_enrollments,
+    get_exam_attempts,
 )
 
 from webapp.views import (
@@ -812,6 +813,7 @@ app.add_url_rule("/cube/study/labs", view_func=cube_study_labs_button)
 app.add_url_rule("/cube/dashboard", view_func=cube_dashboard)
 app.add_url_rule("/cube/courses.json", view_func=get_courses)
 app.add_url_rule("/cube/enrollments.json", view_func=get_daily_enrollments)
+app.add_url_rule("/cube/exam-attempts.json", view_func=get_exam_attempts)
 
 # Charmed OpenStack docs
 openstack_docs = Docs(

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -46,6 +46,9 @@ from webapp.cube.views import (
     cube_study_labs_button,
     get_microcerts,
     post_microcerts_purchase,
+    cube_dashboard,
+    get_courses,
+    get_daily_enrollments,
 )
 
 from webapp.views import (
@@ -806,6 +809,9 @@ app.add_url_rule(
     methods=["POST"],
 )
 app.add_url_rule("/cube/study/labs", view_func=cube_study_labs_button)
+app.add_url_rule("/cube/dashboard", view_func=cube_dashboard)
+app.add_url_rule("/cube/courses.json", view_func=get_courses)
+app.add_url_rule("/cube/enrollments.json", view_func=get_daily_enrollments)
 
 # Charmed OpenStack docs
 openstack_docs = Docs(

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -52,6 +52,7 @@ from webapp.cube.views import (
     get_enrollments,
     get_exam_attempts,
     get_course_grades,
+    get_user_certifications,
 )
 
 from webapp.views import (
@@ -818,6 +819,7 @@ app.add_url_rule("/cube/daily-enrollments.json", view_func=get_daily_enrollments
 app.add_url_rule("/cube/enrollments.json", view_func=get_enrollments)
 app.add_url_rule("/cube/exam-attempts.json", view_func=get_exam_attempts)
 app.add_url_rule("/cube/grades.json", view_func=get_course_grades)
+app.add_url_rule("/cube/certifications.json", view_func=get_user_certifications)
 
 # Charmed OpenStack docs
 openstack_docs = Docs(

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -49,6 +49,7 @@ from webapp.cube.views import (
     cube_dashboard,
     get_courses,
     get_daily_enrollments,
+    get_enrollments,
     get_exam_attempts,
 )
 
@@ -812,7 +813,8 @@ app.add_url_rule(
 app.add_url_rule("/cube/study/labs", view_func=cube_study_labs_button)
 app.add_url_rule("/cube/dashboard", view_func=cube_dashboard)
 app.add_url_rule("/cube/courses.json", view_func=get_courses)
-app.add_url_rule("/cube/enrollments.json", view_func=get_daily_enrollments)
+app.add_url_rule("/cube/daily-enrollments.json", view_func=get_daily_enrollments)
+app.add_url_rule("/cube/enrollments.json", view_func=get_enrollments)
 app.add_url_rule("/cube/exam-attempts.json", view_func=get_exam_attempts)
 
 # Charmed OpenStack docs

--- a/webapp/cube/api.py
+++ b/webapp/cube/api.py
@@ -176,3 +176,15 @@ class EdxAPI:
             "GET",
             uri,
         ).json()
+
+    def get_course_grades(self, course_id: str= "", cursor: str=""):
+        uri = (
+            "/api/grades/v1/courses?"
+            + (f"course_id={course_id}&" if course_id else "")
+            + (f"cursor={cursor}&" if cursor else "")
+            + "page_size=100"
+        )
+        return self.make_request(
+            "GET",
+            uri,
+        ).json()

--- a/webapp/cube/api.py
+++ b/webapp/cube/api.py
@@ -188,3 +188,13 @@ class EdxAPI:
             "GET",
             uri,
         ).json()
+
+    def get_user_certifications(self, username: str):
+        uri = (
+            f"/api/certificates/v0/certificates/{username}?"
+            + "page_size=100"
+        )
+        return self.make_request(
+            "GET",
+            uri,
+        ).json()

--- a/webapp/cube/api.py
+++ b/webapp/cube/api.py
@@ -155,10 +155,9 @@ class EdxAPI:
         return data[0]
 
     def get_course_enrollments(self, course_id: str = "", cursor: str = ""):
-        safe_course_id = quote_plus(course_id)
         uri = (
             "/api/enrollment/v1/enrollments?"
-            + (f"course_id={safe_course_id}&" if safe_course_id else "")
+            + (f"course_id={course_id}&" if course_id else "")
             + (f"cursor={cursor}&" if cursor else "")
             + "page_size=100"
         )

--- a/webapp/cube/api.py
+++ b/webapp/cube/api.py
@@ -1,4 +1,4 @@
-from urllib.parse import quote
+from urllib.parse import quote, quote_plus
 from requests import Session
 
 
@@ -146,3 +146,16 @@ class EdxAPI:
 
         data = response.json()
         return data[0]
+
+    def get_course_enrollments(self, course_id: str = "", cursor: str = ""):
+        safe_course_id = quote_plus(course_id)
+        uri = (
+            "/api/enrollment/v1/enrollments?"
+            + (f"course_id={safe_course_id}&" if safe_course_id else "")
+            + (f"cursor={cursor}&" if cursor else "")
+            + "page_size=100"
+        )
+        return self.make_request(
+            "GET",
+            uri,
+        ).json()

--- a/webapp/cube/views.py
+++ b/webapp/cube/views.py
@@ -537,3 +537,33 @@ def get_exam_attempts(
             page += 1
 
     return flask.jsonify(exam_attempts)
+
+
+def get_grades(
+    badgr_issuer, badge_certification, ua_api, badgr_api, edx_api
+):
+    course_ids = flask.request.args.get("course_id", "").split(",")
+
+    grades = []
+    for course_id in course_ids:
+        cursor = ""
+        has_next = True
+        while has_next:
+            grades = edx_api.get_course_grades(
+                course_id, cursor
+            )
+            parsed_next = urlparse(grades["next"])
+            cursor = parse_qs(parsed_next.query).get("cursor", [""])[0]
+            has_next = True if cursor else False
+            print("!!! grades has_next", has_next)
+
+            for enrollment in grades["results"]:
+                grades.append(
+                    {
+                        "created": enrollment["created"],
+                        "course_id": enrollment["course_id"],
+                        "is_active": enrollment["is_active"],
+                    }
+                )
+
+    return flask.jsonify(grades)

--- a/webapp/cube/views.py
+++ b/webapp/cube/views.py
@@ -539,7 +539,8 @@ def get_exam_attempts(
     return flask.jsonify(exam_attempts)
 
 
-def get_grades(
+@cube_decorator(response="json")
+def get_course_grades(
     badgr_issuer, badge_certification, ua_api, badgr_api, edx_api
 ):
     course_ids = flask.request.args.get("course_id", "").split(",")
@@ -549,20 +550,23 @@ def get_grades(
         cursor = ""
         has_next = True
         while has_next:
-            grades = edx_api.get_course_grades(
+            grades_info = edx_api.get_course_grades(
                 course_id, cursor
             )
-            parsed_next = urlparse(grades["next"])
+            parsed_next = urlparse(grades_info["next"])
             cursor = parse_qs(parsed_next.query).get("cursor", [""])[0]
             has_next = True if cursor else False
             print("!!! grades has_next", has_next)
 
-            for enrollment in grades["results"]:
+            for grade in grades_info["results"]:
                 grades.append(
                     {
-                        "created": enrollment["created"],
-                        "course_id": enrollment["course_id"],
-                        "is_active": enrollment["is_active"],
+                        "course_id": grade["course_id"],
+                        "passed": grade["passed"],
+                        "percent": grade["percent"],
+                        "letter_grade": grade["letter_grade"],
+                        "username": grade["username"],
+                        "email": grade["email"],
                     }
                 )
 


### PR DESCRIPTION
## Done

- Fetch enrollments data from Open edX
  - Display daily and monthly enrollments in a chart filterable by course
- Fetch exam data from Open edX and display it in a table
- CSV download button for enrollments and exam attempts

## QA

- Run the server with dotrun
- Go to http://localhost:8001/cube/dashboard (or http://localhost:8001/cube/dashboard?test_backend=true to see QA data)
- Enrollment data should be displayed in a stacked bar chart
  - Use the search and filter component to filter by course
  - Use the select component to show monthly enrollments
- Enrollment data should be displayed in a table
- Exam attempt data should be displayed in a table

## Issue / Card

https://github.com/canonical-web-and-design/commercial-squad/issues/360
https://github.com/canonical-web-and-design/commercial-squad/issues/402

[Notes](https://docs.google.com/document/d/1SFW9eyrK3oSu38Mde5x1f6hKWWv0hWe_k0kdlH7aOL8/edit)

## Screenshots

![cube-dashboard-monthly](https://user-images.githubusercontent.com/995051/142175875-cd9a8a50-d79b-4ecc-95ab-5011dc90100e.png)

![cube-dashboard-daily](https://user-images.githubusercontent.com/995051/142175887-b5abb435-6d80-4913-b8ef-0cccc2e32636.png)