### PR TITLE
Update security/notices query filter

### DIFF
--- a/webapp/security/views.py
+++ b/webapp/security/views.py
@@ -135,9 +135,10 @@ def notices():
     if details:
         notices_query = notices_query.filter(
             or_(
-                Notice.id.like(f"%{details}%"),
-                Notice.details.like(f"%{details}%"),
-                Notice.cves.any(CVE.id.like(f"%{details}%")),
+                Notice.id.ilike(f"%{details}%"),
+                Notice.details.ilike(f"%{details}%"),
+                Notice.title.ilike(f"%{details}%"),
+                Notice.cves.any(CVE.id.ilike(f"%{details}%")),
             )
         )
 


### PR DESCRIPTION
## Done

- Made search queries case insensitive
- Added ability to search by title
- TODO: add ability to search by package name (will address in separate pr)

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/security/notices
- Search for runc and runC and ensure they both return the same thing
- Attempt to search for notice by title and see that it is returned 

## Issue / Card

Fixes https://github.com/canonical-web-and-design/ubuntu.com/issues/9454
https://github.com/canonical-web-and-design/ubuntu.com/issues/9856
