### PR TITLE
Fix thank you login redirect

### DIFF
--- a/webapp/advantage/decorators.py
+++ b/webapp/advantage/decorators.py
@@ -14,6 +14,7 @@ from requests import Session
 
 PERMISSION_LIST = {
     "user": "Endpoint needs logged in user.",
+    "guest": "Endpoint won't allow logged in user.",
     "user_or_guest": "Endpoint needs user or guest token.",
 }
 
@@ -90,6 +91,14 @@ def advantage_decorator(permission=None, response="json"):
                     message = {"error": "authentication required"}
 
                     return flask.jsonify(message), 401
+
+            if permission == "guest" and response == "html":
+                if user_info(flask.session):
+                    return flask.redirect(
+                        "/advantage?test_backend=true"
+                        if is_test_backend
+                        else "/advantage"
+                    )
 
             if permission == "user_or_guest" and response == "json":
                 if not user_info(flask.session) and not guest_token:

--- a/webapp/advantage/views.py
+++ b/webapp/advantage/views.py
@@ -315,7 +315,7 @@ def payment_methods_view():
     )
 
 
-@advantage_decorator(response="html")
+@advantage_decorator(permission="guest", response="html")
 @use_kwargs({"email": String()}, location="query")
 def advantage_thanks_view(**kwargs):
     return flask.render_template(


### PR DESCRIPTION
## Done

- Fix the login redirect of the thank you page. Right now it sends people back to the thank you page which asks them to register/sign in again, even if the user is already logged in.
- Now we only allow logged out users to hit the /thank-you page

## QA

- Go to https://ubuntu-com-10980.demos.haus/advantage/subscrive/thank-you?email=abc@canonical.com&test_backend=true
- Click the green button to log in
- Log in
- You will hit /advantage?test_backend=true.

## Issue / Card

Fixes #https://github.com/canonical-web-and-design/commercial-squad/issues/423