### PR TITLE
Fix table header on /security/cve

### DIFF
--- a/static/sass/_pattern_cve.scss
+++ b/static/sass/_pattern_cve.scss
@@ -25,6 +25,7 @@
   }
 
   .cve-table thead th {
+    word-wrap: break-word;
     @media only screen and (max-width: $breakpoint-small) {
       &:nth-child(1) {
         background-color: #fff;
@@ -72,8 +73,6 @@
   }
 
   .cve-table .icon-container__text {
-    // overflow: hidden;
-    // text-overflow: ellipsis;
     width: 100%;
     word-wrap: break-word;
   }


### PR DESCRIPTION
## Done
- The table header ellipsis was not fixed by this [PR](https://github.com/canonical-web-and-design/ubuntu.com/pull/10985) 
- Fixed table header ellipsis on medium size screens

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Be sure to test on mobile, tablet and desktop screensizes
- You need to setup your local database with the cve data to see the table
- Please check the responsiveness and check if everything works properly on all screens

## Issue / Card

Fixes #

## Screenshots
from 

![image](https://user-images.githubusercontent.com/57550290/144574964-6bcba397-e14a-4def-804b-384b5f25dc5c.png)

to

![image](https://user-images.githubusercontent.com/57550290/144575240-e4a40711-43d8-4c48-9165-95fad82f942f.png)
## Help

[QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html) - [Commit guidelines](https://canonical-web-and-design.github.io/practices/workflow/commit-messages.html)
