### PR TITLE
Fix tutorial key error issues

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ canonicalwebteam.blog==6.4.0
 canonicalwebteam.search==1.0.0
 canonicalwebteam.templatefinder==1.0.0
 canonicalwebteam.image-template==1.3.1
-canonicalwebteam.discourse==4.0.5
+git+git://github.com/carkod/canonicalwebteam.discourse@fix-tutorials-keyerrors#egg=canonicalwebteam.discourse
 python-dateutil==2.8.1
 pytz==2020.5
 maxminddb-geolite2==2018.703

--- a/templates/tutorials/index.html
+++ b/templates/tutorials/index.html
@@ -90,6 +90,14 @@
 {% else %}
 
 <section class="p-strip has-shadow">
+  <!-- Tutorials errors -->
+  {% if errors|length > 0 %}
+  <div class="row u-equal-height">
+    {% for error in errors %}
+      <p>{{ error }}</p>
+    {% endfor %}
+  </div>
+  {% endif %}
   <div class="row u-equal-height">
     {% if query %}
     <h4 class="col-12">

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -641,7 +641,7 @@ tutorials_path = "/tutorials"
 tutorials_docs = Tutorials(
     parser=TutorialParser(
         api=discourse_api,
-        index_topic_id=13611,
+        index_topic_id=25546,
         url_prefix=tutorials_path,
     ),
     document_template="/tutorials/tutorial.html",

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -356,6 +356,7 @@ def build_tutorials_index(session, tutorials_docs):
             posts_per_page=posts_per_page,
             total_results=total_results,
             total_pages=total_pages,
+            errors=tutorials_docs.parser.errors,
         )
 
     return tutorials_index


### PR DESCRIPTION
For testing https://github.com/canonical-web-and-design/canonicalwebteam.discourse/pull/117

## Done

- [List of work items including drive-bys - remember to add the why and what of this work.]

## QA

- Checkout this branch
- `dotrun clean && dotrun` to make sure you get PR#117 from canonicalwebteam.discourse
- check `/tutorials` to see the errors. These tutorials are test tutorials that use an [index topic](https://discourse.ubuntu.com/t/test-tutorials-errors/25546) that contains errors. Feel free to suggest a better error message (I didn't give it much thought) or play around breaking the keys.

## Issue / Card

Fixes #

## Screenshots

[If relevant, please include a screenshot.]


## Help

[QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html) - [Commit guidelines](https://canonical-web-and-design.github.io/practices/workflow/commit-messages.html)
