### PR TITLE
Update kernel on /about/release-cycle#ubuntu-kernel-release-cycle

### DIFF
--- a/static/js/src/chart-data.js
+++ b/static/js/src/chart-data.js
@@ -1364,7 +1364,7 @@ export var kernelReleaseNames = [
 export var kernelVersionNames = [
   "22.04 kernel",
   "",
-  "21.10 kernel",
+  "5.13 kernel",
   "",
   "5.11 kernel",
   "",

--- a/templates/about/release-cycle.html
+++ b/templates/about/release-cycle.html
@@ -266,7 +266,7 @@
               <td>Mar 2032</td>
             </tr>
             <tr>
-              <td rowspan="2"><strong>21.10 kernel</strong></td>
+              <td rowspan="2"><strong>5.13 kernel</strong></td>
               <td><strong>Ubuntu 20.04.4 LTS</strong></td>
               <td>Feb 2022</td>
               <td>Jul 2022</td>


### PR DESCRIPTION
## Done

- Update "21.10 kernel" to "5.13 kernel" on `/about/release-cycle#ubuntu-kernel-release-cycle`

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/about/release-cycle#ubuntu-kernel-release-cycle
- Be sure to test on mobile, tablet and desktop screen sizes
- Please go to the [issue](https://github.com/canonical-web-and-design/ubuntu.com/issues/10866) and double check if this PR fixes the issue properly

## Issue / Card

Fixes [#10866](https://github.com/canonical-web-and-design/ubuntu.com/issues/10866)

## Screenshots
<img width="971" alt="Screenshot 2021-11-25 at 3 48 05 pm" src="https://user-images.githubusercontent.com/57550290/143471068-118aaf34-c2b7-40e1-adad-d44f4b9a0bf4.png">

## Help

[QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html) - [Commit guidelines](https://canonical-web-and-design.github.io/practices/workflow/commit-messages.html)
