### PR TITLE
Update github action to send message on failure

### DIFF
--- a/.github/workflows/cypress-main.yaml
+++ b/.github/workflows/cypress-main.yaml
@@ -54,3 +54,11 @@ jobs:
           browser: chrome
           config-file: tests/cypress/cypress.json
           config: baseUrl=http://0.0.0.0:8001,integrationFolder=tests/cypress/forms
+
+      - name: Send message on failure
+        if: failure()
+        run: curl -X POST -F "workflow=${GITHUB_WORKFLOW}" -F "repo_name=${GITHUB_REPOSITORY}" -F "action_id=${GITHUB_RUN_ID}" ${{ secrets.BOT_URL }}?room=web--design
+      
+      - name: Send message on failure
+        if: failure()
+        run: curl -X POST -F "workflow=${GITHUB_WORKFLOW}" -F "repo_name=${GITHUB_REPOSITORY}" -F "action_id=${GITHUB_RUN_ID}" ${{ secrets.BOT_URL }}?room=marketing-pub

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![Code coverage](https://codecov.io/gh/canonical-web-and-design/ubuntu.com/branch/master/graph/badge.svg)](https://codecov.io/gh/canonical-web-and-design/ubuntu.com)
 [![Cypress checks](https://github.com/canonical-web-and-design/ubuntu.com/workflows/Cypress%20checks/badge.svg)](https://github.com/canonical-web-and-design/ubuntu.com/actions?query=workflow%3A%22Cypress+checks%22)
+[![Cypress checks / main](https://github.com/canonical-web-and-design/ubuntu.com/workflows/Cypress%20main%20checks/badge.svg)](https://github.com/canonical-web-and-design/ubuntu.com/actions/workflows/cypress-main.yaml?query=workflow%3A%22Cypress+checks%22)
 [![Links in master](https://github.com/canonical-web-and-design/ubuntu.com/workflows/Links%20in%20master/badge.svg)](https://github.com/canonical-web-and-design/ubuntu.com/actions?query=workflow%3A%22Links+in+master%22)
 [![Links on live](https://github.com/canonical-web-and-design/ubuntu.com/workflows/Links%20on%20live/badge.svg)](https://github.com/canonical-web-and-design/ubuntu.com/actions?query=workflow%3A%22Links+on+live%22)
 [![Blog Links](https://github.com/canonical-web-and-design/ubuntu.com/actions/workflows/blog-links.yaml/badge.svg)](https://github.com/canonical-web-and-design/ubuntu.com/actions/workflows/blog-links.yaml)


### PR DESCRIPTION
## Done

- Update github action to send messages to the `web & design` and `marketing` channels on Mattermost when it fails.

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- not sure how we can QA this PR because this github action(`cypress-main` workflow) only runs when a PR is pushed to main (after merge).
- I tested it with the `cypress-pr` workflow and it worked. 

## Issue / Card

Fixes [#4440](https://github.com/canonical-web-and-design/web-squad/issues/4440)

## Screenshot 
![image](https://user-images.githubusercontent.com/57550290/142245836-c912c74a-cfd8-4c1a-b5e9-568cbe317063.png)
