### PR TITLE
Fix 'version/status' not being retained between pages on cve-search

### DIFF
--- a/templates/security/cve/index.html
+++ b/templates/security/cve/index.html
@@ -60,8 +60,8 @@
         </select>
       </div>
     </div>
-    {% if statuses | length > 0 %}
-      {% for status in statuses %}
+    {% if versions | length > 0 %}
+      {% for version in versions %}
         {% with versions=versions, statuses=statuses, releases=releases, index=loop.index - 1 %}
         {% include "security/cve/_version-and-status-row.html" %}
         {% endwith %}

--- a/webapp/context.py
+++ b/webapp/context.py
@@ -141,7 +141,9 @@ def format_date(datestring):
 
 
 def modify_query(params):
-    query_params = parse_qs(flask.request.query_string.decode("utf-8"))
+    query_params = parse_qs(
+        flask.request.query_string.decode("utf-8"), keep_blank_values=True
+    )
     query_params.update(params)
 
     return urlencode(query_params, doseq=True)


### PR DESCRIPTION
## Done

- Fixes 'version/status' not being retained between pages on cve-search

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- Check that the filter parameters are retained between pages, specifically when there is more than one version/status.

## Issue / Card

Fixes https://github.com/canonical-web-and-design/ubuntu.com/issues/10799


## Help

[QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html) - [Commit guidelines](https://canonical-web-and-design.github.io/practices/workflow/commit-messages.html)
