### PR TITLE
Add Ubuntu Advantage as topic category on /tutorials

### DIFF
--- a/templates/tutorials/index.html
+++ b/templates/tutorials/index.html
@@ -41,6 +41,7 @@
           <option value="iot">IoT</option>
           <option value="packaging">Packaging</option>
           <option value="server">Server</option>
+          <option value="ua">Ubuntu Advantage</option>
         </select>
       </div>
     </div>


### PR DESCRIPTION
## Done

- /tutorials now has an option for Ubuntu Advantage
- if you add 'ua' as a cateogry on discourse, it will appear on /tutorials

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/tutorials
    - Be sure to test on mobile, tablet and desktop screen sizes
- See that there are 2 UA tutorials



## Screenshots
![image](https://user-images.githubusercontent.com/441217/144033084-431c21a5-14b5-41a2-98f2-697ab3caeb92.png)
