### PR TITLE
Fix invisible text on /security/cve

### DIFF
--- a/static/sass/_pattern_cve.scss
+++ b/static/sass/_pattern_cve.scss
@@ -53,7 +53,10 @@
     @media only screen and (max-width: $breakpoint-small) {
       &:nth-child(1) {
         background-color: #fff;
-        box-shadow: inset -1px 0 #d9d9d9;
+        border-top: none;
+        -moz-box-shadow: inset -1px 1px #d9d9d9;
+        -webkit-box-shadow: inset -1px 1px #d9d9d9;
+        box-shadow: inset -1px 1px #d9d9d9;
         left: 0;
         position: sticky;
         z-index: 1;

--- a/static/sass/_pattern_cve.scss
+++ b/static/sass/_pattern_cve.scss
@@ -46,6 +46,7 @@
   .cve-table td {
     border-top: 1px solid $color-mid-light;
     position: relative;
+    word-wrap: break-word;
   }
 
   .cve-table-cell-id {
@@ -74,7 +75,6 @@
 
   .cve-table .icon-container__text {
     width: 100%;
-    word-wrap: break-word;
   }
   .cve-table-cell-priority .icon-container__text {
     @media only screen and (min-width: $breakpoint-medium) {


### PR DESCRIPTION
## Done

- Fix the truncated texts/numbers in the table.
- Update styles that didn't work on Firefox. 

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Be sure to test on mobile, tablet and desktop screen sizes
- Please check the responsiveness and check if everything works properly on all screens
- Please QA on Firefox 
1. check if truncated texts are fixed with Firefox custom font setting and 
2. check if borders styles are working properly on Firefox

## Issue / Card

Fixes [#10778](https://github.com/canonical-web-and-design/ubuntu.com/issues/10778)

## Screenshots
![image](https://user-images.githubusercontent.com/57550290/144859185-c2b604ac-26ad-4fad-9db6-b1e921dfbdbb.png)

## Help

[QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html) - [Commit guidelines](https://canonical-web-and-design.github.io/practices/workflow/commit-messages.html)
