### PR TITLE
Update AdGuard specifications to match snapcraft.io

### DIFF
--- a/templates/appliance/adguard/index.md
+++ b/templates/appliance/adguard/index.md
@@ -33,7 +33,7 @@ context:
   compliance:
     1: "EU GDPR"
     2: "California law"
-  base: "core18"
+  base: "core20"
   published_date: "2020-06-16"
   maintenance_date: "2030-06-16"
   snaps:
@@ -43,7 +43,7 @@ context:
       link: "https://snapcraft.io/adguard-home"
       publisher: "AdGuard, (ameshkov)"
       channel: "latest/stable"
-      version: "0.102.0"
+      version: "0.106.3"
       published_date: "15 May 2020"
 ---
 


### PR DESCRIPTION
## Done

- Update AdGuard specifications to match snapcraft.io (see attached issue)

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes

## Issue / Card

Fixes https://github.com/canonical-web-and-design/ubuntu.com/issues/10767

## Help

[QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html) - [Commit guidelines](https://canonical-web-and-design.github.io/practices/workflow/commit-messages.html)
