### PR TITLE
Only escape form comments when they exist

### DIFF
--- a/webapp/views.py
+++ b/webapp/views.py
@@ -647,8 +647,9 @@ def marketo_submit():
     form_fields.pop("g-recaptcha-response", None)
     return_url = form_fields.pop("returnURL", None)
 
-    encoded_comment = html.escape(form_fields["Comments_from_lead__c"])
-    form_fields["Comments_from_lead__c"] = encoded_comment
+    if "Comments_from_lead__c" in form_fields:
+        encoded_comment = html.escape(form_fields["Comments_from_lead__c"])
+        form_fields["Comments_from_lead__c"] = encoded_comment
 
     visitor_data = {
         "userAgentString": flask.request.headers.get("User-Agent"),


### PR DESCRIPTION
## Done
Only escape form comments when they exist

## QA
- Go to /engage/enterprise-kubernetes-comparison
- Submit the form
- Check you land on the thank you page

Resolves: https://sentry.is.canonical.com/canonical/ubuntu-com/issues/23366/