### PR TITLE
Add option to filter for Blender Support invoices

### DIFF
--- a/templates/account/invoices/index.html
+++ b/templates/account/invoices/index.html
@@ -19,6 +19,7 @@
     <div class="col-3" style="padding: 0.75rem 0">
       <select name="marketplace" id="marketplace-dropdown">
         <option value="">All invoices</option>
+        <option value="blender" {% if marketplace == 'blender' %}selected{% endif %}>Blender Support</option>
         <option value="canonical-ua" {% if marketplace == 'canonical-ua' %}selected{% endif %}>Canonical UA</option>
       </select>
     </div>


### PR DESCRIPTION
## Done
Add option to filter for Blender Support invoices

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- If you don't have blender invoices make a test purchase
- Go to /account/invoices
- Filter by blender support

