### PR TITLE
Update download links on '/xilinx'

### DIFF
--- a/templates/download/xilinx/index.html
+++ b/templates/download/xilinx/index.html
@@ -85,15 +85,15 @@
           <td colspan="2">Sysroot for cross-compilation</td>
         </tr>
         <tr>
-          <th><a href="https://people.canonical.com/~platform/images/xilinx/rootfs.ext4.xz">roofts.ext4.xz</a></th>
+          <th><a href="https://people.canonical.com/~platform/images/xilinx/iot-zcu10x-classic-desktop-2004-x07-20210728-85-roofts.ext4.xz">roofts.ext4.xz</a></th>
           <td colspan="2">EXT4 formatted partition containing entire raw rootfs</td>
         </tr>
         <tr>
-          <th><a href="https://people.canonical.com/~platform/images/xilinx/rootfs.tar.gz">rootfs.tar.gz</a></th>
+          <th><a href="https://people.canonical.com/~platform/images/xilinx/iot-zcu10x-classic-desktop-2004-x07-20210728-85-rootfs.tar.gz">rootfs.tar.gz</a></th>
           <td colspan="2">Raw Root filesystem</td>
         </tr>
         <tr>
-          <th><a href="https://people.canonical.com/~platform/images/xilinx/system-boot.tar.gz">system-boot.tar.gz</a></th>
+          <th><a href="https://people.canonical.com/~platform/images/xilinx/iot-zcu10x-classic-desktop-2004-x07-20210728-85-system-boot.tar.gz">system-boot.tar.gz</a></th>
           <td colspan="2">FAT Partition Contents</td>
         </tr>
       </tbody>


### PR DESCRIPTION
## Done

Update the download links as the names have been changed for the new release, the new links can be found in the [copydoc](https://docs.google.com/document/d/1DZxf-ZbJtyS69XQBslJry3Ien1FSHYLB2Qt78iRkhOs/edit#)
## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- [List additional steps to QA the new features or prove the bug has been resolved]

## Issue / Card

Fixes https://github.com/canonical-web-and-design/ubuntu.com/issues/10992


## Help

[QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html) - [Commit guidelines](https://canonical-web-and-design.github.io/practices/workflow/commit-messages.html)
