### PR TITLE
Replace use of 'custom kernels' with 'optimised kernels'

### DIFF
--- a/templates/kernel/index.html
+++ b/templates/kernel/index.html
@@ -102,8 +102,8 @@
 
 <section class="p-strip--light">
   <div class="u-fixed-width">
-    <h2 id="custom-kernels">Custom kernels</h2>
-    <p>Canonical advocates for customers to use the GA kernel shipped with Ubuntu as the best and most cost-effective option in their business environment. We also offer the option for customers to customize their own Ubuntu kernels. Several of our enterprise, Telco and cloud provider customers have systems and workload needs, which justify both the time investment to optimise their kernels and the pay to develop and maintain those custom kernels over time.</p>
+    <h2 id="custom-kernels">Optimised kernels</h2>
+    <p>Canonical advocates for customers to use the GA kernel shipped with Ubuntu as the best and most cost-effective option in their business environment. We also offer the option for customers to customize their own Ubuntu kernels. Several of our enterprise, Telco and cloud provider customers have systems and workload needs, which justify both the time investment to optimise their kernels and the pay to develop and maintain those optimised kernels over time.</p>
   </div>
 </section>
 {% endblock %}


### PR DESCRIPTION
## Done

- Replace use of 'custom kernels' with 'optimised kernels' to follow modern descriptive patterns
- Updated copydoc

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: https://ubuntu-com-10964.demos.haus/kernel
    - Be sure to test on mobile, tablet and desktop screen sizes
- Check no use of 'custom kernel' exist. 

## Issue / Card

Fixes https://github.com/canonical-web-and-design/ubuntu.com/issues/10863


## Help

[QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html) - [Commit guidelines](https://canonical-web-and-design.github.io/practices/workflow/commit-messages.html)
