### PR TITLE
Add links to cloud pages on '/OpenRAN'

### DIFF
--- a/templates/telco/openran.html
+++ b/templates/telco/openran.html
@@ -88,7 +88,7 @@
   <div class="row">
     <div class="col-6">
       <h2>Deploy anywhere</h2>
-      <p>Juju is designed to model hybrid and multi-cloud environments, as well as provide native support for containers (KVM, LXD), container management (Kubernetes), networking/firewalls, and storage.</p>
+      <p>Juju is designed to model <a href="/cloud/hybrid-cloud">hybrid</a> and <a href="/cloud/multi-cloud">multi-cloud</a> environments, as well as provide native support for containers (KVM, LXD), container management (Kubernetes), networking/firewalls, and storage.</p>
       <p>Juju allows you to deploy, configure, manage, maintain, and scale cloud applications on all of these substrates.</p>
       <p>
         <a class="p-link--external" href="https://juju.is/">Read more&nbsp;&rsaquo;</a>


### PR DESCRIPTION
## Done

- Add links to cloud pages on '/OpenRAN' as per [copydoc](https://docs.google.com/document/d/181cqeYzSZ_RinjPTMMNDyAEMwKVvdeoc30iQDrwl4aQ/edit#)

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/telco/openran
    - Be sure to test on mobile, tablet and desktop screen sizes
- Check links work, compare against copydoc

## Issue / Card

Fixes https://github.com/canonical-web-and-design/web-squad/issues/4639

## Help

[QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html) - [Commit guidelines](https://canonical-web-and-design.github.io/practices/workflow/commit-messages.html)
