### PR TITLE
Fix entitlement problem

### DIFF
--- a/tests/advantage/test_parsers.py
+++ b/tests/advantage/test_parsers.py
@@ -1,3 +1,4 @@
+import json
 import unittest
 from typing import List, Dict
 
@@ -306,6 +307,29 @@ class TestParsers(unittest.TestCase):
         parsed_entitlements = parse_entitlements([])
         self.assertIsInstance(parsed_entitlements, List)
         self.assertEqual([], to_dict(parsed_entitlements))
+
+    def test_parses_entitlement_without_obligations(self):
+        raw_entitlements = (
+            '[{"type": "support", "entitled": true, '
+            '"affordances": {"supportLevel": "essential"}}]'
+        )
+
+        parsed_entitlements = parse_entitlements(
+            raw_entitlements=json.loads(raw_entitlements)
+        )
+
+        expected_entitlements = [
+            Entitlement(
+                type="support",
+                support_level="essential",
+                enabled_by_default=False,
+                is_available=True,
+            ),
+        ]
+
+        self.assertEqual(
+            to_dict(parsed_entitlements), to_dict(expected_entitlements)
+        )
 
     def test_parse_renewal(self):
         raw_renewal = get_fixture("renewal")

--- a/webapp/advantage/ua_contracts/parsers.py
+++ b/webapp/advantage/ua_contracts/parsers.py
@@ -83,10 +83,14 @@ def parse_entitlements(
         if affordances:
             support_level = affordances.get("supportLevel")
 
+        enabled_by_default = (
+            obligations.get("enableByDefault") if obligations else False
+        )
+
         entitlement = Entitlement(
             type=raw_entitlement.get("type"),
             support_level=support_level,
-            enabled_by_default=obligations.get("enableByDefault"),
+            enabled_by_default=enabled_by_default,
             is_available=is_available,
         )
 


### PR DESCRIPTION
## Done

- If `obligations.enabledByDefault` was missing from the entitlement payload the code would crash. This change prevents that, defaulting to `False`.

## QA

- Go to /advantage. Does it error out?

## Issue / Card

Fixes #https://github.com/canonical-web-and-design/commercial-squad/issues/420