### PR TITLE
Add cypress test on engage pages

### DIFF
--- a/templates/engage/base.html
+++ b/templates/engage/base.html
@@ -118,7 +118,7 @@
 
 </section>
 
-{% if document["metadata"]["webinar_code"] != "" %}
+{% if document["metadata"]["webinar_code"] is defined %}
 {% if "channel_id" in document["metadata"] %}
   {% set channel_id = document["metadata"]["channel_id"] %}
 {% else %}

--- a/templates/engage/shared/_de_engage_form.html
+++ b/templates/engage/shared/_de_engage_form.html
@@ -1,5 +1,5 @@
 <!-- MARKETO FORM -->
-<form action="/marketo/submit" method="post" id="mktoForm_{{ id }}" onSubmit="fbq('trackCustom', 'Download');">
+<form action="/marketo/submit" method="post" id="mktoForm_{{ id }}" onSubmit='if (typeof fbq === "function"){fbq("trackCustom", "Download"); }'>
   <fieldset class="u-no-padding--top" style="border-bottom-width: 1px;">
     <ul class="p-list u-no-margin--bottom">
       <li class="p-list__item">

--- a/templates/engage/shared/_en_engage_form.html
+++ b/templates/engage/shared/_en_engage_form.html
@@ -3,33 +3,28 @@
   <fieldset class="u-no-padding--top" style="border-bottom-width: 1px;">
     <ul class="p-list">
       <li class="p-list__item">
-        <label for="firstName">First Name:</label>
-        <input required id="firstName" name="firstName" maxlength="255" type="text"
-          aria-label="First Name">
+        <label for="firstName">First name:</label>
+        <input required id="firstName" name="firstName" maxlength="255" type="text">
       </li>
       <li>
-        <label for="lastName">Last Name:</label>
-        <input required id="lastName" name="lastName" maxlength="255" type="text"
-          aria-label="Last Name">
+        <label for="lastName">Last name:</label>
+        <input required id="lastName" name="lastName" maxlength="255" type="text">
       </li>
       <li>
         <label for="email">Work email:</label>
-        <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$"
-          aria-label="Email">
+        <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$">
       </li>
       <li>
-        <label for="company">Company Name:</label>
-        <input required id="company" name="company" maxlength="255" type="text"
-          aria-label="Company Name">
+        <label for="company">Company name:</label>
+        <input required id="company" name="company" maxlength="255" type="text">
       </li>
       <li>
-        <label for="title">Job Title:</label>
-        <input required id="title" name="title" maxlength="255" type="text" aria-label="Job Title">
+        <label for="jobTitle">Job title:</label>
+        <input required id="jobTitle" name="title" maxlength="255" type="text">
       </li>
       <li>
         <label for="phone">Mobile/cell phone number:</label>
-        <input required id="phone" name="phone" maxlength="255" type="tel"
-          aria-label="Phone Number">
+        <input required id="phone" name="phone" maxlength="255" type="tel">
       </li>
       <li>
         <input name="utm_campaign" aria-label="utm_campaign" value="{{utm_campaign}}"

--- a/templates/engage/shared/_en_engage_form.html
+++ b/templates/engage/shared/_en_engage_form.html
@@ -1,5 +1,5 @@
 <!-- MARKETO FORM -->
-<form action="/marketo/submit" method="post" id="mktoForm_{{ id }}" onSubmit="fbq('trackCustom', 'Download');">
+<form action="/marketo/submit" method="post" id="mktoForm_{{ id }}" onSubmit='if (typeof fbq === "function"){fbq("trackCustom", "Download"); }'>
   <fieldset class="u-no-padding--top" style="border-bottom-width: 1px;">
     <ul class="p-list">
       <li class="p-list__item">

--- a/templates/engage/shared/_es_engage_form.html
+++ b/templates/engage/shared/_es_engage_form.html
@@ -1,5 +1,5 @@
 <!-- MARKETO FORM -->
-<form action="/marketo/submit" method="post" id="mktoForm_{{ id }}" onSubmit="fbq('trackCustom', 'Download');">
+<form action="/marketo/submit" method="post" id="mktoForm_{{ id }}" onSubmit='if (typeof fbq === "function"){fbq("trackCustom", "Download"); }'>
   <fieldset class="u-no-padding--top" style="border-bottom-width: 1px;">
     <ul class="p-list">
       <li class="p-list__item">

