### PR TITLE
Add publish date to engage page

### DIFF
--- a/templates/engage/base.html
+++ b/templates/engage/base.html
@@ -21,6 +21,8 @@
 {% block meta_copydoc %}{{document["metadata"]["meta_copydoc"]}}{% endblock meta_copydoc %}
 
 {% block content %}
+
+<span id="publish_date" class="u-hide">{{document["metadata"]["publish_date"]}}</span>
 <section class="p-strip p-engage-banner--{{document['metadata']['banner_class']}}">
   <div class="u-fixed-width navigation-logo-engage">
     <a href="/">


### PR DESCRIPTION
## Done

- Display the engage page publish_date.

## QA

- Go to https://ubuntu-com-10948.demos.haus/engage/developer-desktop-productivity-whitepaper
- Open code inspector, you should find this publish date inside `id="main-content"` with `id="publish_date"`

## Issue / Card

Fixes https://github.com/canonical-web-and-design/ubuntu.com/issues/10598

## Screenshots

[If relevant, please include a screenshot.]


## Help

[QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html) - [Commit guidelines](https://canonical-web-and-design.github.io/practices/workflow/commit-messages.html)
