### PR TITLE
Build a new page on /legal/ubuntu-advantage-service-description/ros-esm-service-description

### DIFF
--- a/navigation.yaml
+++ b/navigation.yaml
@@ -1495,6 +1495,9 @@ legal:
       children:
         - title: Service description
           path: /legal/ubuntu-advantage-service-description
+        - title: ROS ESM Service Description 
+          path: /legal/ubuntu-advantage-service-description/ros-esm-service-description
+          hidden: True
         - title: サービス範囲
           path: /legal/ubuntu-advantage-service-description/ja
           hidden: True

--- a/templates/legal/ubuntu-advantage-service-description/_toc.html
+++ b/templates/legal/ubuntu-advantage-service-description/_toc.html
@@ -136,6 +136,16 @@
       <li class="p-side-navigation__item--title"><a class="p-side-navigation__link" href="#uasd-definitions">Definitions</a></li>
     </ul>
 
+    <ul class="p-side-navigation__list">
+      <li class="p-side-navigation__item--title">
+        <span class="p-side-navigation__text">Specialist service</span>
+      </li>
+      <li class="p-side-navigation__item">
+        <ul class="p-side-navigation__list">
+          <li class="p-side-navigation__item"><a class="p-side-navigation__link" href="/legal/ubuntu-advantage-service-description/ros-esm-service-description ">ROS ESM Service Description</a></li>
+        </ul>
+      </li>
+    </ul>
 
     <ul class="p-side-navigation__list">
       <li class="p-side-navigation__item--title"><span class="p-side-navigation__text">Japanese translation</span></li>

--- a/templates/legal/ubuntu-advantage-service-description/ros-esm-service-description/_base_legal_markdown.html
+++ b/templates/legal/ubuntu-advantage-service-description/ros-esm-service-description/_base_legal_markdown.html
@@ -1,0 +1,22 @@
+{% extends "templates/base.html" %}
+
+{% block outer_content %}
+
+<div class="p-strip is-deep">
+  <div class="row" id="service-description">
+    <div class="col-8 l-legal-pages">
+      {% block content %}
+        {{ content | safe }}
+      {% endblock %}
+    </div>
+    <div class="col-4 sticky-toc">
+      <aside class="p-table-of-contents u-hide--small">
+        {% include '/legal/ubuntu-advantage-service-description/ros-esm-service-description/_toc.html' %}
+      </aside>
+    </div>
+  </div>
+</div>
+
+  {% with first_item="_cloud_bootstack", second_item="_generic_download", third_item="_further_reading" %}{% include "shared/contextual_footers/_contextual_footer.html" %}{% endwith %}
+
+{% endblock %}

--- a/templates/legal/ubuntu-advantage-service-description/ros-esm-service-description/_toc.html
+++ b/templates/legal/ubuntu-advantage-service-description/ros-esm-service-description/_toc.html
@@ -1,0 +1,14 @@
+<div class="p-table-of-contents__section">
+  <h4 class="p-table-of-contents__header">Introduction</h4>
+  <nav class="p-table-of-contents__nav">
+    <ul class="p-list u-no-margin--bottom">
+      <li><a href="#ros-esm-scope">ROS ESM Service and ROS Support Scope</a></li>
+      <li>
+        <ul>
+          <li><a href="#ros-esm-service">1.ROS ESM Service</a></li>
+          <li><a href="#ros-support-scope">2.ROS Support Scope</a></li>
+        </ul>
+      </li>
+    </ul>
+  </nav>
+</div>

