### PR TITLE
Blender auto-renewal settings implementation

### DIFF
--- a/static/js/src/advantage/react/components/Subscriptions/SubscriptionList/ListGroup/ListGroup.test.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/SubscriptionList/ListGroup/ListGroup.test.tsx
@@ -1,21 +1,63 @@
 import React from "react";
-import { shallow } from "enzyme";
+import { mount } from "enzyme";
+import { QueryClient, QueryClientProvider } from "react-query";
+import {
+  userSubscriptionFactory,
+  userSubscriptionStatusesFactory,
+} from "advantage/tests/factories/api";
 
+import { UserSubscriptionMarketplace } from "advantage/api/enum";
 import ListGroup from "./ListGroup";
 
 describe("ListGroup", () => {
-  it("does not display the renewal settings by default", () => {
-    const wrapper = shallow(
-      <ListGroup title="free personal token">Group content</ListGroup>
+  let queryClient: QueryClient;
+
+  beforeEach(async () => {
+    queryClient = new QueryClient();
+  });
+
+  it("does not display the renewal settings when it should not", () => {
+    const subscriptions = [
+      userSubscriptionFactory.build({
+        marketplace: UserSubscriptionMarketplace.CanonicalUA,
+        statuses: userSubscriptionStatusesFactory.build({
+          should_present_auto_renewal: false,
+        }),
+      }),
+    ];
+    queryClient.setQueryData("userSubscriptions", subscriptions);
+    const wrapper = mount(
+      <QueryClientProvider client={queryClient}>
+        <ListGroup
+          title="free personal token"
+          marketplace={UserSubscriptionMarketplace.CanonicalUA}
+        >
+          Group content
+        </ListGroup>
+      </QueryClientProvider>
     );
     expect(wrapper.find("RenewalSettings").exists()).toBe(false);
   });
 
   it("can display the renewal settings", () => {
-    const wrapper = shallow(
-      <ListGroup title="free personal token" showRenewalSettings>
-        Group content
-      </ListGroup>
+    const subscriptions = [
+      userSubscriptionFactory.build({
+        marketplace: UserSubscriptionMarketplace.CanonicalUA,
+        statuses: userSubscriptionStatusesFactory.build({
+          should_present_auto_renewal: true,
+        }),
+      }),
+    ];
+    queryClient.setQueryData("userSubscriptions", subscriptions);
+    const wrapper = mount(
+      <QueryClientProvider client={queryClient}>
+        <ListGroup
+          title="free personal token"
+          marketplace={UserSubscriptionMarketplace.CanonicalUA}
+        >
+          Group content
+        </ListGroup>
+      </QueryClientProvider>
     );
     expect(wrapper.find("RenewalSettings").exists()).toBe(true);
   });

--- a/static/js/src/advantage/react/components/Subscriptions/SubscriptionList/ListGroup/ListGroup.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/SubscriptionList/ListGroup/ListGroup.tsx
@@ -1,19 +1,22 @@
 import React, { useRef, useState } from "react";
 import type { ReactNode } from "react";
+import { selectAutoRenewableSubscriptionsByMarketplace } from "advantage/react/hooks/useUserSubscriptions";
+import { useUserSubscriptions } from "advantage/react/hooks";
 
 import RenewalSettings from "../RenewalSettings";
+import { UserSubscriptionMarketplace } from "advantage/api/enum";
 
 type Props = {
   children: ReactNode;
-  showRenewalSettings?: boolean;
   title: string;
+  marketplace: UserSubscriptionMarketplace;
 };
 
-const ListGroup = ({
-  children,
-  showRenewalSettings = false,
-  title,
-}: Props): JSX.Element => {
+const ListGroup = ({ children, title, marketplace }: Props): JSX.Element => {
+  const { data: renewableSubscriptions } = useUserSubscriptions({
+    select: selectAutoRenewableSubscriptionsByMarketplace(marketplace),
+  });
+
   const positionNode = useRef<HTMLDivElement | null>(null);
   const [, setRefReady] = useState(false);
   return (
@@ -30,8 +33,11 @@ const ListGroup = ({
         <span className="p-text--x-small-capitalised u-align-text--small-to-default u-no-margin--bottom">
           {title}
         </span>
-        {showRenewalSettings ? (
-          <RenewalSettings positionNodeRef={positionNode} />
+        {renewableSubscriptions?.length ?? 0 > 0 ? (
+          <RenewalSettings
+            positionNodeRef={positionNode}
+            marketplace={marketplace}
+          />
         ) : null}
       </div>
       {children}

--- a/static/js/src/advantage/react/components/Subscriptions/SubscriptionList/RenewalSettings/types.ts
+++ b/static/js/src/advantage/react/components/Subscriptions/SubscriptionList/RenewalSettings/types.ts
@@ -1,6 +1,0 @@
-export type AutoRenewal = {
-  period: string;
-  cost: string;
-  when: string | Date;
-  products: string[];
-};

--- a/static/js/src/advantage/react/components/Subscriptions/SubscriptionList/SubscriptionList.test.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/SubscriptionList/SubscriptionList.test.tsx
@@ -14,7 +14,6 @@ import {
   UserSubscriptionMarketplace,
   UserSubscriptionPeriod,
 } from "advantage/api/enum";
-import ListGroup from "./ListGroup";
 
 describe("SubscriptionList", () => {
   let queryClient: QueryClient;
@@ -153,9 +152,7 @@ describe("SubscriptionList", () => {
         />
       </QueryClientProvider>
     );
-    expect(wrapper.find(ListGroup).first().prop("showRenewalSettings")).toBe(
-      true
-    );
+    expect(wrapper.find("RenewalSettings").exists()).toBe(true);
   });
 
   it("does not show the renewal settings if there are no subscriptions for which we should present the auto-renewal option", () => {
@@ -187,8 +184,6 @@ describe("SubscriptionList", () => {
         />
       </QueryClientProvider>
     );
-    expect(wrapper.find(ListGroup).first().prop("showRenewalSettings")).toBe(
-      false
-    );
+    expect(wrapper.find("RenewalSettings").exists()).toBe(false);
   });
 });

--- a/static/js/src/advantage/react/components/Subscriptions/SubscriptionList/SubscriptionList.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/SubscriptionList/SubscriptionList.tsx
@@ -1,10 +1,10 @@
 import { Spinner } from "@canonical/react-components";
+import { UserSubscriptionMarketplace } from "advantage/api/enum";
 import { useUserSubscriptions } from "advantage/react/hooks";
 import {
   selectFreeSubscription,
   selectUASubscriptions,
   selectBlenderSubscriptions,
-  selectPresentableRenewalSubscriptions,
 } from "advantage/react/hooks/useUserSubscriptions";
 import { sortSubscriptionsByStartDate } from "advantage/react/utils";
 import { sendAnalyticsEvent } from "advantage/react/utils/sendAnalyticsEvent";
@@ -38,19 +38,8 @@ const SubscriptionList = ({ selectedId, onSetActive }: Props) => {
   } = useUserSubscriptions({
     select: selectBlenderSubscriptions,
   });
-  const {
-    data: activeUASubscriptions = [],
-    isLoading: isLoadingPresentableRenewalSubscriptions,
-  } = useUserSubscriptions({
-    select: selectPresentableRenewalSubscriptions,
-  });
 
-  if (
-    isLoadingFree ||
-    isLoadingUA ||
-    isLoadingBlender ||
-    isLoadingPresentableRenewalSubscriptions
-  ) {
+  if (isLoadingFree || isLoadingUA || isLoadingBlender) {
     return <Spinner />;
   }
   // Sort the subscriptions so that the most recently started subscription is first.
@@ -104,20 +93,27 @@ const SubscriptionList = ({ selectedId, onSetActive }: Props) => {
           <ListGroup
             data-test="ua-subscriptions-group"
             title="Ubuntu Advantage"
-            showRenewalSettings={activeUASubscriptions?.length > 0}
+            marketplace={UserSubscriptionMarketplace.CanonicalUA}
           >
             {uaSubscriptions}
           </ListGroup>
         ) : null}
 
         {sortedBlenderSubscriptions.length ? (
-          <ListGroup data-test="blender-subscriptions-group" title="Blender">
+          <ListGroup
+            data-test="blender-subscriptions-group"
+            title="Blender"
+            marketplace={UserSubscriptionMarketplace.Blender}
+          >
             {blenderSubscriptions}
           </ListGroup>
         ) : null}
 
         {freeSubscription ? (
-          <ListGroup title="Free personal token" showRenewalSettings={false}>
+          <ListGroup
+            title="Free personal token"
+            marketplace={UserSubscriptionMarketplace.Free}
+          >
             <ListCard
               data-test="free-subscription"
               isSelected={selectedId === freeSubscription.id}

--- a/static/js/src/advantage/react/hooks/useUserSubscriptions.test.tsx
+++ b/static/js/src/advantage/react/hooks/useUserSubscriptions.test.tsx
@@ -3,7 +3,7 @@ import { renderHook, WrapperComponent } from "@testing-library/react-hooks";
 import type { ReactNode } from "react";
 import { QueryClient, QueryClientProvider } from "react-query";
 import {
-  selectAutoRenewableUASubscriptions,
+  selectAutoRenewableSubscriptionsByMarketplace,
   selectFreeSubscription,
   selectStatusesSummary,
   selectSubscriptionById,
@@ -162,7 +162,11 @@ describe("useUserSubscriptions", () => {
     queryClient.setQueryData("userSubscriptions", subscriptions);
     const { result, waitForNextUpdate } = renderHook(
       () =>
-        useUserSubscriptions({ select: selectAutoRenewableUASubscriptions }),
+        useUserSubscriptions({
+          select: selectAutoRenewableSubscriptionsByMarketplace(
+            UserSubscriptionMarketplace.CanonicalUA
+          ),
+        }),
       { wrapper }
     );
     await waitForNextUpdate();

--- a/static/js/src/advantage/react/hooks/useUserSubscriptions.ts
+++ b/static/js/src/advantage/react/hooks/useUserSubscriptions.ts
@@ -73,14 +73,13 @@ export const selectBlenderSubscriptions = (subscriptions: UserSubscription[]) =>
     ({ marketplace }) => marketplace === UserSubscriptionMarketplace.Blender
   );
 
-/**
- * Find the active UA subscriptions that should have their renewal options
- * presented.
- */
-export const selectPresentableRenewalSubscriptions = (
-  subscriptions: UserSubscription[]
-) =>
-  subscriptions.filter(({ statuses }) => statuses.should_present_auto_renewal);
+export const selectAutoRenewableSubscriptionsByMarketplace = (
+  targetMarketplace: UserSubscription["marketplace"]
+) => (subscriptions: UserSubscription[]) =>
+  subscriptions.filter(
+    ({ statuses, marketplace }) =>
+      statuses.should_present_auto_renewal && marketplace === targetMarketplace
+  );
 
 /**
  * Find the subscriptions with for period.
@@ -89,13 +88,6 @@ export const selectSubscriptionsForPeriod = (
   period: UserSubscriptionPeriod
 ) => (subscriptions: UserSubscription[]) =>
   subscriptions.filter((subscription) => subscription.period === period);
-
-export const selectAutoRenewableUASubscriptions = (
-  subscriptions: UserSubscription[]
-) =>
-  selectUASubscriptions(subscriptions).filter(
-    ({ statuses }) => statuses.should_present_auto_renewal
-  );
 
 export const useUserSubscriptions = <D = UserSubscription[]>(
   options?: UseQueryOptions<UserSubscription[], unknown, D>


### PR DESCRIPTION

## Done

- Add selector to filter auto-renewable subscriptions by marketplace
- display blender auto-renewal settings

## QA

- go to https://ubuntu-com-10997.demos.haus/advantage?test_backend=true with a monthly blender sub
- (if you don't have one, you can buy it at https://ubuntu-com-10997.demos.haus/advantage/subscribe/blender?test_backend=true (credit card 4242424242...) )
- See that the auto-renewal dropdown displays at the top of the blender section
- check that the values displayed in the dropdown are correct
- toggle it off and on and see that the change gets saved
- check that it doesn't mess with UA subs

## Issue / Card

Fixes canonical-web-and-design/commercial-squad#380

## Screenshots

![image](https://user-images.githubusercontent.com/11927929/144825597-98b12017-7afe-404b-843c-eb423b86a34d.png)
