### PR TITLE
CVE table styling fix

### DIFF
--- a/templates/security/cve/_cve-table.html
+++ b/templates/security/cve/_cve-table.html
@@ -30,7 +30,7 @@
                 {% elif cve.priority == 'low' %}
                   <i class="p-icon--low-priority"></i>
                 {% elif cve.priority == 'medium' %}
-                  <i class="p-icon--medium-priority cve-tool-tip"></i>
+                  <i class="p-icon--medium-priority"></i>
                 {% elif cve.priority == 'high' %}
                   <i class="p-icon--high-priority"></i>
                 {% elif cve.priority == 'critical' %}

--- a/templates/security/cve/_cve-table.html
+++ b/templates/security/cve/_cve-table.html
@@ -1,7 +1,7 @@
-<table class="cve-table" style="display: block; overflow-x: visible; white-space: normal;">
+<table class="cve-table">
   <thead>
     <tr>
-      <th style="width: 10em; position: sticky; left: 0; background-color: #fff; z-index: 1; box-shadow: inset -1px 0 #d9d9d9;" >ID</th>
+      <th style="width: 10em;" >ID</th>
       <th>Priority</th>
       <th>Package</th>
       {% for release in releases %}
@@ -18,10 +18,10 @@
       {% for package_name, statuses in cve.packages.items() %}
         <tr>
           {% if loop.index == 1 %}
-            <td rowspan="{{ cve.packages | length }}"  style="position: sticky; left: 0; background-color: #fff; z-index: 1; box-shadow: inset -1px 0 #d9d9d9;">
+            <td rowspan="{{ cve.packages | length }}">
               <a href="/security/{{ cve.id }}">{{ cve.id }}</a>
             </td>
-            <td class="cve-table-cell-priority">
+            <td class="cve-table-cell-priority" rowspan="{{ cve.packages | length }}">
               <div class="icon-container__icon">
                 {% if cve.priority == 'unknown' %}
                   <i class="p-icon--placeholder"></i>

--- a/templates/security/cve/_cve-table.html
+++ b/templates/security/cve/_cve-table.html
@@ -1,4 +1,4 @@
-<table class="cve-table" style="display: block; overflow-x: auto; white-space: nowrap;">
+<table class="cve-table" style="display: block; overflow-x: visible; white-space: normal;">
   <thead>
     <tr>
       <th style="width: 10em; position: sticky; left: 0; background-color: #fff; z-index: 1; box-shadow: inset -1px 0 #d9d9d9;" >ID</th>
@@ -30,7 +30,7 @@
                 {% elif cve.priority == 'low' %}
                   <i class="p-icon--low-priority"></i>
                 {% elif cve.priority == 'medium' %}
-                  <i class="p-icon--medium-priority"></i>
+                  <i class="p-icon--medium-priority cve-tool-tip"></i>
                 {% elif cve.priority == 'high' %}
                   <i class="p-icon--high-priority"></i>
                 {% elif cve.priority == 'critical' %}


### PR DESCRIPTION
## Done

- Reverted file to before this [pr merge](https://github.com/canonical-web-and-design/ubuntu.com/pull/10945)
- Still need to reimplement mobile [redesign](https://github.com/canonical-web-and-design/ubuntu.com/issues/9325) in a way that will not break desktop

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: https://ubuntu-com-10975.demos.haus/security/cve
- See that the concerns listed in [issue](https://github.com/canonical-web-and-design/ubuntu.com/issues/10974) are no longer there

## Issue / Card

Fixes https://github.com/canonical-web-and-design/ubuntu.com/issues/10974

