### PR TITLE
Fix thank you redirect

### DIFF
--- a/static/js/src/advantage/subscribe/react/app.tsx
+++ b/static/js/src/advantage/subscribe/react/app.tsx
@@ -12,6 +12,7 @@ declare global {
   interface Window {
     stripePublishableKey?: string;
     isGuest?: boolean;
+    isLoggedIn?: boolean;
     accountId?: string;
     previousPurchaseIds?: string[];
     handleTogglePurchaseModal?: () => void;

--- a/static/js/src/advantage/subscribe/react/components/BuyButton/BuyButton.tsx
+++ b/static/js/src/advantage/subscribe/react/components/BuyButton/BuyButton.tsx
@@ -68,7 +68,7 @@ const BuyButton = ({
     const testBackend = window?.location?.search?.includes("test_backend=true")
       ? "&test_backend=true"
       : "";
-    if (window.isGuest) {
+    if (window.isGuest && !window.isLoggedIn) {
       location.href = `/advantage/subscribe/thank-you?email=${encodeURIComponent(
         userInfo?.customerInfo?.email
       )}${testBackend}`;

--- a/templates/advantage/subscribe/blender/index.html
+++ b/templates/advantage/subscribe/blender/index.html
@@ -111,6 +111,7 @@
 
   window.accountId = "{% if account %}{{ account.id }}{% endif %}";
   window.isGuest = {% if account %}false{% else %}true{% endif %};
+  window.isLoggedIn = {% if user_info %}true{% else %}false{% endif %};
   window.isTrialling = false;
   window.accountName = "{% if account %}{{ account.name }}{% endif %}";
   window.previousPurchaseIds = {

--- a/templates/advantage/subscribe/index.html
+++ b/templates/advantage/subscribe/index.html
@@ -147,6 +147,7 @@
 
   var accountId = "{% if account %}{{ account.id }}{% endif %}";
   var isGuest = {% if account %}false{% else %}true{% endif %};
+  var isLoggedIn = {% if user_info %}true{% else %}false{% endif %};
   var isTrialling = {% if is_trialling %}true{% else %}false{% endif %};
   var accountName = "{% if account %}{{ account.name }}{% endif %}";
   var previousPurchaseIds = {


### PR DESCRIPTION
## Done

- No longer redirects logged in users to the thank you page.

## QA

- Create blank Ubuntu One account
- Login
- Buy a product
- Be redirected to /advantage

## Issue / Card

Fixes #https://github.com/canonical-web-and-design/commercial-squad/issues/395