### PR TITLE
Non-free subscriptions can end in year 9999

### DIFF
--- a/tests/advantage/test_helpers.py
+++ b/tests/advantage/test_helpers.py
@@ -112,7 +112,9 @@ class TestHelpers(unittest.TestCase):
             ),
         ]
 
-        user_subscription_values = get_items_aggregated_values(items=items)
+        user_subscription_values = get_items_aggregated_values(
+            items=items, type="monthly"
+        )
 
         expected_start_date = "2020-01-01T00:00:00Z"
         expected_end_date = "2020-04-02T00:00:00Z"
@@ -140,7 +142,9 @@ class TestHelpers(unittest.TestCase):
             ),
         ]
 
-        user_subscription_values = get_items_aggregated_values(items=items)
+        user_subscription_values = get_items_aggregated_values(
+            items=items, type="free"
+        )
 
         expected_end_date = None
 

--- a/webapp/advantage/ua_contracts/builders.py
+++ b/webapp/advantage/ua_contracts/builders.py
@@ -194,7 +194,7 @@ def build_final_user_subscriptions(
         renewal = group.get("renewal")
         item_id = group.get("item_id")
         subscription_id = group.get("subscription_id")
-        aggregated_values = get_items_aggregated_values(items)
+        aggregated_values = get_items_aggregated_values(items, type)
         number_of_machines = aggregated_values.get("number_of_machines")
         end_date = aggregated_values.get("end_date")
         price_info = get_price_info(number_of_machines, items, listing)

--- a/webapp/advantage/ua_contracts/helpers.py
+++ b/webapp/advantage/ua_contracts/helpers.py
@@ -36,9 +36,7 @@ def group_shop_items(
     return item_groups
 
 
-def get_items_aggregated_values(
-    items: List[ContractItem],
-) -> Dict:
+def get_items_aggregated_values(items: List[ContractItem], type: str) -> Dict:
     start_date = None
     end_date = None
     number_of_machines = 0
@@ -57,9 +55,8 @@ def get_items_aggregated_values(
         if end_date and end_date < item.end_date:
             end_date = item.end_date
 
-    parsed_end_date = parse(end_date)
     # free user subscription end date is None
-    if parsed_end_date.year == 9999:
+    if type == "free":
         end_date = None
 
     return {


### PR DESCRIPTION
## Done

- Before I was assuming that user subscriptions that end in year 9999 are always of type free, if the user subscription is not of type free and would end in year 9999, then the page crashes.

## QA

- Have rights to view as 
- Log in on https://ubuntu.com
- Go to https://ubuntu.com/advantage?email=domas.monkus@canonical.com
- It will error out
- Log in on https://ubuntu-com-10918.demos.haus
- Go to https://ubuntu-com-10918.demos.haus/advantage?email=domas.monkus@canonical.com
- It will work!!!

## Issue / Card

Fixes #https://github.com/canonical-web-and-design/ubuntu.com/issues/10915