### PR TITLE
Re-enable user management

### DIFF
--- a/navigation.yaml
+++ b/navigation.yaml
@@ -1243,6 +1243,9 @@ support:
     - title: Your subscriptions
       path: /advantage
       persist: True
+    - title: Account users
+      path: /advantage/users
+      persist: True
 
     - title: Community support
       path: /support/community-support

--- a/webapp/advantage/views.py
+++ b/webapp/advantage/views.py
@@ -861,6 +861,8 @@ def blender_shop_view():
             # There is no purchase account yet for this user.
             # One will need to be created later; expected condition.
             pass
+        except AccessForbiddenError:
+            return flask.render_template("account/forbidden.html")
 
     all_subscriptions = []
     if account:

--- a/webapp/advantage/views.py
+++ b/webapp/advantage/views.py
@@ -264,7 +264,7 @@ def advantage_account_users_view():
     if account is None or account.role != "admin":
         return flask.render_template("account/forbidden.html")
 
-    return flask.render_template("advantage/maintenance.html")
+    return flask.render_template("advantage/users/index.html")
 
 
 @advantage_decorator(permission="user", response="html")


### PR DESCRIPTION
## Done

- Re-enable user management feature

## QA

Test the user management:
- `billing` cannot: see support portal button, subscription tokens, access user management page 
- `billing` can: view invoices, payment methods, make resizes, cancellations and purchases
- `technical` cannot: edit subscriptions, access buy subscription, invoices, payment methods and user management pages
- `technical` can: see support portal button, subscription token
- `admin` can do all

## Issue / Card

Fixes #https://github.com/canonical-web-and-design/commercial-squad/issues/406