### PR TITLE
Fix responsiveness on /security/cve

### DIFF
--- a/templates/security/cve/_cve-table.html
+++ b/templates/security/cve/_cve-table.html
@@ -1,7 +1,7 @@
-<table class="cve-table">
+<table class="cve-table" style="display: block; overflow-x: auto; white-space: nowrap;">
   <thead>
     <tr>
-      <th style="width: 10em">ID</th>
+      <th style="width: 10em; position: sticky; left: 0; background-color: #fff; z-index: 1; box-shadow: inset -1px 0 #d9d9d9;" >ID</th>
       <th>Priority</th>
       <th>Package</th>
       {% for release in releases %}
@@ -18,10 +18,10 @@
       {% for package_name, statuses in cve.packages.items() %}
         <tr>
           {% if loop.index == 1 %}
-            <td rowspan="{{ cve.packages | length }}">
+            <td rowspan="{{ cve.packages | length }}"  style="position: sticky; left: 0; background-color: #fff; z-index: 1; box-shadow: inset -1px 0 #d9d9d9;">
               <a href="/security/{{ cve.id }}">{{ cve.id }}</a>
             </td>
-            <td class="cve-table-cell-priority" rowspan="{{ cve.packages | length }}">
+            <td class="cve-table-cell-priority">
               <div class="icon-container__icon">
                 {% if cve.priority == 'unknown' %}
                   <i class="p-icon--placeholder"></i>


### PR DESCRIPTION
## Done

- Made a sticky table with first column and horizontal scroll on `/security/cve`

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/security/cve
- Be sure to test on mobile, tablet and desktop screen sizes
- You need to setup your local database with the cve data to see the table (Refer to [this](https://gist.github.com/goulinkh/3b4d6228de316d3a2cb2bf9450a97290) and let me know if you need anything about how to set up) 
- Please check the responsiveness and if everything works properly on all screens 


## Issue / Card

Fixes #9325 

## Screenshots

![ezgif com-gif-maker (1)](https://user-images.githubusercontent.com/57550290/143460514-3044d1dc-5fa1-447f-844a-f03a66e938cf.gif)
## Help

[QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html) - [Commit guidelines](https://canonical-web-and-design.github.io/practices/workflow/commit-messages.html)