--- a/templates/engage/shared/_fr_engage_form.html
+++ b/templates/engage/shared/_fr_engage_form.html
@@ -1,4 +1,4 @@
-<form action="/marketo/submit" method="post" id="mktoForm_{{ id }}" onSubmit="fbq('trackCustom', 'Download');">
+<form action="/marketo/submit" method="post" id="mktoForm_{{ id }}" onSubmit='if (typeof fbq === "function"){fbq("trackCustom", "Download"); }'>
   <fieldset>
     <h3>Prenons contact</h3>
     <ul class="p-list u-no-margin--bottom">

--- a/templates/engage/shared/_it_engage_form.html
+++ b/templates/engage/shared/_it_engage_form.html
@@ -1,5 +1,5 @@
 <!-- MARKETO FORM -->
-<form action="/marketo/submit" method="post" id="mktoForm_{{ id }}" onSubmit="fbq('trackCustom', 'Download');">
+<form action="/marketo/submit" method="post" id="mktoForm_{{ id }}" onSubmit='if (typeof fbq === "function"){fbq("trackCustom", "Download"); }'>
   <fieldset class="u-no-padding--top" style="border-bottom-width: 1px;">
     <ul class="p-list">
       <li class="p-list__item">

--- a/templates/engage/shared/_pt_engage_form.html
+++ b/templates/engage/shared/_pt_engage_form.html
@@ -1,5 +1,5 @@
 <!-- MARKETO FORM -->
-<form action="/marketo/submit" method="post" id="mktoForm_{{ id }}" onSubmit="fbq('trackCustom', 'Download');">
+<form action="/marketo/submit" method="post" id="mktoForm_{{ id }}" onSubmit='if (typeof fbq === "function"){fbq("trackCustom", "Download"); }'>
   <fieldset class="u-no-padding--top" style="border-bottom-width: 1px;">
     <ul class="p-list">
       <li class="p-list__item">

--- a/tests/cypress/forms/forms_spec.js
+++ b/tests/cypress/forms/forms_spec.js
@@ -1,9 +1,4 @@
 /// <reference types="cypress" />
-
-Cypress.on('uncaught:exception', (err, runnable) => {
-    return false;
-  });
-
 import {
   standardFormUrls,
   interactiveForms,

--- a/tests/cypress/forms/forms_spec.js
+++ b/tests/cypress/forms/forms_spec.js
@@ -1,4 +1,9 @@
 /// <reference types="cypress" />
+
+Cypress.on('uncaught:exception', (err, runnable) => {
+    return false;
+  });
+
 import {
   standardFormUrls,
   interactiveForms,
@@ -229,3 +234,25 @@ context("Interactive marketo forms", () => {
     }
   );
 });
+
+context("engage forms", () => {
+    it("should check forms on engage pages", () => {
+      cy.visit("/engage/dockerandros");
+      
+      cy.acceptCookiePolicy();
+    
+      cy.findByLabelText(/First name:/).type("Test");
+      cy.findByLabelText(/Last name:/).type("Test");
+      cy.findByLabelText(/Work email:/).type("test@test.com");
+      cy.findByLabelText(/Company name:/).type("Test");
+      cy.findByLabelText(/Job title:/).type("test", {
+          force: true,
+          });
+      cy.findByLabelText(/Mobile\/cell phone number:/).type("07777777777");
+      cy.findByLabelText(/I agree to receive information/).click({
+          force: true,
+      });
+      cy.findByText(/Download the whitepaper/).click();
+      cy.findByRole("heading", { name: /Thank you/ });
+    });
+  });


### PR DESCRIPTION
## Done

- Add cypress test for forms on engage pages
- Removed `aria-label` and  fixed label texts  in the engage form 

## QA

1. Create `cypress.env.json` file
2. Copy and paste below (Reach out to me if you don't have keys)
`{ "UBUNTU_USERNAME": "", "UBUNTU_PASSWORD": "", "MARKETO_CLIENT_ID": "", "MARKETO_CLIENT_SECRET": "", "MARKETO_AUTHORISED_USER": "", "MARKETO_TOKEN": "" }`
3. Move forms_spec.js file in the /tests/cypress/forms folder to /tests/cypress/integration folder for testing
4. Run the site using the command ./run serve or dotrun
5. Use `yarn run cypress open --config-file tests/cypress/cypress.json --config baseUrl=http://0.0.0.0:8001/` to run cypress test
6. Click `forms_spec.js`
7. Check if the test passes. (You can skip static contact-us page and interactive forms tests by adding `.skip` to `it` -  just do the last one)

## Issue / Card

Fixes [#10920](https://github.com/canonical-web-and-design/ubuntu.com/issues/10920)

## Help

[QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html) - [Commit guidelines](https://canonical-web-and-design.github.io/practices/workflow/commit-messages.html)
