### PR TITLE
Update clouds in the mega menu

### DIFF
--- a/templates/templates/navigation-enterprise-h.html
+++ b/templates/templates/navigation-enterprise-h.html
@@ -130,9 +130,13 @@
       <!-- Public cloud -->
       <div class="col-2">
         <h4 class="p-muted-heading">
-          <a href="/cloud/public-cloud">Public cloud&nbsp;&rsaquo;</a>
+          <a href="/cloud/public-cloud">Cloud&nbsp;&rsaquo;</a>
         </h4>
         <ul class="p-text-list--small is-bordered">
+          <li class="p-list__item"><a href="/cloud/public-cloud">Public cloud</a></li>
+          <li class="p-list__item"><a href="/cloud/private-cloud">Private cloud</a></li>
+          <li class="p-list__item"><a href="/cloud/hybrid-cloud">Hybrid cloud</a></li>
+          <li class="p-list__item"><a href="/cloud/multi-cloud">Multi-cloud</a></li>
           <li class="p-list__item"><a href="/download/cloud">Use Ubuntu on AWS, Azure, Google, Oracle and IBM clouds</a></li>
         </ul>
       </div>


### PR DESCRIPTION
## Done

- Update cloud menus in the mega menu 

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Click `Enterprise` in the navigation bar and check if `Cloud` menu is updated properly
- Refer to this [brief](https://docs.google.com/document/d/1SCt5PuvmXgMdVCiQ837QnAnrMI9XLcJt8KRV4HyNsQ4/edit#)
- Be sure to test on mobile, tablet and desktop screen sizes

## Issue / Card

Fixes [#4645](https://github.com/canonical-web-and-design/web-squad/issues/4645)

## Screenshots

![image](https://user-images.githubusercontent.com/57550290/143892961-b2ef379d-c471-4bde-bdfa-260cfaf61832.png)


## Help

[QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html) - [Commit guidelines](https://canonical-web-and-design.github.io/practices/workflow/commit-messages.html)
