### PR TITLE
90 +- days to renew

### DIFF
--- a/tests/advantage/test_helpers.py
+++ b/tests/advantage/test_helpers.py
@@ -457,6 +457,42 @@ class TestHelpers(unittest.TestCase):
                     "is_expired": True,
                 },
             },
+            "legacy_date_is_91_days_before_expiry": {
+                "type": "legacy",
+                "date": "2020-12-01T00:00:00Z",
+                "expectations": {
+                    "is_expiring": False,
+                    "is_in_grace_period": False,
+                    "is_expired": False,
+                },
+            },
+            "legacy_date_is_90_days_before_expiry": {
+                "type": "legacy",
+                "date": "2020-11-29T00:00:00Z",
+                "expectations": {
+                    "is_expiring": True,
+                    "is_in_grace_period": False,
+                    "is_expired": False,
+                },
+            },
+            "legacy_date_is_90_days_after_expiry": {
+                "type": "legacy",
+                "date": "2020-06-04T00:00:00Z",
+                "expectations": {
+                    "is_expiring": False,
+                    "is_in_grace_period": True,
+                    "is_expired": False,
+                },
+            },
+            "legacy_date_is_91_days_after_expiry": {
+                "type": "legacy",
+                "date": "2020-06-02T00:00:00Z",
+                "expectations": {
+                    "is_expiring": False,
+                    "is_in_grace_period": False,
+                    "is_expired": True,
+                },
+            },
         }
 
         with freeze_time(freeze_datetime):
@@ -810,7 +846,7 @@ class TestHelpers(unittest.TestCase):
                     "is_downsizeable": False,
                     "is_cancellable": False,
                     "is_cancelled": False,
-                    "is_expiring": False,
+                    "is_expiring": True,
                     "is_in_grace_period": False,
                     "is_expired": False,
                     "is_trialled": False,
@@ -836,7 +872,7 @@ class TestHelpers(unittest.TestCase):
                     "is_downsizeable": False,
                     "is_cancellable": False,
                     "is_cancelled": False,
-                    "is_expiring": False,
+                    "is_expiring": True,
                     "is_in_grace_period": False,
                     "is_expired": False,
                     "is_trialled": False,

--- a/webapp/advantage/ua_contracts/builders.py
+++ b/webapp/advantage/ua_contracts/builders.py
@@ -244,12 +244,13 @@ def build_final_user_subscriptions(
 
         # Do not return expired user subscriptions after 30 days
         show_user_subscription = True
+        days_to_show = -120 if type == "legacy" else -30
         if type != "free":
             parsed_end_date = parse(user_subscription.end_date)
             time_now = datetime.utcnow().replace(tzinfo=pytz.utc)
             delta_till_expiry = parsed_end_date - time_now
             days_till_expiry = delta_till_expiry.days
-            show_user_subscription = days_till_expiry >= -30
+            show_user_subscription = days_till_expiry >= days_to_show
 
         if show_user_subscription:
             user_subscriptions.append(user_subscription)

--- a/webapp/advantage/ua_contracts/helpers.py
+++ b/webapp/advantage/ua_contracts/helpers.py
@@ -196,7 +196,7 @@ def get_user_subscription_statuses(
     if type == "free":
         return statuses
 
-    date_statuses = get_date_statuses(type, end_date)
+    date_statuses = get_date_statuses(type, end_date, renewal)
     statuses["is_expiring"] = date_statuses["is_expiring"]
     statuses["is_in_grace_period"] = date_statuses["is_in_grace_period"]
     statuses["is_expired"] = date_statuses["is_expired"]
@@ -283,9 +283,15 @@ def get_date_statuses(type: str, end_date: str) -> dict:
     delta_till_expiry = parsed_end_date - time_now
     days_till_expiry = delta_till_expiry.days
 
-    is_expiring_start = 60 if type == "yearly" else 7
-    is_expiring_end = 0
-    grace_period_end = -14
+    if type != "legacy":
+        is_expiring_start = 60 if type == "yearly" else 7
+        is_expiring_end = 0
+        grace_period_end = -14
+    else:
+        # legacy purchases can be renewed 90 before and after expiry
+        is_expiring_start = 90
+        is_expiring_end = 0
+        grace_period_end = -90
 
     is_expiring = is_expiring_start > days_till_expiry >= is_expiring_end
     is_in_grace_period = is_expiring_end > days_till_expiry >= grace_period_end

--- a/webapp/advantage/ua_contracts/helpers.py
+++ b/webapp/advantage/ua_contracts/helpers.py
@@ -196,7 +196,7 @@ def get_user_subscription_statuses(
     if type == "free":
         return statuses
 
-    date_statuses = get_date_statuses(type, end_date, renewal)
+    date_statuses = get_date_statuses(type, end_date)
     statuses["is_expiring"] = date_statuses["is_expiring"]
     statuses["is_in_grace_period"] = date_statuses["is_in_grace_period"]
     statuses["is_expired"] = date_statuses["is_expired"]


### PR DESCRIPTION
## Done

- Legacy user subscription need to be renewable 90 before and after expiry date: so is_expiring starts 90 days before expiry date and grace period ends 90 after expiry date
- Legacy user subscriptions are listed 90 (of grace period) + 30 days = 120 after expiry

## QA

Before:
- Login with an account that can view as on https://ubuntu.com?test_backend=true
- Check on https://ubuntu.com/advantage?test_backend=true&email=albert.kolozsvari%2Btester26%40canonical.com
- Tester26 has a legacy subscription that has expired more than 30 days ago so it's not listed at all
- Check on https://ubuntu.com/advantage?test_backend=true&email=albert.kolozsvari%2Btester27%40canonical.com
- Tester27 has a legacy subscription that has more than 30 days ago until expiry so there is no warning at all

After:
- Login with an account that can view as on https://ubuntu-com-10923.demos.haus?test_backend=true
- Check on https://ubuntu-com-10923.demos.haus/advantage?test_backend=true&email=albert.kolozsvari%2Btester26%40canonical.com
- Tester26 has a legacy subscription that has expired more than 30 days ago **but it's still showing up allowing the user to renew**
- Check on https://ubuntu-com-10923.demos.haus/advantage?test_backend=true&email=albert.kolozsvari%2Btester27%40canonical.com
- Tester27 has a legacy subscription that has more than 30 days ago until expiry. **The user gets a warning that they are getting close to expiry**
## Issue / Card

Fixes #https://github.com/canonical-web-and-design/commercial-squad/issues/414