### PR TITLE
Add blog post strip to /observability

### DIFF
--- a/templates/observability/index.html
+++ b/templates/observability/index.html
@@ -355,12 +355,15 @@
   </div>
 </section>
 
-<section class="p-strip is-deep">
-  <div class="row">
-    <div class="u-fixed-width">
-      <h2 class="u-sv3">Latest Ubuntu Observability news from <a href="/blog/tag/observability">our blog</a>&nbsp;&rsaquo;</h2>
-    </div>
-  </div>
+<div class="u-fixed-width">
+  <hr />
+</div>
+
+{% with section_classes='p-strip', heading_topic='Observability', tag_name='observability', tag_id='4125', limit='4' %}
+  {% include "shared/_latest_news_strip.html" %}
+{% endwith %}
+
+<section class="p-strip--light">
   <div class="row u-vertically-center">
     <div class="col-5 u-hide--small u-align--center">
       {{ image (
@@ -384,10 +387,6 @@
     </div>
   </div>
 </section>
-
-{% with section_classes='p-strip', heading_topic='Observability', tag_name='observability', tag_id='4125', limit='4' %}
-  {% include "shared/_latest_news_strip.html" %}
-{% endwith %}
 
 <!-- Set default Marketo information for contact form below-->
 <div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/observability-contact-us" data-form-id="4072" data-lp-id="" data-return-url="https://www.ubuntu.com/observability/thank-you.html" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">

--- a/templates/observability/index.html
+++ b/templates/observability/index.html
@@ -385,7 +385,7 @@
   </div>
 </section>
 
-{% with section_classes='p-strip', heading_topic='Observability', tag_name='observability', tag_id='3955', limit='4' %}
+{% with section_classes='p-strip', heading_topic='Observability', tag_name='observability', tag_id='4125', limit='4' %}
   {% include "shared/_latest_news_strip.html" %}
 {% endwith %}
 

--- a/templates/observability/index.html
+++ b/templates/observability/index.html
@@ -389,4 +389,8 @@
 <div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/observability-contact-us" data-form-id="4072" data-lp-id="" data-return-url="https://www.ubuntu.com/observability/thank-you.html" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
 </div>
 
+{% with section_classes='p-strip', heading_topic='Observability', tag_name='observability', tag_id='3955', limit='4' %}
+  {% include "shared/_latest_news_strip.html" %}
+{% endwith %}
+
 {% endblock content%}

--- a/templates/observability/index.html
+++ b/templates/observability/index.html
@@ -355,10 +355,6 @@
   </div>
 </section>
 
-<div class="u-fixed-width">
-  <hr />
-</div>
-
 {% with section_classes='p-strip', heading_topic='Observability', tag_name='observability', tag_id='4125', limit='4' %}
   {% include "shared/_latest_news_strip.html" %}
 {% endwith %}

--- a/templates/observability/index.html
+++ b/templates/observability/index.html
@@ -385,12 +385,12 @@
   </div>
 </section>
 
-<!-- Set default Marketo information for contact form below-->
-<div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/observability-contact-us" data-form-id="4072" data-lp-id="" data-return-url="https://www.ubuntu.com/observability/thank-you.html" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
-</div>
-
 {% with section_classes='p-strip', heading_topic='Observability', tag_name='observability', tag_id='3955', limit='4' %}
   {% include "shared/_latest_news_strip.html" %}
 {% endwith %}
+
+<!-- Set default Marketo information for contact form below-->
+<div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/observability-contact-us" data-form-id="4072" data-lp-id="" data-return-url="https://www.ubuntu.com/observability/thank-you.html" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
+</div>
 
 {% endblock content%}


### PR DESCRIPTION
## Done

- Add blog post strip for the `observability` tag

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- [List additional steps to QA the new features or prove the bug has been resolved]
