### PR TITLE
Make /edge-computing responsive on small screens

### DIFF
--- a/templates/edge-computing/index.html
+++ b/templates/edge-computing/index.html
@@ -310,17 +310,6 @@
 </section>
 
 <section class="p-strip is-bordered">
-  <div class="u-fixed-width u-sv3 u-align--center u-hide--large u-hide--medium">
-    {{ image (
-      url="https://assets.ubuntu.com/v1/3de3935b-edge.png",
-      alt="Edge computing micro cloud architecture",
-      width="230",
-      height="265",
-      hi_def=True,
-      loading="lazy"
-      ) | safe
-    }}
-  </div>
   <div class="u-fixed-width">
     <h2>Micro clouds under the microscope</h2>
   </div>
@@ -346,17 +335,6 @@
 </section>
 
 <section class="p-strip is-bordered">
-  <div class="u-fixed-width u-sv3 u-align--center u-hide--large u-hide--medium">
-    {{ image (
-      url="https://assets.ubuntu.com/v1/5506324e-Edge-computing.svg",
-      alt="",
-      width="400",
-      height="258",
-      hi_def=True,
-      loading="lazy"
-      ) | safe
-    }}
-  </div>
   <div class="row">
     <div class="col-6 u-vertically-center u-align--center u-hide--small">
       {{ image (
@@ -393,17 +371,6 @@
 </section>
 
 <section class="p-strip">
-  <div class="u-fixed-width u-sv3 u-align--center u-hide--large u-hide--medium">
-    {{ image (
-      url="https://assets.ubuntu.com/v1/23cbb344-Design.png",
-      alt="Micro clouds are meant to be customised to specific use cases",
-      width="244",
-      height="140",
-      hi_def=True,
-      loading="lazy"
-      ) | safe
-    }}
-  </div>
   <div class="row">
     <div class="col-6">
       <h2>What is the size of a micro cloud?</h2>

--- a/templates/edge-computing/index.html
+++ b/templates/edge-computing/index.html
@@ -70,10 +70,12 @@
   </div>
 </section>
 
+<hr class="u-hide--large u-hide--medium">
+
 <section class="p-strip is-bordered">
   <div class="row">
-    <div class="col-6 u-hide--small">
-      <div class="u-sv3">
+    <div class="col-6">
+      <div class="u-sv3 u-hide--small">
         {{ image (
           url="https://assets.ubuntu.com/v1/8b16a766-Edge-industrial.svg",
           alt="",
@@ -92,8 +94,8 @@
       </ul>
       <p><a href="/internet-of-things/gateways">Connect IIoT devices to micro clouds&nbsp;&rsaquo;</a></p>
     </div>
-    <div class="col-6 u-hide--small">
-      <div class="u-sv3">
+    <div class="col-6">
+      <div class="u-sv3 u-hide--small">
         {{ image (
           url="https://assets.ubuntu.com/v1/dfb83f4e-Edge-telecoms.svg",
           alt="",
@@ -117,8 +119,8 @@
 
 <section class="p-strip is-bordered">
   <div class="row">
-    <div class="col-6 u-hide--small">
-      <div class="u-sv3">
+    <div class="col-6">
+      <div class="u-sv3 u-hide--small">
         {{ image (
           url="https://assets.ubuntu.com/v1/b6a48d38-Edge-business.svg",
           alt="",
@@ -137,8 +139,8 @@
       </ul>
       <p><a href="/desktop/organisations">Read about Ubuntu in organisations&nbsp;&rsaquo;</a></p>
     </div>
-    <div class="col-6 u-hide--small">
-      <div class="u-sv3">
+    <div class="col-6">
+      <div class="u-sv3 u-hide--small">
         {{ image (
           url="https://assets.ubuntu.com/v1/5e4aba82-Edge-IoT.svg",
           alt="",
@@ -159,6 +161,8 @@
     </div>    
   </div>
 </section>
+
+<hr class="u-hide--large u-hide--medium">
 
 <section class="p-strip">
   <div class="row">
@@ -289,7 +293,6 @@
           }}
         </div>
         <div class="p-logo-section__item">
-
           {{ image (
             url="https://assets.ubuntu.com/v1/80ab9b3c-2018-logo-cisco.svg",
             alt="",
@@ -307,6 +310,17 @@
 </section>
 
 <section class="p-strip is-bordered">
+  <div class="u-fixed-width u-sv3 u-align--center u-hide--large u-hide--medium">
+    {{ image (
+      url="https://assets.ubuntu.com/v1/3de3935b-edge.png",
+      alt="Edge computing micro cloud architecture",
+      width="230",
+      height="265",
+      hi_def=True,
+      loading="lazy"
+      ) | safe
+    }}
+  </div>
   <div class="u-fixed-width">
     <h2>Micro clouds under the microscope</h2>
   </div>
@@ -332,6 +346,17 @@
 </section>
 
 <section class="p-strip is-bordered">
+  <div class="u-fixed-width u-sv3 u-align--center u-hide--large u-hide--medium">
+    {{ image (
+      url="https://assets.ubuntu.com/v1/5506324e-Edge-computing.svg",
+      alt="",
+      width="400",
+      height="258",
+      hi_def=True,
+      loading="lazy"
+      ) | safe
+    }}
+  </div>
   <div class="row">
     <div class="col-6 u-vertically-center u-align--center u-hide--small">
       {{ image (
@@ -368,6 +393,17 @@
 </section>
 
 <section class="p-strip">
+  <div class="u-fixed-width u-sv3 u-align--center u-hide--large u-hide--medium">
+    {{ image (
+      url="https://assets.ubuntu.com/v1/23cbb344-Design.png",
+      alt="Micro clouds are meant to be customised to specific use cases",
+      width="244",
+      height="140",
+      hi_def=True,
+      loading="lazy"
+      ) | safe
+    }}
+  </div>
   <div class="row">
     <div class="col-6">
       <h2>What is the size of a micro cloud?</h2>


### PR DESCRIPTION
## Done

- Make /edge-computing responsive on small screens as per the conversation on the original [PR](https://github.com/canonical-web-and-design/ubuntu.com/pull/10928) 

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: https://ubuntu-com-10960.demos.haus/edge
    - Be sure to test on mobile, tablet and desktop screen sizes
- Check responsiveness of the site on small screens

## Issue / Card

Fixes https://github.com/canonical-web-and-design/ubuntu.com/issues/10959

## Help

[QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html) - [Commit guidelines](https://canonical-web-and-design.github.io/practices/workflow/commit-messages.html)
