### PR TITLE
release-cycle-update

### DIFF
--- a/static/js/src/chart-data.js
+++ b/static/js/src/chart-data.js
@@ -1268,18 +1268,30 @@ export var kubernetesReleases = [
     startDate: new Date("2020-08-16T00:00:00"),
     endDate: new Date("2021-08-16T00:00:00"),
     taskName: "Kubernetes 1.19",
-    status: "CHARMED_KUBERNETES_SUPPORT",
+    status: "CHARMED_KUBERNETES_EXPIRED_SUPPORT",
   },
   {
     startDate: new Date("2020-12-08T00:00:00"),
     endDate: new Date("2021-12-08T00:00:00"),
     taskName: "Kubernetes 1.20",
-    status: "CHARMED_KUBERNETES_SUPPORT",
+    status: "CHARMED_KUBERNETES_EXPIRED_SUPPORT",
   },
   {
     startDate: new Date("2021-04-08T00:00:00"),
     endDate: new Date("2022-04-08T00:00:00"),
     taskName: "Kubernetes 1.21",
+    status: "CHARMED_KUBERNETES_SUPPORT",
+  },
+  {
+    startDate: new Date("2021-08-01T00:00:00"),
+    endDate: new Date("2022-08-01T00:00:00"),
+    taskName: "Kubernetes 1.22",
+    status: "CHARMED_KUBERNETES_SUPPORT",
+  },
+  {
+    startDate: new Date("2021-12-07T00:00:00"),
+    endDate: new Date("2022-12-07T00:00:00"),
+    taskName: "Kubernetes 1.23",
     status: "CHARMED_KUBERNETES_SUPPORT",
   },
 ];
@@ -1500,6 +1512,8 @@ export var openStackReleaseNames = [
 ];
 
 export var kubernetesReleaseNames = [
+  "Kubernetes 1.23",
+  "Kubernetes 1.22",
   "Kubernetes 1.21",
   "Kubernetes 1.20",
   "Kubernetes 1.19",

--- a/templates/about/release-cycle.html
+++ b/templates/about/release-cycle.html
@@ -602,6 +602,16 @@
           </thead>
           <tbody>
             <tr>
+              <td><strong>1.23.x</strong></td>
+              <td align='right'>Dec 2021</td>
+              <td align='right'>Dec 2022</td>
+            </tr>
+            <tr>
+              <td><strong>1.22.x</strong></td>
+              <td align='right'>Aug 2021</td>
+              <td align='right'>Aug 2022</td>
+            </tr>
+            <tr>
               <td><strong>1.21.x</strong></td>
               <td align='right'>Apr 2021</td>
               <td align='right'>Apr 2022</td>


### PR DESCRIPTION
## Done

- Updates the release cycle table for Kubernetes correct as of  2020-12-07

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
 - Be sure to test on mobile, tablet and desktop screen sizes

## Screenshots

![Screenshot from 2021-12-06 16-10-51](https://user-images.githubusercontent.com/115290/144881033-7af26999-656b-4ada-8fcc-05336740e428.png)


## Help

[QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html) - [Commit guidelines](https://canonical-web-and-design.github.io/practices/workflow/commit-messages.html)
