### PR TITLE
Update links on '/security/docker-images'

### DIFF
--- a/templates/security/docker-images.html
+++ b/templates/security/docker-images.html
@@ -83,8 +83,8 @@
     <p class="p-heading--4"><strong>Where are the images?</strong></p>
     <p>On Amazon ECR Public and Docker Hub, images are provided in three groups:</p>
     <ul>
-      <li><a class="p-link--external" href="https://hub.docker.com/u/ubuntu/">Ubuntu on Docker Hub</a> and <a class="p-link--external" href="https://gallery.ecr.aws/?searchTerm=LTS">ECR Public</a> have development releases with security updates</li>
-      <li>LTS ("Canonical") on <a class="p-link--external" href="https://gallery.ecr.aws/?searchTerm=LTS">ECR Public</a> has Free LTS images with up to five years fixes</li>
+      <li><a class="p-link--external" href="https://hub.docker.com/u/ubuntu/">Ubuntu on Docker Hub</a> and <a class="p-link--external" href="https://gallery.ecr.aws/ubuntu">ECR Public</a> have development releases with security updates</li>
+      <li>LTS ("Canonical") on <a class="p-link--external" href="https://gallery.ecr.aws/lts">ECR Public</a> has Free LTS images with up to five years fixes</li>
       <li>Customer-only content with up to ten years of fixes. <a href="/security/contact-us?product=docker" class="js-invoke-modal">Contact us</a>.</li>
     </ul>
     <p>All of our Docker Hub repositories are exempted from per-user rate limits.</p>


### PR DESCRIPTION
## Done

- Update links to 'ECR Public' on '/security/docker-images' as per [copydoc](https://docs.google.com/document/d/1zZibtjU141e4mBxo_0PtfYxJ6e5fyaaAdFZ6v945XAM/edit#)

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: https://ubuntu-com-10981.demos.haus/security/docker-images
    - Be sure to test on mobile, tablet and desktop screen sizes
- Check the 'ECR Public' links go to the right place

## Issue / Card

Fixes https://github.com/canonical-web-and-design/ubuntu.com/issues/10972

## Help

[QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html) - [Commit guidelines](https://canonical-web-and-design.github.io/practices/workflow/commit-messages.html)