--- a/templates/legal/ubuntu-advantage-service-description/ros-esm-service-description/index.html
+++ b/templates/legal/ubuntu-advantage-service-description/ros-esm-service-description/index.html
@@ -1,0 +1,58 @@
+{% extends "/legal/ubuntu-advantage-service-description/ros-esm-service-description/_base_legal_markdown.html" %}
+
+{% block title %}Specialist Services for ROS ESM{% endblock title %}
+{% block meta_description %}Detailed description and explanation of the benefits and services you receive as an ROS ESM customer.{% endblock meta_description %}
+{% block meta_copydoc %}https://docs.google.com/document/d/12OGV0hnxPvwY2pT8gbS2vHQp3icndJeaEyqc1G_oIoM/edit#{% endblock meta_copydoc %}
+{% block meta_image %}https://assets.ubuntu.com/v1/ed348358-logo-cof.svg{% endblock meta_image %}
+
+{% block content %}
+
+<h1>Specialist Services for ROS ESM</h1>
+<p>As a Robot Operating System (ROS) Extended Security Maintenance (ESM) customer, you are entitled to the benefits and services, subject to the exclusions and conditions, as defined in the <a href="/legal/ubuntu-advantage-service-description">Ubuntu Advantage Service Description</a>.</p>
+<p>ROS scope is included in UA Apps and Ubuntu Pro. As an Essential, Standard or Advanced customer, you are also entitled to the benefits and services for ROS as described below.</p>
+
+<h2 id="ros-esm-scope">ROS ESM Service and ROS Support Scope</h2>
+<ol class="p-list--ordered-legal">
+  <li class="p-list__item">
+    <h3 id="ros-esm-service">ROS ESM Service</h3>
+    <ol class="p-list--ordered-legal">
+      <li class="p-list__item">
+        <h4>ROS ESM Service provides:</h4>
+        <ol class="p-list--ordered-legal">
+          <li class="p-list__item">Available High and Critical CVE fixes for a number of core ROS packages for ROS 1 Kinetic and Melodic.  This includes packages in the <a href="https://www.ros.org/reps/rep-0142.html" class="p-link--external">REP-142</a> ‘<a href="https://www.ros.org/reps/rep-0142.html#ros-base" class="p-link--external">ros_base</a>’ and a majority of the ‘<a href="https://www.ros.org/reps/rep-0142.html#desktop-variants" class="p-link--external">desktop</a>’ metapackages for each ROS distribution. </li>
+        </ol>
+      </li>
+      <li class="p-list__item">
+        <h4>ROS ESM Service expressly excludes:</h4>
+        <ol class="p-list--ordered-legal">
+          <li class="p-list__item">Security fixes for CVEs that are not High or Critical.</li>
+          <li class="p-list__item">Managed Services, as per defined in the Ubuntu Advantage Service Description, for ROS or robotic applications. </li>
+        </ol>
+      </li>
+    </ol>
+  </li>
+  <li class="p-list__item">
+    <h3 id="ros-support-scope">ROS Support Scope</h3>
+    <p>As a Standard or Advanced customer, you are also entitled to the benefits and services for ROS ESM and the support described below.</p>
+    <ol class="p-list--ordered-legal">
+      <li class="p-list__item">Support requests will follow the Support Services Process as defined in the Ubuntu Advantage Service Description.</li>
+      <li class="p-list__item">Support requests will follow the Support Severity Levels definition as defined in the Ubuntu Advantage for Applications (UA-A) Service Description.</li>
+      <li class="p-list__item">Support requests for third party and abandoned packages will be categorized as Severity Level 4.</li>
+      <li class="p-list__item">
+        <h4>ROS Support Exclusions</h4>
+        <ol class="p-list--ordered-legal">
+          <li class="p-list__item">Canonical does not guarantee a work-around, resolution or resolution time. </li>
+          <li class="p-list__item">Bug fixes for packages in the end of life release as defined in <a href="http://wiki.ros.org/Distributions" class="p-link--external">ROS release cycles</a>, unless a bug was created by an Extended Security Maintenance security update.</li>
+          <li class="p-list__item">Support for third party packages that have been abandoned.</li>
+          <li class="p-list__item">Support for the installation and configuration of ROS upstream.</li>
+          <li class="p-list__item">Development support for ROS.</li>
+          <li class="p-list__item">Maintenance, configuration and management of robots.</li>
+          <li class="p-list__item">Configuration files, including YAML/XML-launch.</li>
+          <li class="p-list__item">Support for parts of packages containing URDF/SRDF.</li>
+        </ol>
+      </li>
+    </ol>
+  </li>
+</ol>
+
+{% endblock content %}


### PR DESCRIPTION
## Done

- Build a new page on `/legal/ubuntu-advantage-service-description/ros-esm-service-description`
- Added this new page as an element in the content table on `/legal/ubuntu-advantage-service-description`

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/legal/ubuntu-advantage-service-description/ros-esm-service-description
- Be sure to test on mobile, tablet and desktop screen sizes
- Please refer to [Brief](https://docs.google.com/document/d/1TqixK0VoBC-mOUInYKGs1uNZfAwpORlU9SB1oqRcT48/edit) and [Copy doc](https://docs.google.com/document/d/12OGV0hnxPvwY2pT8gbS2vHQp3icndJeaEyqc1G_oIoM/edit#)
- Please check if this new page is linked properly on the`/legal/ubuntu-advantage-service-description`

## Issue / Card

Fixes [#10895](https://github.com/canonical-web-and-design/ubuntu.com/issues/10895)

## Screenshots
<img width="1440" alt="Specialist Services for RO | Ubuntu (2021-11-29 13-33-34)" src="https://user-images.githubusercontent.com/57550290/143877201-1898d46a-c82b-4717-a807-175898f29fcd.png">



## Help

[QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html) - [Commit guidelines](https://canonical-web-and-design.github.io/practices/workflow/commit-messages.html)
