### PR TITLE
Add marketing opt-in checkbox for purchases.

### DIFF
--- a/static/js/src/PurchaseModal/PurchaseModal.tsx
+++ b/static/js/src/PurchaseModal/PurchaseModal.tsx
@@ -18,6 +18,7 @@ import { BuyButtonProps } from "./utils/utils";
 type Props = {
   accountId?: string;
   termsLabel: React.ReactNode;
+  marketingLabel: React.ReactNode;
   product?: any;
   preview?: any;
   quantity: number;
@@ -32,6 +33,7 @@ type Props = {
 const PurchaseModal = ({
   accountId,
   termsLabel,
+  marketingLabel,
   product,
   preview,
   quantity,
@@ -135,6 +137,7 @@ const PurchaseModal = ({
         ) : (
           <StepTwo
             termsLabel={termsLabel}
+            marketingLabel={marketingLabel}
             setStep={setStep}
             error={error}
             setError={setError}

--- a/static/js/src/PurchaseModal/components/ModalSteps/StepTwo.tsx
+++ b/static/js/src/PurchaseModal/components/ModalSteps/StepTwo.tsx
@@ -14,6 +14,7 @@ import { BuyButtonProps } from "../../utils/utils";
 
 type StepTwoProps = {
   termsLabel: React.ReactNode;
+  marketingLabel: React.ReactNode;
   setStep: React.Dispatch<React.SetStateAction<number>>;
   error: React.ReactNode | null;
   setError: React.Dispatch<React.SetStateAction<React.ReactNode>>;
@@ -28,6 +29,7 @@ type StepTwoProps = {
 
 function StepTwo({
   termsLabel,
+  marketingLabel,
   setStep,
   error,
   setError,
@@ -40,6 +42,7 @@ function StepTwo({
   isFreeTrialApplicable = false,
 }: StepTwoProps) {
   const [areTermsChecked, setTermsChecked] = useState(false);
+  const [isMarketingOptInChecked, setIsMarketingOptInChecked] = useState(false);
   const { isLoading: isUserInfoLoading } = useStripeCustomerInfo();
   const [isUsingFreeTrial, setIsUsingFreeTrial] = useState(
     product?.canBeTrialled
@@ -81,6 +84,10 @@ function StepTwo({
           )}
           <PaymentMethodSummary setStep={setStep} />
           <TermsCheckbox label={termsLabel} setTermsChecked={setTermsChecked} />
+          <TermsCheckbox
+            label={marketingLabel}
+            setTermsChecked={setIsMarketingOptInChecked}
+          />
         </>
       </ModalBody>
 
@@ -88,6 +95,8 @@ function StepTwo({
         <BuyButton
           areTermsChecked={areTermsChecked}
           isUsingFreeTrial={isUsingFreeTrial}
+          isMarketingOptInChecked={isMarketingOptInChecked}
+          setIsMarketingOptInChecked={setIsMarketingOptInChecked}
           setTermsChecked={setTermsChecked}
           setError={setError}
           setStep={setStep}

--- a/static/js/src/PurchaseModal/utils/utils.ts
+++ b/static/js/src/PurchaseModal/utils/utils.ts
@@ -95,7 +95,9 @@ export const getIsFreeTrialEnabled = () =>
 export type BuyButtonProps = {
   areTermsChecked: boolean;
   isUsingFreeTrial: boolean;
+  isMarketingOptInChecked: boolean;
   setTermsChecked: React.Dispatch<React.SetStateAction<boolean>>;
+  setIsMarketingOptInChecked: React.Dispatch<React.SetStateAction<boolean>>;
   setError: React.Dispatch<React.SetStateAction<React.ReactNode>>;
   setStep: React.Dispatch<React.SetStateAction<number>>;
 };

--- a/static/js/src/advantage/react/components/Subscriptions/RenewalModal/RenewButton/RenewButton.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/RenewalModal/RenewButton/RenewButton.tsx
@@ -18,7 +18,9 @@ const BuyButton = ({
   renewalID,
   closeModal,
   areTermsChecked,
+  isMarketingOptInChecked,
   setTermsChecked,
+  setIsMarketingOptInChecked,
   setError,
   setStep,
 }: Props) => {
@@ -124,6 +126,7 @@ const BuyButton = ({
         }
       }
       setTermsChecked(false);
+      setIsMarketingOptInChecked(false);
       setStep(1);
     }
   }, [renewalError]);
@@ -141,6 +144,11 @@ const BuyButton = ({
       formData.append("utm_campaign", sessionData?.utm_campaign || "");
       formData.append("utm_source", sessionData?.utm_source || "");
       formData.append("utm_medium", sessionData?.utm_medium || "");
+      formData.append("store_name__c", "ua");
+      formData.append(
+        "canonicalUpdatesOptIn",
+        isMarketingOptInChecked ? "yes" : "no"
+      );
 
       request.open(
         "POST",

--- a/static/js/src/advantage/react/components/Subscriptions/RenewalModal/RenewalModal.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/RenewalModal/RenewalModal.tsx
@@ -26,6 +26,9 @@ const RenewalModal = ({ subscription, closeModal }: Props) => {
     </>
   );
 
+  const marketingLabel =
+    "I agree to receive information about Canonical's products and services";
+
   const RenewalSummary = () => {
     return (
       <Summary
@@ -40,7 +43,9 @@ const RenewalModal = ({ subscription, closeModal }: Props) => {
 
   const BuyButton = ({
     areTermsChecked,
+    isMarketingOptInChecked,
     setTermsChecked,
+    setIsMarketingOptInChecked,
     setError,
     setStep,
     isUsingFreeTrial,
@@ -50,7 +55,9 @@ const RenewalModal = ({ subscription, closeModal }: Props) => {
         renewalID={subscription.renewal_id}
         closeModal={closeModal}
         areTermsChecked={areTermsChecked}
+        isMarketingOptInChecked={isMarketingOptInChecked}
         setTermsChecked={setTermsChecked}
+        setIsMarketingOptInChecked={setIsMarketingOptInChecked}
         setError={setError}
         setStep={setStep}
         isUsingFreeTrial={isUsingFreeTrial}
@@ -72,6 +79,7 @@ const RenewalModal = ({ subscription, closeModal }: Props) => {
         <PurchaseModal
           accountId={subscription.account_id}
           termsLabel={termsLabel}
+          marketingLabel={marketingLabel}
           quantity={subscription.number_of_machines}
           closeModal={closeModal}
           Summary={RenewalSummary}

--- a/static/js/src/advantage/subscribe/blender/BlenderPurchase.tsx
+++ b/static/js/src/advantage/subscribe/blender/BlenderPurchase.tsx
@@ -24,6 +24,9 @@ const BlenderPurchase = () => {
     </>
   );
 
+  const marketingLabel =
+    "I agree to receive information about Canonical's products and services";
+
   const closeModal = () => {
     const purchaseModal = document.querySelector("#purchase-modal");
     purchaseModal?.classList.add("u-hide");
@@ -32,6 +35,7 @@ const BlenderPurchase = () => {
   return (
     <PurchaseModal
       termsLabel={termsLabel}
+      marketingLabel={marketingLabel}
       product={product}
       preview={preview}
       quantity={quantity}

--- a/static/js/src/advantage/subscribe/blender/BuyButton.tsx
+++ b/static/js/src/advantage/subscribe/blender/BuyButton.tsx
@@ -12,7 +12,9 @@ import { checkoutEvent, purchaseEvent } from "../../ecom-events";
 
 const BuyButton = ({
   areTermsChecked,
+  isMarketingOptInChecked,
   setTermsChecked,
+  setIsMarketingOptInChecked,
   setError,
   setStep,
 }: BuyButtonProps) => {
@@ -122,6 +124,7 @@ const BuyButton = ({
         );
       }
       setTermsChecked(false);
+      setIsMarketingOptInChecked(false);
       setStep(1);
     }
   }, [purchaseError]);
@@ -148,6 +151,11 @@ const BuyButton = ({
       formData.append("utm_campaign", sessionData?.utm_campaign || "");
       formData.append("utm_source", sessionData?.utm_source || "");
       formData.append("utm_medium", sessionData?.utm_medium || "");
+      formData.append("store_name__c", "blender");
+      formData.append(
+        "canonicalUpdatesOptIn",
+        isMarketingOptInChecked ? "yes" : "no"
+      );
 
       request.open(
         "POST",

--- a/static/js/src/advantage/subscribe/react/UAPurchase.tsx
+++ b/static/js/src/advantage/subscribe/react/UAPurchase.tsx
@@ -22,11 +22,15 @@ const UAPurchase = () => {
     </>
   );
 
+  const marketingLabel =
+    "I agree to receive information about Canonical's products and services";
+
   const closeModal = window.handleTogglePurchaseModal ?? (() => {});
 
   return (
     <PurchaseModal
       termsLabel={termsLabel}
+      marketingLabel={marketingLabel}
       product={product}
       preview={preview}
       quantity={quantity}

--- a/static/js/src/advantage/subscribe/react/components/BuyButton/BuyButton.tsx
+++ b/static/js/src/advantage/subscribe/react/components/BuyButton/BuyButton.tsx
@@ -15,7 +15,9 @@ import { checkoutEvent, purchaseEvent } from "../../../../ecom-events";
 const BuyButton = ({
   areTermsChecked,
   isUsingFreeTrial,
+  isMarketingOptInChecked,
   setTermsChecked,
+  setIsMarketingOptInChecked,
   setError,
   setStep,
 }: BuyButtonProps) => {
@@ -176,6 +178,7 @@ const BuyButton = ({
         }
       }
       setTermsChecked(false);
+      setIsMarketingOptInChecked(false);
       setStep(1);
     }
   }, [purchaseError]);
@@ -207,6 +210,11 @@ const BuyButton = ({
       formData.append("utm_campaign", sessionData?.utm_campaign || "");
       formData.append("utm_source", sessionData?.utm_source || "");
       formData.append("utm_medium", sessionData?.utm_medium || "");
+      formData.append("store_name__c", "ua");
+      formData.append(
+        "canonicalUpdatesOptIn",
+        isMarketingOptInChecked ? "yes" : "no"
+      );
 
       request.open(
         "POST",

--- a/static/js/src/advantage/subscribe/react/utils/utils.ts
+++ b/static/js/src/advantage/subscribe/react/utils/utils.ts
@@ -93,7 +93,9 @@ export const getIsFreeTrialEnabled = () =>
 export type BuyButtonProps = {
   areTermsChecked: boolean;
   isUsingFreeTrial: boolean;
+  isMarketingOptInChecked: boolean;
   setTermsChecked: React.Dispatch<React.SetStateAction<boolean>>;
+  setIsMarketingOptInChecked: React.Dispatch<React.SetStateAction<boolean>>;
   setError: React.Dispatch<React.SetStateAction<React.ReactNode>>;
   setStep: React.Dispatch<React.SetStateAction<number>>;
 };


### PR DESCRIPTION
## Done

- Add marketing opt-in checkbox to the purchase modal (for Advantage, Blender, and renewals)
- Add checkbox value and store name to Marketo form

## QA

- Run the server with `dotrun`
- Go to http://localhost:8001/advantage/subscribe?test_backend=true
- Click the "Buy now" button and enter payment info to get to step 2 of the purchase modal
  - Verify that the marketing opt-in checkbox appears and is functional
  - Complete the purchase
  - Verify in Marketo that the settings have been updated (Morgan can check for you)
- Go to http://localhost:8001/advantage/subscribe/blender?test_backend=true and repeat

## Issue / Card

Fixes https://github.com/canonical-web-and-design/commercial-squad/issues/399

## Screenshots
![blender-purchase-modal-opt-in](https://user-images.githubusercontent.com/995051/144398840-5f61b9bf-1d4a-47b5-a47f-27eb5dc449da.png)

