### PR TITLE
Fix Blender redirects

### DIFF
--- a/static/js/src/advantage/subscribe/blender/BuyButton.tsx
+++ b/static/js/src/advantage/subscribe/blender/BuyButton.tsx
@@ -166,7 +166,7 @@ const BuyButton = ({
       request.onreadystatechange = () => {
         if (request.readyState === 4) {
           //redirect
-          if (window.isGuest) {
+          if (window.isGuest && !window.isLoggedIn) {
             const queryString = window.location.search;
             const testBackend = queryString.includes("test_backend=true")
               ? "&test_backend=true"

--- a/webapp/advantage/views.py
+++ b/webapp/advantage/views.py
@@ -892,7 +892,7 @@ def blender_shop_view():
 @use_kwargs({"email": String()}, location="query")
 def blender_thanks_view(**kwargs):
     return flask.render_template(
-        "advantage/blender/thank-you.html",
+        "advantage/subscribe/blender/thank-you.html",
         email=kwargs.get("email"),
     )
 

--- a/webapp/advantage/views.py
+++ b/webapp/advantage/views.py
@@ -888,7 +888,7 @@ def blender_shop_view():
     )
 
 
-@advantage_decorator(response="html")
+@advantage_decorator(permission="guest", response="html")
 @use_kwargs({"email": String()}, location="query")
 def blender_thanks_view(**kwargs):
     return flask.render_template(

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -407,7 +407,10 @@ app.add_url_rule(
     methods=["PUT"],
 )
 
-app.add_url_rule("/advantage/subscribe/blender/thank-you", view_func=blender_thanks_view)
+app.add_url_rule(
+    "/advantage/subscribe/blender/thank-you",
+    view_func=blender_thanks_view,
+)
 
 app.add_url_rule("/account", view_func=account_view)
 

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -407,7 +407,7 @@ app.add_url_rule(
     methods=["PUT"],
 )
 
-app.add_url_rule("/advantage/blender/thank-you", view_func=blender_thanks_view)
+app.add_url_rule("/advantage/subscribe/blender/thank-you", view_func=blender_thanks_view)
 
 app.add_url_rule("/account", view_func=account_view)
 


### PR DESCRIPTION
## Done

- Fix Blender redirects

## QA

Two places to check:
1. Check the thank you allows only guest users
- Go to: https://ubuntu-com-11000.demos.haus/advantage/subscribe/blender/thank-you
- If you are logged in it will redirect you to /advantage otherwise you will see the thank you page
2. Logged in user without purchase account gets redirected to /advantage
- Create a fresh UO account
- Login at: https://ubuntu-com-11000.demos.haus?test_backend=true
- Buy a blender product at https://ubuntu-com-11000.demos.haus/advantage/subscribe/blender?test_backend=true
- The modal will show you the 1st step of the purchase flow
- One you click buy, you will be sent directly to /advantage instead of the thank you page

## Issue / Card

Fixes #https://github.com/canonical-web-and-design/commercial-squad/issues/428