### PR TITLE
Separate engage pages and takeover views

### DIFF
--- a/tests/cassettes/TestRoutes.test_engage_index.yaml
+++ b/tests/cassettes/TestRoutes.test_engage_index.yaml
@@ -1,2256 +1,1397 @@
 interactions:
 - request:
     body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - python-requests/2.24.0
+    headers: {}
     method: GET
-    uri: https://discourse.ubuntu.com/t/17229.json
+    uri: https://discourse.ubuntu.com/t/18033.json
   response:
     body:
-      string: "{\"post_stream\":{\"posts\":[{\"id\":48547,\"name\":\"Peter Mahnke\"\
-        ,\"username\":\"peterm-ubuntu\",\"avatar_template\":\"/user_avatar/discourse.ubuntu.com/peterm-ubuntu/{size}/7873_2.png\"\
-        ,\"created_at\":\"2020-07-14T09:57:15.584Z\",\"cooked\":\"\\u003ch1\\u003eEngage\
-        \ pages\\u003c/h1\\u003e\\n\\u003cp\\u003eThe content of topics in this category\
-        \ are displayed at \\u003ca href=\\\"https://ubuntu.com/engage\\\" rel=\\\"\
-        nofollow noopener\\\"\\u003ehttps://ubuntu.com/engage\\u003c/a\\u003e.\\u003c/p\\\
-        u003e\\n\\u003ch2\\u003eMetadata\\u003c/h2\\u003e\\n\\u003cdetails\\u003e\\\
-        n\\u003csummary\\u003e\\nMapping table\\u003c/summary\\u003e\\n\\u003cdiv\
-        \ class=\\\"md-table\\\"\\u003e\\n\\u003ctable\\u003e\\n\\u003cthead\\u003e\\\
-        n\\u003ctr\\u003e\\n\\u003cth\\u003etopic\\u003c/th\\u003e\\n\\u003cth\\u003epath\\\
-        u003c/th\\u003e\\n\\u003cth\\u003etype\\u003c/th\\u003e\\n\\u003cth\\u003etags\\\
-        u003c/th\\u003e\\n\\u003cth\\u003epublish_date\\u003c/th\\u003e\\n\\u003cth\\\
-        u003elanguage\\u003c/th\\u003e\\n\\u003cth\\u003esubtitle\\u003c/th\\u003e\\\
-        n\\u003cth\\u003eactive\\u003c/th\\u003e\\n\\u003c/tr\\u003e\\n\\u003c/thead\\\
-        u003e\\n\\u003ctbody\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca\
-        \ href=\\\"https://discourse.ubuntu.com/t/cinque-strategie-per-accelerare-limplementazione-di-kubernetes-nellimpresa/19381\\\
-        \"\\u003eCinque strategie per accelerare l\u2019implementazione di Kubernetes\
-        \ nell\u2019impresa\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/it/deployment-azienda-manuale\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003eenterprise\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-11-17\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003eit\\u003c/td\\u003e\\n\\u003ctd\\u003eCome scegliere\
-        \ il miglior approccio Kubernetes per la tua azienda\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003efalse\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
-        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/confronto-fra-red-hats-openstack-platform-e-charmed-openstack-di-canaonical/19362\\\
-        \"\\u003eConfronto fra \u201CRed Hat\u2019s Openstack platform\u201D e Charmed\
-        \ Openstack di Canaonical\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/it/redhat-openstack-confronto-manuale\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003eRed Hat\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-11-16\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003eit\\u003c/td\\u003e\\n\\u003ctd\\u003eCharmed Openstack riduce\
-        \ significativamente il costo totale di propriet\xE0\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
-        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/confronto-fra-red-hats-openstack-platform-e-charmed-openstack-di-canaonical/19361\\\
-        \"\\u003eGuide pour r\xE9ussir l\u2019adoption et le d\xE9ploiement d\u2019\
-        OpenStack\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/fr/guide-adoption-openstack\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003eopenstack\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-11-16\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003efr\\u003c/td\\u003e\\n\\u003ctd\\u003eD\xE9couvrez l\u2019\
-        \xE9prouv\xE9 processus d\u2019impl\xE9mentation OpenStack de Canonical\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\\
-        n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/funf-strategien-zur-beschleunigung-von-kubernetes-in-unternehmen/19284\\\
-        \"\\u003eF\xFCnf Strategien zur Beschleunigung von Kubernetes in Unternehmen\\\
-        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/de/kubernetes-implementierung-fur-unternehmen\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003eenterprise\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-11-11\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003ede\\u003c/td\\u003e\\n\\u003ctd\\u003eEntscheidungskriterien\
-        \ zur optimalen Herangehensweise an Kubernetes f\xFCr Ihr Unternehmen\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\\
-        u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/vergleich-von-red-hat-openstack-platform-und-charmed-openstack-von-canonical/19285\\\
-        \"\\u003eVergleich von Red Hat OpenStack Platform und Charmed OpenStack von\
-        \ Canonical\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/de/redhat-openstack-vergleich\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003eRed Hat\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-11-11\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003ede\\u003c/td\\u003e\\n\\u003ctd\\u003eSenken Sie Ihre Gesamtkosten\
-        \ deutlich mit Charmed OpenStack\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\\
-        u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\\
-        u003ca href=\\\"https://discourse.ubuntu.com/t/9-out-of-top-10-us-financial-institutions-use-ubuntu/19304\\\
-        \"\\u003e9 out of top 10 US \\u0026amp; European financial institutions use\
-        \ Ubuntu\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/finance\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003efinance\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-11-11\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eFind out why multi-cloud\
-        \ is fundamental to financial services transformation\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
-        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/cinco-estrategias-para-acelerar-a-los-kubernetes-en-la-empresa/19208\\\
-        \"\\u003eCinco estrategias para acelerar a los Kubernetes en la empresa\\\
-        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/es/kubernetes-despliegue-empresa-manual\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003eenterprise, kubernetes\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-11-04\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003ees\\u003c/td\\u003e\\n\\u003ctd\\u003eC\xF3\
-        mo elegir el mejor enfoque de Kubernetes para su negocio\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
-        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/comparando-la-plataforma-openstack-de-red-hat-y-la-charmed-openstack-de-canonical/19194\\\
-        \"\\u003eComparando la plataforma OpenStack de Red Hat y la Charmed OpenStack\
-        \ de Canonical\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/es/redhat-openstack-comparacion-manual\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003eopenstack\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-11-03\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003ees\\u003c/td\\u003e\\n\\u003ctd\\u003eReducir significativamente\
-        \ el coste total de propiedad con Charmed OpenStack\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
-        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/optimised-authentication-methods-for-ubuntu-desktop/19133\\\
-        \"\\u003eOptimised authentication methods for Ubuntu Desktop\\u003c/a\\u003e\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/desktop-authentication-whitepaper\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003edesktop, security\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-08-07\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eSecuring enterprise\
-        \ desktops with modern authentication options\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\\
-        u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/open-digital-platforms-for-the-industrial-edge-cloud-in-2020/19068\\\
-        \"\\u003eOpen digital platforms for the industrial edge cloud in 2020\\u003c/a\\\
-        u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/pac-radar\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003epac-radar\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e2020-10-27\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eThe next wave of cloud-native innovations\
-        \ at the edge\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\\
-        u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/ubuntu-20-10-what-s-new/19050\\\
-        \"\\u003eUbuntu 20.10: What\u2019s new?\\u003c/a\\u003e\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003e/engage/ubuntu-20.10\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003eubuntu server, maas, kubernetes\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e2020-10-26\\u003c/td\\u003e\\n\\u003ctd\\u003een\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003eLearn about new features in Ubuntu Server,\
-        \ MAAS, Charmed OpenStack and Charmed Kubernetes\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\\
-        u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/ubuntu-for-raspberry-pi-live-on-youtube/18577\\\
-        \"\\u003eUbuntu for Raspberry Pi intro video\\u003c/a\\u003e\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003e/engage/raspberry-pi-livestream\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eraspberry-pi, desktop\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e2020-10-21\\u003c/td\\u003e\\n\\u003ctd\\u003een\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\\
-        u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\\
-        u003ca href=\\\"https://discourse.ubuntu.com/t/cloud-gaming-for-android/18757\\\
-        \"\\u003eCloud gaming for Android\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003e/engage/anbox-cloud-gaming-whitepaper\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eanbox, gaming\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e2020-01-21\\u003c/td\\u003e\\n\\u003ctd\\u003een\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003eBuilding a high performing and scalable\
-        \ platform\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\\
-        u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/extend-your-openstack-cloud-with-native-backup-and-recover/18911\\\
-        \"\\u003eExtend your OpenStack cloud with native backup and recovery\\u003c/a\\\
-        u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/trilio-backup-recovery\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e2020-09-31\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eLearn how TrilioVault can be easily\
-        \ deployed in a Charmed OpenStack environment\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\\
-        u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/transforming-telco-infrastructure-a-virtual-event/18162\\\
-        \"\\u003eTransforming telco infrastructure\\u003c/a\\u003e\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003e/engage/telco-virtual-event\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003eevent\\u003c/td\\u003e\\n\\u003ctd\\u003eopen-source\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003e2020-09-24\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003eCanonical\u2019s experts explore the telecommunication\
-        \ industry\u2019s latest technologies. Join us live on 24 September 2020.\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\\
-        n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/guia-para-la-implementacion-de-openstack/18480\\\
-        \"\\u003eGu\xEDa para la implementaci\xF3n de OpenStack\\u003c/a\\u003e\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/es/guia-para-la-implementacion-de-openstack\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003eopenstack\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-09-16\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003ees\\u003c/td\\u003e\\n\\u003ctd\\u003eDescubre el probado\
-        \ proceso de implementaci\xF3n de OpenStack de Canonical\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
-        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/da-vmware-a-charmed-openstack/18478\\\
-        \"\\u003eDa VMware a Charmed Openstack\\u003c/a\\u003e\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003e/engage/it/da-vmware-a-charmed-openstack\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e2020-09-15\\u003c/td\\u003e\\n\\u003ctd\\u003eit\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003eCome la migrazione a Charmed OpenStack pu\xF2\
-        \ ridurre significativamente il TCO\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\\
-        u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\\
-        u003ca href=\\\"https://discourse.ubuntu.com/t/gmo-pepabo-ubuntu/18476\\\"\
-        \\u003eGMO Pepabo \\u0026amp; Ubuntu\\u003c/a\\u003e\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003e/engage/case-study-gmo-pepabo\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003ecase study\\u003c/td\\u003e\\n\\u003ctd\\u003eserver, kubernetes,ubuntu-advantage\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e2020-09-14\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eGMO Pepabo cuts OPEX costs with\
-        \ live kernel patching and saves 2,500 hours of manual work\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
-        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/da-vmware-a-openstack/18164\\\
-        \"\\u003eDa VMware a OpenStack\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003e/engage/it/da-vmware-a-openstack\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003eopenstack\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003e2020-09-04\\u003c/td\\u003e\\n\\u003ctd\\u003eit\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003eCome la migrazione a Charmed OpenStack pu\xF2 ridurre significativamente\
-        \ il TCO\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\\
-        u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/five-strategies-to-accelerate-kubernetes-deployment-in-the-enterprise/18161\\\
-        \"\\u003eFive strategies to accelerate Kubernetes in the enterprise\\u003c/a\\\
-        u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/kubernetes-deployment-enterprise-whitepaper\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003ekubernetes\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-09-02\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eHow to choose\
-        \ the best approach to Kubernetes for your business\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
-        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/production-ai-from-data-lake-to-server-webinar/18163\\\
-        \"\\u003eProduction AI from data lake to server\\u003c/a\\u003e\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e/engage/data-lake_2_server_webinar\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eai\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e2020-08-13\\u003c/td\\u003e\\n\\u003ctd\\u003een\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003eSolving hardware challenges in ML environments\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\\
-        n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/building-powerful-customer-solutions/18481\\\
-        \"\\u003eBuilding powerful customer solutions\\u003c/a\\u003e\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e/engage/gsi-webinar-series\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003ecloud, kubernetes\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e2020-07-31\\u003c/td\\u003e\\n\\u003ctd\\u003een\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003eA webinar series for GSIs seizing new models\
-        \ for scalable, automated and repeatable deployments\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
-        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/comparing-red-hat-openstack-platform-and-canonicals-charmed-openstack/18159\\\
-        \"\\u003eComparing Red Hat OpenStack Platform and Canonical\u2019s Charmed\
-        \ OpenStack\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/redhat-openstack-comparison-whitepaper\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003eopenstack\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-07-29\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eImprove security and\
-        \ efficiency at a reduced total cost of ownership with Charmed OpenStack\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\\
-        n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/do-vmware-ao-charmed-openstack/18165\\\
-        \"\\u003eDo VMware ao Charmed OpenStack\\u003c/a\\u003e\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003e/engage/pt/vmware-para-o-openstack\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e2020-07-22\\u003c/td\\u003e\\n\\u003ctd\\u003ept\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003eReduza os custos e aumente a efici\xEAncia\
-        \ da sua infraestrutura com ado\xE7\xE3o de c\xF3digo aberto\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
-        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/busting-the-myth-of-private-cloud-economics/17244\\\
-        \"\\u003eBusting the myth of private cloud economics\\u003c/a\\u003e\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e/engage/cloud-economics\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003ecase-study\\u003c/td\\u003e\\n\\u003ctd\\u003ecloud, openstack\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e2019-07-12\\u003c/td\\u003e\\n\\u003ctd\\u003een\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\\
-        u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\\
-        u003ca href=\\\"https://discourse.ubuntu.com/t/scale-android-applications-economically-in-the-cloud-with-anbox-cloud/17401\\\
-        \"\\u003eScale Android applications economically in the cloud with Anbox Cloud\\\
-        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/intro-to-anbox-cloud-whitepaper\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003ecloud\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-07-08\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eDiscover Canonical\u2019\
-        s scalable, hardware-agnostic mobile cloud computing platform\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\\
-        u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/accelerating-iot-device-time-to-market/17399\\\
-        \"\\u003eAccelerating IoT device time to market\\u003c/a\\u003e\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e/engage/smart-start-whitepaper\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eiot\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e2020-07-03\\u003c/td\\u003e\\n\\u003ctd\\u003een\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003eIntroducing a packaged solution to condense\
-        \ IoT decision-making into a 2-week, fixed cost process\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
-        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/kubernetes-from-cloud-to-edge/17398\\\
-        \"\\u003eKubernetes from Cloud to Edge\\u003c/a\\u003e\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003e/engage/kubernetes-event-us\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003ekubernetes, cloud, edge\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e2020-06-24\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eHow to streamline your Kubernetes\
-        \ deployment and operations from Canonical\u2019s experts.\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
-        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/scaling-on-azure-with-ubuntu-pro/17397\\\
-        \"\\u003eScaling on Azure with Ubuntu Pro\\u003c/a\\u003e\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003e/engage/scaling-securely-ubuntu-azure\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003eeBook\\u003c/td\\u003e\\n\\u003ctd\\u003eopen-source, cloud\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e2020-06-17\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eScale your open-source infrastructure\
-        \ with speed, security, and compliance\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\\
-        u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\\
-        u003ca href=\\\"https://discourse.ubuntu.com/t/a-technical-intro-to-ubuntu-pro/17396\\\
-        \"\\u003eA technical intro to Ubuntu Pro\\u003c/a\\u003e\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003e/engage/ubuntu-pro-intro\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003eopen-source\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003e2020-06-16\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\\
-        n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"\
-        https://discourse.ubuntu.com/t/migrating-your-infrastructure-to-ubuntu-20-04-lts/17395\\\
-        \"\\u003eMigrating your infrastructure to Ubuntu 20.04 LTS\\u003c/a\\u003e\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/migrating-to-20.04\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eopen-source\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e2020-06-11\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eHow, when and why?\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\\
-        u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/utilising-cloud-init-on-microsoft-azure/17394\\\
-        \"\\u003eUtilising cloud-init on Microsoft Azure\\u003c/a\\u003e\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e/engage/azure-cloud-init-whitepaper\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003ecloud\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e2020-06-03\\u003c/td\\u003e\\n\\u003ctd\\u003een\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003eSimplify cloud instance deployment with\
-        \ Ubuntu on Azure\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\\
-        n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"\
-        https://discourse.ubuntu.com/t/standardising-machine-learning-from-workstation-to-production/17393\\\
-        \"\\u003eStandardising machine learning \u2014 from workstation to production\\\
-        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/ml-dell-webinar\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eai,\
-        \ ml, kubernetes\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-06-02\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\\
-        u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/kafka-in-production/17392\\\
-        \"\\u003eKafka in production\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003e/engage/kafka-in-production\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003ekafka\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-05-28\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eMaking\
-        \ sure your deployment is fast, reliable and secure\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
-        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/solving-the-software-update-challenge-for-iot-devices/17391\\\
-        \"\\u003eSolving the software update challenge for IoT devices\\u003c/a\\\
-        u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/snapd-whitepaper\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eiot,\
-        \ ubuntu-core, snaps\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-05-15\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eHow Ubuntu Core\
-        \ transforms over-the-air software updates\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\\
-        u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/secure-iot-device-management/17390\\\
-        \"\\u003eSecure IoT device management\\u003c/a\\u003e\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003e/engage/iot-device-management-whitepaper\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eiot, security,\
-        \ ubuntu-core\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-05-13\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eBuild and deploy a\
-        \ central IoT management solution\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\\
-        u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\\
-        u003ca href=\\\"https://discourse.ubuntu.com/t/leveraging-open-source-with-ubuntu-pro-on-azure/17389\\\
-        \"\\u003eLeveraging open source with Ubuntu Pro on Azure\\u003c/a\\u003e\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/azure-webinar\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eopen-source\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e2020-05-12\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eEconomics, velocity and security\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\\
-        n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/streamlined-kubernetes-from-cloud-to-edge/17388\\\
-        \"\\u003eStreamlined Kubernetes, from Cloud to Edge\\u003c/a\\u003e\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e/engage/eu-kubernetes-event\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003ekubernetes, cloud,\
-        \ edge\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-05-11\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eInnovating and scaling\
-        \ efficiently, with Charmed Kubernetes and MicroK8s\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
-        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/embracing-the-open-source-mandate/17387\\\
-        \"\\u003eEmbracing the open source mandate\\u003c/a\\u003e\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003e/engage/moving-to-opensource-whitepaper\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eopen-source\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e2020-04-28\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e85% of enterprises have an open\
-        \ source mandate, preference or are exploring\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\\
-        u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/what-s-new-in-ubuntu-20-04-lts/17386\\\
-        \"\\u003eWhat\u2019s new in Ubuntu 20.04 LTS?\\u003c/a\\u003e\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e/engage/20.04-webinars\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003edesktop, server\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e2020-04-16\\u003c/td\\u003e\\n\\u003ctd\\u003een\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003eTwo webinars to help you understand what\
-        \ makes 20.04 our most secure and reliable release to date\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
-        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/maintaining-business-focus-in-a-cloud-native-world-with-managed-apps/17385\\\
-        \"\\u003eMaintaining business focus in a cloud-native world with Managed Apps\\\
-        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/managed-apps-webinar\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003ecloud\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e2020-04-09\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\\
-        u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/ubuntu-core-a-cybersecurity-analysis/17381\\\
-        \"\\u003eUbuntu Core: a cybersecurity analysis\\u003c/a\\u003e\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e/engage/ubuntu-core-security-audit\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eubuntu-core,\
-        \ security, iot\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-03-31\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eAn independent\
-        \ evaluation of Ubuntu Core\u2019s security capabilities\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
-        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/openstack-deployment-guide/17384\\\
-        \"\\u003eOpenStack deployment guide\\u003c/a\\u003e\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003e/engage/openstack-deployment-guide\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003e2020-03-31\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003eDiscover Canonical\u2019s proven OpenStack implementation\
-        \ process\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\\
-        u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/installez-et-mettez-openstack-a-lechelle-en-toute-simplicite/17418\\\
-        \"\\u003eInstallez et mettez OpenStack \xE0 l\u2019\xE9chelle en toute simplicit\xE9\
-        \\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/fr/openstack-made-easy\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003eeBook\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e2020-03-29\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003efr\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\\
-        u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/virtual-event-microk8s-kubernetes/17380\\\
-        \"\\u003eVirtual event: MicroK8s \\u0026amp; Kubernetes\\u003c/a\\u003e\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/pre-kubecon-event\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003eevent\\u003c/td\\u003e\\n\\u003ctd\\u003ekubernetes\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e2020-03-24\\u003c/td\\u003e\\n\\u003ctd\\u003een\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003eJoin our virtual event to learn more about\
-        \ MicroK8s, what it is and why you should use it. This event will also include\
-        \ discussions on Kubernetes, an introduction to Canonical and much more!\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\\
-        n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/rigado-cuts-customers-time-to-market/17379\\\
-        \"\\u003eRigado cuts customers\u2019 time-to-market\\u003c/a\\u003e\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e/engage/case-study-rigado\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003ecase study\\u003c/td\\u003e\\n\\u003ctd\\u003eiot, ubuntu-core, snaps\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e2020-03-19\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003een\\u003c/td\\u003e\\n\\u003ctd\\u003ewith Ubuntu Core and AWS\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\\
-        u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/securing-ros-robotics-platforms/17378\\\
-        \"\\u003eSecuring ROS robotics platforms\\u003c/a\\u003e\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003e/engage/securing-ros-on-robotics-platforms-whitepaper\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003erobotics,\
-        \ security\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-03-11\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eSteps to maximise robotics\
-        \ security with Ubuntu\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\\
-        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\
-        \"https://discourse.ubuntu.com/t/smart-card-login-on-ubuntu/17377\\\"\\u003eSmart\
-        \ card login on Ubuntu\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/smart-card-whitepaper\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003esecurity\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-03-09\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eConfigure Ubuntu 18.04\
-        \ LTS for smart card operation\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\\
-        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\
-        \"https://discourse.ubuntu.com/t/hosted-private-cloud-infrastructure-a-cost-analysis/17375\\\
-        \"\\u003eHosted private cloud infrastructure: a cost analysis\\u003c/a\\u003e\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/private-cloud-cost-analysis-webinar\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack,\
-        \ cloud, kubernetes, maas\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-03-02\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eAccelerate\
-        \ initial deployment and reduce operational costs by outsourcing private cloud\
-        \ infrastructure management\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\\
-        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\
-        \"https://discourse.ubuntu.com/t/an-introduction-to-anbox-cloud/17374\\\"\\\
-        u003eAccelerating IoT device time to market\\u003c/a\\u003e\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003e/engage/smart-start-webinar\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eiot\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003e2020-02-26\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003eChallenges and solutions for IoT execution\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\\
-        u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/an-introduction-to-anbox-cloud/17374\\\
-        \"\\u003eAn introduction to Anbox Cloud\\u003c/a\\u003e\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003e/engage/anbox-cloud-webinar\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003ecloud\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003e2020-02-25\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003eScalable Android\u2122 in the cloud\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
-        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/esm-maintains-interanas-system-security-while-upgrading/17376\\\
-        \"\\u003eESM maintains Interana\u2019s system security while upgrading\\u003c/a\\\
-        u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/interana-casestudy\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003ecase study\\u003c/td\\u003e\\n\\u003ctd\\u003esecurity\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e2020-02-17\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\\
-        u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/artificial-intelligence-at-the-edge-in-a-5g-world/17372\\\
-        \"\\u003eArtificial Intelligence at the edge in a 5G world\\u003c/a\\u003e\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/ai-edge-webinar\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eai, ml, edge\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e2020-02-07\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eDeploying AI/ML solutions in latency-sensitive\
-        \ environments requires a new solution architecture approach\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
-        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/deploy-kubernetes-in-your-data-centre/17373\\\
-        \"\\u003eDeploy Kubernetes in your data centre\\u003c/a\\u003e\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e/engage/dell-kubernetes-webinar\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003ekubernetes\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e2020-02-07\\u003c/td\\u003e\\n\\u003ctd\\u003een\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\\
-        u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\\
-        u003ca href=\\\"https://discourse.ubuntu.com/t/migration-von-vmware-zu-openstack/17370\\\
-        \"\\u003eMigration von VMware zu OpenStack\\u003c/a\\u003e\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003e/engage/de/migration-von-vmware-zu-openstack\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e2020-02-04\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003ede\\u003c/td\\u003e\\n\\u003ctd\\u003eWie ein Umstieg auf Charmed OpenStack\
-        \ die Gesamtkosten sp\xFCrbar senken kann\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\\
-        u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\\
-        u003ca href=\\\"https://discourse.ubuntu.com/t/de-vmware-a-charmed-openstack/17371\\\
-        \"\\u003eDe VMware a Charmed OpenStack\\u003c/a\\u003e\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003e/engage/es/vmware-a-charmed-openstack\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e2020-02-04\\u003c/td\\u003e\\n\\u003ctd\\u003ees\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003eC\xF3mo la migraci\xF3n a Charmed OpenStack\
-        \ puede reducir significativamente el TCO\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\\
-        u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\\
-        u003ca href=\\\"https://discourse.ubuntu.com/t/kubernetes-a-secure-flexible-and-automated-edge-for-iot-developers/17369\\\
-        \"\\u003eKubernetes: a secure, flexible and automated edge for IoT developers\\\
-        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/microk8s-451research\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003ekubernetes, edge, iot\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-01-10\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eThe\
-        \ factors for implementing Kubernetes successfully at the edge\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\\
-        u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/an-intro-to-microk8s/17367\\\
-        \"\\u003eAn intro to MicroK8s\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003e/engage/intro-to-microk8s-webinar\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003ekubernetes\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003e2019-12-19\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003eReliable, fast, small and upstream Kubernetes\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
-        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/ubuntu-desktop-for-the-enterprise/17368\\\
-        \"\\u003eUbuntu Desktop for the enterprise\\u003c/a\\u003e\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003e/engage/linux-enterprise-whitepaper\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003edesktop\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e2019-12-19\\u003c/td\\u003e\\n\\u003ctd\\u003een\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003eLearn why enterprises are beginning to adopt\
-        \ Linux as a desktop operating system\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\\
-        u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\\
-        u003ca href=\\\"https://discourse.ubuntu.com/t/cyberdyne-keeps-cleaning-robots-up-to-date-in-the-field-with-snaps/17366\\\
-        \"\\u003eCyberdyne keeps cleaning robots up-to-date in the field with snaps\\\
-        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/cyberdyne\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003ecase study\\u003c/td\\u003e\\n\\u003ctd\\u003erobotics,\
-        \ iot\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-12-18\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
-        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/sbi-group-unlocks-infrastructure-automation-with-secure-on-premises-openstack-cloud/17364\\\
-        \"\\u003eSBI Group unlocks infrastructure automation with secure, on-premises\
-        \ OpenStack cloud\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/sbi-casestudy\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003ecase study\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003eopenstack\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-12-06\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
-        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/register-for-wslconf/17365\\\
-        \"\\u003eRegister for WSLConf\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003e/engage/wslconf\\u003c/td\\u003e\\n\\u003ctd\\u003eevent\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003ewsl\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-12-06\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\\
-        n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/build-smart-display-devices-with-mir-fast-to-production-secure-open-source/17363\\\
-        \"\\u003eBuild smart display devices with Mir: fast to production, secure,\
-        \ open-source\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/build-smart-devices-with-mir-whitepaper\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003eiot\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-11-27\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
-        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/linux-security-with-ubuntu/17362\\\
-        \"\\u003eLinux security with Ubuntu\\u003c/a\\u003e\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003e/engage/linux_security_webinar\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003esecurity\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003e2019-11-14\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003eSecuring Ubuntu systems for reduced downtime and optimum\
-        \ CVE coverage.\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\\
-        n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"\
-        https://discourse.ubuntu.com/t/lessons-learned-from-100-private-cloud-builds/17361\\\
-        \"\\u003eLessons learned from 100+ Private cloud builds\\u003c/a\\u003e\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/private-cloud-build-webinar\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack,\
-        \ cloud\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-11-12\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eReducing the complexities\
-        \ of building a private cloud on OpenStack\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\\
-        u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/the-wellcome-sanger-institute-turns-to-canonical-for-high-level-ceph-support/17360\\\
-        \"\\u003eThe Wellcome Sanger Institute turns to Canonical for high level Ceph\
-        \ support\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/wellcome-sanger-case-study\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003ecase study\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003eceph, openstack\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-11-04\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\\
-        u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/ensuring-security-and-isolation-in-kubernetes-with-kata-containers/17359\\\
-        \"\\u003eEnsuring security and isolation in Kubernetes with Kata Containers\\\
-        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/kata-containers-webinar\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003esecurity\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e2019-11-01\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\\
-        u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/tim-ensures-system-security-and-client-confidence-with-esm/17358\\\
-        \"\\u003eTIM ensures system security and client confidence with ESM\\u003c/a\\\
-        u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/case-study-acuris\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003ecase study\\u003c/td\\u003e\\n\\u003ctd\\u003esecurity,\
-        \ ubuntu-advantage\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-10-22\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\\
-        u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/what-s-new-in-ubuntu-19-10/17357\\\
-        \"\\u003eWhat\u2019s new in Ubuntu 19.10\\u003c/a\\u003e\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003e/engage/19-10-webinar\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003edesktop\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-10-17\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eUbuntu\
-        \ 19.10 includes enhanced K8s capabilities for edge and AI/ML, OpenStack Train\
-        \ live-migration extensions for easier infrastructure deployments and more.\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\\
-        n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/how-domotz-streamlined-provisioning-of-iot-devices/17356\\\
-        \"\\u003eHow Domotz streamlined provisioning of IoT devices\\u003c/a\\u003e\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/domotz-case-study\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003ecase study\\u003c/td\\u003e\\n\\u003ctd\\u003eubuntu-core,\
-        \ snaps, iot\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-10-10\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eLearn how Ubuntu Core\
-        \ and snaps gives Domotz a competitive advantage\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\\
-        u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/yahoo-japan-builds-their-iaas-environment-with-canonical/17355\\\
-        \"\\u003eYahoo! Japan builds their IaaS environment with Canonical\\u003c/a\\\
-        u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/yahoo-japan-case-study\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003ecase study\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003eopenstack, maas, juju, ubuntu-advantage, security\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003e2019-10-08\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\\
-        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\
-        \"https://discourse.ubuntu.com/t/accelerating-deep-tech-with-ubuntu/17354\\\
-        \"\\u003eAccelerating deep tech with Ubuntu\\u003c/a\\u003e\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003e/engage/deeptech\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003eiot, robotics\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003e2019-10-02\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\\
-        n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"\
-        https://discourse.ubuntu.com/t/from-vmware-to-charmed-openstack/17343\\\"\\\
-        u003eFrom VMWare To Charmed OpenStack\\u003c/a\\u003e\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003e/engage/vmware-to-charmed-openstack\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003e2019-09-04\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003eReduce costs and increase the efficiency of your infrastructure\
-        \ with open source adoption\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\\
-        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\
-        \"https://discourse.ubuntu.com/t/machine-learning-operations-mlops/17353\\\
-        \"\\u003eMachine Learning Operations (MLOps)\\u003c/a\\u003e\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003e/engage/get-started-with-ai-part-2\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eai, ml\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e2019-09-11\\u003c/td\\u003e\\n\\u003ctd\\u003een\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003eDeploy at scale\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\\
-        u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/how-to-manage-snaps-in-an-enterprise-environment/17352\\\
-        \"\\u003eHow to manage snaps in an enterprise environment\\u003c/a\\u003e\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/enterprise-snap-management\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003esnaps,\
-        \ security\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-08-20\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eHow the Snap Store\
-        \ Proxy overcomes challenges presented by restricted networks and management\
-        \ policies\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\\
-        u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/a-guide-to-developing-android-apps-on-ubuntu/17351\\\
-        \"\\u003eA guide to developing Android apps on Ubuntu\\u003c/a\\u003e\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e/engage/developing-android-on-ubuntu\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003edesktop, apps\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e2019-08-13\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\\
-        u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/creating-a-cloud-like-bare-metal-experience-in-the-data-centre/17348\\\
-        \"\\u003eCreating a cloud-like bare metal experience in the data centre\\\
-        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/maas-hardware-testing\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003emaas\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-08-08\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
-        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/creating-accurate-ai-models-with-data/17349\\\
-        \"\\u003eCreating accurate AI models with data\\u003c/a\\u003e\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e/engage/data-pipelines-kubeflow\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003ekubeflow, ai\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e2019-08-08\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eHow Kubeflow and machine learning\
-        \ help you get the most out of your data\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\\
-        u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\\
-        u003ca href=\\\"https://discourse.ubuntu.com/t/ims-evolve-adopts-ubuntu-core-to-provide-iot-enabled-business-intelligence-in-the-supply-chain/17284\\\
-        \"\\u003eIMS Evolve adopts Ubuntu Core to provide IoT-enabled business intelligence\
-        \ in the supply chain\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/casestudy-imsevolve\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003ecase study\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003eiot\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-17\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
-        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/rocket-chat-communication-platform-enables-simplicity-through-snaps/17288\\\
-        \"\\u003eRocket.Chat communication platform enables simplicity through snaps\\\
-        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/casestudy-rocketchat\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003ecase study\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003esnaps, apps\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-17\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\\
-        u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/server-provisioning-what-network-admins-it-pros-need-to-know/17307\\\
-        \"\\u003eServer Provisioning: What Network Admins \\u0026amp; IT Pros Need\
-        \ to Know\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/ebook-maas\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003eeBook\\u003c/td\\u003e\\n\\u003ctd\\u003eserver\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-17\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\\
-        u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/building-a-private-cloud-take-the-leap/17331\\\
-        \"\\u003eBuilding a private cloud? Take the leap!\\u003c/a\\u003e\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e/engage/private-cloud\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003eeBook\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack, cloud\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e2019-07-17\\u003c/td\\u003e\\n\\u003ctd\\u003een\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\\
-        u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\\
-        u003ca href=\\\"https://discourse.ubuntu.com/t/make-it-rain-public-cloud-on-ubuntu-openstack/17332\\\
-        \"\\u003eMake IT rain: public cloud on Ubuntu OpenStack\\u003c/a\\u003e\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/public-cloud\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003eeBook\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack, cloud\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-17\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\\
-        u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/learn-whats-new-in-ubuntu-server-14-04-lts/17344\\\
-        \"\\u003eLearn What\u2019s New In Ubuntu Server 14.04 LTS\\u003c/a\\u003e\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/whats-new-ubuntu-14-04-lts\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eserver,\
-        \ openstack\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-17\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
-        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/how-ubuntu-helped-innovapos-revolutionise-the-vending-machine-industry/17285\\\
-        \"\\u003eHow Ubuntu helped InnovaPOS revolutionise the vending machine industry\\\
-        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/casestudy-innovapos\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003ecase study\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003eiot\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-16\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
-        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/nexiona-collaborates-with-canonical-and-dell-to-create-miimetiq-edge/17287\\\
-        \"\\u003eNEXIONA collaborates with Canonical and Dell to create MIIMETIQ EDGE\\\
-        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/casestudy-nexiona\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003ecase study\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003eiot\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-16\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
-        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/azeti-uses-ubuntu-core-to-improve-deployment-and-security/17278\\\
-        \"\\u003eAzeti uses Ubuntu Core to improve deployment and security\\u003c/a\\\
-        u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/casestudy-azeti\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003ecase study\\u003c/td\\u003e\\n\\u003ctd\\u003esecurity,\
-        \ iot\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-16\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
-        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/azlogica-utilise-ubuntu-core-for-customised-iot-agricultural-solutions/17279\\\
-        \"\\u003eAZLOGICA utilise Ubuntu Core for customised IoT agricultural solutions\\\
-        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/casestudy-azlogica\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003ecase study\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003eiot\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-16\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
-        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/botsandus-builds-a-social-robot-on-ubuntu/17280\\\
-        \"\\u003eBotsAndUs builds a social robot on Ubuntu\\u003c/a\\u003e\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e/engage/casestudy-botsandus\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003ecase study\\u003c/td\\u003e\\n\\u003ctd\\u003erobotics\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e2019-07-16\\u003c/td\\u003e\\n\\u003ctd\\u003een\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\\
-        u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\\
-        u003ca href=\\\"https://discourse.ubuntu.com/t/cinergy-makes-significant-digital-signage-saving-with-screenly-pro-and-ubuntu-core/17281\\\
-        \"\\u003eCinergy makes significant digital signage saving with Screenly Pro\
-        \ and Ubuntu Core\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/casestudy-cinergy\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003ecase study\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003edigital-signage\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-16\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\\
-        u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/commercetools-uses-ubuntu-server-to-power-its-next-generation-ecommerce-platform/17283\\\
-        \"\\u003eCommercetools uses Ubuntu Server to power its next-generation ecommerce\
-        \ platform\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/casestudy-commercetools\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003ecase study\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003eserver, e-commerce\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-16\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\\
-        u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/for-ctos-the-no-nonsense-way-to-accelerate-your-business-with-containers/17345\\\
-        \"\\u003eFor CTOs: the no-nonsense way to accelerate your business with containers\\\
-        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/whitepaper-containers\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003etelco\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-16\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
-        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/taking-charge-of-the-iots-security-vulnerabilities/17346\\\
-        \"\\u003eTaking charge of the IoT\u2019s security vulnerabilities\\u003c/a\\\
-        u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/whitepaper-iot-security\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003eiot, security\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-16\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\\
-        u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/the-essential-guide-for-telecoms-and-service-providers-adopting-big-data-solutions/17309\\\
-        \"\\u003eThe essential guide for Telecoms and Service Providers adopting big\
-        \ data solutions\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/essential-guide-big-data-solutions\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003eeBook\\u003c/td\\u003e\\n\\u003ctd\\u003etelco,\
-        \ openstack\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-15\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
-        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/city-network-brings-openstack-cloud-hosting-to-the-financial-services-sector-with-canonical/17282\\\
-        \"\\u003eCity Network brings OpenStack cloud hosting to the financial services\
-        \ sector with Canonical\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/casestudy-city-network\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003ecase study\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003ecloud\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-15\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
-        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/cto-s-guide-to-sdn-nfv-vnf/17293\\\
-        \"\\u003eCTO\u2019s guide to SDN, NFV \\u0026amp; VNF\\u003c/a\\u003e\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e/engage/cto-guide-sdn-nfv-vnf\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003eeBook\\u003c/td\\u003e\\n\\u003ctd\\u003enetworking\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e2019-07-15\\u003c/td\\u003e\\n\\u003ctd\\u003een\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003eWhy is the transition happening and why\
-        \ is it important?\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\\
-        n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"\
-        https://discourse.ubuntu.com/t/sensape-uses-landscape-to-remotely-support-revolutionary-interactive-retail-displays/17289\\\
-        \"\\u003eSensape uses Landscape to remotely support revolutionary interactive\
-        \ retail displays\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/casestudy-sensape\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003ecase study\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003edigital-signage\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-15\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\\
-        u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/how-to-face-the-challenges-of-becoming-a-cloud-operator/17290\\\
-        \"\\u003eHow to face the challenges of becoming a cloud operator\\u003c/a\\\
-        u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/cloud-fray\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003eeBook\\u003c/td\\u003e\\n\\u003ctd\\u003ecloud, openstack,\
-        \ telco\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-15\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
-        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/low-latency-and-real-time-kernels-for-telco-and-nfv/17321\\\
-        \"\\u003eLow latency and real time kernels for telco and NFV\\u003c/a\\u003e\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/low-latency-report\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003etelco\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e2019-07-15\\u003c/td\\u003e\\n\\u003ctd\\u003een\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\\
-        u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\\
-        u003ca href=\\\"https://discourse.ubuntu.com/t/how-to-escape-stuckstack-and-profit-from-your-openstack-investment/17337\\\
-        \"\\u003eHow to escape StuckStack and profit from your OpenStack investment\\\
-        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/stuckstack-ebook\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003eeBook\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-15\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\\
-        u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/carrier-cloudification-what-every-telecom-executive-needs-to-know/17338\\\
-        \"\\u003eCarrier Cloudification: What every telecom executive needs to know\\\
-        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/telco-cloudification-ebook\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003eeBook\\u003c/td\\u003e\\n\\u003ctd\\u003etelco,\
-        \ cloud, openstack\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-15\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\\
-        u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/nfv-and-sdn-on-openstack/17326\\\
-        \"\\u003eNFV and SDN on OpenStack\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003e/engage/nfv-sdn-openstack\\u003c/td\\u003e\\n\\u003ctd\\u003eeBook\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003eopenstack, networking\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003e2019-07-12\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\\
-        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\
-        \"https://discourse.ubuntu.com/t/openstack-made-easy/17328\\\"\\u003eOpenStack\
-        \ made easy\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/openstack-made-easy\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003eeBook\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-12\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eWith the right tools, OpenStack\
-        \ can be easy\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\\
-        u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/telcos-and-service-providers-expect-near-100-uptime/17330\\\
-        \"\\u003eTelcos and Service Providers expect near 100% uptime\\u003c/a\\u003e\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/openstack-telco-clouds\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003eeBook\\u003c/td\\u003e\\n\\u003ctd\\u003etelco, openstack,\
-        \ cloud\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-12\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eThis requires a proven\
-        \ cloud platform that minimises time-to-revenue and ensures predictable costs.\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\\
-        n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/a-shift-to-the-linux-app-store-experience/17347\\\
-        \"\\u003eA shift to the Linux app store experience\\u003c/a\\u003e\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e/engage/shift-to-app-store-experience\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eapps,\
-        \ snaps\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-11\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eThe key to optimising\
-        \ software distribution in a fragmented environment.\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
-        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/le-support-d-ubuntu-14-04-lts-est-maintenant-passe-a-esm/17413\\\
-        \"\\u003eLe support d\u2019Ubuntu 14.04 LTS est maintenant pass\xE9 \xE0 ESM\\\
-        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/fr/esm_1404\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003eblog\\u003c/td\\u003e\\n\\u003ctd\\u003esecurity\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e2019-06-28\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003efr\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\\
-        u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/a-guide-to-edge-computing-and-the-tools-you-need/17308\\\
-        \"\\u003eA guide to edge computing and the tools you need\\u003c/a\\u003e\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/edge-month\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eedge, cloud, kubernetes,\
-        \ maas\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-06-27\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eLearn how edge computing\
-        \ provides enterprises with real-time data processing, cost-effective security\
-        \ and scalability.\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\\
-        n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"\
-        https://discourse.ubuntu.com/t/sicherheit-in-der-private-cloud/17411\\\"\\\
-        u003eSicherheit in der Private Cloud\\u003c/a\\u003e\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003e/engage/de/openstack-security-de\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack, cloud\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e2019-06-19\\u003c/td\\u003e\\n\\u003ctd\\u003ede\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003eH\xF6chste Anforderungen in Unternehmensumgebungen\
-        \ mit OpenStack erf\xFCllen.\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\\
-        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\
-        \"https://discourse.ubuntu.com/t/how-to-get-started-and-progress-with-an-ai-program/17245\\\
-        \"\\u003eHow to get started and progress with an AI program\\u003c/a\\u003e\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/ai-gettingstarted\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eai, ml\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e2019-06-11\\u003c/td\\u003e\\n\\u003ctd\\u003een\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\\
-        u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\\
-        u003ca href=\\\"https://discourse.ubuntu.com/t/the-future-of-mobile-connectivity/17342\\\
-        \"\\u003eThe future of mobile connectivity\\u003c/a\\u003e\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003e/engage/ubuntu-lime-telco\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003etelco\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003e2019-06-12\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003eMajor mobile operators are adopting open source versus\
-        \ proprietary technologies to reduce costs.\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\\
-        u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/north-america-s-first-autonomous-runway-snowplough/17327\\\
-        \"\\u003eNorth America\u2018s first autonomous runway snowplough\\u003c/a\\\
-        u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/northstar\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003ecase study\\u003c/td\\u003e\\n\\u003ctd\\u003erobotics, iot\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e2019-06-05\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eThe robots helping to address off-highway\
-        \ labour shortages\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\\
-        n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"\
-        https://discourse.ubuntu.com/t/small-robot-company-sows-the-seeds-for-autonomous-and-more-profitable-farming/17334\\\
-        \"\\u003eSmall Robot Company sows the seeds for autonomous and more profitable\
-        \ farming\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/small-robot-company\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003ecase study\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003erobotics, ai\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-06-04\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\\
-        u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/how-to-integrate-ubuntu-desktop-with-active-directory/17323\\\
-        \"\\u003eHow to integrate Ubuntu Desktop with Active Directory\\u003c/a\\\
-        u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/microsoft-active-directory\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003edesktop, active-directory\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-06-04\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\\
-        n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/connected-cars-and-autonomous-driving/17243\\\
-        \"\\u003eConnected cars and autonomous driving\\u003c/a\\u003e\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e/engage/451-automotive\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eiot\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003e2019-05-31\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003eAddressing risk and complexity with software\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\\
-        u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/why-ubuntu-core-is-the-most-secure-choice-for-iot/17292\\\
-        \"\\u003eWhy Ubuntu Core is the most secure choice for IoT\\u003c/a\\u003e\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/core18-security\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003esecurity, iot,\
-        \ ubuntu-core\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-05-29\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
-        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/getting-started-with-ai/17336\\\
-        \"\\u003eGetting started with AI\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003e/engage/starting-with-ai\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003eai, ml\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-05-11\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\\
-        n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/the-transformation-of-the-devops-journey-in-iot/17422\\\
-        \"\\u003eThe transformation of the DevOps journey in IoT\\u003c/a\\u003e\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/iot-devops\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eiot\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e2019-05-07\\u003c/td\\u003e\\n\\u003ctd\\u003een\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\\
-        u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\\
-        u003ca href=\\\"https://discourse.ubuntu.com/t/cloud-init/17291\\\"\\u003eCloud\
-        \ init\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/cloud-init-whitepaper\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003ecloud\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-05-01\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
-        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/how-to-build-a-lightweight-system-container-cluster/17322\\\
-        \"\\u003eHow to build a lightweight system container cluster\\u003c/a\\u003e\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/lxd-whitepaper\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003elxd\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e2019-04-30\\u003c/td\\u003e\\n\\u003ctd\\u003een\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003eYou will learn how working in this environment:\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\\
-        n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/the-transformation-of-the-devops-journey-in-iot-webinar/17306\\\
-        \"\\u003eThe transformation of the DevOps journey in IoT Webinar\\u003c/a\\\
-        u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/devops-iot-webinar\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eiot\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e2019-04-29\\u003c/td\\u003e\\n\\u003ctd\\u003een\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\\
-        u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\\
-        u003ca href=\\\"https://discourse.ubuntu.com/t/private-cloud-security-webinar/17329\\\
-        \"\\u003ePrivate cloud security Webinar\\u003c/a\\u003e\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003e/engage/openstack-security-webinar\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack, security\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e2019-04-24\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eHow Charmed OpenStack is decreasing\
-        \ common security concerns\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\\
-        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\
-        \"https://discourse.ubuntu.com/t/private-cloud-security/17421\\\"\\u003ePrivate\
-        \ cloud security\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/openstack-security-whitepaper\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003eopenstack, security\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-04-24\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eMeeting the\
-        \ highest levels of enterprise requirements with OpenStack\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
-        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/hiri-successfully-monetises-their-snap/17314\\\
-        \"\\u003eHiri successfully monetises their snap\\u003c/a\\u003e\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e/engage/hiri-case-study\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003ecase study\\u003c/td\\u003e\\n\\u003ctd\\u003eapps, snaps\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e2019-04-25\\u003c/td\\u003e\\n\\u003ctd\\u003een\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\\
-        u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\\
-        u003ca href=\\\"https://discourse.ubuntu.com/t/whats-new-in-ubuntu-19-04/17240\\\
-        \"\\u003eWhat\u2019s new in Ubuntu 19.04?\\u003c/a\\u003e\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003e/engage/19-04-webinar\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003eopenstack, kubernetes, ceph, iot, desktop\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e2019-04-18\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eJoin Canonical Product Director\
-        \ Stephan Fabel and Ubuntu Product Managers to discuss everything new in Ubuntu\
-        \ 19.04 \u2018Disco Dingo\u2019\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\\
-        u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\\
-        u003ca href=\\\"https://discourse.ubuntu.com/t/optimising-iot-bandwidth-with-delta-updates/17335\\\
-        \"\\u003eOptimising IoT bandwidth with delta updates\\u003c/a\\u003e\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e/engage/snap-deltas\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eiot, snaps\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e2019-03-16\\u003c/td\\u003e\\n\\u003ctd\\u003een\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003eLearn how snap deltas\u2019 over-the-air\
-        \ updates are efficient and effective.\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\\
-        u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\\
-        u003ca href=\\\"https://discourse.ubuntu.com/t/an-introduction-to-apparmor/17277\\\
-        \"\\u003eAn introduction to AppArmor\\u003c/a\\u003e\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003e/engage/apparmor-intro\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003esecurity\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003e2019-03-16\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003eAn explanation of AppArmor and its key features.\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\\
-        u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/get-started-with-devops-best-practices-ci-cd/17305\\\
-        \"\\u003eGet started with DevOps best practices: CI/CD\\u003c/a\\u003e\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e/engage/devops-cicd-webinar\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003ekubernetes\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e2019-03-07\\u003c/td\\u003e\\n\\u003ctd\\u003een\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\\
-        u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\\
-        u003ca href=\\\"https://discourse.ubuntu.com/t/esm-for-ubuntu-14-04-lts-trusty-tahr/17275\\\
-        \"\\u003eESM for Ubuntu 14.04 LTS Trusty Tahr\\u003c/a\\u003e\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e/engage/14-04-esm\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003esecurity\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003e2019-02-21\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003eLearn how to maintain ongoing security compliance for your 14.04\
-        \ systems.\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\\
-        u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/securing-iot-device-data-against-physical-access/17318\\\
-        \"\\u003eSecuring IoT device data against physical access\\u003c/a\\u003e\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/iot-disk-encryption\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eiot,\
-        \ security, ubuntu-core\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-02-11\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eA technical\
-        \ overview of how Ubuntu Core with full disk encryption and secure boot can\
-        \ be implemented to harden IoT devices\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\\
-        u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\\
-        u003ca href=\\\"https://discourse.ubuntu.com/t/multi-cloud-fundamental-to-financial-services-transformation/17312\\\
-        \"\\u003eMulti-cloud fundamental to financial services transformation\\u003c/a\\\
-        u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/finserv-multi-cloud\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003ecloud,\
-        \ finance, ai\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-02-04\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
-        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/extension-securite-et-maintenance-pour-ubuntu-14-04/17414\\\
-        \"\\u003eExtension S\xE9curit\xE9 et Maintenance pour Ubuntu 14.04\\u003c/a\\\
-        u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/fr/esm\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003eblog\\u003c/td\\u003e\\n\\u003ctd\\u003esecurity\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e2019-01-31\\u003c/td\\u003e\\n\\u003ctd\\u003efr\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\\
-        u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\\
-        u003ca href=\\\"https://discourse.ubuntu.com/t/utiliser-des-gpus-avec-kubernetes/17419\\\
-        \"\\u003eUtiliser des GPUs avec Kubernetes\\u003c/a\\u003e\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003e/engage/fr/utiliser-gpgpus-avec-kubernetes\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003eblog\\u003c/td\\u003e\\n\\u003ctd\\u003ekubernetes\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e2018-12-20\\u003c/td\\u003e\\n\\u003ctd\\u003efr\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\\
-        u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\\
-        u003ca href=\\\"https://discourse.ubuntu.com/t/apellix-engineers-safer-work-environments-with-ubuntu-powered-aerial-robotics/17315\\\
-        \"\\u003eApellix engineers safer work environments with Ubuntu powered aerial\
-        \ robotics\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/industrial-drones-case-study\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003ecase study\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003erobotics, iot\\u003c/td\\u003e\\n\\u003ctd\\u003e2018-12-14\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\\
-        u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/allan-gray-unlocks-unprecedented-availability-and-productivity-with-charmed-kubernetes/17319\\\
-        \"\\u003eAllan Gray unlocks unprecedented availability and productivity with\
-        \ Charmed Kubernetes\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/k8s-allan-gray\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003ecase study\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003efinance, kubernetes\\u003c/td\\u003e\\n\\u003ctd\\u003e2018-12-13\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\\
-        u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/six-reasons-why-developers-choose-ubuntu-desktop/17304\\\
-        \"\\u003eSix reasons why developers choose Ubuntu Desktop\\u003c/a\\u003e\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/developer-desktop\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003edesktop\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e2018-11-23\\u003c/td\\u003e\\n\\u003ctd\\u003een\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\\
-        u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\\
-        u003ca href=\\\"https://discourse.ubuntu.com/t/modernise-your-cloud/17324\\\
-        \"\\u003eModernise your cloud\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003e/engage/modern-cloud\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003ecloud\\u003c/td\\u003e\\n\\u003ctd\\u003e2018-11-22\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eDiscover\
-        \ how Trilio and Canonical help organisations transition to new, maintainable\
-        \ cloud architecture in just weeks.\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\\
-        u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\\
-        u003ca href=\\\"https://discourse.ubuntu.com/t/precision-drones-on-ubuntu-flying-at-the-edge-of-innovation/17316\\\
-        \"\\u003ePrecision drones on Ubuntu: flying at the edge of innovation\\u003c/a\\\
-        u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/industrial-drones\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003erobotics,\
-        \ iot\\u003c/td\\u003e\\n\\u003ctd\\u003e2018-11-20\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eHow Apellix uses Ubuntu\
-        \ on drones to replace human workers in potentially dangerous scenarios.\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\\
-        n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/securing-the-enterprise-how-ubuntu-is-at-the-forefront-of-security-and-compliance/17340\\\
-        \"\\u003eSecuring the enterprise: how Ubuntu is at the forefront of security\
-        \ and compliance\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/ubuntu-compliance\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003esecurity\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e2018-11-12\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\\
-        u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/itstrategen-keeps-legacy-applications-secure-with-extended-security-maintenance/17286\\\
-        \"\\u003eITstrategen keeps legacy applications secure with Extended Security\
-        \ Maintenance\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/ITstrategen-case-study\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003ecase study\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003esecurity\\u003c/td\\u003e\\n\\u003ctd\\u003e2018-10-29\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
-        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/what-s-new-in-ubuntu-18-10/17339\\\
-        \"\\u003eWhat\u2019s New in Ubuntu 18.10\\u003c/a\\u003e\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003e/engage/ubuntu-18-10\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003edesktop, server\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003e2018-10-29\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003eCanonical product managers discuss the new Ubuntu 18.10 release\
-        \ features in this on-demand webinar\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\\
-        u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\\
-        u003ca href=\\\"https://discourse.ubuntu.com/t/ubuntu-core-and-kura-a-framework-for-iot-gateways/17341\\\
-        \"\\u003eUbuntu Core and Kura: A framework for IoT gateways\\u003c/a\\u003e\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/ubuntu-core-and-kura\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eubuntu-core,\
-        \ iot, edge, snaps\\u003c/td\\u003e\\n\\u003ctd\\u003e2018-10-23\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\\
-        u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/keep-up-with-evolving-software/17310\\\
-        \"\\u003eKeep up with evolving software\\u003c/a\\u003e\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003e/engage/evolving-software\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003ejuju, cloud\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e2018-10-22\\u003c/td\\u003e\\n\\u003ctd\\u003een\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003eLearn how Juju can help solve software management\
-        \ complexity.\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\\
-        u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/wofur-konnen-sie-kubernetes-einsetzen/17410\\\
-        \"\\u003eWof\xFCr k\xF6nnen Sie Kubernetes einsetzen?\\u003c/a\\u003e\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e/engage/de/what-can-you-do-with-kubernetes\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003ekubernetes\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e2018-10-19\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003ede\\u003c/td\\u003e\\n\\u003ctd\\u003eDieses Webinar liefert Ihnen alles\
-        \ Wichtige zum Einstieg.\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\\
-        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\
-        \"https://discourse.ubuntu.com/t/low-latency-and-real-time-kernels-for-telco-and-nfv/17320\\\
-        \"\\u003eLow latency and real-time kernels for telco and NFV\\u003c/a\\u003e\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/kernel-telco-nfv\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003etelco\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e2018-10-08\\u003c/td\\u003e\\n\\u003ctd\\u003een\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\\
-        u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\\
-        u003ca href=\\\"https://discourse.ubuntu.com/t/future-proofing-fingbox-the-iot-home-network-monitoring-device/17313\\\
-        \"\\u003eFuture-proofing Fingbox, the IoT home network monitoring device\\\
-        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/future-proof-iot\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eiot,\
-        \ ubuntu-core\\u003c/td\\u003e\\n\\u003ctd\\u003e2018-10-02\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
-        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/how-to-build-and-deploy-your-first-ai-ml-model-on-ubuntu/17294\\\
-        \"\\u003eHow to build and deploy your first AI/ML model on Ubuntu\\u003c/a\\\
-        u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/deploy-ai-ml-model\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eai, ml,\
-        \ kubeflow, kubernetes\\u003c/td\\u003e\\n\\u003ctd\\u003e2018-09-26\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eAn introduction\
-        \ to AI and ML workloads on Ubuntu workstations, servers and in the cloud\
-        \ on a Kubernetes stack.\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\\
-        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\
-        \"https://discourse.ubuntu.com/t/openstack-problemlos-installieren-und-skalieren/17409\\\
-        \"\\u003eOpenStack problemlos installieren und skalieren\\u003c/a\\u003e\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/de/openstack-made-easy\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003eeBook\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e2018-09-05\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003ede\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\\
-        u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/key-considerations-when-choosing-a-robot-s-operating-system/17333\\\
-        \"\\u003eKey considerations when choosing a robot\u2019s operating system\\\
-        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/robot-operating-system-choice\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003erobotics\\u003c/td\\u003e\\n\\u003ctd\\u003e2018-09-05\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
-        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/cio-guide-to-multi-cloud-operations/17325\\\
-        \"\\u003eCIO guide to multi-cloud operations\\u003c/a\\u003e\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003e/engage/multi-cloud-guide\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003ecloud, kubernetes, container\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e2018-09-03\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\\
-        u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/canonical-presents-financial-services-month/17241\\\
-        \"\\u003eCanonical presents Financial Services Month\\u003c/a\\u003e\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e/engage/financial-services-month\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003efinance, ai, ml\
-        \ cloud\\u003c/td\\u003e\\n\\u003ctd\\u003e2018-09-03\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eFilmed at the London Stock\
-        \ exchange with representatives from Canonical, 451 Research, IBM, and a former\
-        \ Deutsche Bank storage CTO, Canonical took a deep dive look in to the rise\
-        \ of multi-cloud in the financial services industry.\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
-        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/establishing-a-software-defined-iot-business-model/17317\\\
-        \"\\u003eEstablishing a software defined IoT business model\\u003c/a\\u003e\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/iot-business-model\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eiot\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e2018-08-24\\u003c/td\\u003e\\n\\u003ctd\\u003een\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\\
-        u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\\
-        u003ca href=\\\"https://discourse.ubuntu.com/t/artificial-intelligence-machine-learning-and-ubuntu/17276\\\
-        \"\\u003eArtificial intelligence, machine learning and Ubuntu\\u003c/a\\u003e\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/ai-ml-ubuntu\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eai, ml, kubernetes\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e2018-08-16\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\\
-        u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/von-vmware-zu-canonical-openstack/17408\\\
-        \"\\u003eVon VMware zu Canonical OpenStack\\u003c/a\\u003e\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003e/engage/de/vmware-to-openstack\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003e2018-08-06\\u003c/td\\u003e\\n\\u003ctd\\u003ede\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\\
-        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\
-        \"https://discourse.ubuntu.com/t/fing-serves-30-000-customers-with-a-secure-future-proof-iot-device/17311\\\
-        \"\\u003eFing serves 30,000 customers with a secure, future-proof IoT device\\\
-        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/fingbox-case-study\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003eiot, ubuntu-core, snaps\\u003c/td\\u003e\\n\\u003ctd\\u003e2018-06-25\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\\
-        n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/canonical-integre-containerd-a-ubuntu-kubernetes/17412\\\
-        \"\\u003eCanonical int\xE8gre containerd \xE0 Ubuntu Kubernetes\\u003c/a\\\
-        u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/fr/canonical-ajoute-containerd-a-ubuntu-kubernetes\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003eblog\\u003c/td\\u003e\\n\\u003ctd\\u003ekubernetes\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e2020-05-22\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003efr\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\\
-        u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/guide-du-dsi-pour-les-operations-multicloud/17415\\\
-        \"\\u003eGUIDE DU DSI pour les op\xE9rations multicloud\\u003c/a\\u003e\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/fr/guide-du-DSI-pour-les-operations-multicloud\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003ecloud, kubernetes\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-05-22\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003efr\\u003c/td\\u003e\\n\\u003ctd\\u003eChoisir une\
-        \ architecture cloud rentable\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\\
-        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\
-        \"https://discourse.ubuntu.com/t/canonical-annonce-managed-apps-linfogerance-des-applications-sur-votre-cloud/17416\\\
-        \"\\u003eCanonical annonce Managed Apps: l\u2019infog\xE9rance des applications\
-        \ sur votre cloud.\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/fr/managed-apps\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003eblog\\u003c/td\\u003e\\n\\u003ctd\\u003eapps\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e2020-05-18\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003efr\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\\
-        u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/migrer-de-vmware-a-openstack/17417\\\
-        \"\\u003eMigrer de VMWare \xE0 OpenStack\\u003c/a\\u003e\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003e/engage/fr/migrer-de-vmware-a-openstack\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e2020-05-18\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003efr\\u003c/td\\u003e\\n\\u003ctd\\u003ePassez \xE0 Charmed OpenStack et\
-        \ r\xE9duisez consid\xE9rablement vos co\xFBts\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\\
-        u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/migrer-de-vmware-a-openstack-webinaire/17420\\\
-        \"\\u003eMigrer de VMware \xE0 Openstack Webinaire\\u003c/a\\u003e\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e/engage/fr/vmware-to-openstack\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e2020-05-18\\u003c/td\\u003e\\n\\u003ctd\\u003efr\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003eApprenez comment migrer d\u2019un environnement\
-        \ traditionnel et propri\xE9taire \xE0 un cloud OpenStack\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
-        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/charmed-kubernetes-reference-architecture/19159\\\
-        \"\\u003eCharmed Kubernetes reference architecture\\u003c/a\\u003e\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e/engage/dell-k8s-reference-architecture\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003ekubernetes\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e2019-11-07\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eIntegration with VxFlex OS delivered\
-        \ by Dell EMC and Canonical.\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\\
-        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\
-        \"https://discourse.ubuntu.com/t/charmed-openstack-reference-architecture/19160\\\
-        \"\\u003eCharmed OpenStack reference architecture\\u003c/a\\u003e\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e/engage/dell-openstack-reference-architecture\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e2019-11-07\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eWith Dell EMC PowerEdge servers\
-        \ for workloads and storage and Dell EMC Networking and Canonical.\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\\
-        u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/at-t-private-offer-on-azure-ubuntu-pro-support/19161\\\
-        \"\\u003eAT\\u0026amp;T Private Offer on Azure - Ubuntu Pro + Support\\u003c/a\\\
-        u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/at\\u0026amp;t-azure-webinar\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eubuntu-advantage\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e2020-06-30\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eSecure, updated Ubuntu with 24x7\
-        \ support special pricing and SLAs for AT\\u0026amp;T.\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003c/tbody\\\
-        u003e\\n\\u003c/table\\u003e\\n\\u003c/div\\u003e\\u003c/details\\u003e\\\
-        n\\u003ch2\\u003eTakeovers\\u003c/h2\\u003e\\n\\u003cdetails\\u003e\\n\\u003csummary\\\
-        u003e\\nMapping table\\u003c/summary\\u003e\\n\\u003cdiv class=\\\"md-table\\\
-        \"\\u003e\\n\\u003ctable\\u003e\\n\\u003cthead\\u003e\\n\\u003ctr\\u003e\\\
-        n\\u003cth\\u003etitle\\u003c/th\\u003e\\n\\u003cth\\u003esubtitle\\u003c/th\\\
-        u003e\\n\\u003cth\\u003epublish_date\\u003c/th\\u003e\\n\\u003cth\\u003elang\\\
-        u003c/th\\u003e\\n\\u003cth\\u003elang_skip\\u003c/th\\u003e\\n\\u003cth\\\
-        u003eclass\\u003c/th\\u003e\\n\\u003cth\\u003eimage\\u003c/th\\u003e\\n\\\
-        u003cth\\u003eimage_width\\u003c/th\\u003e\\n\\u003cth\\u003eimage_height\\\
-        u003c/th\\u003e\\n\\u003cth\\u003eprimary_cta\\u003c/th\\u003e\\n\\u003cth\\\
-        u003eprimary_url\\u003c/th\\u003e\\n\\u003cth\\u003esecondary_cta\\u003c/th\\\
-        u003e\\n\\u003cth\\u003esecondary_url\\u003c/th\\u003e\\n\\u003cth\\u003eactive\\\
-        u003c/th\\u003e\\n\\u003cth\\u003eequal_cols\\u003c/th\\u003e\\n\\u003c/tr\\\
-        u003e\\n\\u003c/thead\\u003e\\n\\u003ctbody\\u003e\\n\\u003ctr\\u003e\\n\\\
-        u003ctd\\u003eUbuntu Masters 4\\u003c/td\\u003e\\n\\u003ctd\\u003eA virtual\
-        \ event on open source innovation, featuring leaders from Bosch, Oracle, and\
-        \ more.\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-11-17\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003egrad\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://assets.ubuntu.com/v1/7757c907-ubuntu-masters-logo-wht.svg\\\
-        \" rel=\\\"nofollow noopener\\\"\\u003ehttps://assets.ubuntu.com/v1/7757c907-ubuntu-masters-logo-wht.svg\\\
-        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e270\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003e270\\u003c/td\\u003e\\n\\u003ctd\\u003eBrowse sessions\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e/masters-conference?utm_source=Takeover\\u0026amp;utm_medium=Takeover\\\
-        u0026amp;utm_campaign=CY20_DC_Kubernetes_VEVT_EU2020\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003etrue\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\\
-        u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003eCinque strategie per accelerare\
-        \ l\u2019implementazione di Kubernetes nell\u2019impresa\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003eCome scegliere il miglior approccio Kubernetes per la tua\
-        \ azienda\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-11-17\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003eit\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003edark\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"\
-        https://assets.ubuntu.com/v1/11d594e7-K8s+logo+white+outline.svg\\\" rel=\\\
-        \"nofollow noopener\\\"\\u003ehttps://assets.ubuntu.com/v1/11d594e7-K8s+logo+white+outline.svg\\\
-        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e240\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003e234\\u003c/td\\u003e\\n\\u003ctd\\u003eScarica il whitepaper\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/it/deployment-azienda-manuale?utm_source=Takeover\\\
-        u0026amp;utm_medium=Takeover\\u0026amp;utm_campaign=CY20_DC_Kubernetes_IT_Whitepaper_K8sEnterpriseChallenges\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\\
-        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003eConfronto fra\
-        \ \u201CRed Hat\u2019s Openstack platform\u201D e Charmed Openstack di Canaonical\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003eCharmed Openstack riduce significativamente\
-        \ il costo totale di propriet\xE0\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-11-16\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003eit\\u003c/td\\u003e\\n\\u003ctd\\u003e\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003edark\\u003c/td\\u003e\\n\\u003ctd\\u003e\\\
-        u003ca href=\\\"https://assets.ubuntu.com/v1/2d935f28-openstack-cloud.svg\\\
-        \" rel=\\\"nofollow noopener\\\"\\u003ehttps://assets.ubuntu.com/v1/2d935f28-openstack-cloud.svg\\\
-        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e280\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003e280\\u003c/td\\u003e\\n\\u003ctd\\u003eScarica il whitepaper\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/it/redhat-openstack-confronto-manuale?utm_source=Takeover\\\
-        u0026amp;utm_medium=Takeover\\u0026amp;utm_campaign=7013z000001Wld9AAC\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\\
-        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003eGuide pour\
-        \ r\xE9ussir l\u2019adoption et le d\xE9ploiement d\u2019OpenStack\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003eD\xE9couvrez l\u2019\xE9prouv\xE9 processus d\u2019\
-        impl\xE9mentation OpenStack de Canonical\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-11-16\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003efr\\u003c/td\\u003e\\n\\u003ctd\\u003e\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003edark\\u003c/td\\u003e\\n\\u003ctd\\u003e\\\
-        u003ca href=\\\"https://assets.ubuntu.com/v1/2d935f28-openstack-cloud.svg\\\
-        \" rel=\\\"nofollow noopener\\\"\\u003ehttps://assets.ubuntu.com/v1/2d935f28-openstack-cloud.svg\\\
-        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e250\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003e250\\u003c/td\\u003e\\n\\u003ctd\\u003eT\xE9l\xE9charger guide\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/fr/guide-adoption-openstack?utm_source=Takeover\\\
-        u0026amp;\\u0026amp;utm_medium=Takeover\\u0026amp;utm_campaign=7013z000001WjOjAAK\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\\
-        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003eF\xFCnf Strategien\
-        \ zur Beschleunigung von Kubernetes in Unternehmen\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003eEntscheidungskriterien zur optimalen Herangehensweise an Kubernetes f\xFC\
-        r Ihr Unternehmen\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-11-11\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003ede\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003edark\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\
-        \"https://assets.ubuntu.com/v1/11d594e7-K8s+logo+white+outline.svg\\\" rel=\\\
-        \"nofollow noopener\\\"\\u003ehttps://assets.ubuntu.com/v1/11d594e7-K8s+logo+white+outline.svg\\\
-        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e240\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003e234\\u003c/td\\u003e\\n\\u003ctd\\u003eLaden Sie das White Paper\
-        \ herunter\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/de/kubernetes-implementierung-fur-unternehmen\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\\
-        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003eVergleich von\
-        \ Red Hat OpenStack Platform und Charmed OpenStack von Canonical\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003eSenken Sie Ihre Gesamtkosten deutlich mit Charmed\
-        \ OpenStack\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-11-11\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003ede\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003edark\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"\
-        https://assets.ubuntu.com/v1/2d935f28-openstack-cloud.svg\\\" rel=\\\"nofollow\
-        \ noopener\\\"\\u003ehttps://assets.ubuntu.com/v1/2d935f28-openstack-cloud.svg\\\
-        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e250\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003e250\\u003c/td\\u003e\\n\\u003ctd\\u003eLaden Sie das White Paper\
-        \ herunter\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/de/redhat-openstack-vergleich\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\\
-        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003eCinco estrategias\
-        \ para acelerar a los Kubernetes en la empresa\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003eC\xF3mo elegir el mejor enfoque de Kubernetes para su negocio\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e2020-11-04\\u003c/td\\u003e\\n\\u003ctd\\u003ees\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003edark\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://assets.ubuntu.com/v1/11d594e7-K8s+logo+white+outline.svg\\\
-        \" rel=\\\"nofollow noopener\\\"\\u003ehttps://assets.ubuntu.com/v1/11d594e7-K8s+logo+white+outline.svg\\\
-        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e240\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003e234\\u003c/td\\u003e\\n\\u003ctd\\u003eDescargar el manual\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/es/kubernetes-despliegue-empresa-manual?utm_source=Takeover\\\
-        u0026amp;utm_medium=Takeover\\u0026amp;utm_campaign=7013z000001WkLAAA0\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\\
-        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003eComparando\
-        \ la plataforma OpenStack de Red Hat y la Charmed OpenStack de Canonical\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003eReducir significativamente el coste total\
-        \ de propiedad con Charmed OpenStack\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-11-03\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003ees\\u003c/td\\u003e\\n\\u003ctd\\u003e\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003edark\\u003c/td\\u003e\\n\\u003ctd\\u003e\\\
-        u003ca href=\\\"https://assets.ubuntu.com/v1/2d935f28-openstack-cloud.svg\\\
-        \" rel=\\\"nofollow noopener\\\"\\u003ehttps://assets.ubuntu.com/v1/2d935f28-openstack-cloud.svg\\\
-        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e300\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003e230\\u003c/td\\u003e\\n\\u003ctd\\u003eDescargar el manual\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/es/redhat-openstack-comparacion-manual?utm_source=Takeover\\\
-        u0026amp;utm_medium=Takeover\\u0026amp;utm_campaign=7013z000001WkRmAAK\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\\
-        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003eSecurity, cloud\
-        \ native \\u0026amp; confidential computing\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003eA deep dive into securing against the threats of cyber attacks and data\
-        \ breaches\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-10-23\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003egrad\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://assets.ubuntu.com/v1/cea1e4c7-IBM-Z-logo-white.png\\\
-        \" rel=\\\"nofollow noopener\\\"\\u003ehttps://assets.ubuntu.com/v1/cea1e4c7-IBM-Z-logo-white.png\\\
-        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e180\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003e180\\u003c/td\\u003e\\n\\u003ctd\\u003eRegister for the webinar\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://www.brighttalk.com/webcast/6793/440529?utm_source=Takeover\\\
-        u0026amp;utm_medium=Takeover\\u0026amp;utm_campaign=7013z000001G3QyAAK\\\"\
-        \ rel=\\\"nofollow noopener\\\"\\u003ehttps://www.brighttalk.com/webcast/6793/440529?utm_source=Takeover\\\
-        u0026amp;utm_medium=Takeover\\u0026amp;utm_campaign=7013z000001G3QyAAK\\u003c/a\\\
-        u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\\
-        u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003eWhat\u2019\
-        s new in\\u003cbr\\u003eUbuntu 20.10?\\u003c/td\\u003e\\n\\u003ctd\\u003eIntroducing\
-        \ the Ubuntu Desktop for Raspberry Pi, the latest desktop features and micro\
-        \ clouds.\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-10-22\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003egrad\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://assets.ubuntu.com/v1/fe951eda-20.10_Groovy+Gorilla_RPi_Sketch.svg\\\
-        \" rel=\\\"nofollow noopener\\\"\\u003ehttps://assets.ubuntu.com/v1/fe951eda-20.10_Groovy+Gorilla_RPi_Sketch.svg\\\
-        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e250\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003e388\\u003c/td\\u003e\\n\\u003ctd\\u003eGet Ubuntu 20.10\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e/download\\u003c/td\\u003e\\n\\u003ctd\\u003eLearn\
-        \ more about Ubuntu on the Raspberry Pi\\u003c/td\\u003e\\n\\u003ctd\\u003e/raspberry-pi\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\\
-        u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003eHow\
-        \ to manage risk with secure managed service providers\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003eLearn the standards and control objects that should be met\
-        \ through a certified MSP provide\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-10-23\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003egrad\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\
-        \"https://assets.ubuntu.com/v1/0a819c9c-managed-private-cloud_wht_lrg.svg\\\
-        \" rel=\\\"nofollow noopener\\\"\\u003ehttps://assets.ubuntu.com/v1/0a819c9c-managed-private-cloud_wht_lrg.svg\\\
-        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e220\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003e220\\u003c/td\\u003e\\n\\u003ctd\\u003eRegister for the webinar\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://www.brighttalk.com/webcast/6793/440499?utm_source=Takeover\\\
-        u0026amp;utm_medium=Takeover\\u0026amp;utm_campaign=7013z000001G3QyAAK\\\"\
-        \ rel=\\\"nofollow noopener\\\"\\u003ehttps://www.brighttalk.com/webcast/6793/440499?utm_source=Takeover\\\
-        u0026amp;utm_medium=Takeover\\u0026amp;utm_campaign=7013z000001G3QyAAK\\u003c/a\\\
-        u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003efalse\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\\
-        u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003eCassandra\
-        \ in production\\u003c/td\\u003e\\n\\u003ctd\\u003eReliability and scalability\
-        \ for Cassandra deployments\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-09-31\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003edark\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\
-        \"https://assets.ubuntu.com/v1/f880a3bd-Enterprise+support.svg\\\" rel=\\\"\
-        nofollow noopener\\\"\\u003ehttps://assets.ubuntu.com/v1/f880a3bd-Enterprise+support.svg\\\
-        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e250\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003e250\\u003c/td\\u003e\\n\\u003ctd\\u003eRegister for the webinar\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://www.brighttalk.com/webcast/6793/439718?utm_source=Takeover\\\
-        \" rel=\\\"nofollow noopener\\\"\\u003ehttps://www.brighttalk.com/webcast/6793/439718?utm_source=Takeover\\\
-        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003e\\u003c/td\\u003e\\n\\u003ctd\\u003efalse\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\\
-        u003eStill running Ubuntu 14.04 LTS?\\u003c/td\\u003e\\n\\u003ctd\\u003eLearn\
-        \ how to maintain ongoing security compliance for your Ubuntu 14.04 LTS systems.\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e2019-02-27\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003edark\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://assets.ubuntu.com/v1/2217d1c8-Security.svg\\\
-        \" rel=\\\"nofollow noopener\\\"\\u003ehttps://assets.ubuntu.com/v1/2217d1c8-Security.svg\\\
-        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e154\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003e154\\u003c/td\\u003e\\n\\u003ctd\\u003eWatch the webinar\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e/engage/14-04-esm?utm_source=takeover\\u0026amp;utm_campaign=CY19_DC_UA_WBN_ESM14-04\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003efalse\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\\
-        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003eConnected cars\
-        \ and autonomous driving\\u003c/td\\u003e\\n\\u003ctd\\u003eManaging software\
-        \ for the ultimate edge device including development, extensibility, risk\
-        \ mitigation and security factors.\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-05-31\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003edark\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\
-        \"https://assets.ubuntu.com/v1/5096c143-451-research-vector-white-logo.svg\\\
-        \" rel=\\\"nofollow noopener\\\"\\u003ehttps://assets.ubuntu.com/v1/5096c143-451-research-vector-white-logo.svg\\\
-        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e250\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003e250\\u003c/td\\u003e\\n\\u003ctd\\u003eWatch the webinar\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e/engage/451-automotive?utm_source=Takeover\\u0026amp;utm_medium=Takeover\\\
-        u0026amp;utm_campaign=CY19_IOT_Automotive_WBN_451\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003efalse\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\\
-        n\\u003ctr\\u003e\\n\\u003ctd\\u003eKubernetes for IoT developers\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003eSecurity, flexibility and automation - implementing\
-        \ Kubernetes at the edge.\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-01-10\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003egrad\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\
-        \"https://assets.ubuntu.com/v1/5096c143-451-research-vector-white-logo.svg\\\
-        \" rel=\\\"nofollow noopener\\\"\\u003ehttps://assets.ubuntu.com/v1/5096c143-451-research-vector-white-logo.svg\\\
-        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e311\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003e116\\u003c/td\\u003e\\n\\u003ctd\\u003eDownload the report\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/microk8s-451research?utm_source=Takeover\\\
-        u0026amp;utm_medium=Takeover\\u0026amp;utm_campaign=3)CY20_DC_Kubernetes_Whitepaper_MicroK8s_451Research\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003efalse\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\\
-        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003eUbuntu 17.04\
-        \ has arrived\\u003c/td\\u003e\\n\\u003ctd\\u003eFrom the smallest device\
-        \ to the largest cloud.\\u003c/td\\u003e\\n\\u003ctd\\u003e2017-04-31\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003egrad\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"\
-        https://assets.ubuntu.com/v1/5096c143-451-research-vector-white-logo.svg\\\
-        \" rel=\\\"nofollow noopener\\\"\\u003ehttps://assets.ubuntu.com/v1/5096c143-451-research-vector-white-logo.svg\\\
-        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e311\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003e116\\u003c/td\\u003e\\n\\u003ctd\\u003eGet Ubuntu 17.04\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e/download\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003efalse\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\\
-        u003e\\n\\u003ctd\\u003eUbuntu 17.10\\u003c/td\\u003e\\n\\u003ctd\\u003eBrand\
-        \ new Ubuntu desktop!\\u003c/td\\u003e\\n\\u003ctd\\u003e2017-04-31\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003elight\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\
-        \"https://assets.ubuntu.com/v1/b0b06642-Laptop.png?w=654\\\" rel=\\\"nofollow\
-        \ noopener\\\"\\u003ehttps://assets.ubuntu.com/v1/b0b06642-Laptop.png?w=654\\\
-        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e311\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003e116\\u003c/td\\u003e\\n\\u003ctd\\u003eGet Ubuntu 17.04\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e/download\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003efalse\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\\
-        u003e\\n\\u003ctd\\u003eCloud gaming for Android\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003eBuilding a high performing and scalable platform.\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003e2020-01-31\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003egrad\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://assets.ubuntu.com/v1/b0b06642-Laptop.png?w=654\\\
-        \" rel=\\\"nofollow noopener\\\"\\u003ehttps://assets.ubuntu.com/v1/b0b06642-Laptop.png?w=654\\\
-        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e338\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003e246\\u003c/td\\u003e\\n\\u003ctd\\u003eDownload the whitepaper\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/anbox-cloud-gaming-whitepaper?utm_source=Takeover\\\
-        u0026amp;utm_medium=Takeover\\u0026amp;utm_campaign=CY20_IOT_Mobile_Whitepaper_AnboxCloud\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003efalse\\u003c/td\\u003e\\n\\u003ctd\\u003efalse\\u003c/td\\\
-        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003eAn introduction\
-        \ to Anbox Cloud\\u003c/td\\u003e\\n\\u003ctd\\u003eScalable Android in the\
-        \ cloud\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-01-31\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003egrad\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://assets.ubuntu.com/v1/7e3bd1ed-Anbox-Cloud+computing_outline.svg\\\
-        \" rel=\\\"nofollow noopener\\\"\\u003ehttps://assets.ubuntu.com/v1/7e3bd1ed-Anbox-Cloud+computing_outline.svg\\\
-        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e338\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003e246\\u003c/td\\u003e\\n\\u003ctd\\u003eDownload the whitepaper\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/anbox-cloud-webinar?utm_source=Takeover\\\
-        u0026amp;utm_medium=Takeover\\u0026amp;utm_campaign=CY20_DC_AnboxCloud_WBN_IntrotoAnboxCloud\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003efalse\\u003c/td\\u003e\\n\\u003ctd\\u003efalse\\u003c/td\\\
-        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003ePrecision drone\
-        \ flights at the edge of innovation\\u003c/td\\u003e\\n\\u003ctd\\u003eDiscover\
-        \ how Apellix has designed revolutionary software to solve industrial IoT\
-        \ challenges.\\u003c/td\\u003e\\n\\u003ctd\\u003e2017-04-31\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003egrad\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://assets.ubuntu.com/v1/7e3bd1ed-Anbox-Cloud+computing_outline.svg\\\
-        \" rel=\\\"nofollow noopener\\\"\\u003ehttps://assets.ubuntu.com/v1/7e3bd1ed-Anbox-Cloud+computing_outline.svg\\\
-        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e338\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003e246\\u003c/td\\u003e\\n\\u003ctd\\u003eDownload the whitepaper\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/anbox-cloud-webinar?utm_source=Takeover\\\
-        u0026amp;utm_medium=Takeover\\u0026amp;utm_campaign=CY20_DC_AnboxCloud_WBN_IntrotoAnboxCloud\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003efalse\\u003c/td\\u003e\\n\\u003ctd\\u003efalse\\u003c/td\\\
-        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003eComparing Red\
-        \ Hat OpenStack Platform and Canonical\u2019s Charmed OpenStack\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003eSignificantly reduce TCO with Charmed OpenStack\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e2020-07-29\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003egrad\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://assets.ubuntu.com/v1/2d935f28-openstack-cloud.svg\\\
-        \" rel=\\\"nofollow noopener\\\"\\u003ehttps://assets.ubuntu.com/v1/2d935f28-openstack-cloud.svg\\\
-        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e300\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003e300\\u003c/td\\u003e\\n\\u003ctd\\u003eDownload the whitepaper\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/redhat-openstack-comparison-whitepaper?utm_source=Takeover\\\
-        u0026amp;utm_medium=Takeover\\u0026amp;utm_campaign=CY20_DC_Openstack_Whitepaper_RedHatComparison\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003efalse\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\\
-        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003eFive strategies\
-        \ to\\u003cbr\\u003eaccelerate Kubernetes\\u003cbr\\u003ein the enterprise\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003eHow to choose the best approach to Kubernetes\\\
-        u003cbr\\u003efor your business\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-09-02\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003edark\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\
-        \"https://assets.ubuntu.com/v1/11d594e7-K8s+logo+white+outline.svg\\\" rel=\\\
-        \"nofollow noopener\\\"\\u003ehttps://assets.ubuntu.com/v1/11d594e7-K8s+logo+white+outline.svg\\\
-        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e240\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003e234\\u003c/td\\u003e\\n\\u003ctd\\u003eDownload the whitepaper\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e//engage/kubernetes-deployment-enterprise-whitepaper?utm_source=Takeover\\\
-        u0026amp;utm_medium=Takeover\\u0026amp;utm_campaign=CY20_DC_Kubernetes_Whitepaper_K8sEnterpriseChallenges\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003efalse\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\\
-        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003eFIPS certification\
-        \ and CIS compliance with Ubuntu\\u003c/td\\u003e\\n\\u003ctd\\u003eLearn\
-        \ about Ubuntu CIS and FIPS certified components to enable operating under\
-        \ compliance regimes like FedRAMP, HIPAA, PCI and ISO.\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003e2020-09-02\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003elight\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://assets.ubuntu.com/v1/b576398c-compliance-wht.svg\\\
-        \" rel=\\\"nofollow noopener\\\"\\u003ehttps://assets.ubuntu.com/v1/b576398c-compliance-wht.svg\\\
-        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e400\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003e234\\u003c/td\\u003e\\n\\u003ctd\\u003eRegister for the webinar\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://www.brighttalk.com/webcast/6793/432536?utm_source=Takeover\\\
-        \" rel=\\\"nofollow noopener\\\"\\u003ehttps://www.brighttalk.com/webcast/6793/432536?utm_source=Takeover\\\
-        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003e\\u003c/td\\u003e\\n\\u003ctd\\u003efalse\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\\
-        u003eUbuntu Security: Security and compliance for the full stack\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003eThe full Ubuntu security story. Learn how our teams\
-        \ are securing all your open source, from cloud to edge.\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003e2020-10-01\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003egrad\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://assets.ubuntu.com/v1/1899df43-ubuntu-advantage-circular_white.svg\\\
-        \" rel=\\\"nofollow noopener\\\"\\u003ehttps://assets.ubuntu.com/v1/1899df43-ubuntu-advantage-circular_white.svg\\\
-        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e280\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003e280\\u003c/td\\u003e\\n\\u003ctd\\u003eLearn more\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e/security-series?utm_source=Takeover\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003efalse\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\\
-        n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003eExtend your OpenStack\
-        \ cloud with native backup and recovery\\u003c/td\\u003e\\n\\u003ctd\\u003eLearn\
-        \ how TrilioVault can be easily deployed in a Charmed OpenStack environment\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e2020-09-30\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003edark\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://assets.ubuntu.com/v1/469b4b31-Trilio-openstack-canonical.svg\\\
-        \" rel=\\\"nofollow noopener\\\"\\u003ehttps://assets.ubuntu.com/v1/469b4b31-Trilio-openstack-canonical.svg\\\
-        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e350\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eRegister for the webinar\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/trilio-backup-recovery?utm_source=Takeover\\\
-        u0026amp;utm_medium=Takeover\\u0026amp;utm_campaign=CY20_DC_WBN_OpenStack_Trilio\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003efalse\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\\
-        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003eChoisir une\
-        \ architecture cloud rentable\\u003c/td\\u003e\\n\\u003ctd\\u003eD\xE9couvrez\
-        \ les diff\xE9rentes architectures clouds et comment choisir une architecture\
-        \ rentable\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-03-29\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003efr\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003edark\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"\
-        https://assets.ubuntu.com/v1/2acca081-choosingacloud-white.svg\\\" rel=\\\"\
-        nofollow noopener\\\"\\u003ehttps://assets.ubuntu.com/v1/2acca081-choosingacloud-white.svg\\\
-        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e393\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003e345\\u003c/td\\u003e\\n\\u003ctd\\u003eLire le whitepaper\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/fr/guide-du-DSI-pour-les-operations-multicloud?utm_source=Takeover\\\
-        u0026amp;utm_medium=Takeover\\u0026amp;utm_campaign=7013z000001GHleAAG\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003efalse\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\\
-        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003eMigrer de VMWare\
-        \ \xE0 Openstack\\u003c/td\\u003e\\n\\u003ctd\\u003eApprenez comment migrer\
-        \ d\u2019un environnement traditionnel et propri\xE9taire \xE0 un cloud OpenStack\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e2020-03-29\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003efr\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003elight\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://assets.ubuntu.com/v1/35515576-openstack-cloud.svg\\\
-        \" rel=\\\"nofollow noopener\\\"\\u003ehttps://assets.ubuntu.com/v1/35515576-openstack-cloud.svg\\\
-        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e393\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003e345\\u003c/td\\u003e\\n\\u003ctd\\u003eS\u2019inscrire au webinar\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/fr/vmware-to-openstack?utm_source=Takeover\\\
-        u0026amp;utm_medium=Takeover\\u0026amp;utm_campaign=CY19_DC_France_Openstack_WBN_VmwaretoOpenstack\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003efalse\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\\
-        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003eDo VMware ao\
-        \ Charmed OpenStack\\u003c/td\\u003e\\n\\u003ctd\\u003eReduza os custos e\
-        \ aumente a efici\xEAncia da sua infraestrutura com ado\xE7\xE3o de c\xF3\
-        digo aberto\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-07-22\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003ept\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003edark\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"\
-        https://assets.ubuntu.com/v1/2d935f28-openstack-cloud.svg\\\" rel=\\\"nofollow\
-        \ noopener\\\"\\u003ehttps://assets.ubuntu.com/v1/2d935f28-openstack-cloud.svg\\\
-        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e300\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eLeia o documento t\xE9cnico\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/pt/vmware-para-o-openstack?utm_source=Takeover\\\
-        u0026amp;utm_medium=Takeover\\u0026amp;utm_campaign=7013z000001WaxFAAS\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003efalse\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\\
-        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003eDa VMware a\
-        \ OpenStack\\u003c/td\\u003e\\n\\u003ctd\\u003eCome la migrazione a Charmed\
-        \ OpenStack pu\xF2 ridurre significativamente il TCO\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003e2020-09-02\\u003c/td\\u003e\\n\\u003ctd\\u003eit\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003edark\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://assets.ubuntu.com/v1/2d935f28-openstack-cloud.svg\\\
-        \" rel=\\\"nofollow noopener\\\"\\u003ehttps://assets.ubuntu.com/v1/2d935f28-openstack-cloud.svg\\\
-        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e300\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eScarica il whitepaper\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/it/da-vmware-a-openstack?utm_source=Takeover\\\
-        u0026amp;utm_medium=Takeover\\u0026amp;utm_campaign=CY20_DC_OpenStack_IT_Whitepaper_VMwaretoOpenstack\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003efalse\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\\
-        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003eDa VMware a\
-        \ Charmed Openstack\\u003c/td\\u003e\\n\\u003ctd\\u003eCome la migrazione\
-        \ pu\xF2 tagliare i costi\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-09-15\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003eit\\u003c/td\\u003e\\n\\u003ctd\\u003e\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003edark\\u003c/td\\u003e\\n\\u003ctd\\u003e\\\
-        u003ca href=\\\"https://assets.ubuntu.com/v1/2d935f28-openstack-cloud.svg\\\
-        \" rel=\\\"nofollow noopener\\\"\\u003ehttps://assets.ubuntu.com/v1/2d935f28-openstack-cloud.svg\\\
-        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e300\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eRegistrati al webinar\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/it/da-vmware-a-charmed-openstack?utm_source=Takeover\\\
-        u0026amp;utm_medium=Takeover\\u0026amp;utm_campaign=2)CY20_DC_OpenStack_IT_WBN_VMwaretoOpenstack\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003efalse\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\\
-        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003eUna gu\xED\
-        a para la adopci\xF3n y el despliegue satisfactorios de OpenStack\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003eSuperar los desaf\xEDos de la adopci\xF3n de OpenStack\
-        \ siguiendo un proceso de adopci\xF3n probado\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003e2020-09-15\\u003c/td\\u003e\\n\\u003ctd\\u003ees\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003edark\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003e\\u003ca href=\\\"https://assets.ubuntu.com/v1/dcb2963c-openstack+cloud+outlines.svg\\\
-        \" rel=\\\"nofollow noopener\\\"\\u003ehttps://assets.ubuntu.com/v1/dcb2963c-openstack+cloud+outlines.svg\\\
-        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e320\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eDescargar el manual\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e/engage/es/guia-implementacion-openstack?utm_source=Takeover\\\
-        u0026amp;utm_medium=Takeover\\u0026amp;utm_campaign=7013z000001WhDoAAK\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003efalse\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\\
-        u003e\\n\\u003c/tr\\u003e\\n\\u003c/tbody\\u003e\\n\\u003c/table\\u003e\\\
-        n\\u003c/div\\u003e\\u003c/details\\u003e\",\"post_number\":1,\"post_type\"\
-        :1,\"updated_at\":\"2020-11-18T22:50:16.694Z\",\"reply_count\":0,\"reply_to_post_number\"\
-        :null,\"quote_count\":0,\"incoming_link_count\":23,\"reads\":21,\"score\"\
-        :119.2,\"yours\":false,\"topic_id\":17229,\"topic_slug\":\"engage-pages-and-takeovers\"\
-        ,\"display_username\":\"Peter Mahnke\",\"primary_group_name\":\"Canonical\"\
-        ,\"primary_group_flair_url\":\"https://launchpadlibrarian.net/68730579/64.png\"\
-        ,\"primary_group_flair_bg_color\":\"\",\"primary_group_flair_color\":\"\"\
-        ,\"version\":26,\"can_edit\":false,\"can_delete\":false,\"can_recover\":false,\"\
-        can_wiki\":false,\"link_counts\":[{\"url\":\"https://ubuntu.com/engage\",\"\
-        internal\":false,\"reflection\":false,\"title\":\"Ubuntu case studies, whitepapers\
-        \ and webinars | Ubuntu\",\"clicks\":5},{\"url\":\"https://discourse.ubuntu.com/t/do-vmware-ao-charmed-openstack/18165\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Do VMware ao Charmed OpenStack\"\
-        ,\"clicks\":3},{\"url\":\"https://discourse.ubuntu.com/t/openstack-deployment-guide/17384\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"OpenStack deployment guide\"\
-        ,\"clicks\":2},{\"url\":\"https://discourse.ubuntu.com/t/five-strategies-to-accelerate-kubernetes-deployment-in-the-enterprise/18161\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Five strategies to accelerate\
-        \ Kubernetes deployment in the enterprise\",\"clicks\":2},{\"url\":\"https://discourse.ubuntu.com/t/sensape-uses-landscape-to-remotely-support-revolutionary-interactive-retail-displays/17289\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Sensape uses Landscape\
-        \ to remotely support revolutionary interactive retail displays\",\"clicks\"\
-        :1},{\"url\":\"https://discourse.ubuntu.com/t/kubernetes-from-cloud-to-edge/17398\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Kubernetes from Cloud\
-        \ to Edge\",\"clicks\":1},{\"url\":\"https://discourse.ubuntu.com/t/extension-securite-et-maintenance-pour-ubuntu-14-04/17414\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Extension S\xE9curit\xE9\
-        \ et Maintenance pour Ubuntu 14.04\",\"clicks\":1},{\"url\":\"https://discourse.ubuntu.com/t/cloud-gaming-for-android/18757\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Cloud gaming for Android\"\
-        ,\"clicks\":1},{\"url\":\"https://assets.ubuntu.com/v1/1899df43-ubuntu-advantage-circular_white.svg\"\
-        ,\"internal\":false,\"reflection\":false,\"title\":\"1899df43-ubuntu-advantage-circular_white.svg\"\
-        ,\"clicks\":1},{\"url\":\"https://discourse.ubuntu.com/t/ubuntu-20-10-what-s-new/19050\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Ubuntu 20.10: What\u2019\
-        s new?\",\"clicks\":1},{\"url\":\"https://discourse.ubuntu.com/t/transforming-telco-infrastructure-a-virtual-event/18162\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Transforming telco infrastructure:\
-        \ A virtual event\",\"clicks\":1},{\"url\":\"https://discourse.ubuntu.com/t/keep-up-with-evolving-software/17310\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Keep up with evolving\
-        \ software\",\"clicks\":1},{\"url\":\"https://discourse.ubuntu.com/t/botsandus-builds-a-social-robot-on-ubuntu/17280\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"BotsAndUs builds a social\
-        \ robot on Ubuntu\",\"clicks\":1},{\"url\":\"https://discourse.ubuntu.com/t/openstack-problemlos-installieren-und-skalieren/17409\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"OpenStack problemlos installieren\
-        \ und skalieren\",\"clicks\":1},{\"url\":\"https://discourse.ubuntu.com/t/cinco-estrategias-para-acelerar-a-los-kubernetes-en-la-empresa/19208\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Cinco estrategias para\
-        \ acelerar a los Kubernetes en la empresa\",\"clicks\":1},{\"url\":\"https://discourse.ubuntu.com/t/an-introduction-to-apparmor/17277\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"An introduction to AppArmor\"\
-        ,\"clicks\":1},{\"url\":\"https://discourse.ubuntu.com/t/whats-new-in-ubuntu-19-04/17240\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"What's new in Ubuntu 19.04?\"\
-        ,\"clicks\":1},{\"url\":\"https://discourse.ubuntu.com/t/how-to-build-and-deploy-your-first-ai-ml-model-on-ubuntu/17294\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"How to build and deploy\
-        \ your first AI/ML model on Ubuntu\",\"clicks\":1},{\"url\":\"https://discourse.ubuntu.com/t/confronto-fra-red-hats-openstack-platform-e-charmed-openstack-di-canaonical/19362\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Confronto fra \\\"Red\
-        \ Hat's Openstack platform\\\" e Charmed Openstack di Canaonical\",\"clicks\"\
-        :1},{\"url\":\"https://discourse.ubuntu.com/t/cinque-strategie-per-accelerare-limplementazione-di-kubernetes-nellimpresa/19381\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Cinque strategie per accelerare\
-        \ l'implementazione di Kubernetes nell'impresa\",\"clicks\":1},{\"url\":\"\
-        https://discourse.ubuntu.com/t/da-vmware-a-openstack/18164\",\"internal\"\
-        :true,\"reflection\":false,\"title\":\"Da VMware a OpenStack\",\"clicks\"\
-        :1},{\"url\":\"https://discourse.ubuntu.com/t/how-to-face-the-challenges-of-becoming-a-cloud-operator/17290\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"How to face the challenges\
-        \ of becoming a cloud operator\",\"clicks\":1},{\"url\":\"https://assets.ubuntu.com/v1/11d594e7-K8s+logo+white+outline.svg\"\
-        ,\"internal\":false,\"reflection\":false,\"title\":\"11d594e7-K8s+logo+white+outline.svg\"\
-        ,\"clicks\":0},{\"url\":\"https://assets.ubuntu.com/v1/7e3bd1ed-Anbox-Cloud+computing_outline.svg\"\
-        ,\"internal\":false,\"reflection\":false,\"title\":\"7e3bd1ed-Anbox-Cloud+computing_outline.svg\"\
-        ,\"clicks\":0},{\"url\":\"https://assets.ubuntu.com/v1/2d935f28-openstack-cloud.svg\"\
-        ,\"internal\":false,\"reflection\":false,\"title\":\"2d935f28-openstack-cloud.svg\"\
-        ,\"clicks\":0},{\"url\":\"https://assets.ubuntu.com/v1/b0b06642-Laptop.png?w=654\"\
-        ,\"internal\":false,\"reflection\":false,\"clicks\":0},{\"url\":\"https://assets.ubuntu.com/v1/5096c143-451-research-vector-white-logo.svg\"\
-        ,\"internal\":false,\"reflection\":false,\"title\":\"5096c143-451-research-vector-white-logo.svg\"\
-        ,\"clicks\":0},{\"url\":\"https://assets.ubuntu.com/v1/2217d1c8-Security.svg\"\
-        ,\"internal\":false,\"reflection\":false,\"title\":\"2217d1c8-Security.svg\"\
-        ,\"clicks\":0},{\"url\":\"https://assets.ubuntu.com/v1/f880a3bd-Enterprise+support.svg\"\
-        ,\"internal\":false,\"reflection\":false,\"title\":\"f880a3bd-Enterprise+support.svg\"\
-        ,\"clicks\":0},{\"url\":\"https://assets.ubuntu.com/v1/fe951eda-20.10_Groovy+Gorilla_RPi_Sketch.svg\"\
-        ,\"internal\":false,\"reflection\":false,\"title\":\"fe951eda-20.10_Groovy+Gorilla_RPi_Sketch.svg\"\
-        ,\"clicks\":0},{\"url\":\"https://www.brighttalk.com/webcast/6793/440529?utm_source=Takeover\\\
-        u0026utm_medium=Takeover\\u0026utm_campaign=7013z000001G3QyAAK\",\"internal\"\
-        :false,\"reflection\":false,\"clicks\":0},{\"url\":\"https://assets.ubuntu.com/v1/cea1e4c7-IBM-Z-logo-white.png\"\
-        ,\"internal\":false,\"reflection\":false,\"title\":\"cea1e4c7-IBM-Z-logo-white.png\"\
-        ,\"clicks\":0},{\"url\":\"https://www.brighttalk.com/webcast/6793/440499?utm_source=Takeover\\\
-        u0026utm_medium=Takeover\\u0026utm_campaign=7013z000001G3QyAAK\",\"internal\"\
-        :false,\"reflection\":false,\"clicks\":0},{\"url\":\"https://assets.ubuntu.com/v1/0a819c9c-managed-private-cloud_wht_lrg.svg\"\
-        ,\"internal\":false,\"reflection\":false,\"title\":\"0a819c9c-managed-private-cloud_wht_lrg.svg\"\
-        ,\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/open-digital-platforms-for-the-industrial-edge-cloud-in-2020/19068\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Open digital platforms\
-        \ for the industrial edge cloud in 2020\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/watch-the-raspberry-pi-ubuntu-desktop-intro-video/18577\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Watch the Raspberry Pi\
-        \ Ubuntu Desktop intro video\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/extend-your-openstack-cloud-with-native-backup-and-recover/18911\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Extend your OpenStack\
-        \ cloud with native backup and recover\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/busting-the-myth-of-private-cloud-economics/17244\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Busting the myth of private\
-        \ cloud economics\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/building-powerful-customer-solutions/18481\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Building powerful customer\
-        \ solutions\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/gmo-pepabo-ubuntu/18476\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"GMO Pepabo \\u0026 Ubuntu\"\
-        ,\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/da-vmware-a-charmed-openstack/18478\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Da VMware a Charmed Openstack\"\
-        ,\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/guia-para-la-implementacion-de-openstack/18480\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Gu\xEDa para la implementaci\xF3\
-        n de OpenStack\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/comparing-red-hat-openstack-platform-and-canonicals-charmed-openstack/18159\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Comparing Red Hat OpenStack\
-        \ Platform and Canonical's Charmed OpenStack\",\"clicks\":0},{\"url\":\"https://www.brighttalk.com/webcast/6793/439718?utm_source=Takeover\"\
-        ,\"internal\":false,\"reflection\":false,\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/nfv-and-sdn-on-openstack-for-network-operators/17326\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"NFV and SDN on OpenStack\
-        \ for network operators\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/still-running-ubuntu-14-04/17275\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Still running Ubuntu 14.04?\"\
-        ,\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/production-ai-from-data-lake-to-server-webinar/18163\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Production AI from data\
-        \ lake to server webinar\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/utiliser-des-gpus-avec-kubernetes/17419\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Utiliser des GPUs avec\
-        \ Kubernetes\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/installez-et-mettez-openstack-a-lechelle-en-toute-simplicite/17418\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Installez et mettez OpenStack\
-        \ \xE0 l'\xE9chelle en toute simplicit\xE9\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/le-support-d-ubuntu-14-04-lts-est-maintenant-passe-a-esm/17413\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Le support d\u2019Ubuntu\
-        \ 14.04 LTS est maintenant pass\xE9 \xE0 ESM\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/sicherheit-in-der-private-cloud/17411\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Sicherheit in der Private\
-        \ Cloud\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/wofur-konnen-sie-kubernetes-einsetzen/17410\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Wof\xFCr k\xF6nnen Sie\
-        \ Kubernetes einsetzen?\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/von-vmware-zu-canonical-openstack/17408\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Von VMware zu Canonical\
-        \ OpenStack\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/scale-android-applications-economically-in-the-cloud-with-anbox-cloud/17401\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Scale Android applications\
-        \ economically in the cloud with Anbox Cloud\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/accelerating-iot-device-time-to-market/17399\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Accelerating IoT device\
-        \ time to market\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/scaling-on-azure-with-ubuntu-pro/17397\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Scaling on Azure with\
-        \ Ubuntu Pro\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/a-technical-intro-to-ubuntu-pro/17396\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"A technical intro to Ubuntu\
-        \ Pro\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/migrating-your-infrastructure-to-ubuntu-20-04-lts/17395\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Migrating your infrastructure\
-        \ to Ubuntu 20.04 LTS\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/utilising-cloud-init-on-microsoft-azure/17394\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Utilising cloud-init on\
-        \ Microsoft Azure\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/standardising-machine-learning-from-workstation-to-production/17393\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Standardising machine\
-        \ learning \u2014 from workstation to production\",\"clicks\":0},{\"url\"\
-        :\"https://discourse.ubuntu.com/t/kafka-in-production/17392\",\"internal\"\
-        :true,\"reflection\":false,\"title\":\"Kafka in production\",\"clicks\":0},{\"\
-        url\":\"https://discourse.ubuntu.com/t/solving-the-software-update-challenge-for-iot-devices/17391\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Solving the software update\
-        \ challenge for IoT devices\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/secure-iot-device-management/17390\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Secure IoT device management\"\
-        ,\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/leveraging-open-source-with-ubuntu-pro-on-azure/17389\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Leveraging open source\
-        \ with Ubuntu Pro on Azure\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/streamlined-kubernetes-from-cloud-to-edge/17388\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Streamlined Kubernetes,\
-        \ from Cloud to Edge\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/embracing-the-open-source-mandate/17387\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Embracing the open source\
-        \ mandate\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/what-s-new-in-ubuntu-20-04-lts/17386\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"What\u2019s new in Ubuntu\
-        \ 20.04 LTS?\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/maintaining-business-focus-in-a-cloud-native-world-with-managed-apps/17385\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Maintaining business focus\
-        \ in a cloud-native world with Managed Apps\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/ubuntu-core-a-cybersecurity-analysis/17381\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Ubuntu Core: a cybersecurity\
-        \ analysis\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/virtual-event-microk8s-kubernetes/17380\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Virtual event: MicroK8s\
-        \ \\u0026 Kubernetes\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/rigado-cuts-customers-time-to-market/17379\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Rigado cuts customers'\
-        \ time-to-market\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/securing-ros-robotics-platforms/17378\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Securing ROS robotics\
-        \ platforms\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/smart-card-login-on-ubuntu/17377\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Smart card login on Ubuntu\"\
-        ,\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/esm-maintains-interanas-system-security-while-upgrading/17376\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"ESM maintains Interana's\
-        \ system security while upgrading\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/hosted-private-cloud-infrastructure-a-cost-analysis/17375\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Hosted private cloud infrastructure:\
-        \ a cost analysis\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/an-introduction-to-anbox-cloud/17374\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"An introduction to Anbox\
-        \ Cloud\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/deploy-kubernetes-in-your-data-centre/17373\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Deploy Kubernetes in your\
-        \ data centre\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/artificial-intelligence-at-the-edge-in-a-5g-world/17372\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Artificial Intelligence\
-        \ at the edge in a 5G world\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/de-vmware-a-charmed-openstack/17371\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"De VMware a Charmed OpenStack\"\
-        ,\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/migration-von-vmware-zu-openstack/17370\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Migration von VMware zu\
-        \ OpenStack\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/kubernetes-a-secure-flexible-and-automated-edge-for-iot-developers/17369\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Kubernetes: a secure,\
-        \ flexible and automated edge for IoT developers\",\"clicks\":0},{\"url\"\
-        :\"https://discourse.ubuntu.com/t/ubuntu-desktop-for-the-enterprise/17368\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Ubuntu Desktop for the\
-        \ enterprise\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/an-intro-to-microk8s/17367\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"An intro to MicroK8s\"\
-        ,\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/cyberdyne-keeps-cleaning-robots-up-to-date-in-the-field-with-snaps/17366\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Cyberdyne keeps cleaning\
-        \ robots up-to-date in the field with snaps\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/register-for-wslconf/17365\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Register for WSLConf\"\
-        ,\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/sbi-group-unlocks-infrastructure-automation-with-secure-on-premises-openstack-cloud/17364\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"SBI Group unlocks infrastructure\
-        \ automation with secure, on-premises OpenStack cloud\",\"clicks\":0},{\"\
-        url\":\"https://discourse.ubuntu.com/t/build-smart-display-devices-with-mir-fast-to-production-secure-open-source/17363\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Build smart display devices\
-        \ with Mir: fast to production, secure, open-source\",\"clicks\":0},{\"url\"\
-        :\"https://discourse.ubuntu.com/t/linux-security-with-ubuntu/17362\",\"internal\"\
-        :true,\"reflection\":false,\"title\":\"Linux security with Ubuntu\",\"clicks\"\
-        :0},{\"url\":\"https://discourse.ubuntu.com/t/lessons-learned-from-100-private-cloud-builds/17361\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Lessons learned from 100+\
-        \ Private cloud builds\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/the-wellcome-sanger-institute-turns-to-canonical-for-high-level-ceph-support/17360\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"The Wellcome Sanger Institute\
-        \ turns to Canonical for high level Ceph support\",\"clicks\":0},{\"url\"\
-        :\"https://discourse.ubuntu.com/t/ensuring-security-and-isolation-in-kubernetes-with-kata-containers/17359\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Ensuring security and\
-        \ isolation in Kubernetes with Kata Containers\",\"clicks\":0},{\"url\":\"\
-        https://discourse.ubuntu.com/t/tim-ensures-system-security-and-client-confidence-with-esm/17358\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"TIM ensures system security\
-        \ and client confidence with ESM\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/what-s-new-in-ubuntu-19-10/17357\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"What\u2019s new in Ubuntu\
-        \ 19.10\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/how-domotz-streamlined-provisioning-of-iot-devices/17356\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"How Domotz streamlined\
-        \ provisioning of IoT devices\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/yahoo-japan-builds-their-iaas-environment-with-canonical/17355\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Yahoo! Japan builds their\
-        \ IaaS environment with Canonical\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/accelerating-deep-tech-with-ubuntu/17354\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Accelerating deep tech\
-        \ with Ubuntu\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/machine-learning-operations-mlops/17353\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Machine Learning Operations\
-        \ (MLOps)\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/how-to-manage-snaps-in-an-enterprise-environment/17352\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"How to manage snaps in\
-        \ an enterprise environment\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/a-guide-to-developing-android-apps-on-ubuntu/17351\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"A guide to developing\
-        \ Android apps on Ubuntu\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/creating-accurate-ai-models-with-data/17349\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Creating accurate AI models\
-        \ with data\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/creating-a-cloud-like-bare-metal-experience-in-the-data-centre/17348\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Creating a cloud-like\
-        \ bare metal experience in the data centre\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/a-shift-to-the-linux-app-store-experience/17347\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"A shift to the Linux app\
-        \ store experience\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/taking-charge-of-the-iots-security-vulnerabilities/17346\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Taking charge of the IoT's\
-        \ security vulnerabilities\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/for-ctos-the-no-nonsense-way-to-accelerate-your-business-with-containers/17345\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"For CTOs: the no-nonsense\
-        \ way to accelerate your business with containers\",\"clicks\":0},{\"url\"\
-        :\"https://discourse.ubuntu.com/t/learn-whats-new-in-ubuntu-server-14-04-lts/17344\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Learn What's New In Ubuntu\
-        \ Server 14.04 LTS\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/from-vmware-to-charmed-openstack/17343\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"From VMWare To Charmed\
-        \ OpenStack\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/the-future-of-mobile-connectivity/17342\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"The future of mobile connectivity\"\
-        ,\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/ubuntu-core-and-kura-a-framework-for-iot-gateways/17341\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Ubuntu Core and Kura:\
-        \ A framework for IoT gateways\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/securing-the-enterprise-how-ubuntu-is-at-the-forefront-of-security-and-compliance/17340\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Securing the enterprise:\
-        \ how Ubuntu is at the forefront of security and compliance\",\"clicks\":0},{\"\
-        url\":\"https://discourse.ubuntu.com/t/what-s-new-in-ubuntu-18-10/17339\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"What\u2019s New in Ubuntu\
-        \ 18.10\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/carrier-cloudification-what-every-telecom-executive-needs-to-know/17338\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Carrier Cloudification:\
-        \ What every telecom executive needs to know\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/how-to-escape-stuckstack-and-profit-from-your-openstack-investment/17337\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"How to escape StuckStack\
-        \ and profit from your OpenStack investment\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/getting-started-with-ai/17336\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Getting started with AI\"\
-        ,\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/optimising-iot-bandwidth-with-delta-updates/17335\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Optimising IoT bandwidth\
-        \ with delta updates\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/small-robot-company-sows-the-seeds-for-autonomous-and-more-profitable-farming/17334\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Small Robot Company sows\
-        \ the seeds for autonomous and more profitable farming\",\"clicks\":0},{\"\
-        url\":\"https://discourse.ubuntu.com/t/key-considerations-when-choosing-a-robot-s-operating-system/17333\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Key considerations when\
-        \ choosing a robot\u2019s operating system\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/make-it-rain-public-cloud-on-ubuntu-openstack/17332\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Make IT rain: public cloud\
-        \ on Ubuntu OpenStack\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/building-a-private-cloud-take-the-leap/17331\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Building a private cloud?\
-        \ Take the leap!\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/telcos-and-service-providers-expect-near-100-uptime/17330\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Telcos and Service Providers\
-        \ expect near 100% uptime\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/private-cloud-security/17421\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Private cloud security\"\
-        ,\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/private-cloud-security-webinar/17329\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Private cloud security\
-        \ Webinar\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/openstack-made-easy/17328\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"OpenStack made easy\"\
-        ,\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/north-america-s-first-autonomous-runway-snowplough/17327\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"North America\u2018s first\
-        \ autonomous runway snowplough\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/cio-guide-to-multi-cloud-operations/17325\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"CIO guide to multi-cloud\
-        \ operations\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/modernise-your-cloud/17324\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Modernise your cloud\"\
-        ,\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/how-to-integrate-ubuntu-desktop-with-active-directory/17323\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"How to integrate Ubuntu\
-        \ Desktop with Active Directory\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/how-to-build-a-lightweight-system-container-cluster/17322\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"How to build a lightweight\
-        \ system container cluster\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/low-latency-and-real-time-kernels-for-telco-and-nfv/17321\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Low latency and real time\
-        \ kernels for telco and NFV\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/low-latency-and-real-time-kernels-for-telco-and-nfv/17320\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Low latency and real-time\
-        \ kernels for telco and NFV\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/allan-gray-unlocks-unprecedented-availability-and-productivity-with-charmed-kubernetes/17319\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Allan Gray unlocks unprecedented\
-        \ availability and productivity with Charmed Kubernetes\",\"clicks\":0},{\"\
-        url\":\"https://discourse.ubuntu.com/t/securing-iot-device-data-against-physical-access/17318\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Securing IoT device data\
-        \ against physical access\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/the-transformation-of-the-devops-journey-in-iot/17422\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"The transformation of\
-        \ the DevOps journey in IoT\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/establishing-a-software-defined-iot-business-model/17317\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Establishing a software\
-        \ defined IoT business model\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/precision-drones-on-ubuntu-flying-at-the-edge-of-innovation/17316\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Precision drones on Ubuntu:\
-        \ flying at the edge of innovation\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/apellix-engineers-safer-work-environments-with-ubuntu-powered-aerial-robotics/17315\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Apellix engineers safer\
-        \ work environments with Ubuntu powered aerial robotics\",\"clicks\":0},{\"\
-        url\":\"https://discourse.ubuntu.com/t/hiri-successfully-monetises-their-snap/17314\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Hiri successfully monetises\
-        \ their snap\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/future-proofing-fingbox-the-iot-home-network-monitoring-device/17313\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Future-proofing Fingbox,\
-        \ the IoT home network monitoring device\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/multi-cloud-fundamental-to-financial-services-transformation/17312\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Multi-cloud fundamental\
-        \ to financial services transformation\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/fing-serves-30-000-customers-with-a-secure-future-proof-iot-device/17311\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Fing serves 30,000 customers\
-        \ with a secure, future-proof IoT device\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/canonical-presents-financial-services-month/17241\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Canonical presents Financial\
-        \ Services Month\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/the-essential-guide-for-telecoms-and-service-providers-adopting-big-data-solutions/17309\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"The essential guide for\
-        \ Telecoms and Service Providers adopting big data solutions\",\"clicks\"\
-        :0},{\"url\":\"https://discourse.ubuntu.com/t/a-guide-to-edge-computing-and-the-tools-you-need/17308\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"A guide to edge computing\
-        \ and the tools you need\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/server-provisioning-what-network-admins-it-pros-need-to-know/17307\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Server Provisioning: What\
-        \ Network Admins \\u0026 IT Pros Need to Know\",\"clicks\":0},{\"url\":\"\
-        https://discourse.ubuntu.com/t/the-transformation-of-the-devops-journey-in-iot-webinar/17306\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"The transformation of\
-        \ the DevOps journey in IoT Webinar\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/get-started-with-devops-best-practices-ci-cd/17305\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Get started with DevOps\
-        \ best practices: CI/CD\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/cto-s-guide-to-sdn-nfv-vnf/17293\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"CTO\u2019s guide to SDN,\
-        \ NFV \\u0026 VNF\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/why-ubuntu-core-is-the-most-secure-choice-for-iot/17292\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Why Ubuntu Core is the\
-        \ most secure choice for IoT\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/cloud-init/17291\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Cloud init\",\"clicks\"\
-        :0},{\"url\":\"https://discourse.ubuntu.com/t/rocket-chat-communication-platform-enables-simplicity-through-snaps/17288\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Rocket.Chat communication\
-        \ platform enables simplicity through snaps\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/nexiona-collaborates-with-canonical-and-dell-to-create-miimetiq-edge/17287\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"NEXIONA collaborates with\
-        \ Canonical and Dell to create MIIMETIQ EDGE\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/itstrategen-keeps-legacy-applications-secure-with-extended-security-maintenance/17286\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"ITstrategen keeps legacy\
-        \ applications secure with Extended Security Maintenance\",\"clicks\":0},{\"\
-        url\":\"https://discourse.ubuntu.com/t/how-ubuntu-helped-innovapos-revolutionise-the-vending-machine-industry/17285\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"How Ubuntu helped InnovaPOS\
-        \ revolutionise the vending machine industry\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/ims-evolve-adopts-ubuntu-core-to-provide-iot-enabled-business-intelligence-in-the-supply-chain/17284\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"IMS Evolve adopts Ubuntu\
-        \ Core to provide IoT-enabled business intelligence in the supply chain\"\
-        ,\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/commercetools-uses-ubuntu-server-to-power-its-next-generation-ecommerce-platform/17283\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Commercetools uses Ubuntu\
-        \ Server to power its next-generation ecommerce platform\",\"clicks\":0},{\"\
-        url\":\"https://discourse.ubuntu.com/t/city-network-brings-openstack-cloud-hosting-to-the-financial-services-sector-with-canonical/17282\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"City Network brings OpenStack\
-        \ cloud hosting to the financial services sector with Canonical\",\"clicks\"\
-        :0},{\"url\":\"https://discourse.ubuntu.com/t/cinergy-makes-significant-digital-signage-saving-with-screenly-pro-and-ubuntu-core/17281\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Cinergy makes significant\
-        \ digital signage saving with Screenly Pro and Ubuntu Core\",\"clicks\":0},{\"\
-        url\":\"https://discourse.ubuntu.com/t/azlogica-utilise-ubuntu-core-for-customised-iot-agricultural-solutions/17279\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"AZLOGICA utilise Ubuntu\
-        \ Core for customised IoT agricultural solutions\",\"clicks\":0},{\"url\"\
-        :\"https://discourse.ubuntu.com/t/azeti-uses-ubuntu-core-to-improve-deployment-and-security/17278\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Azeti uses Ubuntu Core\
-        \ to improve deployment and security\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/artificial-intelligence-machine-learning-and-ubuntu/17276\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Artificial intelligence,\
-        \ machine learning and Ubuntu\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/how-to-get-started-and-progress-with-an-ai-program/17245\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"How to get started and\
-        \ progress with an AI program\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/connected-cars-and-autonomous-driving/17243\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Connected cars and autonomous\
-        \ driving\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/six-reasons-why-developers-choose-ubuntu-desktop/17304\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Six reasons why developers\
-        \ choose Ubuntu Desktop\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/9-out-of-top-10-us-european-financial-institutions-use-ubuntu/19304\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"9 out of top 10 US \\\
-        u0026 European financial institutions use Ubuntu\",\"clicks\":0},{\"url\"\
-        :\"https://assets.ubuntu.com/v1/7757c907-ubuntu-masters-logo-wht.svg\",\"\
-        internal\":false,\"reflection\":false,\"title\":\"7757c907-ubuntu-masters-logo-wht.svg\"\
-        ,\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/guide-pour-reussir-ladoption-et-le-deploiement-dopenstack/19361\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Guide pour r\xE9ussir\
-        \ l'adoption et le d\xE9ploiement d'OpenStack\",\"clicks\":0},{\"url\":\"\
-        https://discourse.ubuntu.com/t/funf-strategien-zur-beschleunigung-von-kubernetes-in-unternehmen/19284\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"F\xFCnf Strategien zur\
-        \ Beschleunigung von Kubernetes in Unternehmen\",\"clicks\":0},{\"url\":\"\
-        https://discourse.ubuntu.com/t/vergleich-von-red-hat-openstack-platform-und-charmed-openstack-von-canonical/19285\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Vergleich von Red Hat\
-        \ OpenStack Platform und Charmed OpenStack von Canonical\",\"clicks\":0},{\"\
-        url\":\"https://discourse.ubuntu.com/t/comparando-la-plataforma-openstack-de-red-hat-y-la-charmed-openstack-de-canonical/19194\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Comparando la plataforma\
-        \ OpenStack de Red Hat y la Charmed OpenStack de Canonical\",\"clicks\":0},{\"\
-        url\":\"https://discourse.ubuntu.com/t/at-t-private-offer-on-azure-ubuntu-pro-support/19161\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"AT\\u0026T Private Offer\
-        \ on Azure - Ubuntu Pro + Support\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/charmed-openstack-reference-architecture/19160\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Charmed OpenStack reference\
-        \ architecture\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/charmed-kubernetes-reference-architecture/19159\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Charmed Kubernetes reference\
-        \ architecture\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/migrer-de-vmware-a-openstack-webinaire/17420\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Migrer de VMware \xE0\
-        \ Openstack Webinaire\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/migrer-de-vmware-a-openstack/17417\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Migrer de VMWare \xE0\
-        \ OpenStack\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/canonical-annonce-managed-apps-linfogerance-des-applications-sur-votre-cloud/17416\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Canonical annonce Managed\
-        \ Apps: l'infog\xE9rance des applications sur votre cloud\",\"clicks\":0},{\"\
-        url\":\"https://discourse.ubuntu.com/t/guide-du-dsi-pour-les-operations-multicloud/17415\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"GUIDE DU DSI pour les\
-        \ op\xE9rations multicloud\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/canonical-integre-containerd-a-ubuntu-kubernetes/17412\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Canonical int\xE8gre containerd\
-        \ \xE0 Ubuntu Kubernetes\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/optimised-authentication-methods-for-ubuntu-desktop/19133\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Optimised authentication\
-        \ methods for Ubuntu Desktop\",\"clicks\":0},{\"url\":\"https://assets.ubuntu.com/v1/dcb2963c-openstack+cloud+outlines.svg\"\
-        ,\"internal\":false,\"reflection\":false,\"title\":\"dcb2963c-openstack+cloud+outlines.svg\"\
-        ,\"clicks\":0},{\"url\":\"https://assets.ubuntu.com/v1/35515576-openstack-cloud.svg\"\
-        ,\"internal\":false,\"reflection\":false,\"title\":\"35515576-openstack-cloud.svg\"\
-        ,\"clicks\":0},{\"url\":\"https://assets.ubuntu.com/v1/2acca081-choosingacloud-white.svg\"\
-        ,\"internal\":false,\"reflection\":false,\"title\":\"2acca081-choosingacloud-white.svg\"\
-        ,\"clicks\":0},{\"url\":\"https://assets.ubuntu.com/v1/469b4b31-Trilio-openstack-canonical.svg\"\
-        ,\"internal\":false,\"reflection\":false,\"title\":\"469b4b31-Trilio-openstack-canonical.svg\"\
-        ,\"clicks\":0},{\"url\":\"https://www.brighttalk.com/webcast/6793/432536?utm_source=Takeover\"\
-        ,\"internal\":false,\"reflection\":false,\"clicks\":0},{\"url\":\"https://assets.ubuntu.com/v1/b576398c-compliance-wht.svg\"\
-        ,\"internal\":false,\"reflection\":false,\"title\":\"b576398c-compliance-wht.svg\"\
-        ,\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/how-to-add-engage-pages/18185\"\
-        ,\"internal\":true,\"reflection\":true,\"title\":\"How to add engage pages\"\
-        ,\"clicks\":4}],\"read\":true,\"user_title\":null,\"actions_summary\":[],\"\
-        moderator\":false,\"admin\":true,\"staff\":true,\"user_id\":320,\"hidden\"\
-        :false,\"trust_level\":2,\"deleted_at\":null,\"user_deleted\":false,\"edit_reason\"\
-        :null,\"can_view_edit_history\":true,\"wiki\":false,\"can_accept_answer\"\
-        :false,\"can_unaccept_answer\":false,\"accepted_answer\":false}],\"stream\"\
-        :[48547]},\"timeline_lookup\":[[1,128]],\"suggested_topics\":[{\"id\":17336,\"\
-        title\":\"Getting started with AI\",\"fancy_title\":\"Getting started with\
-        \ AI\",\"slug\":\"getting-started-with-ai\",\"posts_count\":1,\"reply_count\"\
-        :0,\"highest_post_number\":1,\"image_url\":null,\"created_at\":\"2020-07-17T13:22:28.750Z\"\
-        ,\"last_posted_at\":\"2020-07-17T13:22:28.901Z\",\"bumped\":true,\"bumped_at\"\
-        :\"2020-07-17T13:22:28.901Z\",\"unseen\":false,\"pinned\":false,\"unpinned\"\
-        :null,\"visible\":true,\"closed\":false,\"archived\":false,\"bookmarked\"\
-        :null,\"liked\":null,\"tags\":[],\"archetype\":\"regular\",\"like_count\"\
-        :0,\"views\":134,\"category_id\":51,\"featured_link\":null,\"has_accepted_answer\"\
-        :false,\"posters\":[{\"extras\":\"latest single\",\"description\":\"Original\
-        \ Poster, Most Recent Poster\",\"user\":{\"id\":11720,\"username\":\"owenrm\"\
-        ,\"name\":\"Owenrm\",\"avatar_template\":\"/letter_avatar/owenrm/{size}/5_6d6f4cde2641c35611d5cac2fb97c77e.png\"\
-        }}]},{\"id\":17338,\"title\":\"Carrier Cloudification: What every telecom\
-        \ executive needs to know\",\"fancy_title\":\"Carrier Cloudification: What\
-        \ every telecom executive needs to know\",\"slug\":\"carrier-cloudification-what-every-telecom-executive-needs-to-know\"\
-        ,\"posts_count\":1,\"reply_count\":0,\"highest_post_number\":1,\"image_url\"\
-        :null,\"created_at\":\"2020-07-17T13:23:55.609Z\",\"last_posted_at\":\"2020-07-17T13:23:55.743Z\"\
-        ,\"bumped\":true,\"bumped_at\":\"2020-07-17T13:23:55.743Z\",\"unseen\":false,\"\
-        pinned\":false,\"unpinned\":null,\"visible\":true,\"closed\":false,\"archived\"\
-        :false,\"bookmarked\":null,\"liked\":null,\"tags\":[],\"archetype\":\"regular\"\
-        ,\"like_count\":0,\"views\":95,\"category_id\":51,\"featured_link\":null,\"\
-        has_accepted_answer\":false,\"posters\":[{\"extras\":\"latest single\",\"\
-        description\":\"Original Poster, Most Recent Poster\",\"user\":{\"id\":11720,\"\
-        username\":\"owenrm\",\"name\":\"Owenrm\",\"avatar_template\":\"/letter_avatar/owenrm/{size}/5_6d6f4cde2641c35611d5cac2fb97c77e.png\"\
-        }}]},{\"id\":17285,\"title\":\"How Ubuntu helped InnovaPOS revolutionise the\
-        \ vending machine industry\",\"fancy_title\":\"How Ubuntu helped InnovaPOS\
-        \ revolutionise the vending machine industry\",\"slug\":\"how-ubuntu-helped-innovapos-revolutionise-the-vending-machine-industry\"\
-        ,\"posts_count\":1,\"reply_count\":0,\"highest_post_number\":1,\"image_url\"\
-        :null,\"created_at\":\"2020-07-17T10:36:54.656Z\",\"last_posted_at\":\"2020-07-17T10:36:54.813Z\"\
-        ,\"bumped\":true,\"bumped_at\":\"2020-07-17T10:36:54.813Z\",\"unseen\":false,\"\
-        pinned\":false,\"unpinned\":null,\"visible\":true,\"closed\":false,\"archived\"\
-        :false,\"bookmarked\":null,\"liked\":null,\"tags\":[],\"archetype\":\"regular\"\
-        ,\"like_count\":0,\"views\":118,\"category_id\":51,\"featured_link\":null,\"\
-        has_accepted_answer\":false,\"posters\":[{\"extras\":\"latest single\",\"\
-        description\":\"Original Poster, Most Recent Poster\",\"user\":{\"id\":11720,\"\
-        username\":\"owenrm\",\"name\":\"Owenrm\",\"avatar_template\":\"/letter_avatar/owenrm/{size}/5_6d6f4cde2641c35611d5cac2fb97c77e.png\"\
-        }}]},{\"id\":17306,\"title\":\"The transformation of the DevOps journey in\
-        \ IoT Webinar\",\"fancy_title\":\"The transformation of the DevOps journey\
-        \ in IoT Webinar\",\"slug\":\"the-transformation-of-the-devops-journey-in-iot-webinar\"\
-        ,\"posts_count\":1,\"reply_count\":0,\"highest_post_number\":1,\"image_url\"\
-        :null,\"created_at\":\"2020-07-17T12:27:22.792Z\",\"last_posted_at\":\"2020-07-17T12:27:22.947Z\"\
-        ,\"bumped\":true,\"bumped_at\":\"2020-07-17T16:56:51.056Z\",\"unseen\":false,\"\
-        pinned\":false,\"unpinned\":null,\"visible\":true,\"closed\":false,\"archived\"\
-        :false,\"bookmarked\":null,\"liked\":null,\"tags\":[],\"archetype\":\"regular\"\
-        ,\"like_count\":0,\"views\":117,\"category_id\":51,\"featured_link\":null,\"\
-        has_accepted_answer\":false,\"posters\":[{\"extras\":\"latest single\",\"\
-        description\":\"Original Poster, Most Recent Poster\",\"user\":{\"id\":320,\"\
-        username\":\"peterm-ubuntu\",\"name\":\"Peter Mahnke\",\"avatar_template\"\
-        :\"/user_avatar/discourse.ubuntu.com/peterm-ubuntu/{size}/7873_2.png\"}}]},{\"\
-        id\":17393,\"title\":\"Standardising machine learning \u2014 from workstation\
-        \ to production\",\"fancy_title\":\"Standardising machine learning \u2014\
-        \ from workstation to production\",\"slug\":\"standardising-machine-learning-from-workstation-to-production\"\
-        ,\"posts_count\":1,\"reply_count\":0,\"highest_post_number\":1,\"image_url\"\
-        :null,\"created_at\":\"2020-07-17T16:12:37.317Z\",\"last_posted_at\":\"2020-07-17T16:12:37.436Z\"\
-        ,\"bumped\":true,\"bumped_at\":\"2020-07-17T16:12:37.436Z\",\"unseen\":false,\"\
-        pinned\":false,\"unpinned\":null,\"visible\":true,\"closed\":false,\"archived\"\
-        :false,\"bookmarked\":null,\"liked\":null,\"tags\":[],\"archetype\":\"regular\"\
-        ,\"like_count\":0,\"views\":121,\"category_id\":51,\"featured_link\":null,\"\
-        has_accepted_answer\":false,\"posters\":[{\"extras\":\"latest single\",\"\
-        description\":\"Original Poster, Most Recent Poster\",\"user\":{\"id\":11720,\"\
-        username\":\"owenrm\",\"name\":\"Owenrm\",\"avatar_template\":\"/letter_avatar/owenrm/{size}/5_6d6f4cde2641c35611d5cac2fb97c77e.png\"\
-        }}]}],\"tags\":[],\"id\":17229,\"title\":\"Engage pages and Takeovers\",\"\
-        fancy_title\":\"Engage pages and Takeovers\",\"posts_count\":1,\"created_at\"\
-        :\"2020-07-14T09:57:15.561Z\",\"views\":350,\"reply_count\":0,\"like_count\"\
-        :0,\"last_posted_at\":null,\"visible\":true,\"closed\":false,\"archived\"\
-        :false,\"has_summary\":false,\"archetype\":\"regular\",\"slug\":\"engage-pages-and-takeovers\"\
-        ,\"category_id\":51,\"word_count\":7985,\"deleted_at\":null,\"user_id\":320,\"\
-        featured_link\":null,\"pinned_globally\":false,\"pinned_at\":\"2020-07-14T09:57:15.469Z\"\
-        ,\"pinned_until\":null,\"draft\":null,\"draft_key\":\"topic_17229\",\"draft_sequence\"\
-        :null,\"unpinned\":null,\"pinned\":true,\"current_post_number\":1,\"highest_post_number\"\
-        :1,\"deleted_by\":null,\"actions_summary\":[{\"id\":4,\"count\":0,\"hidden\"\
-        :false,\"can_act\":false},{\"id\":8,\"count\":0,\"hidden\":false,\"can_act\"\
-        :false},{\"id\":7,\"count\":0,\"hidden\":false,\"can_act\":false}],\"chunk_size\"\
-        :20,\"bookmarked\":null,\"topic_timer\":null,\"message_bus_last_id\":227,\"\
-        participant_count\":1,\"details\":{\"notification_level\":1,\"participants\"\
-        :[{\"id\":320,\"username\":\"peterm-ubuntu\",\"name\":\"Peter Mahnke\",\"\
-        avatar_template\":\"/user_avatar/discourse.ubuntu.com/peterm-ubuntu/{size}/7873_2.png\"\
-        ,\"post_count\":1,\"primary_group_name\":\"Canonical\",\"primary_group_flair_url\"\
-        :\"https://launchpadlibrarian.net/68730579/64.png\",\"primary_group_flair_color\"\
-        :\"\",\"primary_group_flair_bg_color\":\"\"}],\"created_by\":{\"id\":320,\"\
-        username\":\"peterm-ubuntu\",\"name\":\"Peter Mahnke\",\"avatar_template\"\
-        :\"/user_avatar/discourse.ubuntu.com/peterm-ubuntu/{size}/7873_2.png\"},\"\
-        last_poster\":{\"id\":320,\"username\":\"peterm-ubuntu\",\"name\":\"Peter\
-        \ Mahnke\",\"avatar_template\":\"/user_avatar/discourse.ubuntu.com/peterm-ubuntu/{size}/7873_2.png\"\
-        },\"links\":[{\"url\":\"https://ubuntu.com/engage\",\"title\":\"Ubuntu case\
-        \ studies, whitepapers and webinars | Ubuntu\",\"internal\":false,\"attachment\"\
-        :false,\"reflection\":false,\"clicks\":5,\"user_id\":320,\"domain\":\"ubuntu.com\"\
-        ,\"root_domain\":\"ubuntu.com\"},{\"url\":\"https://discourse.ubuntu.com/t/how-to-add-engage-pages/18185\"\
-        ,\"title\":\"How to add engage pages\",\"internal\":true,\"attachment\":false,\"\
-        reflection\":true,\"clicks\":4,\"user_id\":9642,\"domain\":\"discourse.ubuntu.com\"\
-        ,\"root_domain\":\"ubuntu.com\"},{\"url\":\"https://discourse.ubuntu.com/t/do-vmware-ao-charmed-openstack/18165\"\
-        ,\"title\":\"Do VMware ao Charmed OpenStack\",\"internal\":true,\"attachment\"\
-        :false,\"reflection\":false,\"clicks\":3,\"user_id\":320,\"domain\":\"discourse.ubuntu.com\"\
-        ,\"root_domain\":\"ubuntu.com\"},{\"url\":\"https://discourse.ubuntu.com/t/five-strategies-to-accelerate-kubernetes-deployment-in-the-enterprise/18161\"\
-        ,\"title\":\"Five strategies to accelerate Kubernetes deployment in the enterprise\"\
-        ,\"internal\":true,\"attachment\":false,\"reflection\":false,\"clicks\":2,\"\
-        user_id\":320,\"domain\":\"discourse.ubuntu.com\",\"root_domain\":\"ubuntu.com\"\
-        },{\"url\":\"https://discourse.ubuntu.com/t/openstack-deployment-guide/17384\"\
-        ,\"title\":\"OpenStack deployment guide\",\"internal\":true,\"attachment\"\
-        :false,\"reflection\":false,\"clicks\":2,\"user_id\":320,\"domain\":\"discourse.ubuntu.com\"\
-        ,\"root_domain\":\"ubuntu.com\"},{\"url\":\"https://discourse.ubuntu.com/t/cloud-gaming-for-android/18757\"\
-        ,\"title\":\"Cloud gaming for Android\",\"internal\":true,\"attachment\":false,\"\
-        reflection\":false,\"clicks\":1,\"user_id\":320,\"domain\":\"discourse.ubuntu.com\"\
-        ,\"root_domain\":\"ubuntu.com\"},{\"url\":\"https://discourse.ubuntu.com/t/confronto-fra-red-hats-openstack-platform-e-charmed-openstack-di-canaonical/19362\"\
-        ,\"title\":\"Confronto fra \\\"Red Hat's Openstack platform\\\" e Charmed\
-        \ Openstack di Canaonical\",\"internal\":true,\"attachment\":false,\"reflection\"\
-        :false,\"clicks\":1,\"user_id\":320,\"domain\":\"discourse.ubuntu.com\",\"\
-        root_domain\":\"ubuntu.com\"},{\"url\":\"https://discourse.ubuntu.com/t/da-vmware-a-openstack/18164\"\
-        ,\"title\":\"Da VMware a OpenStack\",\"internal\":true,\"attachment\":false,\"\
-        reflection\":false,\"clicks\":1,\"user_id\":320,\"domain\":\"discourse.ubuntu.com\"\
-        ,\"root_domain\":\"ubuntu.com\"},{\"url\":\"https://discourse.ubuntu.com/t/extension-securite-et-maintenance-pour-ubuntu-14-04/17414\"\
-        ,\"title\":\"Extension S\xE9curit\xE9 et Maintenance pour Ubuntu 14.04\",\"\
-        internal\":true,\"attachment\":false,\"reflection\":false,\"clicks\":1,\"\
-        user_id\":320,\"domain\":\"discourse.ubuntu.com\",\"root_domain\":\"ubuntu.com\"\
-        },{\"url\":\"https://assets.ubuntu.com/v1/1899df43-ubuntu-advantage-circular_white.svg\"\
-        ,\"title\":\"1899df43-ubuntu-advantage-circular_white.svg\",\"internal\":false,\"\
-        attachment\":false,\"reflection\":false,\"clicks\":1,\"user_id\":320,\"domain\"\
-        :\"assets.ubuntu.com\",\"root_domain\":\"ubuntu.com\"},{\"url\":\"https://discourse.ubuntu.com/t/how-to-build-and-deploy-your-first-ai-ml-model-on-ubuntu/17294\"\
-        ,\"title\":\"How to build and deploy your first AI/ML model on Ubuntu\",\"\
-        internal\":true,\"attachment\":false,\"reflection\":false,\"clicks\":1,\"\
-        user_id\":320,\"domain\":\"discourse.ubuntu.com\",\"root_domain\":\"ubuntu.com\"\
-        },{\"url\":\"https://discourse.ubuntu.com/t/how-to-face-the-challenges-of-becoming-a-cloud-operator/17290\"\
-        ,\"title\":\"How to face the challenges of becoming a cloud operator\",\"\
-        internal\":true,\"attachment\":false,\"reflection\":false,\"clicks\":1,\"\
-        user_id\":320,\"domain\":\"discourse.ubuntu.com\",\"root_domain\":\"ubuntu.com\"\
-        },{\"url\":\"https://discourse.ubuntu.com/t/keep-up-with-evolving-software/17310\"\
-        ,\"title\":\"Keep up with evolving software\",\"internal\":true,\"attachment\"\
-        :false,\"reflection\":false,\"clicks\":1,\"user_id\":320,\"domain\":\"discourse.ubuntu.com\"\
-        ,\"root_domain\":\"ubuntu.com\"},{\"url\":\"https://discourse.ubuntu.com/t/kubernetes-from-cloud-to-edge/17398\"\
-        ,\"title\":\"Kubernetes from Cloud to Edge\",\"internal\":true,\"attachment\"\
-        :false,\"reflection\":false,\"clicks\":1,\"user_id\":320,\"domain\":\"discourse.ubuntu.com\"\
-        ,\"root_domain\":\"ubuntu.com\"},{\"url\":\"https://discourse.ubuntu.com/t/openstack-problemlos-installieren-und-skalieren/17409\"\
-        ,\"title\":\"OpenStack problemlos installieren und skalieren\",\"internal\"\
-        :true,\"attachment\":false,\"reflection\":false,\"clicks\":1,\"user_id\":320,\"\
-        domain\":\"discourse.ubuntu.com\",\"root_domain\":\"ubuntu.com\"},{\"url\"\
-        :\"https://discourse.ubuntu.com/t/sensape-uses-landscape-to-remotely-support-revolutionary-interactive-retail-displays/17289\"\
-        ,\"title\":\"Sensape uses Landscape to remotely support revolutionary interactive\
-        \ retail displays\",\"internal\":true,\"attachment\":false,\"reflection\"\
-        :false,\"clicks\":1,\"user_id\":320,\"domain\":\"discourse.ubuntu.com\",\"\
-        root_domain\":\"ubuntu.com\"},{\"url\":\"https://discourse.ubuntu.com/t/transforming-telco-infrastructure-a-virtual-event/18162\"\
-        ,\"title\":\"Transforming telco infrastructure: A virtual event\",\"internal\"\
-        :true,\"attachment\":false,\"reflection\":false,\"clicks\":1,\"user_id\":320,\"\
-        domain\":\"discourse.ubuntu.com\",\"root_domain\":\"ubuntu.com\"},{\"url\"\
-        :\"https://discourse.ubuntu.com/t/ubuntu-20-10-what-s-new/19050\",\"title\"\
-        :\"Ubuntu 20.10: What\u2019s new?\",\"internal\":true,\"attachment\":false,\"\
-        reflection\":false,\"clicks\":1,\"user_id\":320,\"domain\":\"discourse.ubuntu.com\"\
-        ,\"root_domain\":\"ubuntu.com\"},{\"url\":\"https://discourse.ubuntu.com/t/whats-new-in-ubuntu-19-04/17240\"\
-        ,\"title\":\"What's new in Ubuntu 19.04?\",\"internal\":true,\"attachment\"\
-        :false,\"reflection\":false,\"clicks\":1,\"user_id\":320,\"domain\":\"discourse.ubuntu.com\"\
-        ,\"root_domain\":\"ubuntu.com\"},{\"url\":\"https://discourse.ubuntu.com/t/botsandus-builds-a-social-robot-on-ubuntu/17280\"\
-        ,\"title\":\"BotsAndUs builds a social robot on Ubuntu\",\"internal\":true,\"\
-        attachment\":false,\"reflection\":false,\"clicks\":1,\"user_id\":320,\"domain\"\
-        :\"discourse.ubuntu.com\",\"root_domain\":\"ubuntu.com\"},{\"url\":\"https://discourse.ubuntu.com/t/an-introduction-to-apparmor/17277\"\
-        ,\"title\":\"An introduction to AppArmor\",\"internal\":true,\"attachment\"\
-        :false,\"reflection\":false,\"clicks\":1,\"user_id\":320,\"domain\":\"discourse.ubuntu.com\"\
-        ,\"root_domain\":\"ubuntu.com\"},{\"url\":\"https://discourse.ubuntu.com/t/cinco-estrategias-para-acelerar-a-los-kubernetes-en-la-empresa/19208\"\
-        ,\"title\":\"Cinco estrategias para acelerar a los Kubernetes en la empresa\"\
-        ,\"internal\":true,\"attachment\":false,\"reflection\":false,\"clicks\":1,\"\
-        user_id\":320,\"domain\":\"discourse.ubuntu.com\",\"root_domain\":\"ubuntu.com\"\
-        },{\"url\":\"https://discourse.ubuntu.com/t/cinque-strategie-per-accelerare-limplementazione-di-kubernetes-nellimpresa/19381\"\
-        ,\"title\":\"Cinque strategie per accelerare l'implementazione di Kubernetes\
-        \ nell'impresa\",\"internal\":true,\"attachment\":false,\"reflection\":false,\"\
-        clicks\":1,\"user_id\":320,\"domain\":\"discourse.ubuntu.com\",\"root_domain\"\
-        :\"ubuntu.com\"}]}}"
+      string: "{\"post_stream\":{\"posts\":[{\"id\":50258,\"name\":\"Carlos Wu Fei\",\"username\":\"carkod\",\"avatar_template\":\"/letter_avatar/carkod/{size}/5_6d6f4cde2641c35611d5cac2fb97c77e.png\",\"created_at\":\"2020-08-25T11:17:26.382Z\",\"cooked\":\"\\u003ch1\\u003eEngage
+        pages\\u003c/h1\\u003e\\n\\u003cp\\u003eThe content of topics in this category
+        are displayed at \\u003ca href=\\\"https://ubuntu.com/engage\\\"\\u003ehttps://ubuntu.com/engage\\u003c/a\\u003e.\\u003c/p\\u003e\\n\\u003ch2\\u003eMetadata\\u003c/h2\\u003e\\n\\u003cdetails\\u003e\\n\\u003csummary\\u003e\\nMapping
+        table\\u003c/summary\\u003e\\n\\u003cdiv class=\\\"md-table\\\"\\u003e\\n\\u003ctable\\u003e\\n\\u003cthead\\u003e\\n\\u003ctr\\u003e\\n\\u003cth\\u003etopic\\u003c/th\\u003e\\n\\u003cth\\u003epath\\u003c/th\\u003e\\n\\u003cth\\u003etype\\u003c/th\\u003e\\n\\u003cth\\u003etags\\u003c/th\\u003e\\n\\u003cth\\u003epublish_date\\u003c/th\\u003e\\n\\u003cth\\u003elanguage\\u003c/th\\u003e\\n\\u003cth\\u003esubtitle\\u003c/th\\u003e\\n\\u003cth\\u003eactive\\u003c/th\\u003e\\n\\u003c/tr\\u003e\\n\\u003c/thead\\u003e\\n\\u003ctbody\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/embedded-kubernetes-for-secure-iot-edge/25635\\\"\\u003eEmbedded
+        Kubernetes for secure IoT Edge\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/embedded-kubernetes-for-secure-iot-edge-webinar\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar,
+        internet of things, ubuntu core, embedded\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-12-06\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eMicroK8s
+        on Ubuntu Core\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/bare-metal-provisioning-what-s-new-in-maas-3-1/25607\\\"\\u003eBare
+        metal provisioning: What\u2019s new in MAAS 3.1?\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/maas-whats-new-3-1\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eMaas,
+        bare metal, bare metal cloud, bare metal provisioning\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-12-03\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eThe
+        latest and greatest news about bare metal provisioning with MAAS\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/evaluating-microsoft-sql-server-options-for-azure/25594\\\"\\u003eEvaluating
+        Microsoft SQL Server Options for Azure\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/Evaluating-MSFT-SQL-Server-whitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eManaged
+        Apps\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-12-01\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eThis
+        white paper provides an in-depth examination of the most popular approaches
+        to running SQL Server on Azure, including SQL Server on Ubuntu Pro for Azure.\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/migrating-to-ubuntu-lts-six-facts-for-centos-users/25585\\\"\\u003eMigrating
+        to Ubuntu LTS: six facts for CentOS users\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/migrating-to-ubuntu-lts-six-facts-for-centos-users\\u003c/td\\u003e\\n\\u003ctd\\u003etakeover
+        only\\u003c/td\\u003e\\n\\u003ctd\\u003ecentos , Compliance , developers ,
+        hpc , livepatch , Migration , Open source , OpenStack , Security , Support\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eConsidering
+        migrating to Ubuntu from other Linux platforms, such as CentOS?\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/how-to-increase-developer-productivity-with-ubuntu-desktop/25426\\\"\\u003eHow
+        to increase developer productivity with Ubuntu Desktop\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/developer-desktop-productivity-whitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eubuntu,
+        desktop, enterprise, ubuntu advantage,\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-11-23\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eA
+        guide for CTOs, IT managers and sysadmins\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/nfv-orchestration-for-open-source-telco-integrating-and-managing-open-source-network-functions/25422\\\"\\u003eNFV
+        Orchestration For Open Source Telco\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/nfv-management-and-orchestration-charmed-open-source-mano\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eosm,
+        gsi, cloud, open source, orchestration\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eIntegrating
+        And Managing Open Source Network Functions\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/ubuntu-pro-no-microsoft-azure/25392\\\"\\u003eUbuntu
+        Pro em Azure\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/ubuntu-pro-azure-webinar-Portuguese\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eManaged
+        Apps, cloud, pro\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-10-29\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eExplore
+        recursos como seguran\xE7a estendida, conformidade certificada e prote\xE7\xE3o
+        para Ubuntu Pro em Azure.\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/docker-ros-when-all-you-have-is-a-hammer-everything-looks-like-a-nail/25389\\\"\\u003eDocker
+        \\u0026amp; ROS: When all you have is a hammer, everything looks like a nail\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/dockerandros\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003erobotics,
+        whitepaper, iot\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-11-22\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eKey
+        Docker limitations for ROS and the snap alternative\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/ubunto-pro-en-azure-sp-wbn/25388\\\"\\u003eUbunto
+        Pro en Azure \\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/ubuntu-pro-azure-webinar-spanish\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eManaged
+        Apps, cloud, pro\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-10-29\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eExplora
+        caracter\xEDsticas como seguridad extendida, cumplimiento certificado y refuerzo
+        para Ubuntu Pro en Azure.\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/introducing-sql-server-on-ubuntu-pro-for-azure-part-2/25350\\\"\\u003eIntroducing
+        SQL Server on Ubuntu Pro for Azure Part 2\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/SQLServerWebinarPart2\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eManaged
+        Apps, SQL\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-10-29\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eIn
+        this talk will deep dive on the anatomy of the performance features of SQL
+        Server on Ubuntu Pro and setting up AD.\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/webinar-building-cost-efficient-open-source-cloud-operations/25347\\\"\\u003eBuilding
+        cost-efficient open source cloud operations\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/cost-efficient-open-source-cloud-operations\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eManaged
+        IT Services, Managed Cloud Services, OpenStack, Kubernetes, Ceph\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/nayatel-builds-public-cloud-service-with-charmed-openstack/25331\\\"\\u003eNayatel
+        builds public cloud service with Charmed OpenStack\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/nayatel-casestudy-charmed-openstack\\u003c/td\\u003e\\n\\u003ctd\\u003ecase
+        study\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eLearn
+        how Nayatel partnered with Canonical to build Pakistan\u2019s first cost-effective
+        enterprise-grade public cloud\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/ceph-for-enterprise/25305\\\"\\u003eCeph
+        for Enterprise\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/enterprise-ceph\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eceph,
+        managed services\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eThe
+        best open-source enterprise storage solution\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/getting-started-with-shells-custom-ubuntu-pro-image-on-azure/25267\\\"\\u003eGetting
+        started with Shell\u2019s custom Ubuntu Pro image on Azure\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/ShellOnboarding\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eAzure,
+        Ubuntu Pro, Security\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-11-15\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eIn
+        this technical video you\u2019ll learn how to get started with Shell\u2019s
+        custom images of Ubuntu Pro with Support on Azure.\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/introducing-sql-server-on-ubuntu-pro-for-azure-part-1/25193\\\"\\u003eIntroducing
+        SQL Server on Ubuntu Pro for Azure Part 1\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/SQLServerWebinarPart1\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eManaged
+        Apps, SQL\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-10-29\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eIn
+        this talk we will introduce SQL Server on Ubuntu Pro for Azure and deep dive
+        on patching regimes and high availability clustering for SQL Server on Ubuntu
+        Pro.\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/microk8s-on-z-minimal-footprint-meets-zero-downtime/25183\\\"\\u003eMicroK8s
+        on IBM Z \u2014 minimal footprint meets zero downtime\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/webinar-microk8s-on-z\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003emicrok8s,
+        kubernetes, ibm\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-11-09\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eA
+        low-ops, minimal production Kubernetes on Ubuntu for your IBM Z / LinuxONE
+        system.\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/finserv-it-infrastructure-migrating-from-vmware-to-openstack/25179\\\"\\u003eFinserv
+        IT infrastructure: Migrating from VMWare to OpenStack\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/finserv-vmware-to-openstack\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eCIOs\u2019
+        guide to migrating your private cloud infrastructure to a more cost effective
+        solution\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/ubuntu/25158\\\"\\u003e\u958B\u767C\u8005\u9078\u64C7Ubuntu\u7684\u516D\u5927\u7406\u7531\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/developer-desktop-tw\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003edesktop,
+        ubuntu\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-11-08\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\u6700\u6D41\u884C\u7684linux
+        os \u64CD\u4F5C\u7CFB\u7D71\uFF0C\u9078\u64C7Ubuntu\u7684\u516D\u5927\u7406\u7531\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/ceph-in-the-modern-data-center/25046\\\"\\u003eCeph
+        in the modern data center\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/webinar-ceph-modern-data-center\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eceph,
+        storage, poweredge\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-11-18\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eManage
+        exponential data growth with Canonical Charmed Ceph and Dell PowerEdge Servers\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/telecom-infrastructure-the-open-source-way/25038\\\"\\u003eTelecom
+        infrastructure the open source way\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/open-source-telco-infrastructure-whitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003etelco,
+        telecommunications, 5G, cloud\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-10-02\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eAutomated,
+        secure and cloud native telco\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/cybersecurity-compliance-with-ubuntu/24933\\\"\\u003eCybersecurity
+        and Compliance with Ubuntu\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/ubuntu-cybersecurity-webinar\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003ecybersecurity\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-10-28\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eJoin
+        the live webinar\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/atresmedia-domina-il-mercato-spagnolo-dei-media-ott-con-larchitettura-di-microservizi-charmed-kubernetes/24897\\\"\\u003eAtresmedia
+        domina il mercato spagnolo dei media OTT con l\u2019architettura di microservizi
+        Charmed Kubernetes\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/it/atresmedia-charmed-kubernetes-case-study\\u003c/td\\u003e\\n\\u003ctd\\u003ecase
+        study\\u003c/td\\u003e\\n\\u003ctd\\u003eKubernetes, K8s\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-10-27\\u003c/td\\u003e\\n\\u003ctd\\u003eit\\u003c/td\\u003e\\n\\u003ctd\\u003eCome
+        l\u2019azienda ha ottenuto un\u2019alta disponibilit\xE0 e una produttivit\xE0
+        senza precedenti\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/secure-ai-models-deployment-at-the-edge-with-openvino-on-ubuntu-containers/24894\\\"\\u003eSecure
+        AI models deployment at the edge with OpenVINO on Ubuntu containers\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/webinar-ai-containers-edge-deployment\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar,
+        containers, AI,\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-10-27\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eJoin
+        Intel and Canonical for a webinar on Nov. 17\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/smartdrone-fast-tracks-drone-infrastructure-revolution-with-ubuntu-core/24821\\\"\\u003eSmartDrone
+        fast-tracks drone infrastructure revolution with Ubuntu Core\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/drone-infrastructure-case-study-smartdrone\\u003c/td\\u003e\\n\\u003ctd\\u003ecase
+        study\\u003c/td\\u003e\\n\\u003ctd\\u003erobotics, case study, iot\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-10-25\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/ubuntu-16-04-lts-verso-la-manutenzione-estesa-della-sicurezza/24781\\\"\\u003eUbuntu
+        16.04 LTS verso la Manutenzione Estesa della Sicurezza\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/ubuntu-16.04-esm-webinar\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eesm,
+        ubuntu 16.04, ubuntu lts\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eit\\u003c/td\\u003e\\n\\u003ctd\\u003eSei
+        aspetti da considerare nella pianificazione della migrazione\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/openstack-upgrades-with-minimal-downtime/24756\\\"\\u003eOpenStack
+        Upgrades with Minimal Downtime\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/openstack-upgrades-webinar\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack,
+        publiccloud\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/architecting-price-performance-private-cloud/24721\\\"\\u003eArchitecting
+        price-performance Private Cloud\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/architecting-price-performance-private-cloud\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack,
+        privatecloud\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eLearn
+        how to build the most cost-efficient private cloud infrastructure using open
+        source technologies\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/7-approaches-to-accelerating-apache-kafka-on-k8s/24711\\\"\\u003e7
+        approaches to accelerating Apache Kafka on K8s\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/7-approaches-accelerating-kafka-whitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eManaged
+        Apps\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-08-31\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eIn
+        this white paper, we will review seven techniques that can help to reduce
+        latency in high volume, low criticality Kafka solutions running on Kubernetes.\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/ctos-guide-to-micro-clouds/24533\\\"\\u003eCTOs\u2019
+        Guide to Micro Clouds\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/CTO-guide-to-micro-clouds-2021\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eedge,
+        microclouds, edgecomputing\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eMicro
+        Clouds an Edge Computing Solution\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/workstations-on-the-ai-journey-deploying-your-model/24401\\\"\\u003eWorkstations
+        on the AI Journey - Deploying Your Model\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/webinar-ai-journey-deploying-your-model\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eworkstations,
+        AI, dell, webinar\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-10-12\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eIn
+        the fourth and final part of this webinar series, Canonical and Dell will
+        talk about inference engines deployment.\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/driving-robotics-innovation/24442\\\"\\u003eDriving
+        robotics innovation\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/rosworld2021\\u003c/td\\u003e\\n\\u003ctd\\u003eevent\\u003c/td\\u003e\\n\\u003ctd\\u003eevent\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-09-16\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eCanonical
+        \\u0026amp; Ubuntu at ROS World 2021\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/embedded-linux-make-or-buy-tw/24602\\\"\\u003e
+        \u5D4C\u5165\u5F0FLinux\uFF1A\u81EA\u88FD\u6216\u5916\u8CFC\uFF1F\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/embedded-linux-make-or-buy-tw\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eCore\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-10-13\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\u5169\u96E3\u7684\u9078\u64C7\uFF1A\u5546\u696D\u652F\u63F4VS\u81EA\u7814\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/enterprise-kubernetes-use-cases-4-real-world-stories/24588\\\"\\u003eEnterprise
+        Kubernetes use cases: 4 real-world stories\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/kubernetes-use-cases-webinar\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eK8s,
+        Kubernetes\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-10-12\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eJoin
+        the live webinar\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/canonical-ubuntu-at-nvidia-gtc-2021/24671\\\"\\u003eCanonical
+        \\u0026amp; Ubuntu at Nvidia GTC 2021\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/gtc_nvidia_2021\\u003c/td\\u003e\\n\\u003ctd\\u003eevent\\u003c/td\\u003e\\n\\u003ctd\\u003eevent\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-10-15\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eJoin
+        us on November 8-11!\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/edge-kubernetes-what-s-brewing/24492\\\"\\u003eEdge
+        Kubernetes: what\u2019s brewing?\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/edge-kubernetes-coffee-webinar\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eK8s,
+        kubernetes, containerization, cloud\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-10-05\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/managed-it-services/24285\\\"\\u003eManaged
+        IT Services\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/managed-services-overcoming-cio-challenges-2021\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-09-17\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eHow
+        to build a strategic IT model that drives innovation while cutting down operational
+        costs\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/beat-disruption-white-paper/24237\\\"\\u003eBeat
+        disruption: how to adapt your IT strategy for changing markets\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/beat-disruption-wp\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eManaged
+        Apps\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-08-31\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eRead
+        our whitepaper to learn more about the fast changing modern business landscape
+        - cloud \\u0026amp; SaaS, agile, and outsourcing - and learn about a strategy
+        to help navigate through the jungle.\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/canonical-ubuntu-at-arm-dev-summit-2021/24204\\\"\\u003eCanonical
+        \\u0026amp; Ubuntu at ARM Dev Summit 2021\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/armdevsummit2021\\u003c/td\\u003e\\n\\u003ctd\\u003eevent\\u003c/td\\u003e\\n\\u003ctd\\u003eevent\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-09-16\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eJoin
+        us virtually on October 19-21, 2021\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/building-graphical-applications-in-embedded-devices/24167\\\"\\u003eBuilding
+        graphical applications in embedded devices\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/webinarintrotoframe\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003edigital
+        signage, mir, ubuntu frame\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-09-14\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eJoin
+        us for a webinar introducing Ubuntu Frame on November 3rd at 5pm BST and 12pm
+        ET\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/its-like-a-jungle-out-there-how-to-adapt-your-it-strategy-for-changing-markets/24077\\\"\\u003eIt\u2019s
+        like a jungle out there\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/adapt-your-it-strategy\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar
+        , Managed Apps\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-08-31\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eLearn
+        strategies to help you navigate the fast changing modern business landscape
+        - cloud and SaaS, agile and outsourcing\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/self-healing-kubernetes-at-the-edge-microk8s-raspberry-pis-and-portainer/24070\\\"\\u003eSelf-healing
+        Kubernetes at the edge: MicroK8s, Raspberry Pis and Portainer\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/self-healing-edge-kubernetes-webinar\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003ek8s,
+        kubernetes, edge, MicroK8s\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-09-97\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/atresmedia-domine-le-marche-des-medias-en-espagne-avec-l-architecture-de-microservices-charmed-kubernetes/24009\\\"\\u003eAtresmedia
+        domine le march\xE9 des m\xE9dia en Espagne avec l\u2019architecture de microservices
+        Charmed Kubernetes\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/fr/atresmedia-charmed-kubernetes\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003ekubernetes,
+        k8s\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-09-02\\u003c/td\\u003e\\n\\u003ctd\\u003efr\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/how-to-manage-risks-with-the-top-1-managed-service-providers/23983\\\"\\u003eHow
+        to manage risks with the top 1% Managed Service Providers\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/MSPAlliance-Canonical-Webinar\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar
+        , Managed Service\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-08-31\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eJoin
+        our webinar to learn more about Canonical\u2019s MSP Alliance security verification,
+        and how the top 1% managed service providers help minimise your security risks
+        and optimise your clouds.\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/kubernetes-platform-comparison-red-hat-openshift-suse-rancher-and-canonical-kubernetes/23982\\\"\\u003eKubernetes
+        platform comparison: Red Hat OpenShift, SUSE Rancher and Canonical Kubernetes\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/enterprise-kubernetes-comparison\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003ekubernetes,
+        k8s, containerization, cloud\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-08-31\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eHow
+        to choose the right Kubernetes distribution for your business\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/containers-as-a-service/23970\\\"\\u003eContainers-as-a-service:
+        Deploy faster with Canonical and Portainer\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/containers-as-a-service-webinar\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003ekubernetes,
+        k8s, cloud\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-08-31\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/helping-developers-reach-new-heights/23873\\\"\\u003eHelping
+        developers reach new heights \\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/px4devsummit\\u003c/td\\u003e\\n\\u003ctd\\u003eevent\\u003c/td\\u003e\\n\\u003ctd\\u003eevent,
+        devsummit, drones, iot\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-08-24\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eCanonical
+        \\u0026amp; Ubuntu at PX4 Developer Summit\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/running-enterprise-grade-edge-applications-with-edgex-on-ubuntu-core/23773\\\"\\u003eRunning
+        enterprise-grade edge applications with EdgeX on Ubuntu Core\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/webinarcoreedgex\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar,
+        internet of things, ubuntu core, edgex\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-08-17\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eJoin
+        us for a webinar on September 29th 5AM BST \\u0026amp; 12PM ET\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/applied-ai-for-fraud-prevention-and-detection/23734\\\"\\u003eApplied
+        AI for fraud prevention and detection\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/ai-fraud-prevention-finserv\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003efinserv\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-08-16\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eHow
+        open source AI/ML solutions can assist banks\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/atresmedia-accesses-high-availability-and-unprecedented-productivity-with-charmed-kubernetes/23693\\\"\\u003eAtresmedia
+        dominates the OTT services market with Charmed Kubernetes\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/atresmedia-charmed-kubernetes-case-study\\u003c/td\\u003e\\n\\u003ctd\\u003ecase
+        study\\u003c/td\\u003e\\n\\u003ctd\\u003eKubernetes, K8s\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-08-12\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eHow
+        the company accessed high availability and unprecedented productivity\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/free-cloud-pricing-report-2021/23455\\\"\\u003eCloud
+        pricing report 2021\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/cloud-pricing-report-2021\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003ecloud\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-07-26\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eGet
+        the report to compare cloud pricing across leading public and private cloud
+        platforms, including AWS, Azure, Google, VMWare and OpenStack\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/sbi-group-sblocca-lautomazione-dellinfrastruttura-con-un-cloud-openstack-sicuro-e-on-premises/23286\\\"\\u003eSBI
+        Group sblocca l\u2019automazione dell\u2019infrastruttura con un cloud OpenStack
+        sicuro e on-premises \\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/it/sbi-casestudy\\u003c/td\\u003e\\n\\u003ctd\\u003ecase
+        study\\u003c/td\\u003e\\n\\u003ctd\\u003eOpenstack, private cloud\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-07-15\\u003c/td\\u003e\\n\\u003ctd\\u003eit\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/a-small-to-medium-size-business-guide-to-cybersecurity/23274\\\"\\u003eA
+        business guide to cybersecurity\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/a-small-to-medium-size-business-guide-to-cybersecurity\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003esecurity,
+        cybersecurity\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-07-14\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/handlungsoptionen-nach-dem-endof-life-der-suse-openstack-cloud/23173\\\"\\u003eHandlungsoptionen
+        nach dem Endof-life der SUSE OpenStack Cloud\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/de/suse-openstack-whitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eOpenStack\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-07-07\\u003c/td\\u003e\\n\\u003ctd\\u003ede\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/atresmedia-accede-a-una-alta-disponibilidad-y-productividad-sin-precedentes-con-charmed-kubernetes/23125\\\"\\u003eAtresmedia
+        domina el mercado de servicios OTT \\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/es/atresmedia-charmed-kubernetes-caso-de-estudio\\u003c/td\\u003e\\n\\u003ctd\\u003ecase
+        study\\u003c/td\\u003e\\n\\u003ctd\\u003eKubernetes\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-07-05\\u003c/td\\u003e\\n\\u003ctd\\u003ees\\u003c/td\\u003e\\n\\u003ctd\\u003eCon
+        la arquitectura de microservicios Charmed Kubernetes\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/kaust-selects-canonicals-openstack-cloud/22858\\\"\\u003eKAUST
+        selects Canonical\u2019s OpenStack cloud\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/openstack-cloud-kaust\\u003c/td\\u003e\\n\\u003ctd\\u003ecase
+        study\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack, private cloud, cloud\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-06-24\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eNew
+        OpenStack and Kubernetes deployments improve computing performance for researchers,
+        easing management pains for IT staff\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/das-wellcome-sanger-institute-ermoglicht-weltweite-zusammenarbeit-in-der-genomforschung-mit-von-canonical-unterstutztem-ceph-speicher/22811\\\"\\u003eDas
+        Wellcome Sanger Institute erm\xF6glicht weltweite Zusammenarbeit in der Genomforschung
+        mit von Canonical unterst\xFCtztem Ceph-Speicher\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/de/wellcome-sanger-case-study\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eceph\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-06-03\\u003c/td\\u003e\\n\\u003ctd\\u003ede\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/a-technical-introduction-to-the-snap-store-proxy/22762\\\"\\u003eA
+        technical introduction to the Snap Store Proxy\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/snap-store-proxy-intro-webinar\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eiot,
+        edge\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-06-18\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/che-cose-il-mec-il-telco-edge/22748\\\"\\u003eChe
+        cos\u2019\xE8 il MEC? Il telco edge.\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/it/mec-telco-edge\\u003c/td\\u003e\\n\\u003ctd\\u003eblog\\u003c/td\\u003e\\n\\u003ctd\\u003etelco,
+        edge\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eit\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/ubuntu-pro-on-azure/22674\\\"\\u003eUbuntu
+        Pro on Azure \\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/ubuntu-pro-azure-latam\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eubuntu
+        pro, microsoft, azure, cloud, security, latam\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-06-09\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eExplore
+        features like extended security, certified compliance and hardening for Ubuntu
+        Pro on Azure.\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/enterprise-mlops-in-hybrid-cloud-scenarios-best-practices/22650\\\"\\u003eEnterprise
+        MLOps in hybrid-cloud scenarios: best practices\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/enterprise-mlops-in-hybrid-cloud-scenarios-best-practices\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eelo,
+        hybrid-cloud, enterprise, kubeflow\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-06-07\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eLearn
+        about architectural best practices that have recently emerged\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/openstack-public-cloud-implementation/22648\\\"\\u003eOpenStack
+        public cloud implementation\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/public-cloud-openstack-implementation\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack,
+        public-cloud\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-06-02\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eReduce
+        total cost of ownership with local public cloud infrastructure\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/ros-support-with-ros-esm/22595\\\"\\u003eROS
+        Support\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/ros-support\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eros\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-06-04\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eSecurity
+        maintenance and enterprise support for your ROS environment\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/preparing-for-the-suse-openstack-cloud-end-of-life/22587\\\"\\u003eSUSE
+        OpenStack Cloud end-of-life\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/suse-openstack-cloud-eol\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack,
+        cloud, suse\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-06-03\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eA
+        preparation guide\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/data-lab-architectures/22247\\\"\\u003eData
+        Lab Architectures\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/data-lab-architectures-whitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003ebig
+        data, data driven, AI, ML\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-06-02\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eA
+        field practitioner guide to building and accelerating data lab initiatives\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/guida-cio-alle-operazioni-multi-cloud/22564\\\"\\u003eGuida
+        CIO alle operazioni multi-cloud\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/it/operazioni-multi-cloud\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003emulti-cloud,
+        finance\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-10-05\\u003c/td\\u003e\\n\\u003ctd\\u003eit\\u003c/td\\u003e\\n\\u003ctd\\u003eCome
+        scegliere un\u2019architettura cloud conveniente\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/kubernetes-e-ubuntu-in-italia/22562\\\"\\u003eKubernetes
+        e Ubuntu in Italia\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/it/kubernetes-e-ubuntu-in-italia\\u003c/td\\u003e\\n\\u003ctd\\u003eblog\\u003c/td\\u003e\\n\\u003ctd\\u003ekubernetes,
+        ubuntu, openstack\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-06-02\\u003c/td\\u003e\\n\\u003ctd\\u003eit\\u003c/td\\u003e\\n\\u003ctd\\u003eUn\u2019esplorazione
+        tecnica delle ultime tecnologie di infrastruttura\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/private-cloud-for-financial-services/22500\\\"\\u003ePrivate
+        cloud for Financial Services\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/private-cloud-financial-services\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003efinserv,
+        openstack\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-05-28\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eComparing
+        Red Hat OpenStack Platform and Canonical\u2019s Charmed OpenStack\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/canonical-at-mwc-2021/22348\\\"\\u003eCanonical
+        at MWC 2021\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/canonical-ubuntu-mwc-2021\\u003c/td\\u003e\\n\\u003ctd\\u003eblog\\u003c/td\\u003e\\n\\u003ctd\\u003etelco,
+        telecommunications, 5G, events\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-05-18\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/open-source-private-5g-and-lte-networks/22346\\\"\\u003eOpen
+        source private 5G and LTE networks\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/5g-and-lte-networks-webinar\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003etelco,
+        telecommunications, 5G\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-05-18\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eUse-cases,
+        tools and technologies\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/kubernetes-at-the-edge-easy-as-pi/22342\\\"\\u003eKubernetes
+        at the edge: easy as Pi\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/edge-kubernetes-raspberry-pi-webinar\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eKubernetes,
+        K8s, edge\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-05-18\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/suse-openstack-cloud-wird-eingestellt/22283\\\"\\u003eSUSE
+        OpenStack Cloud wird eingestellt.\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/de/suse-openstack-webinar\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003esuse,
+        openstack\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-05-13\\u003c/td\\u003e\\n\\u003ctd\\u003ede\\u003c/td\\u003e\\n\\u003ctd\\u003eSind
+        Sie vorbereitet?\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/building-and-orchestrating-network-functions/22269\\\"\\u003eBuilding
+        and orchestrating network functions\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/telco-network-functions-whitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003etelco,
+        telecommunications, 5G, OSM\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-05-12\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eAccelerate
+        migration towards NFV with Open Source MANO\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/simplifying-kubernetes-across-the-clouds-microk8s-on-nvidia-tech-stack/22260\\\"\\u003eSimplifying
+        Kubernetes across the Clouds \\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/microk8s-nvidia-tech-stack\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003emicrok8s,
+        edge, kubernetes, k8s\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-05-11\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eMicroK8s
+        on NVIDIA Tech Stack\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/data-lab-architectures/22247\\\"\\u003eData
+        Lab Architectures\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/data-lab-architectures-whitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003ebig
+        data, data driven, AI, ML\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-05-10\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eA
+        field practitioner guide to building and accelerating data lab initiatives\\u003c/td\\u003e\\n\\u003ctd\\u003efalse\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/a-business-guide-to-multi-cloud/22093\\\"\\u003eA
+        business guide to multi-cloud\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/multi-cloud-business-guide\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-04-30\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eA
+        cost-effective extension to the public cloud infrastructure\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/a-business-guide-to-hybrid-cloud/22092\\\"\\u003eA
+        business guide to hybrid cloud\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/hybrid-cloud-business-guide\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-04-30\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eA
+        cost-effective extension to the public cloud infrastructure\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/ros-kinetic-end-of-life/21952\\\"\\u003eROS
+        Kinetic End-Of-Life\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/ros-kinetic-eol\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003erobotics\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-04-20\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eKeep
+        your robots secure with ROS ESM\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/migrare-a-ubuntu-lts-sei-fatti-per-gli-utenti-centos/21959\\\"\\u003eMigrare
+        ad Ubuntu LTS: 6 fatti per gli utenti CentOS\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/it/migrare-a-ubuntu-lts-centos\\u003c/td\\u003e\\n\\u003ctd\\u003eblog\\u003c/td\\u003e\\n\\u003ctd\\u003ecentos\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eit\\u003c/td\\u003e\\n\\u003ctd\\u003eState
+        pensando di migrare a Ubuntu da altre piattaforme Linux, come CentOS?\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/meno-di-6-mesi-a-ubuntu-16-04-esm-6-cose-da-preparare/21958\\\"\\u003eMeno
+        di 6 mesi a Ubuntu 16.04 ESM: 6 cose da preparare\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/it/ubuntu-16-04-esm\\u003c/td\\u003e\\n\\u003ctd\\u003eblog\\u003c/td\\u003e\\n\\u003ctd\\u003eubuntu,
+        esm\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eit\\u003c/td\\u003e\\n\\u003ctd\\u003eQuesto
+        articolo spiega come funziona il periodo ESM e fornisce una guida a sei considerazioni
+        chiave per la pianificazione di un percorso di migrazione da Ubuntu 16.04
+        LTS.\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/infrastruttura-multi-cloud-in-italia/21894\\\"\\u003eInfrastruttura
+        multi-cloud in Italia\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/it/infrastruttura-multi-cloud\\u003c/td\\u003e\\n\\u003ctd\\u003eblog\\u003c/td\\u003e\\n\\u003ctd\\u003emulti-cloud,
+        kubernetes\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eL\u2019evento,
+        della durata di 2 ore, si terr\xE0 il 12 maggio 2021 su BrightTalk. Dai live
+        talk dei nostri speaker alle sessioni di Q\\u0026amp;A.\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/data-science-workstations-journey/21828\\\"\\u003eData
+        Science Workstations\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/workstations-journey-to-ai\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eAI/ML\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-04-15\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eTake
+        a deep dive into how workstations enable the AI journey in part 2 of our series\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/unleashing-z-workstations-by-hp-powered-by-ubuntu/21825\\\"\\u003eUnleashing
+        Z by HP Workstation Power with Ubuntu\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/Z-Workstation-Ubuntu\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eOpen
+        Source, Linux, Data Science, AI, Machine Learning, HP\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-04-15\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eExplore
+        key solutions for AI, Machine Learning, and Data Science Workflows\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/what-s-new-in-ubuntu-server-21-04/21802\\\"\\u003eWhat\u2019s
+        new in Ubuntu Server 21.04?\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/ubuntu-21.04-release-webinar\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eserver\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-04-14\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eIntroducing
+        native integration with Microsoft SQL Server\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/the-value-of-open-source-in-2021/21790\\\"\\u003eThe
+        Value of Open Source in 2021\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/open-source-value\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eOpen
+        Source, Kubernetes, Dell, OpenStack, Edge\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-04-12\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eExplore
+        the latest open source market trends and dive into OpenStack, Kubernetes and
+        Edge solutions from Dell and Canonical.\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/elkhart-lake/21775\\\"\\u003eElkhart
+        Lake\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/iot-elkhart-lake\\u003c/td\\u003e\\n\\u003ctd\\u003eblog\\u003c/td\\u003e\\n\\u003ctd\\u003eintel,
+        iot\\u003c/td\\u003e\\n\\u003ctd\\u003e4/16/2021\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eEmbedded
+        silicon from Intel focusing on IoT features for the next generation of edge
+        devices.\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/elkhart-lake/21775\\\"\\u003eElkhart
+        Lake\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/elkhart-lake\\u003c/td\\u003e\\n\\u003ctd\\u003eblog\\u003c/td\\u003e\\n\\u003ctd\\u003eintel,
+        iot\\u003c/td\\u003e\\n\\u003ctd\\u003e4/16/2021\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eEmbedded
+        silicon from Intel focusing on IoT features for the next generation of edge
+        devices.\\u003c/td\\u003e\\n\\u003ctd\\u003efalse\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/telecom-ai-a-guide-for-data-teams/21740\\\"\\u003eTelecom
+        AI: a guide for data teams\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/telecom-ai-guide\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eAI/ML,
+        telco, telecommunications\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-04-09\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eOptimising
+        AI for production in the telco space\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/data-science-workstations/21739\\\"\\u003eData
+        Science Workstations\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/data-science-workstations\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eAI/ML\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-04-09\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eTake
+        a deep dive into how workstations enable the AI journey in this four-part
+        webinar series\\u003c/td\\u003e\\n\\u003ctd\\u003efalse\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/canonical-ubuntu-at-nvidia-gtc-2021-digital/21524\\\"\\u003eCanonical
+        \\u0026amp; Ubuntu at NVIDIA GTC 2021 Digital\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/ubuntu-at-nvidia-gtc-2021\\u003c/td\\u003e\\n\\u003ctd\\u003eblog\\u003c/td\\u003e\\n\\u003ctd\\u003eAI/ML,
+        MicroK8s, edge\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-03-24\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eMeet
+        us there on April 12-16\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/model-driven-audit-trail-logs-infrastructure-for-telco-vnfs/21500\\\"\\u003eModel-driven
+        Audit Trail Logs infrastructure for Telco VNFs\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/audit-trail-logs-for-telco\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003etelecommunications\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-03-23\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eLive
+        webinar on April 15th\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/esm-garantisce-la-sicurezza-dei-sistemi-interana-anche-durante-laggiornamento/21378\\\"\\u003eESM
+        garantisce la sicurezza dei sistemi Interana anche durante l\u2019aggiornamento\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/it/interana-casestudy\\u003c/td\\u003e\\n\\u003ctd\\u003ecase
+        study\\u003c/td\\u003e\\n\\u003ctd\\u003eesm, security, interana\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-03-16\\u003c/td\\u003e\\n\\u003ctd\\u003eit\\u003c/td\\u003e\\n\\u003ctd\\u003eCaso
+        di studio - Interana\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/securing-open-source-from-cloud-to-edge/21394\\\"\\u003eSecuring
+        open source from cloud to edge\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/open-source-security-cloud-edge-webinar\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003esecurity,
+        ubuntu pro\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-03-16\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eGet
+        the full Ubuntu security story and see how our teams are securing Ubuntu systems
+        across cloud, device and edge environments.\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/migrar-a-ubuntu-lts-seis-factores-a-tener-en-cuenta-para-los-usuarios-de-centos/21315\\\"\\u003eMigrar
+        a Ubuntu LTS: seis factores a tener en cuenta para los usuarios de CentOS\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/es/migrar-de-centos-a-ubuntu-lts\\u003c/td\\u003e\\n\\u003ctd\\u003eblog\\u003c/td\\u003e\\n\\u003ctd\\u003eserver,
+        ubuntu\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-03-09\\u003c/td\\u003e\\n\\u003ctd\\u003ees\\u003c/td\\u003e\\n\\u003ctd\\u003e\xBFEst\xE1
+        considerando migrar a Ubuntu desde otras plataformas Linux, como CentOS?\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/from-yocto-buildroot-to-ubuntu-core-20/21248\\\"\\u003eFrom
+        Yocto \\u0026amp; Buildroot to Ubuntu Core 20\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/yocto-buildroot-to-ubuntu-core\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eubuntu-core\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-03-05\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eThe
+        path to enterprise-grade embedded Linux\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/costruire-infrastrutture-multi-cloud-con-ubuntu-e-kubernetes/21247\\\"\\u003eCostruire
+        infrastrutture multi-cloud con Ubuntu e Kubernetes\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/it/multi-cloud-infrastrutture-kubernetes-italy\\u003c/td\\u003e\\n\\u003ctd\\u003eevent\\u003c/td\\u003e\\n\\u003ctd\\u003emulti-cloud,
+        infrastructure, kubernetes\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eit\\u003c/td\\u003e\\n\\u003ctd\\u003eUn\u2019esplorazione
+        tecnica delle ultime tecnologie di infrastruttura\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/kubeflow-operations-guide/21213\\\"\\u003eKubeflow
+        operations guide\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/kubeflow-operations-guide\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003ekubeflow,
+        machine learning, AI/ML\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eAutomating
+        day-0 to day-2 with Kubernetes operators\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/suse-openstack-cloud-arrive-en-fin-de-vie/21096\\\"\\u003eSUSE
+        OpenStack Cloud arrive en fin de vie\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/fr/suse-openstack-fin-de-vie\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003esuse,
+        openstack\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-02-25\\u003c/td\\u003e\\n\\u003ctd\\u003efr\\u003c/td\\u003e\\n\\u003ctd\\u003ePreparez
+        pour votre migration d\u2019OpenStack\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/whats-next-for-centos-users/21090\\\"\\u003eWhat\u2019s
+        next for CentOS users?\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/centos-live-q\\u0026amp;A\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-02-24\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eLive
+        Q\\u0026amp;A with Ubuntu\u2019s technical experts\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/a-technical-introduction-to-ubuntu-core-20/21068\\\"\\u003eA
+        technical introduction to Ubuntu Core 20\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/technical-intro-to-ubuntu-core-20\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eubuntu-core\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-02-23\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eFull-disk
+        encryption, secure boot, device recovery and more\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/ubuntu-16-04-esm-6-choses-a-preparer/21058\\\"\\u003eUbuntu
+        16.04 ESM: 6 choses \xE0 pr\xE9parer\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/fr/ubuntu-1604-esm\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003esecurity\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-02-22\\u003c/td\\u003e\\n\\u003ctd\\u003efr\\u003c/td\\u003e\\n\\u003ctd\\u003eUn
+        guide de migration\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/migration-vers-ubuntu-lts-six-points-cles-pour-les-utilisateurs-de-centos/21054\\\"\\u003eMigration
+        vers Ubuntu LTS: six points cl\xE9s pour les utilisateurs de CentOS\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/centos-vers-ubuntu\\u003c/td\\u003e\\n\\u003ctd\\u003eblog\\u003c/td\\u003e\\n\\u003ctd\\u003esecurity\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-02-22\\u003c/td\\u003e\\n\\u003ctd\\u003efr\\u003c/td\\u003e\\n\\u003ctd\\u003ePr\xE9parez
+        vos prochaines \xE9tapes\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/simplifying-ai-ml-adoption-in-telco-with-modern-operations-practices/20996\\\"\\u003eSimplifying
+        AI/ML adoption in telco with modern operations practices\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/ai-ml-telco-modern-operations\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eAI/ML,
+        telecommunications\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-02-17\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eLeveraging
+        open source software for optimal TCO\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/enterprise-kubernetes-a-buyer-s-guide/20979\\\"\\u003eEnterprise
+        Kubernetes: A buyer\u2019s guide\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/enterprise-kubernetes-guide\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eKubernetes,
+        K8s, Cloud\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-02-16\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eFind
+        the right Kubernetes for your business\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/secure-container-orchestration-at-the-edge/20965\\\"\\u003eSecure
+        container orchestration at the edge\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/container-orchestration-edge\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eKubernetes,
+        edge, MicroK8s\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-02-15\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eDevelop
+        your cloud-native apps with micro clouds\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/edge-use-cases-enabled-by-mec-and-5g/20873\\\"\\u003eEdge
+        use-cases enabled by MEC and 5G\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/mec-5g-use-cases\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eTelecommunications,
+        5G\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-02-10\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eLeveraging
+        open source software in the telco space\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/open-source-in-government/20843\\\"\\u003eOpen
+        source in Government\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/gov-webinar\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-02-09\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eThe
+        Public Sector team discusses adoption and procurement of secure open source
+        tech, tooling and support.\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/mantenimiento-de-seguridad-extendido/20747\\\"\\u003eMantenimiento
+        de Seguridad Extendido\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/es/esm\\u003c/td\\u003e\\n\\u003ctd\\u003eblog\\u003c/td\\u003e\\n\\u003ctd\\u003eesm\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-02-04\\u003c/td\\u003e\\n\\u003ctd\\u003ees\\u003c/td\\u003e\\n\\u003ctd\\u003eActualizaciones
+        de seguridad para Ubuntu 16.04 LTS hasta el 2024 y Ubuntu 14.04 LTS hasta
+        el 2022.\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/integrazione-di-ubuntu-desktop-con-microsoft-active-directory/20746\\\"\\u003eIntegrazione
+        di Ubuntu Desktop con Microsoft Active Directory\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/it/ubuntu-desktop-active-directory\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eactive
+        directory, desktop\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-02-04\\u003c/td\\u003e\\n\\u003ctd\\u003eit\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/end-to-end-wiring-using-kubeflow-kafka-and-elasticsearch/20704\\\"\\u003eEnd-to-end
+        wiring using Kubeflow, Kafka and ElasticSearch\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/end-to-end-wiring-with-kubeflow-kafka-elasticsearch\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eAI/ML,
+        Kubeflow\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-02-03\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eOur
+        latest webinar provides real world application and demo for end-to-end wiring
+        using Kubeflow, Kafka and ElasticSearch.\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/embedded-linux-make-or-buy/20696\\\"\\u003eEmbedded
+        Linux: make or buy?\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/embedded-linux-make-or-buy\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-02-02\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eCommercial
+        support vs roll your own: a dilemma\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/an-introduction-to-ubuntu-core-20/20687\\\"\\u003eAn
+        introduction to Ubuntu Core 20\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/ubuntu-core-20-webinar\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003ecore,
+        iot, embedded, security\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-02-02\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eImproving
+        usability, security and time-to-market\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/kubeflow-reference-architecture/20467\\\"\\u003eKubeflow
+        reference architecture\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/dell-kubeflow-reference-architecture\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003ekubeflow,
+        ai/ml, dell\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-01-21\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/industrial-process-transformation-with-machine-learning-using-kubeflow/20436\\\"\\u003eIndustrial
+        process transformation with Machine Learning using Kubeflow\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/industrial-process-ml-kubeflow\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eAI/ML,
+        Kubeflow\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-01-18\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eAccelerate
+        the time from model development to deployment\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/comparaison-de-red-hat-openstack-platform-et-de-charmed-openstack-de-canonical/20432\\\"\\u003eComparaison
+        entre Red Hat OpenStack et Charmed OpenStack de Canonical\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/fr/red-hat-canonical-openstack-comparaison\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eOpenStack\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-01-29\\u003c/td\\u003e\\n\\u003ctd\\u003efr\\u003c/td\\u003e\\n\\u003ctd\\u003eAm\xE9liorez
+        la s\xE9curit\xE9 et l\u2019efficacit\xE9 \xE0 un co\xFBt total de possession
+        r\xE9duit avec Charmed OpenStack\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/automation-through-open-source-operators/20215\\\"\\u003eAutomation
+        through open source operators \\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/automation-through-open-source-operators\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eapps,
+        Juju, Forrester\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-01-08\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eA
+        Forrester Consulting study on the state of infrastructure and application
+        deployment\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/cloud-native-driving-agility-and-innovation-in-financial-services/20244\\\"\\u003eCloud-native
+        driving agility and innovation in financial services\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/cloud-native-agility-financial-services\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003ecloud-native,
+        finance\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-01-07\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eAdapt,
+        innovate and transform\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/android-in-the-cloud-on-arm-native-servers/20015\\\"\\u003eAndroid
+        in the cloud on Arm native servers\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/android-on-arm-whitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eandroid\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-12-18\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eHigh
+        performance. Power efficiency. Hardware rooted security.\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/staying-compliant-while-delivering-innovation-in-government-services/19960\\\"\\u003eStaying
+        compliant while delivering innovation in government services\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/azure-ubuntu-pro-fips-whitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eazure,
+        ubuntu pro, fips\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-12-17\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eHow
+        Ubuntu Pro FIPS on Microsoft Azure gives government agencies and contractors
+        new ways to control costs and boost innovation while maintaining FIPS compliance.\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/menos-de-6-meses-para-16-04-esm-seis-aspectos-a-tener-en-cuenta/19925\\\"\\u003eMenos
+        de 6 meses para 16.04 ESM: seis aspectos a tener en cuenta\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/es/ubuntu-16-04-esm\\u003c/td\\u003e\\n\\u003ctd\\u003eblog\\u003c/td\\u003e\\n\\u003ctd\\u003eesm,
+        security, ubuntu advantage\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-12-17\\u003c/td\\u003e\\n\\u003ctd\\u003ees\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/in-weniger-als-6-monaten-kommt-ubuntu-16-04-esm-6-punkte-fur-ihre-vorbereitung/19895\\\"\\u003eIn
+        weniger als 6 Monaten kommt Ubuntu 16.04 ESM: 6 Punkte f\xFCr Ihre Vorbereitung\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/de/ubuntu-16-04-esm\\u003c/td\\u003e\\n\\u003ctd\\u003eblog\\u003c/td\\u003e\\n\\u003ctd\\u003eesm,
+        security, ubuntu advantage\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-12-17\\u003c/td\\u003e\\n\\u003ctd\\u003ede\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/workstations-ai/19766\\\"\\u003eWorkstations
+        AI\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/it/workstation-ai\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003ekubeflow\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-12-09\\u003c/td\\u003e\\n\\u003ctd\\u003eit\\u003c/td\\u003e\\n\\u003ctd\\u003eCome
+        e perch\xE9 Kubeflow migliora i workflow AI\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/suse-openstack-cloud-to-be-discontinued/19765\\\"\\u003eSUSE
+        OpenStack Cloud to be discontinued\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/suse-openstack-webinar\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack,
+        cloud, suse\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-12-23\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eAre
+        you prepared?\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/lightweight-kubernetes-in-the-enterprise/19716\\\"\\u003eLightweight
+        Kubernetes in the enterprise\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/451-research-microk8s-high-availability\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003ekubernetes,
+        451, microk8s\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-12-09\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eProduction
+        workloads in cloud and server deployments made faster than ever\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/ai-deployment-and-inference/19692\\\"\\u003eAI
+        deployment and inference\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/ai-deployment-and-inference\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003einference\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-12-07\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eReliable
+        infrastructure and streamlined operations\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/agility-and-innovation-in-financial-services-with-open-source/19601\\\"\\u003eAgility
+        and innovation in Financial Services with open source \\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/open-source-financial-services\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003efinance\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-12-01\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eLearn
+        how managed open source can help financial institutions deliver business value.\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/ubuntu-pro-for-aws/19600\\\"\\u003eUbuntu
+        Pro for AWS\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/ubuntu-pro-for-aws\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eaws,
+        Ubuntu Pro\\u003c/td\\u003e\\n\\u003ctd\\u003e2020 -12 01\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eFIPS
+        compliance made easy\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/ubuntu-16-04-lts-moving-to-extended-security-maintenance/19598\\\"\\u003eUbuntu
+        16.04 LTS moving to Extended Security Maintenance\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/16-04-ESM-webinar\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eesm,
+        security, ubuntu advantage\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-12-01\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eSix
+        things to consider when migration planning\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/micro-clouds/19424\\\"\\u003eMicro
+        clouds\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/micro-clouds\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eedge\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-11-19\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eBuilding
+        your Kubernetes edge computing strategy\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/cinque-strategie-per-accelerare-limplementazione-di-kubernetes-nellimpresa/19381\\\"\\u003eCinque
+        strategie per accelerare l\u2019implementazione di Kubernetes nell\u2019impresa\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/it/deployment-azienda-manuale\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eenterprise\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-11-17\\u003c/td\\u003e\\n\\u003ctd\\u003eit\\u003c/td\\u003e\\n\\u003ctd\\u003eCome
+        scegliere il miglior approccio Kubernetes per la tua azienda\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/confronto-fra-red-hats-openstack-platform-e-charmed-openstack-di-canaonical/19362\\\"\\u003eConfronto
+        fra \u201CRed Hat\u2019s Openstack platform\u201D e Charmed Openstack di Canaonical\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/it/redhat-openstack-confronto-manuale\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eRed
+        Hat\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-11-16\\u003c/td\\u003e\\n\\u003ctd\\u003eit\\u003c/td\\u003e\\n\\u003ctd\\u003eCharmed
+        Openstack riduce significativamente il costo totale di propriet\xE0\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/confronto-fra-red-hats-openstack-platform-e-charmed-openstack-di-canaonical/19361\\\"\\u003eGuide
+        pour r\xE9ussir l\u2019adoption et le d\xE9ploiement d\u2019OpenStack\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/fr/guide-adoption-openstack\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-11-16\\u003c/td\\u003e\\n\\u003ctd\\u003efr\\u003c/td\\u003e\\n\\u003ctd\\u003eD\xE9couvrez
+        l\u2019\xE9prouv\xE9 processus d\u2019impl\xE9mentation OpenStack de Canonical\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/funf-strategien-zur-beschleunigung-von-kubernetes-in-unternehmen/19284\\\"\\u003eF\xFCnf
+        Strategien zur Beschleunigung von Kubernetes in Unternehmen\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/de/kubernetes-implementierung-fur-unternehmen\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eenterprise\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-11-11\\u003c/td\\u003e\\n\\u003ctd\\u003ede\\u003c/td\\u003e\\n\\u003ctd\\u003eEntscheidungskriterien
+        zur optimalen Herangehensweise an Kubernetes f\xFCr Ihr Unternehmen\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/vergleich-von-red-hat-openstack-platform-und-charmed-openstack-von-canonical/19285\\\"\\u003eVergleich
+        von Red Hat OpenStack Platform und Charmed OpenStack von Canonical\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/de/redhat-openstack-vergleich\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eRed
+        Hat\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-11-11\\u003c/td\\u003e\\n\\u003ctd\\u003ede\\u003c/td\\u003e\\n\\u003ctd\\u003eSenken
+        Sie Ihre Gesamtkosten deutlich mit Charmed OpenStack\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/9-out-of-top-10-us-financial-institutions-use-ubuntu/19304\\\"\\u003e9
+        out of top 10 US \\u0026amp; European financial institutions use Ubuntu\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/ubuntu-finance-sector-whitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003efinance\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-11-11\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eFind
+        out why multi-cloud is fundamental to financial services transformation\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/cinco-estrategias-para-acelerar-el-despliegue-de-kubernetes/19208\\\"\\u003eCinco
+        estrategias para acelerar el despliegue de Kubernetes\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/es/kubernetes-despliegue-empresa-manual\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eenterprise,
+        kubernetes\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-11-04\\u003c/td\\u003e\\n\\u003ctd\\u003ees\\u003c/td\\u003e\\n\\u003ctd\\u003eC\xF3mo
+        elegir el mejor enfoque de Kubernetes para su negocio\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/comparando-la-plataforma-openstack-de-red-hat-y-la-charmed-openstack-de-canonical/19194\\\"\\u003eComparando
+        la plataforma OpenStack de Red Hat y la Charmed OpenStack de Canonical\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/es/redhat-openstack-comparacion-manual\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-11-03\\u003c/td\\u003e\\n\\u003ctd\\u003ees\\u003c/td\\u003e\\n\\u003ctd\\u003eReducir
+        significativamente el coste total de propiedad con Charmed OpenStack\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/optimised-authentication-methods-for-ubuntu-desktop/19133\\\"\\u003eOptimised
+        authentication methods for Ubuntu Desktop\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/desktop-authentication-whitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003edesktop,
+        security\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-08-07\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eSecuring
+        enterprise desktops with modern authentication options\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/open-digital-platforms-for-the-industrial-edge-cloud-in-2020/19068\\\"\\u003eOpen
+        digital platforms for the industrial edge cloud in 2020\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/pac-radar\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003epac-radar\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-10-27\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eThe
+        next wave of cloud-native innovations at the edge\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/ubuntu-20-10-what-s-new/19050\\\"\\u003eUbuntu
+        20.10: What\u2019s new?\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/ubuntu-20.10\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eubuntu
+        server, maas, kubernetes\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-10-26\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eLearn
+        about new features in Ubuntu Server, MAAS, Charmed OpenStack and Charmed Kubernetes\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/ubuntu-for-raspberry-pi-live-on-youtube/18577\\\"\\u003eUbuntu
+        for Raspberry Pi intro video\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/raspberry-pi-livestream\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eraspberry-pi,
+        desktop\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-10-21\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/cloud-gaming-for-android/18757\\\"\\u003eCloud
+        gaming for Android\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/anbox-cloud-gaming-whitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eanbox,
+        gaming\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-01-21\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eBuilding
+        a high performing and scalable platform\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/extend-your-openstack-cloud-with-native-backup-and-recover/18911\\\"\\u003eExtend
+        your OpenStack cloud with native backup and recovery\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/trilio-backup-recovery\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-09-31\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eLearn
+        how TrilioVault can be easily deployed in a Charmed OpenStack environment\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/transforming-telco-infrastructure-a-virtual-event/18162\\\"\\u003eTransforming
+        telco infrastructure\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/telco-virtual-event\\u003c/td\\u003e\\n\\u003ctd\\u003eevent\\u003c/td\\u003e\\n\\u003ctd\\u003eopen-source\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-09-24\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eCanonical\u2019s
+        experts explore the telecommunication industry\u2019s latest technologies.\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/guia-para-la-implementacion-de-openstack/18480\\\"\\u003eGu\xEDa
+        para la implementaci\xF3n de OpenStack\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/es/guia-para-la-implementacion-de-openstack\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-09-16\\u003c/td\\u003e\\n\\u003ctd\\u003ees\\u003c/td\\u003e\\n\\u003ctd\\u003eDescubre
+        el probado proceso de implementaci\xF3n de OpenStack de Canonical\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/da-vmware-a-charmed-openstack/18478\\\"\\u003eDa
+        VMware a Charmed Openstack\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/it/da-vmware-a-charmed-openstack\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-09-15\\u003c/td\\u003e\\n\\u003ctd\\u003eit\\u003c/td\\u003e\\n\\u003ctd\\u003eCome
+        la migrazione a Charmed OpenStack pu\xF2 ridurre significativamente il TCO\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/gmo-pepabo-ubuntu/18476\\\"\\u003eGMO
+        Pepabo \\u0026amp; Ubuntu\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/case-study-gmo-pepabo\\u003c/td\\u003e\\n\\u003ctd\\u003ecase
+        study\\u003c/td\\u003e\\n\\u003ctd\\u003eserver, kubernetes,ubuntu-advantage\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-09-14\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eGMO
+        Pepabo cuts OPEX costs with live kernel patching and saves 2,500 hours of
+        manual work\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/da-vmware-a-openstack/18164\\\"\\u003eDa
+        VMware a OpenStack\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/it/da-vmware-a-openstack\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-09-04\\u003c/td\\u003e\\n\\u003ctd\\u003eit\\u003c/td\\u003e\\n\\u003ctd\\u003eCome
+        la migrazione a Charmed OpenStack pu\xF2 ridurre significativamente il TCO\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/five-strategies-to-accelerate-kubernetes-deployment-in-the-enterprise/18161\\\"\\u003eFive
+        strategies to accelerate Kubernetes in the enterprise\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/kubernetes-deployment-enterprise-whitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003ekubernetes\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-09-02\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eHow
+        to choose the best approach to Kubernetes for your business\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/production-ai-from-data-lake-to-server-webinar/18163\\\"\\u003eProduction
+        AI from data lake to server\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/data-lake_2_server_webinar\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eai\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-08-13\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eSolving
+        hardware challenges in ML environments\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/building-powerful-customer-solutions/18481\\\"\\u003eBuilding
+        powerful customer solutions\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/gsi-webinar-series\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003ecloud,
+        kubernetes\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-07-31\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eA
+        webinar series for GSIs seizing new models for scalable, automated and repeatable
+        deployments\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/red-hat-openstack-platform-vs-canonicals-charmed-openstack/18159\\\"\\u003eRed
+        Hat OpenStack Platform vs Canonical\u2019s Charmed OpenStack\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/redhat-openstack-comparison-whitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-07-29\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eImprove
+        security and efficiency at a reduced total cost of ownership with Charmed
+        OpenStack\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/do-vmware-ao-charmed-openstack/18165\\\"\\u003eDo
+        VMware ao Charmed OpenStack\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/pt/vmware-para-o-openstack\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-07-22\\u003c/td\\u003e\\n\\u003ctd\\u003ept\\u003c/td\\u003e\\n\\u003ctd\\u003eReduza
+        os custos e aumente a efici\xEAncia da sua infraestrutura com ado\xE7\xE3o
+        de c\xF3digo aberto\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/busting-the-myth-of-private-cloud-economics/17244\\\"\\u003eBusting
+        the myth of private cloud economics\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/cloud-economics\\u003c/td\\u003e\\n\\u003ctd\\u003ecase
+        study\\u003c/td\\u003e\\n\\u003ctd\\u003ecloud, openstack\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-12\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/scale-android-applications-economically-in-the-cloud-with-anbox-cloud/17401\\\"\\u003eScale
+        Android applications economically in the cloud with Anbox Cloud\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/intro-to-anbox-cloud-whitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003ecloud\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-07-08\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eDiscover
+        Canonical\u2019s scalable, hardware-agnostic mobile cloud computing platform\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/accelerating-iot-device-time-to-market/17399\\\"\\u003eAccelerating
+        IoT device time to market\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/smart-start-whitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eiot\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-07-03\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eIntroducing
+        a packaged solution to condense IoT decision-making into a 2-week, fixed cost
+        process\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/kubernetes-from-cloud-to-edge/17398\\\"\\u003eKubernetes
+        from Cloud to Edge\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/kubernetes-event-us\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003ekubernetes,
+        cloud, edge\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-06-24\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eHow
+        to streamline your Kubernetes deployment and operations from Canonical\u2019s
+        experts.\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/scaling-on-azure-with-ubuntu-pro/17397\\\"\\u003eScaling
+        on Azure with Ubuntu Pro\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/scaling-securely-ubuntu-azure\\u003c/td\\u003e\\n\\u003ctd\\u003eeBook\\u003c/td\\u003e\\n\\u003ctd\\u003eopen-source,
+        cloud\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-06-17\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eScale
+        your open-source infrastructure with speed, security, and compliance\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/a-technical-intro-to-ubuntu-pro/17396\\\"\\u003eA
+        technical intro to Ubuntu Pro\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/ubuntu-pro-intro\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eopen-source\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-06-16\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/migrating-your-infrastructure-to-ubuntu-20-04-lts/17395\\\"\\u003eMigrating
+        your infrastructure to Ubuntu 20.04 LTS\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/migrating-to-20.04\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eopen-source\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-06-11\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eHow,
+        when and why?\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/utilising-cloud-init-on-microsoft-azure/17394\\\"\\u003eUtilising
+        cloud-init on Microsoft Azure\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/azure-cloud-init-whitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003ecloud\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-06-03\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eSimplify
+        cloud instance deployment with Ubuntu on Azure\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/standardising-machine-learning-from-workstation-to-production/17393\\\"\\u003eStandardising
+        machine learning \u2014 from workstation to production\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/ml-dell-webinar\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eai,
+        ml, kubernetes\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-06-02\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/kafka-in-production/17392\\\"\\u003eKafka
+        in production\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/kafka-in-production\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003ekafka\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-05-28\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eMaking
+        sure your deployment is fast, reliable and secure\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/solving-the-software-update-challenge-for-iot-devices/17391\\\"\\u003eSolving
+        the software update challenge for IoT devices\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/snapd-whitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eiot,
+        ubuntu-core, snaps\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-05-15\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eHow
+        Ubuntu Core transforms over-the-air software updates\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/secure-iot-device-management/17390\\\"\\u003eSecure
+        IoT device management\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/iot-device-management-whitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eiot,
+        security, ubuntu-core\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-05-13\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eBuild
+        and deploy a central IoT management solution\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/leveraging-open-source-with-ubuntu-pro-on-azure/17389\\\"\\u003eLeveraging
+        open source with Ubuntu Pro on Azure\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/azure-webinar\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eopen-source\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-05-12\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eEconomics,
+        velocity and security\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/streamlined-kubernetes-from-cloud-to-edge/17388\\\"\\u003eStreamlined
+        Kubernetes, from Cloud to Edge\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/eu-kubernetes-event\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003ekubernetes,
+        cloud, edge\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-05-11\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eInnovating
+        and scaling efficiently, with Charmed Kubernetes and MicroK8s\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/embracing-the-open-source-mandate/17387\\\"\\u003eEmbracing
+        the open source mandate\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/moving-to-opensource-whitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eopen-source\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-04-28\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e85%
+        of enterprises have an open source mandate, preference or are exploring\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/what-s-new-in-ubuntu-20-04-lts/17386\\\"\\u003eWhat\u2019s
+        new in Ubuntu 20.04 LTS?\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/20.04-webinars\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003edesktop,
+        server\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-04-16\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eTwo
+        webinars to help you understand what makes 20.04 our most secure and reliable
+        release to date\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/maintaining-business-focus-in-a-cloud-native-world-with-managed-apps/17385\\\"\\u003eMaintaining
+        business focus in a cloud-native world with Managed Apps\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/managed-apps-webinar\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003ecloud\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-04-09\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/ubuntu-core-a-cybersecurity-analysis/17381\\\"\\u003eUbuntu
+        Core: a cybersecurity analysis\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/ubuntu-core-security-audit\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eubuntu-core,
+        security, iot\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-03-31\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eAn
+        independent evaluation of Ubuntu Core\u2019s security capabilities\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/openstack-deployment-guide/17384\\\"\\u003eOpenStack
+        deployment guide\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/openstack-deployment-guide\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-03-31\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eDiscover
+        Canonical\u2019s proven OpenStack implementation process\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/installez-et-mettez-openstack-a-lechelle-en-toute-simplicite/17418\\\"\\u003eInstallez
+        et mettez OpenStack \xE0 l\u2019\xE9chelle en toute simplicit\xE9\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/fr/openstack-made-easy\\u003c/td\\u003e\\n\\u003ctd\\u003eeBook\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-03-29\\u003c/td\\u003e\\n\\u003ctd\\u003efr\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/virtual-event-microk8s-kubernetes/17380\\\"\\u003eVirtual
+        event: MicroK8s \\u0026amp; Kubernetes\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/pre-kubecon-event\\u003c/td\\u003e\\n\\u003ctd\\u003eevent\\u003c/td\\u003e\\n\\u003ctd\\u003ekubernetes\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-03-24\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eJoin
+        our virtual event to learn more about MicroK8s, what it is and why you should
+        use it. This event will also include discussions on Kubernetes, an introduction
+        to Canonical and much more!\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/rigado-cuts-customers-time-to-market/17379\\\"\\u003eRigado
+        cuts customers\u2019 time-to-market\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/case-study-rigado\\u003c/td\\u003e\\n\\u003ctd\\u003ecase
+        study\\u003c/td\\u003e\\n\\u003ctd\\u003eiot, ubuntu-core, snaps\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-03-19\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003ewith
+        Ubuntu Core and AWS\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/securing-ros-robotics-platforms/17378\\\"\\u003eSecuring
+        ROS robotics platforms\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/securing-ros-on-robotics-platforms-whitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003erobotics,
+        security\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-03-11\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eSteps
+        to maximise robotics security with Ubuntu\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/smart-card-login-on-ubuntu/17377\\\"\\u003eSmart
+        card login on Ubuntu\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/smart-card-whitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003esecurity\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-03-09\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eConfigure
+        Ubuntu 18.04 LTS for smart card operation\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/hosted-private-cloud-infrastructure-a-cost-analysis/17375\\\"\\u003eHosted
+        private cloud infrastructure: a cost analysis\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/private-cloud-cost-analysis-webinar\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack,
+        cloud, kubernetes, maas\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-03-02\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eAccelerate
+        initial deployment and reduce operational costs by outsourcing private cloud
+        infrastructure management\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/an-introduction-to-anbox-cloud/17374\\\"\\u003eAccelerating
+        IoT device time to market\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/smart-start-webinar\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eiot\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-02-26\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eChallenges
+        and solutions for IoT execution\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/an-introduction-to-anbox-cloud/17374\\\"\\u003eAn
+        introduction to Anbox Cloud\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/anbox-cloud-webinar\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003ecloud\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-02-25\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eScalable
+        Android\u2122 in the cloud\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/esm-maintains-interanas-system-security-while-upgrading/17376\\\"\\u003eESM
+        maintains Interana\u2019s system security while upgrading\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/interana-casestudy\\u003c/td\\u003e\\n\\u003ctd\\u003ecase
+        study\\u003c/td\\u003e\\n\\u003ctd\\u003esecurity\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-02-17\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/artificial-intelligence-at-the-edge-in-a-5g-world/17372\\\"\\u003eArtificial
+        Intelligence at the edge in a 5G world\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/ai-edge-webinar\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eai,
+        ml, edge\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-02-07\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eDeploying
+        AI/ML solutions in latency-sensitive environments requires a new solution
+        architecture approach\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/deploy-kubernetes-in-your-data-centre/17373\\\"\\u003eDeploy
+        Kubernetes in your data centre\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/dell-kubernetes-webinar\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003ekubernetes\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-02-07\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/migration-von-vmware-zu-openstack/17370\\\"\\u003eMigration
+        von VMware zu OpenStack\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/de/migration-von-vmware-zu-openstack\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-02-04\\u003c/td\\u003e\\n\\u003ctd\\u003ede\\u003c/td\\u003e\\n\\u003ctd\\u003eWie
+        ein Umstieg auf Charmed OpenStack die Gesamtkosten sp\xFCrbar senken kann\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/de-vmware-a-charmed-openstack/17371\\\"\\u003eDe
+        VMware a Charmed OpenStack\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/es/vmware-a-charmed-openstack\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-02-04\\u003c/td\\u003e\\n\\u003ctd\\u003ees\\u003c/td\\u003e\\n\\u003ctd\\u003eC\xF3mo
+        la migraci\xF3n a Charmed OpenStack puede reducir significativamente el TCO\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/kubernetes-a-secure-flexible-and-automated-edge-for-iot-developers/17369\\\"\\u003eKubernetes:
+        a secure, flexible and automated edge for IoT developers\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/microk8s-451research\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003ekubernetes,
+        edge, iot\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-01-10\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eThe
+        factors for implementing Kubernetes successfully at the edge\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/an-intro-to-microk8s/17367\\\"\\u003eAn
+        intro to MicroK8s\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/intro-to-microk8s-webinar\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003ekubernetes\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-12-19\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eReliable,
+        fast, small and upstream Kubernetes\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/ubuntu-desktop-for-the-enterprise/17368\\\"\\u003eUbuntu
+        Desktop for the enterprise\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/linux-enterprise-whitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003edesktop\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-12-19\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eLearn
+        why enterprises are beginning to adopt Linux as a desktop operating system\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/cyberdyne-keeps-cleaning-robots-up-to-date-in-the-field-with-snaps/17366\\\"\\u003eCyberdyne
+        keeps cleaning robots up-to-date in the field with snaps\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/cyberdyne\\u003c/td\\u003e\\n\\u003ctd\\u003ecase
+        study\\u003c/td\\u003e\\n\\u003ctd\\u003erobotics, iot\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-12-18\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/sbi-group-unlocks-infrastructure-automation-with-secure-on-premises-openstack-cloud/17364\\\"\\u003eSBI
+        Group unlocks infrastructure automation with secure, on-premises OpenStack
+        cloud\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/sbi-casestudy\\u003c/td\\u003e\\n\\u003ctd\\u003ecase
+        study\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-12-06\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/register-for-wslconf/17365\\\"\\u003eRegister
+        for WSLConf\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/wslconf\\u003c/td\\u003e\\n\\u003ctd\\u003eevent\\u003c/td\\u003e\\n\\u003ctd\\u003ewsl\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-12-06\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/build-smart-display-devices-with-mir-fast-to-production-secure-open-source/17363\\\"\\u003eBuild
+        smart display devices with Mir: fast to production, secure, open-source\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/build-smart-devices-with-mir-whitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eiot\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-11-27\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/linux-security-with-ubuntu/17362\\\"\\u003eLinux
+        security with Ubuntu\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/linux_security_webinar\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003esecurity\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-11-14\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eSecuring
+        Ubuntu systems for reduced downtime and optimum CVE coverage.\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/lessons-learned-from-100-private-cloud-builds/17361\\\"\\u003eLessons
+        learned from 100+ Private cloud builds\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/private-cloud-build-webinar\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack,
+        cloud\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-11-12\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eReducing
+        the complexities of building a private cloud on OpenStack\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/the-wellcome-sanger-institute-turns-to-canonical-for-high-level-ceph-support/17360\\\"\\u003eThe
+        Wellcome Sanger Institute turns to Canonical for high level Ceph support\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/wellcome-sanger-case-study\\u003c/td\\u003e\\n\\u003ctd\\u003ecase
+        study\\u003c/td\\u003e\\n\\u003ctd\\u003eceph, openstack\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-11-04\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/ensuring-security-and-isolation-in-kubernetes-with-kata-containers/17359\\\"\\u003eEnsuring
+        security and isolation in Kubernetes with Kata Containers\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/kata-containers-webinar\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003esecurity\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-11-01\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/tim-ensures-system-security-and-client-confidence-with-esm/17358\\\"\\u003eTIM
+        ensures system security and client confidence with ESM\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/case-study-acuris\\u003c/td\\u003e\\n\\u003ctd\\u003ecase
+        study\\u003c/td\\u003e\\n\\u003ctd\\u003esecurity, ubuntu-advantage\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-10-22\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/what-s-new-in-ubuntu-19-10/17357\\\"\\u003eWhat\u2019s
+        new in Ubuntu 19.10\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/19-10-webinar\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003edesktop\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-10-17\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eUbuntu
+        19.10 includes enhanced K8s capabilities for edge and AI/ML, OpenStack Train
+        live-migration extensions for easier infrastructure deployments and more.\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/how-domotz-streamlined-provisioning-of-iot-devices/17356\\\"\\u003eHow
+        Domotz streamlined provisioning of IoT devices\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/domotz-case-study\\u003c/td\\u003e\\n\\u003ctd\\u003ecase
+        study\\u003c/td\\u003e\\n\\u003ctd\\u003eubuntu-core, snaps, iot\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-10-10\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eLearn
+        how Ubuntu Core and snaps gives Domotz a competitive advantage\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/yahoo-japan-builds-their-iaas-environment-with-canonical/17355\\\"\\u003eYahoo!
+        Japan builds their IaaS environment with Canonical\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/yahoo-japan-case-study\\u003c/td\\u003e\\n\\u003ctd\\u003ecase
+        study\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack, maas, juju, ubuntu-advantage,
+        security\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-10-08\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/accelerating-deep-tech-with-ubuntu/17354\\\"\\u003eAccelerating
+        deep tech with Ubuntu\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/deeptech\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eiot,
+        robotics\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-10-02\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/from-vmware-to-charmed-openstack/17343\\\"\\u003eFrom
+        VMWare To Charmed OpenStack\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/vmware-to-charmed-openstack\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-09-04\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eReduce
+        costs and increase the efficiency of your infrastructure with open source
+        adoption\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/machine-learning-operations-mlops/17353\\\"\\u003eMachine
+        Learning Operations (MLOps)\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/get-started-with-ai-part-2\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eai,
+        ml\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-09-11\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eDeploy
+        at scale\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/how-to-manage-snaps-in-an-enterprise-environment/17352\\\"\\u003eHow
+        to manage snaps in an enterprise environment\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/enterprise-snap-management\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003esnaps,
+        security\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-08-20\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eHow
+        the Snap Store Proxy overcomes challenges presented by restricted networks
+        and management policies\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/a-guide-to-developing-android-apps-on-ubuntu/17351\\\"\\u003eA
+        guide to developing Android apps on Ubuntu\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/developing-android-on-ubuntu\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003edesktop,
+        apps\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-08-13\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/creating-a-cloud-like-bare-metal-experience-in-the-data-centre/17348\\\"\\u003eCreating
+        a cloud-like bare metal experience in the data centre\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/maas-hardware-testing\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003emaas\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-08-08\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/creating-accurate-ai-models-with-data/17349\\\"\\u003eCreating
+        accurate AI models with data\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/data-pipelines-kubeflow\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003ekubeflow,
+        ai\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-08-08\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eHow
+        Kubeflow and machine learning help you get the most out of your data\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/ims-evolve-adopts-ubuntu-core-to-provide-iot-enabled-business-intelligence-in-the-supply-chain/17284\\\"\\u003eIMS
+        Evolve adopts Ubuntu Core to provide IoT-enabled business intelligence in
+        the supply chain\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/casestudy-imsevolve\\u003c/td\\u003e\\n\\u003ctd\\u003ecase
+        study\\u003c/td\\u003e\\n\\u003ctd\\u003eiot\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-17\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/rocket-chat-communication-platform-enables-simplicity-through-snaps/17288\\\"\\u003eRocket.Chat
+        communication platform enables simplicity through snaps\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/casestudy-rocketchat\\u003c/td\\u003e\\n\\u003ctd\\u003ecase
+        study\\u003c/td\\u003e\\n\\u003ctd\\u003esnaps, apps\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-17\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/server-provisioning-what-network-admins-it-pros-need-to-know/17307\\\"\\u003eServer
+        Provisioning: What Network Admins \\u0026amp; IT Pros Need to Know\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/ebook-maas\\u003c/td\\u003e\\n\\u003ctd\\u003eeBook\\u003c/td\\u003e\\n\\u003ctd\\u003eserver\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-17\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/building-a-private-cloud-take-the-leap/17331\\\"\\u003eBuilding
+        a private cloud? Take the leap!\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/private-cloud\\u003c/td\\u003e\\n\\u003ctd\\u003eeBook\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack,
+        cloud\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-17\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/make-it-rain-public-cloud-on-ubuntu-openstack/17332\\\"\\u003eMake
+        IT rain: public cloud on Ubuntu OpenStack\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/public-cloud\\u003c/td\\u003e\\n\\u003ctd\\u003eeBook\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack,
+        cloud\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-17\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/learn-whats-new-in-ubuntu-server-14-04-lts/17344\\\"\\u003eLearn
+        What\u2019s New In Ubuntu Server 14.04 LTS\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/whats-new-ubuntu-14-04-lts\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eserver,
+        openstack\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-17\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/how-ubuntu-helped-innovapos-revolutionise-the-vending-machine-industry/17285\\\"\\u003eHow
+        Ubuntu helped InnovaPOS revolutionise the vending machine industry\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/casestudy-innovapos\\u003c/td\\u003e\\n\\u003ctd\\u003ecase
+        study\\u003c/td\\u003e\\n\\u003ctd\\u003eiot\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-16\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/nexiona-collaborates-with-canonical-and-dell-to-create-miimetiq-edge/17287\\\"\\u003eNEXIONA
+        collaborates with Canonical and Dell to create MIIMETIQ EDGE\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/casestudy-nexiona\\u003c/td\\u003e\\n\\u003ctd\\u003ecase
+        study\\u003c/td\\u003e\\n\\u003ctd\\u003eiot\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-16\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/azeti-uses-ubuntu-core-to-improve-deployment-and-security/17278\\\"\\u003eAzeti
+        uses Ubuntu Core to improve deployment and security\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/casestudy-azeti\\u003c/td\\u003e\\n\\u003ctd\\u003ecase
+        study\\u003c/td\\u003e\\n\\u003ctd\\u003esecurity, iot\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-16\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/azlogica-utilise-ubuntu-core-for-customised-iot-agricultural-solutions/17279\\\"\\u003eAZLOGICA
+        utilise Ubuntu Core for customised IoT agricultural solutions\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/casestudy-azlogica\\u003c/td\\u003e\\n\\u003ctd\\u003ecase
+        study\\u003c/td\\u003e\\n\\u003ctd\\u003eiot\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-16\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/botsandus-builds-a-social-robot-on-ubuntu/17280\\\"\\u003eBotsAndUs
+        builds a social robot on Ubuntu\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/casestudy-botsandus\\u003c/td\\u003e\\n\\u003ctd\\u003ecase
+        study\\u003c/td\\u003e\\n\\u003ctd\\u003erobotics\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-16\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/cinergy-makes-significant-digital-signage-saving-with-screenly-pro-and-ubuntu-core/17281\\\"\\u003eCinergy
+        makes significant digital signage saving with Screenly Pro and Ubuntu Core\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/casestudy-cinergy\\u003c/td\\u003e\\n\\u003ctd\\u003ecase
+        study\\u003c/td\\u003e\\n\\u003ctd\\u003edigital-signage\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-16\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/commercetools-uses-ubuntu-server-to-power-its-next-generation-ecommerce-platform/17283\\\"\\u003eCommercetools
+        uses Ubuntu Server to power its next-generation ecommerce platform\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/casestudy-commercetools\\u003c/td\\u003e\\n\\u003ctd\\u003ecase
+        study\\u003c/td\\u003e\\n\\u003ctd\\u003eserver, e-commerce\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-16\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/for-ctos-the-no-nonsense-way-to-accelerate-your-business-with-containers/17345\\\"\\u003eFor
+        CTOs: the no-nonsense way to accelerate your business with containers\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/whitepaper-containers\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003etelco\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-16\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/taking-charge-of-the-iots-security-vulnerabilities/17346\\\"\\u003eTaking
+        charge of the IoT\u2019s security vulnerabilities\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/whitepaper-iot-security\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eiot,
+        security\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-16\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/the-essential-guide-for-telecoms-and-service-providers-adopting-big-data-solutions/17309\\\"\\u003eThe
+        essential guide for Telecoms and Service Providers adopting big data solutions\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/essential-guide-big-data-solutions\\u003c/td\\u003e\\n\\u003ctd\\u003eeBook\\u003c/td\\u003e\\n\\u003ctd\\u003etelco,
+        openstack\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-15\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/city-network-brings-openstack-cloud-hosting-to-the-financial-services-sector-with-canonical/17282\\\"\\u003eCity
+        Network brings OpenStack cloud hosting to the financial services sector with
+        Canonical\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/casestudy-city-network\\u003c/td\\u003e\\n\\u003ctd\\u003ecase
+        study\\u003c/td\\u003e\\n\\u003ctd\\u003ecloud\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-15\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/cto-s-guide-to-sdn-nfv-vnf/17293\\\"\\u003eCTO\u2019s
+        guide to SDN, NFV \\u0026amp; VNF\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/cto-guide-sdn-nfv-vnf\\u003c/td\\u003e\\n\\u003ctd\\u003eeBook\\u003c/td\\u003e\\n\\u003ctd\\u003enetworking\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-15\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eWhy
+        is the transition happening and why is it important?\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/sensape-uses-landscape-to-remotely-support-revolutionary-interactive-retail-displays/17289\\\"\\u003eSensape
+        uses Landscape to remotely support revolutionary interactive retail displays\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/casestudy-sensape\\u003c/td\\u003e\\n\\u003ctd\\u003ecase
+        study\\u003c/td\\u003e\\n\\u003ctd\\u003edigital-signage\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-15\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/how-to-face-the-challenges-of-becoming-a-cloud-operator/17290\\\"\\u003eHow
+        to face the challenges of becoming a cloud operator\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/cloud-fray\\u003c/td\\u003e\\n\\u003ctd\\u003eeBook\\u003c/td\\u003e\\n\\u003ctd\\u003ecloud,
+        openstack, telco\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-15\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/low-latency-and-real-time-kernels-for-telco-and-nfv/17321\\\"\\u003eLow
+        latency and real time kernels for telco and NFV\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/low-latency-report\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003etelco\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-15\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/how-to-escape-stuckstack-and-profit-from-your-openstack-investment/17337\\\"\\u003eHow
+        to escape StuckStack and profit from your OpenStack investment\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/stuckstack-ebook\\u003c/td\\u003e\\n\\u003ctd\\u003eeBook\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-15\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/carrier-cloudification-what-every-telecom-executive-needs-to-know/17338\\\"\\u003eCarrier
+        Cloudification: What every telecom executive needs to know\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/telco-cloudification-ebook\\u003c/td\\u003e\\n\\u003ctd\\u003eeBook\\u003c/td\\u003e\\n\\u003ctd\\u003etelco,
+        cloud, openstack\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-15\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/nfv-and-sdn-on-openstack/17326\\\"\\u003eNFV
+        and SDN on OpenStack\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/nfv-sdn-openstack\\u003c/td\\u003e\\n\\u003ctd\\u003eeBook\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack,
+        networking\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-12\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/openstack-made-easy/17328\\\"\\u003eOpenStack
+        made easy\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/openstack-made-easy\\u003c/td\\u003e\\n\\u003ctd\\u003eeBook\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-12\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eWith
+        the right tools, OpenStack can be easy\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/telcos-and-service-providers-expect-near-100-uptime/17330\\\"\\u003eTelcos
+        and Service Providers expect near 100% uptime\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/openstack-telco-clouds\\u003c/td\\u003e\\n\\u003ctd\\u003eeBook\\u003c/td\\u003e\\n\\u003ctd\\u003etelco,
+        openstack, cloud\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-12\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eThis
+        requires a proven cloud platform that minimises time-to-revenue and ensures
+        predictable costs.\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/a-shift-to-the-linux-app-store-experience/17347\\\"\\u003eA
+        shift to the Linux app store experience\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/shift-to-app-store-experience\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eapps,
+        snaps\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-11\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eThe
+        key to optimising software distribution in a fragmented environment.\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/le-support-d-ubuntu-14-04-lts-est-maintenant-passe-a-esm/17413\\\"\\u003eLe
+        support d\u2019Ubuntu 14.04 LTS est maintenant pass\xE9 \xE0 ESM\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/fr/esm_1404\\u003c/td\\u003e\\n\\u003ctd\\u003eblog\\u003c/td\\u003e\\n\\u003ctd\\u003esecurity\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-06-28\\u003c/td\\u003e\\n\\u003ctd\\u003efr\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/a-guide-to-edge-computing-and-the-tools-you-need/17308\\\"\\u003eA
+        guide to edge computing and the tools you need\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/edge-month\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eedge,
+        cloud, kubernetes, maas\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-06-27\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eLearn
+        how edge computing provides enterprises with real-time data processing, cost-effective
+        security and scalability.\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/sicherheit-in-der-private-cloud/17411\\\"\\u003eSicherheit
+        in der Private Cloud\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/de/openstack-security-de\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack,
+        cloud\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-06-19\\u003c/td\\u003e\\n\\u003ctd\\u003ede\\u003c/td\\u003e\\n\\u003ctd\\u003eH\xF6chste
+        Anforderungen in Unternehmensumgebungen mit OpenStack erf\xFCllen.\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/how-to-get-started-and-progress-with-an-ai-program/17245\\\"\\u003eHow
+        to get started and progress with an AI program\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/ai-gettingstarted\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eai,
+        ml\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-06-11\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/the-future-of-mobile-connectivity/17342\\\"\\u003eThe
+        future of mobile connectivity\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/ubuntu-lime-telco\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003etelco\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-06-12\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eMajor
+        mobile operators are adopting open source versus proprietary technologies
+        to reduce costs.\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/north-america-s-first-autonomous-runway-snowplough/17327\\\"\\u003eNorth
+        America\u2018s first autonomous runway snowplough\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/northstar\\u003c/td\\u003e\\n\\u003ctd\\u003ecase
+        study\\u003c/td\\u003e\\n\\u003ctd\\u003erobotics, iot\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-06-05\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eThe
+        robots helping to address off-highway labour shortages\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/small-robot-company-sows-the-seeds-for-autonomous-and-more-profitable-farming/17334\\\"\\u003eSmall
+        Robot Company sows the seeds for autonomous and more profitable farming\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/small-robot-company\\u003c/td\\u003e\\n\\u003ctd\\u003ecase
+        study\\u003c/td\\u003e\\n\\u003ctd\\u003erobotics, ai\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-06-04\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/how-to-integrate-ubuntu-desktop-with-active-directory/17323\\\"\\u003eHow
+        to integrate Ubuntu Desktop with Active Directory\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/microsoft-active-directory\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003edesktop,
+        active-directory\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-06-04\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/connected-cars-and-autonomous-driving/17243\\\"\\u003eConnected
+        cars and autonomous driving\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/451-automotive\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eiot\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-05-31\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eAddressing
+        risk and complexity with software\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/why-ubuntu-core-is-the-most-secure-choice-for-iot/17292\\\"\\u003eWhy
+        Ubuntu Core is the most secure choice for IoT\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/core18-security\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003esecurity,
+        iot, ubuntu-core\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-05-29\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/getting-started-with-ai/17336\\\"\\u003eGetting
+        started with AI\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/starting-with-ai\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eai,
+        ml\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-05-11\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/the-transformation-of-the-devops-journey-in-iot/17422\\\"\\u003eThe
+        transformation of the DevOps journey in IoT\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/iot-devops\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eiot\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-05-07\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/cloud-init/17291\\\"\\u003eCloud init\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/cloud-init-whitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003ecloud\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-05-01\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/how-to-build-a-lightweight-system-container-cluster/17322\\\"\\u003eHow
+        to build a lightweight system container cluster\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/lxd-whitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003elxd\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-04-30\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eYou
+        will learn how working in this environment:\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/the-transformation-of-the-devops-journey-in-iot-webinar/17306\\\"\\u003eThe
+        transformation of the DevOps journey in IoT Webinar\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/devops-iot-webinar\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eiot\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-04-29\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/private-cloud-security-webinar/17329\\\"\\u003ePrivate
+        cloud security Webinar\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/openstack-security-webinar\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack,
+        security\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-04-24\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eHow
+        Charmed OpenStack is decreasing common security concerns\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/private-cloud-security/17421\\\"\\u003ePrivate
+        cloud security\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/openstack-security-whitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack,
+        security\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-04-24\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eMeeting
+        the highest levels of enterprise requirements with OpenStack\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/hiri-successfully-monetises-their-snap/17314\\\"\\u003eHiri
+        successfully monetises their snap\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/hiri-case-study\\u003c/td\\u003e\\n\\u003ctd\\u003ecase
+        study\\u003c/td\\u003e\\n\\u003ctd\\u003eapps, snaps\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-04-25\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/whats-new-in-ubuntu-19-04/17240\\\"\\u003eWhat\u2019s
+        new in Ubuntu 19.04?\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/19-04-webinar\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack,
+        kubernetes, ceph, iot, desktop\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-04-18\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eJoin
+        Canonical Product Director Stephan Fabel and Ubuntu Product Managers to discuss
+        everything new in Ubuntu 19.04 \u2018Disco Dingo\u2019\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/optimising-iot-bandwidth-with-delta-updates/17335\\\"\\u003eOptimising
+        IoT bandwidth with delta updates\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/snap-deltas\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eiot,
+        snaps\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-03-16\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eLearn
+        how snap deltas\u2019 over-the-air updates are efficient and effective.\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/an-introduction-to-apparmor/17277\\\"\\u003eAn
+        introduction to AppArmor\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/apparmor-intro\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003esecurity\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-03-16\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eAn
+        explanation of AppArmor and its key features.\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/get-started-with-devops-best-practices-ci-cd/17305\\\"\\u003eGet
+        started with DevOps best practices: CI/CD\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/devops-cicd-webinar\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003ekubernetes\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-03-07\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/esm-for-ubuntu-14-04-lts-trusty-tahr/17275\\\"\\u003eESM
+        for Ubuntu 14.04 LTS Trusty Tahr\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/14-04-esm\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003esecurity\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-02-21\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eLearn
+        how to maintain ongoing security compliance for your 14.04 systems.\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/securing-iot-device-data-against-physical-access/17318\\\"\\u003eSecuring
+        IoT device data against physical access\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/iot-disk-encryption\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eiot,
+        security, ubuntu-core\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-02-11\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eA
+        technical overview of how Ubuntu Core with full disk encryption and secure
+        boot can be implemented to harden IoT devices\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/multi-cloud-fundamental-to-financial-services-transformation/17312\\\"\\u003eMulti-cloud
+        fundamental to financial services transformation\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/finserv-multi-cloud\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003ecloud,
+        finance, ai\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-02-04\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/extension-securite-et-maintenance-pour-ubuntu-14-04/17414\\\"\\u003eExtension
+        S\xE9curit\xE9 et Maintenance pour Ubuntu 14.04\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/fr/esm\\u003c/td\\u003e\\n\\u003ctd\\u003eblog\\u003c/td\\u003e\\n\\u003ctd\\u003esecurity\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-01-31\\u003c/td\\u003e\\n\\u003ctd\\u003efr\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/utiliser-des-gpus-avec-kubernetes/17419\\\"\\u003eUtiliser
+        des GPUs avec Kubernetes\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/fr/utiliser-gpgpus-avec-kubernetes\\u003c/td\\u003e\\n\\u003ctd\\u003eblog\\u003c/td\\u003e\\n\\u003ctd\\u003ekubernetes\\u003c/td\\u003e\\n\\u003ctd\\u003e2018-12-20\\u003c/td\\u003e\\n\\u003ctd\\u003efr\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/apellix-engineers-safer-work-environments-with-ubuntu-powered-aerial-robotics/17315\\\"\\u003eApellix
+        engineers safer work environments with Ubuntu powered aerial robotics\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/industrial-drones-case-study\\u003c/td\\u003e\\n\\u003ctd\\u003ecase
+        study\\u003c/td\\u003e\\n\\u003ctd\\u003erobotics, iot\\u003c/td\\u003e\\n\\u003ctd\\u003e2018-12-14\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/allan-gray-unlocks-unprecedented-availability-and-productivity-with-charmed-kubernetes/17319\\\"\\u003eAllan
+        Gray unlocks unprecedented availability and productivity with Charmed Kubernetes\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/k8s-allan-gray\\u003c/td\\u003e\\n\\u003ctd\\u003ecase
+        study\\u003c/td\\u003e\\n\\u003ctd\\u003efinance, kubernetes\\u003c/td\\u003e\\n\\u003ctd\\u003e2018-12-13\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/six-reasons-why-developers-choose-ubuntu-desktop/17304\\\"\\u003eSix
+        reasons why developers choose Ubuntu Desktop\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/developer-desktop\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003edesktop\\u003c/td\\u003e\\n\\u003ctd\\u003e2018-11-23\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/modernise-your-cloud/17324\\\"\\u003eModernise
+        your cloud\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/modern-cloud\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003ecloud\\u003c/td\\u003e\\n\\u003ctd\\u003e2018-11-22\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eDiscover
+        how Trilio and Canonical help organisations transition to new, maintainable
+        cloud architecture in just weeks.\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/precision-drones-on-ubuntu-flying-at-the-edge-of-innovation/17316\\\"\\u003ePrecision
+        drones on Ubuntu: flying at the edge of innovation\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/industrial-drones\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003erobotics,
+        iot\\u003c/td\\u003e\\n\\u003ctd\\u003e2018-11-20\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eHow
+        Apellix uses Ubuntu on drones to replace human workers in potentially dangerous
+        scenarios.\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/securing-the-enterprise-how-ubuntu-is-at-the-forefront-of-security-and-compliance/17340\\\"\\u003eSecuring
+        the enterprise: how Ubuntu is at the forefront of security and compliance\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/ubuntu-compliance\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003esecurity\\u003c/td\\u003e\\n\\u003ctd\\u003e2018-11-12\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/itstrategen-keeps-legacy-applications-secure-with-extended-security-maintenance/17286\\\"\\u003eITstrategen
+        keeps legacy applications secure with Extended Security Maintenance\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/ITstrategen-case-study\\u003c/td\\u003e\\n\\u003ctd\\u003ecase
+        study\\u003c/td\\u003e\\n\\u003ctd\\u003esecurity\\u003c/td\\u003e\\n\\u003ctd\\u003e2018-10-29\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/what-s-new-in-ubuntu-18-10/17339\\\"\\u003eWhat\u2019s
+        New in Ubuntu 18.10\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/ubuntu-18-10\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003edesktop,
+        server\\u003c/td\\u003e\\n\\u003ctd\\u003e2018-10-29\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eCanonical
+        product managers discuss the new Ubuntu 18.10 release features in this on-demand
+        webinar\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/ubuntu-core-and-kura-a-framework-for-iot-gateways/17341\\\"\\u003eUbuntu
+        Core and Kura: A framework for IoT gateways\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/ubuntu-core-and-kura\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eubuntu-core,
+        iot, edge, snaps\\u003c/td\\u003e\\n\\u003ctd\\u003e2018-10-23\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/keep-up-with-evolving-software/17310\\\"\\u003eKeep
+        up with evolving software\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/evolving-software\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003ejuju,
+        cloud\\u003c/td\\u003e\\n\\u003ctd\\u003e2018-10-22\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eLearn
+        how Juju can help solve software management complexity.\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/wofur-konnen-sie-kubernetes-einsetzen/17410\\\"\\u003eWof\xFCr
+        k\xF6nnen Sie Kubernetes einsetzen?\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/de/what-can-you-do-with-kubernetes\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003ekubernetes\\u003c/td\\u003e\\n\\u003ctd\\u003e2018-10-19\\u003c/td\\u003e\\n\\u003ctd\\u003ede\\u003c/td\\u003e\\n\\u003ctd\\u003eDieses
+        Webinar liefert Ihnen alles Wichtige zum Einstieg.\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/low-latency-and-real-time-kernels-for-telco-and-nfv/17320\\\"\\u003eLow
+        latency and real-time kernels for telco and NFV\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/kernel-telco-nfv\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003etelco\\u003c/td\\u003e\\n\\u003ctd\\u003e2018-10-08\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/future-proofing-fingbox-the-iot-home-network-monitoring-device/17313\\\"\\u003eFuture-proofing
+        Fingbox, the IoT home network monitoring device\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/future-proof-iot\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eiot,
+        ubuntu-core\\u003c/td\\u003e\\n\\u003ctd\\u003e2018-10-02\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/how-to-build-and-deploy-your-first-ai-ml-model-on-ubuntu/17294\\\"\\u003eHow
+        to build and deploy your first AI/ML model on Ubuntu\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/deploy-ai-ml-model\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eai,
+        ml, kubeflow, kubernetes\\u003c/td\\u003e\\n\\u003ctd\\u003e2018-09-26\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eAn
+        introduction to AI and ML workloads on Ubuntu workstations, servers and in
+        the cloud on a Kubernetes stack.\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/openstack-problemlos-installieren-und-skalieren/17409\\\"\\u003eOpenStack
+        problemlos installieren und skalieren\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/de/openstack-made-easy\\u003c/td\\u003e\\n\\u003ctd\\u003eeBook\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack\\u003c/td\\u003e\\n\\u003ctd\\u003e2018-09-05\\u003c/td\\u003e\\n\\u003ctd\\u003ede\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/key-considerations-when-choosing-a-robot-s-operating-system/17333\\\"\\u003eKey
+        considerations when choosing a robot\u2019s operating system\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/robot-operating-system-choice\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003erobotics\\u003c/td\\u003e\\n\\u003ctd\\u003e2018-09-05\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/cio-guide-to-multi-cloud-operations/17325\\\"\\u003eCIO
+        guide to multi-cloud operations\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/multi-cloud-guide\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003ecloud,
+        kubernetes, container\\u003c/td\\u003e\\n\\u003ctd\\u003e2018-09-03\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/canonical-presents-financial-services-month/17241\\\"\\u003eCanonical
+        presents Financial Services Month\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/financial-services-month\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003efinance,
+        ai, ml cloud\\u003c/td\\u003e\\n\\u003ctd\\u003e2018-09-03\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eFilmed
+        at the London Stock exchange with representatives from Canonical, 451 Research,
+        IBM, and a former Deutsche Bank storage CTO, Canonical took a deep dive look
+        in to the rise of multi-cloud in the financial services industry.\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/establishing-a-software-defined-iot-business-model/17317\\\"\\u003eEstablishing
+        a software defined IoT business model\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/iot-business-model\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eiot\\u003c/td\\u003e\\n\\u003ctd\\u003e2018-08-24\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/artificial-intelligence-machine-learning-and-ubuntu/17276\\\"\\u003eArtificial
+        intelligence, machine learning and Ubuntu\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/ai-ml-ubuntu\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eai,
+        ml, kubernetes\\u003c/td\\u003e\\n\\u003ctd\\u003e2018-08-16\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/von-vmware-zu-canonical-openstack/17408\\\"\\u003eVon
+        VMware zu Canonical OpenStack\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/de/vmware-to-openstack\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack\\u003c/td\\u003e\\n\\u003ctd\\u003e2018-08-06\\u003c/td\\u003e\\n\\u003ctd\\u003ede\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/fing-serves-30-000-customers-with-a-secure-future-proof-iot-device/17311\\\"\\u003eFing
+        serves 30,000 customers with a secure, future-proof IoT device\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/fingbox-case-study\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eiot,
+        ubuntu-core, snaps\\u003c/td\\u003e\\n\\u003ctd\\u003e2018-06-25\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/canonical-integre-containerd-a-ubuntu-kubernetes/17412\\\"\\u003eCanonical
+        int\xE8gre containerd \xE0 Ubuntu Kubernetes\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/fr/canonical-ajoute-containerd-a-ubuntu-kubernetes\\u003c/td\\u003e\\n\\u003ctd\\u003eblog\\u003c/td\\u003e\\n\\u003ctd\\u003ekubernetes\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-05-22\\u003c/td\\u003e\\n\\u003ctd\\u003efr\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/guide-du-dsi-pour-les-operations-multicloud/17415\\\"\\u003eGUIDE
+        DU DSI pour les op\xE9rations multicloud\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/fr/guide-du-DSI-pour-les-operations-multicloud\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003ecloud,
+        kubernetes\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-05-22\\u003c/td\\u003e\\n\\u003ctd\\u003efr\\u003c/td\\u003e\\n\\u003ctd\\u003eChoisir
+        une architecture cloud rentable\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/canonical-annonce-managed-apps-linfogerance-des-applications-sur-votre-cloud/17416\\\"\\u003eCanonical
+        annonce Managed Apps: l\u2019infog\xE9rance des applications sur votre cloud.\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/fr/managed-apps\\u003c/td\\u003e\\n\\u003ctd\\u003eblog\\u003c/td\\u003e\\n\\u003ctd\\u003eapps\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-05-18\\u003c/td\\u003e\\n\\u003ctd\\u003efr\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/migrer-de-vmware-a-openstack/17417\\\"\\u003eMigrer
+        de VMWare \xE0 OpenStack\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/fr/migrer-de-vmware-a-openstack\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-05-18\\u003c/td\\u003e\\n\\u003ctd\\u003efr\\u003c/td\\u003e\\n\\u003ctd\\u003ePassez
+        \xE0 Charmed OpenStack et r\xE9duisez consid\xE9rablement vos co\xFBts\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/migrer-de-vmware-a-openstack-webinaire/17420\\\"\\u003eMigrer
+        de VMware \xE0 Openstack Webinaire\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/fr/vmware-to-openstack\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-05-18\\u003c/td\\u003e\\n\\u003ctd\\u003efr\\u003c/td\\u003e\\n\\u003ctd\\u003eApprenez
+        comment migrer d\u2019un environnement traditionnel et propri\xE9taire \xE0
+        un cloud OpenStack\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/charmed-kubernetes-reference-architecture/19159\\\"\\u003eCharmed
+        Kubernetes reference architecture\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/dell-k8s-reference-architecture\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003ekubernetes\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-11-07\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eIntegration
+        with VxFlex OS delivered by Dell EMC and Canonical.\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/charmed-openstack-reference-architecture/19160\\\"\\u003eCharmed
+        OpenStack reference architecture\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/dell-openstack-reference-architecture\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-11-07\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eWith
+        Dell EMC PowerEdge servers for workloads and storage and Dell EMC Networking
+        and Canonical.\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/at-t-private-offer-on-azure-ubuntu-pro-support/19161\\\"\\u003eAT\\u0026amp;T
+        Private Offer on Azure - Ubuntu Pro + Support\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/at\\u0026amp;t-azure-webinar\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eubuntu-advantage\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-06-30\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eSecure,
+        updated Ubuntu with 24x7 support special pricing and SLAs for AT\\u0026amp;T.\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/finserv-open-source-infrastructure-powers-hybrid-cloud-strategy/24008\\\"\\u003eFinserv
+        open source infrastructure powers hybrid cloud strategy\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/finserv-hybrid-cloud-webinar\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003efinancial
+        services, open source, openstack, cloud, hybrid cloud\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-09-02\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eAn
+        overview of how to simplify the deployment and management of an OpenStack
+        cloud.\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003c/tbody\\u003e\\n\\u003c/table\\u003e\\n\\u003c/div\\u003e\\u003c/details\\u003e\",\"post_number\":1,\"post_type\":1,\"updated_at\":\"2021-12-07T13:03:15.023Z\",\"reply_count\":0,\"reply_to_post_number\":null,\"quote_count\":0,\"incoming_link_count\":4,\"reads\":17,\"readers_count\":16,\"score\":13.2,\"yours\":true,\"topic_id\":18033,\"topic_slug\":\"engage-pages-for-ubuntu-com\",\"display_username\":\"Carlos
+        Wu Fei\",\"primary_group_name\":\"Canonical\",\"primary_group_flair_url\":\"/uploads/short-url/paWz8RxxmKxiYXUmH2ABvqKp0Gg.png\",\"primary_group_flair_bg_color\":\"\",\"primary_group_flair_color\":\"\",\"version\":50,\"can_edit\":true,\"can_delete\":false,\"can_recover\":false,\"can_wiki\":true,\"link_counts\":[{\"url\":\"https://ubuntu.com/engage\",\"internal\":false,\"reflection\":false,\"title\":\"Ubuntu
+        case studies, whitepapers and webinars | Ubuntu\",\"clicks\":3},{\"url\":\"https://discourse.ubuntu.com/t/at-t-private-offer-on-azure-ubuntu-pro-support/19161\",\"internal\":true,\"reflection\":false,\"title\":\"AT\\u0026T
+        Private Offer on Azure - Ubuntu Pro + Support\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/charmed-openstack-reference-architecture/19160\",\"internal\":true,\"reflection\":false,\"title\":\"Charmed
+        OpenStack reference architecture\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/charmed-kubernetes-reference-architecture/19159\",\"internal\":true,\"reflection\":false,\"title\":\"Charmed
+        Kubernetes reference architecture\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/migrer-de-vmware-a-openstack-webinaire/17420\",\"internal\":true,\"reflection\":false,\"title\":\"Migrer
+        de VMware \xE0 Openstack Webinaire\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/migrer-de-vmware-a-openstack/17417\",\"internal\":true,\"reflection\":false,\"title\":\"Migrer
+        de VMWare \xE0 OpenStack\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/canonical-annonce-managed-apps-linfogerance-des-applications-sur-votre-cloud/17416\",\"internal\":true,\"reflection\":false,\"title\":\"Canonical
+        annonce Managed Apps: l'infog\xE9rance des applications sur votre cloud\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/guide-du-dsi-pour-les-operations-multicloud/17415\",\"internal\":true,\"reflection\":false,\"title\":\"GUIDE
+        DU DSI pour les op\xE9rations multicloud\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/canonical-integre-containerd-a-ubuntu-kubernetes/17412\",\"internal\":true,\"reflection\":false,\"title\":\"Canonical
+        int\xE8gre containerd \xE0 Ubuntu Kubernetes\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/fing-serves-30-000-customers-with-a-secure-future-proof-iot-device/17311\",\"internal\":true,\"reflection\":false,\"title\":\"Fing
+        serves 30,000 customers with a secure, future-proof IoT device\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/von-vmware-zu-canonical-openstack/17408\",\"internal\":true,\"reflection\":false,\"title\":\"Von
+        VMware zu Canonical OpenStack\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/artificial-intelligence-machine-learning-and-ubuntu/17276\",\"internal\":true,\"reflection\":false,\"title\":\"Artificial
+        intelligence, machine learning and Ubuntu\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/establishing-a-software-defined-iot-business-model/17317\",\"internal\":true,\"reflection\":false,\"title\":\"Establishing
+        a software defined IoT business model\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/canonical-presents-financial-services-month/17241\",\"internal\":true,\"reflection\":false,\"title\":\"Canonical
+        presents Financial Services Month\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/cio-guide-to-multi-cloud-operations/17325\",\"internal\":true,\"reflection\":false,\"title\":\"CIO
+        guide to multi-cloud operations\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/key-considerations-when-choosing-a-robot-s-operating-system/17333\",\"internal\":true,\"reflection\":false,\"title\":\"Key
+        considerations when choosing a robot\u2019s operating system\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/openstack-problemlos-installieren-und-skalieren/17409\",\"internal\":true,\"reflection\":false,\"title\":\"OpenStack
+        problemlos installieren und skalieren\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/how-to-build-and-deploy-your-first-ai-ml-model-on-ubuntu/17294\",\"internal\":true,\"reflection\":false,\"title\":\"How
+        to build and deploy your first AI/ML model on Ubuntu\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/future-proofing-fingbox-the-iot-home-network-monitoring-device/17313\",\"internal\":true,\"reflection\":false,\"title\":\"Future-proofing
+        Fingbox, the IoT home network monitoring device\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/low-latency-and-real-time-kernels-for-telco-and-nfv/17320\",\"internal\":true,\"reflection\":false,\"title\":\"Low
+        latency and real-time kernels for telco and NFV\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/wofur-konnen-sie-kubernetes-einsetzen/17410\",\"internal\":true,\"reflection\":false,\"title\":\"Wof\xFCr
+        k\xF6nnen Sie Kubernetes einsetzen?\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/keep-up-with-evolving-software/17310\",\"internal\":true,\"reflection\":false,\"title\":\"Keep
+        up with evolving software\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/ubuntu-core-and-kura-a-framework-for-iot-gateways/17341\",\"internal\":true,\"reflection\":false,\"title\":\"Ubuntu
+        Core and Kura: A framework for IoT gateways\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/what-s-new-in-ubuntu-18-10/17339\",\"internal\":true,\"reflection\":false,\"title\":\"What\u2019s
+        New in Ubuntu 18.10\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/itstrategen-keeps-legacy-applications-secure-with-extended-security-maintenance/17286\",\"internal\":true,\"reflection\":false,\"title\":\"ITstrategen
+        keeps legacy applications secure with Extended Security Maintenance\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/securing-the-enterprise-how-ubuntu-is-at-the-forefront-of-security-and-compliance/17340\",\"internal\":true,\"reflection\":false,\"title\":\"Securing
+        the enterprise: how Ubuntu is at the forefront of security and compliance\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/precision-drones-on-ubuntu-flying-at-the-edge-of-innovation/17316\",\"internal\":true,\"reflection\":false,\"title\":\"Precision
+        drones on Ubuntu: flying at the edge of innovation\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/modernise-your-cloud/17324\",\"internal\":true,\"reflection\":false,\"title\":\"Modernise
+        your cloud\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/six-reasons-why-developers-choose-ubuntu-desktop/17304\",\"internal\":true,\"reflection\":false,\"title\":\"Six
+        reasons why developers choose Ubuntu Desktop\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/allan-gray-unlocks-unprecedented-availability-and-productivity-with-charmed-kubernetes/17319\",\"internal\":true,\"reflection\":false,\"title\":\"Allan
+        Gray unlocks unprecedented availability and productivity with Charmed Kubernetes\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/apellix-engineers-safer-work-environments-with-ubuntu-powered-aerial-robotics/17315\",\"internal\":true,\"reflection\":false,\"title\":\"Apellix
+        engineers safer work environments with Ubuntu powered aerial robotics\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/utiliser-des-gpus-avec-kubernetes/17419\",\"internal\":true,\"reflection\":false,\"title\":\"Utiliser
+        des GPUs avec Kubernetes\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/extension-securite-et-maintenance-pour-ubuntu-14-04/17414\",\"internal\":true,\"reflection\":false,\"title\":\"Extension
+        S\xE9curit\xE9 et Maintenance pour Ubuntu 14.04\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/multi-cloud-fundamental-to-financial-services-transformation/17312\",\"internal\":true,\"reflection\":false,\"title\":\"Multi-cloud
+        fundamental to financial services transformation\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/securing-iot-device-data-against-physical-access/17318\",\"internal\":true,\"reflection\":false,\"title\":\"Securing
+        IoT device data against physical access\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/still-running-ubuntu-14-04/17275\",\"internal\":true,\"reflection\":false,\"title\":\"Still
+        running Ubuntu 14.04?\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/get-started-with-devops-best-practices-ci-cd/17305\",\"internal\":true,\"reflection\":false,\"title\":\"Get
+        started with DevOps best practices: CI/CD\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/an-introduction-to-apparmor/17277\",\"internal\":true,\"reflection\":false,\"title\":\"An
+        introduction to AppArmor\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/optimising-iot-bandwidth-with-delta-updates/17335\",\"internal\":true,\"reflection\":false,\"title\":\"Optimising
+        IoT bandwidth with delta updates\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/whats-new-in-ubuntu-19-04/17240\",\"internal\":true,\"reflection\":false,\"title\":\"What's
+        new in Ubuntu 19.04?\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/hiri-successfully-monetises-their-snap/17314\",\"internal\":true,\"reflection\":false,\"title\":\"Hiri
+        successfully monetises their snap\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/private-cloud-security/17421\",\"internal\":true,\"reflection\":false,\"title\":\"Private
+        cloud security\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/private-cloud-security-webinar/17329\",\"internal\":true,\"reflection\":false,\"title\":\"Private
+        cloud security Webinar\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/the-transformation-of-the-devops-journey-in-iot-webinar/17306\",\"internal\":true,\"reflection\":false,\"title\":\"The
+        transformation of the DevOps journey in IoT Webinar\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/how-to-build-a-lightweight-system-container-cluster/17322\",\"internal\":true,\"reflection\":false,\"title\":\"How
+        to build a lightweight system container cluster\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/cloud-init/17291\",\"internal\":true,\"reflection\":false,\"title\":\"Cloud
+        init\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/the-transformation-of-the-devops-journey-in-iot/17422\",\"internal\":true,\"reflection\":false,\"title\":\"The
+        transformation of the DevOps journey in IoT\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/getting-started-with-ai/17336\",\"internal\":true,\"reflection\":false,\"title\":\"Getting
+        started with AI\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/why-ubuntu-core-is-the-most-secure-choice-for-iot/17292\",\"internal\":true,\"reflection\":false,\"title\":\"Why
+        Ubuntu Core is the most secure choice for IoT\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/connected-cars-and-autonomous-driving/17243\",\"internal\":true,\"reflection\":false,\"title\":\"Connected
+        cars and autonomous driving\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/how-to-integrate-ubuntu-desktop-with-active-directory/17323\",\"internal\":true,\"reflection\":false,\"title\":\"How
+        to integrate Ubuntu Desktop with Active Directory\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/small-robot-company-sows-the-seeds-for-autonomous-and-more-profitable-farming/17334\",\"internal\":true,\"reflection\":false,\"title\":\"Small
+        Robot Company sows the seeds for autonomous and more profitable farming\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/north-america-s-first-autonomous-runway-snowplough/17327\",\"internal\":true,\"reflection\":false,\"title\":\"North
+        America\u2018s first autonomous runway snowplough\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/the-future-of-mobile-connectivity/17342\",\"internal\":true,\"reflection\":false,\"title\":\"The
+        future of mobile connectivity\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/how-to-get-started-and-progress-with-an-ai-program/17245\",\"internal\":true,\"reflection\":false,\"title\":\"How
+        to get started and progress with an AI program\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/sicherheit-in-der-private-cloud/17411\",\"internal\":true,\"reflection\":false,\"title\":\"Sicherheit
+        in der Private Cloud\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/a-guide-to-edge-computing-and-the-tools-you-need/17308\",\"internal\":true,\"reflection\":false,\"title\":\"A
+        guide to edge computing and the tools you need\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/le-support-d-ubuntu-14-04-lts-est-maintenant-passe-a-esm/17413\",\"internal\":true,\"reflection\":false,\"title\":\"Le
+        support d\u2019Ubuntu 14.04 LTS est maintenant pass\xE9 \xE0 ESM\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/a-shift-to-the-linux-app-store-experience/17347\",\"internal\":true,\"reflection\":false,\"title\":\"A
+        shift to the Linux app store experience\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/telcos-and-service-providers-expect-near-100-uptime/17330\",\"internal\":true,\"reflection\":false,\"title\":\"Telcos
+        and Service Providers expect near 100% uptime\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/openstack-made-easy/17328\",\"internal\":true,\"reflection\":false,\"title\":\"OpenStack
+        made easy\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/nfv-and-sdn-on-openstack-for-network-operators/17326\",\"internal\":true,\"reflection\":false,\"title\":\"NFV
+        and SDN on OpenStack for network operators\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/carrier-cloudification-what-every-telecom-executive-needs-to-know/17338\",\"internal\":true,\"reflection\":false,\"title\":\"Carrier
+        Cloudification: What every telecom executive needs to know\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/how-to-escape-stuckstack-and-profit-from-your-openstack-investment/17337\",\"internal\":true,\"reflection\":false,\"title\":\"How
+        to escape StuckStack and profit from your OpenStack investment\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/low-latency-and-real-time-kernels-for-telco-and-nfv/17321\",\"internal\":true,\"reflection\":false,\"title\":\"Low
+        latency and real time kernels for telco and NFV\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/how-to-face-the-challenges-of-becoming-a-cloud-operator/17290\",\"internal\":true,\"reflection\":false,\"title\":\"How
+        to face the challenges of becoming a cloud operator\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/sensape-uses-landscape-to-remotely-support-revolutionary-interactive-retail-displays/17289\",\"internal\":true,\"reflection\":false,\"title\":\"Sensape
+        uses Landscape to remotely support revolutionary interactive retail displays\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/cto-s-guide-to-sdn-nfv-vnf/17293\",\"internal\":true,\"reflection\":false,\"title\":\"CTO\u2019s
+        guide to SDN, NFV \\u0026 VNF\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/city-network-brings-openstack-cloud-hosting-to-the-financial-services-sector-with-canonical/17282\",\"internal\":true,\"reflection\":false,\"title\":\"City
+        Network brings OpenStack cloud hosting to the financial services sector with
+        Canonical\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/the-essential-guide-for-telecoms-and-service-providers-adopting-big-data-solutions/17309\",\"internal\":true,\"reflection\":false,\"title\":\"The
+        essential guide for Telecoms and Service Providers adopting big data solutions\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/taking-charge-of-the-iots-security-vulnerabilities/17346\",\"internal\":true,\"reflection\":false,\"title\":\"Taking
+        charge of the IoT's security vulnerabilities\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/for-ctos-the-no-nonsense-way-to-accelerate-your-business-with-containers/17345\",\"internal\":true,\"reflection\":false,\"title\":\"For
+        CTOs: the no-nonsense way to accelerate your business with containers\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/commercetools-uses-ubuntu-server-to-power-its-next-generation-ecommerce-platform/17283\",\"internal\":true,\"reflection\":false,\"title\":\"Commercetools
+        uses Ubuntu Server to power its next-generation ecommerce platform\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/cinergy-makes-significant-digital-signage-saving-with-screenly-pro-and-ubuntu-core/17281\",\"internal\":true,\"reflection\":false,\"title\":\"Cinergy
+        makes significant digital signage saving with Screenly Pro and Ubuntu Core\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/botsandus-builds-a-social-robot-on-ubuntu/17280\",\"internal\":true,\"reflection\":false,\"title\":\"BotsAndUs
+        builds a social robot on Ubuntu\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/azlogica-utilise-ubuntu-core-for-customised-iot-agricultural-solutions/17279\",\"internal\":true,\"reflection\":false,\"title\":\"AZLOGICA
+        utilise Ubuntu Core for customised IoT agricultural solutions\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/azeti-uses-ubuntu-core-to-improve-deployment-and-security/17278\",\"internal\":true,\"reflection\":false,\"title\":\"Azeti
+        uses Ubuntu Core to improve deployment and security\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/nexiona-collaborates-with-canonical-and-dell-to-create-miimetiq-edge/17287\",\"internal\":true,\"reflection\":false,\"title\":\"NEXIONA
+        collaborates with Canonical and Dell to create MIIMETIQ EDGE\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/how-ubuntu-helped-innovapos-revolutionise-the-vending-machine-industry/17285\",\"internal\":true,\"reflection\":false,\"title\":\"How
+        Ubuntu helped InnovaPOS revolutionise the vending machine industry\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/learn-whats-new-in-ubuntu-server-14-04-lts/17344\",\"internal\":true,\"reflection\":false,\"title\":\"Learn
+        What's New In Ubuntu Server 14.04 LTS\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/make-it-rain-public-cloud-on-ubuntu-openstack/17332\",\"internal\":true,\"reflection\":false,\"title\":\"Make
+        IT rain: public cloud on Ubuntu OpenStack\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/building-a-private-cloud-take-the-leap/17331\",\"internal\":true,\"reflection\":false,\"title\":\"Building
+        a private cloud? Take the leap!\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/server-provisioning-what-network-admins-it-pros-need-to-know/17307\",\"internal\":true,\"reflection\":false,\"title\":\"Server
+        Provisioning: What Network Admins \\u0026 IT Pros Need to Know\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/rocket-chat-communication-platform-enables-simplicity-through-snaps/17288\",\"internal\":true,\"reflection\":false,\"title\":\"Rocket.Chat
+        communication platform enables simplicity through snaps\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/ims-evolve-adopts-ubuntu-core-to-provide-iot-enabled-business-intelligence-in-the-supply-chain/17284\",\"internal\":true,\"reflection\":false,\"title\":\"IMS
+        Evolve adopts Ubuntu Core to provide IoT-enabled business intelligence in
+        the supply chain\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/creating-accurate-ai-models-with-data/17349\",\"internal\":true,\"reflection\":false,\"title\":\"Creating
+        accurate AI models with data\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/creating-a-cloud-like-bare-metal-experience-in-the-data-centre/17348\",\"internal\":true,\"reflection\":false,\"title\":\"Creating
+        a cloud-like bare metal experience in the data centre\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/a-guide-to-developing-android-apps-on-ubuntu/17351\",\"internal\":true,\"reflection\":false,\"title\":\"A
+        guide to developing Android apps on Ubuntu\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/how-to-manage-snaps-in-an-enterprise-environment/17352\",\"internal\":true,\"reflection\":false,\"title\":\"How
+        to manage snaps in an enterprise environment\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/machine-learning-operations-mlops/17353\",\"internal\":true,\"reflection\":false,\"title\":\"Machine
+        Learning Operations (MLOps)\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/from-vmware-to-charmed-openstack/17343\",\"internal\":true,\"reflection\":false,\"title\":\"From
+        VMWare To Charmed OpenStack\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/accelerating-deep-tech-with-ubuntu/17354\",\"internal\":true,\"reflection\":false,\"title\":\"Accelerating
+        deep tech with Ubuntu\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/yahoo-japan-builds-their-iaas-environment-with-canonical/17355\",\"internal\":true,\"reflection\":false,\"title\":\"Yahoo!
+        Japan builds their IaaS environment with Canonical\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/how-domotz-streamlined-provisioning-of-iot-devices/17356\",\"internal\":true,\"reflection\":false,\"title\":\"How
+        Domotz streamlined provisioning of IoT devices\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/what-s-new-in-ubuntu-19-10/17357\",\"internal\":true,\"reflection\":false,\"title\":\"What\u2019s
+        new in Ubuntu 19.10\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/tim-ensures-system-security-and-client-confidence-with-esm/17358\",\"internal\":true,\"reflection\":false,\"title\":\"TIM
+        ensures system security and client confidence with ESM\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/ensuring-security-and-isolation-in-kubernetes-with-kata-containers/17359\",\"internal\":true,\"reflection\":false,\"title\":\"Ensuring
+        security and isolation in Kubernetes with Kata Containers\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/the-wellcome-sanger-institute-turns-to-canonical-for-high-level-ceph-support/17360\",\"internal\":true,\"reflection\":false,\"title\":\"The
+        Wellcome Sanger Institute turns to Canonical for high level Ceph support\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/lessons-learned-from-100-private-cloud-builds/17361\",\"internal\":true,\"reflection\":false,\"title\":\"Lessons
+        learned from 100+ Private cloud builds\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/linux-security-with-ubuntu/17362\",\"internal\":true,\"reflection\":false,\"title\":\"Linux
+        security with Ubuntu\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/build-smart-display-devices-with-mir-fast-to-production-secure-open-source/17363\",\"internal\":true,\"reflection\":false,\"title\":\"Build
+        smart display devices with Mir: fast to production, secure, open-source\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/register-for-wslconf/17365\",\"internal\":true,\"reflection\":false,\"title\":\"Register
+        for WSLConf\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/sbi-group-unlocks-infrastructure-automation-with-secure-on-premises-openstack-cloud/17364\",\"internal\":true,\"reflection\":false,\"title\":\"SBI
+        Group unlocks infrastructure automation with secure, on-premises OpenStack
+        cloud\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/cyberdyne-keeps-cleaning-robots-up-to-date-in-the-field-with-snaps/17366\",\"internal\":true,\"reflection\":false,\"title\":\"Cyberdyne
+        keeps cleaning robots up-to-date in the field with snaps\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/ubuntu-desktop-for-the-enterprise/17368\",\"internal\":true,\"reflection\":false,\"title\":\"Ubuntu
+        Desktop for the enterprise\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/an-intro-to-microk8s/17367\",\"internal\":true,\"reflection\":false,\"title\":\"An
+        intro to MicroK8s\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/kubernetes-a-secure-flexible-and-automated-edge-for-iot-developers/17369\",\"internal\":true,\"reflection\":false,\"title\":\"Kubernetes:
+        a secure, flexible and automated edge for IoT developers\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/de-vmware-a-charmed-openstack/17371\",\"internal\":true,\"reflection\":false,\"title\":\"De
+        VMware a Charmed OpenStack\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/migration-von-vmware-zu-openstack/17370\",\"internal\":true,\"reflection\":false,\"title\":\"Migration
+        von VMware zu OpenStack\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/deploy-kubernetes-in-your-data-centre/17373\",\"internal\":true,\"reflection\":false,\"title\":\"Deploy
+        Kubernetes in your data centre\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/artificial-intelligence-at-the-edge-in-a-5g-world/17372\",\"internal\":true,\"reflection\":false,\"title\":\"Artificial
+        Intelligence at the edge in a 5G world\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/esm-maintains-interanas-system-security-while-upgrading/17376\",\"internal\":true,\"reflection\":false,\"title\":\"ESM
+        maintains Interana's system security while upgrading\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/an-introduction-to-anbox-cloud/17374\",\"internal\":true,\"reflection\":false,\"title\":\"An
+        introduction to Anbox Cloud\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/hosted-private-cloud-infrastructure-a-cost-analysis/17375\",\"internal\":true,\"reflection\":false,\"title\":\"Hosted
+        private cloud infrastructure: a cost analysis\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/smart-card-login-on-ubuntu/17377\",\"internal\":true,\"reflection\":false,\"title\":\"Smart
+        card login on Ubuntu\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/securing-ros-robotics-platforms/17378\",\"internal\":true,\"reflection\":false,\"title\":\"Securing
+        ROS robotics platforms\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/rigado-cuts-customers-time-to-market/17379\",\"internal\":true,\"reflection\":false,\"title\":\"Rigado
+        cuts customers' time-to-market\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/virtual-event-microk8s-kubernetes/17380\",\"internal\":true,\"reflection\":false,\"title\":\"Virtual
+        event: MicroK8s \\u0026 Kubernetes\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/installez-et-mettez-openstack-a-lechelle-en-toute-simplicite/17418\",\"internal\":true,\"reflection\":false,\"title\":\"Installez
+        et mettez OpenStack \xE0 l'\xE9chelle en toute simplicit\xE9\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/openstack-deployment-guide/17384\",\"internal\":true,\"reflection\":false,\"title\":\"OpenStack
+        deployment guide\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/ubuntu-core-a-cybersecurity-analysis/17381\",\"internal\":true,\"reflection\":false,\"title\":\"Ubuntu
+        Core: a cybersecurity analysis\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/maintaining-business-focus-in-a-cloud-native-world-with-managed-apps/17385\",\"internal\":true,\"reflection\":false,\"title\":\"Maintaining
+        business focus in a cloud-native world with Managed Apps\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/what-s-new-in-ubuntu-20-04-lts/17386\",\"internal\":true,\"reflection\":false,\"title\":\"What\u2019s
+        new in Ubuntu 20.04 LTS?\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/embracing-the-open-source-mandate/17387\",\"internal\":true,\"reflection\":false,\"title\":\"Embracing
+        the open source mandate\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/streamlined-kubernetes-from-cloud-to-edge/17388\",\"internal\":true,\"reflection\":false,\"title\":\"Streamlined
+        Kubernetes, from Cloud to Edge\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/leveraging-open-source-with-ubuntu-pro-on-azure/17389\",\"internal\":true,\"reflection\":false,\"title\":\"Leveraging
+        open source with Ubuntu Pro on Azure\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/secure-iot-device-management/17390\",\"internal\":true,\"reflection\":false,\"title\":\"Secure
+        IoT device management\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/solving-the-software-update-challenge-for-iot-devices/17391\",\"internal\":true,\"reflection\":false,\"title\":\"Solving
+        the software update challenge for IoT devices\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/kafka-in-production/17392\",\"internal\":true,\"reflection\":false,\"title\":\"Kafka
+        in production\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/standardising-machine-learning-from-workstation-to-production/17393\",\"internal\":true,\"reflection\":false,\"title\":\"Standardising
+        machine learning \u2014 from workstation to production\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/utilising-cloud-init-on-microsoft-azure/17394\",\"internal\":true,\"reflection\":false,\"title\":\"Utilising
+        cloud-init on Microsoft Azure\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/migrating-your-infrastructure-to-ubuntu-20-04-lts/17395\",\"internal\":true,\"reflection\":false,\"title\":\"Migrating
+        your infrastructure to Ubuntu 20.04 LTS\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/a-technical-intro-to-ubuntu-pro/17396\",\"internal\":true,\"reflection\":false,\"title\":\"A
+        technical intro to Ubuntu Pro\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/scaling-on-azure-with-ubuntu-pro/17397\",\"internal\":true,\"reflection\":false,\"title\":\"Scaling
+        on Azure with Ubuntu Pro\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/kubernetes-from-cloud-to-edge/17398\",\"internal\":true,\"reflection\":false,\"title\":\"Kubernetes
+        from Cloud to Edge\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/accelerating-iot-device-time-to-market/17399\",\"internal\":true,\"reflection\":false,\"title\":\"Accelerating
+        IoT device time to market\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/scale-android-applications-economically-in-the-cloud-with-anbox-cloud/17401\",\"internal\":true,\"reflection\":false,\"title\":\"Scale
+        Android applications economically in the cloud with Anbox Cloud\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/busting-the-myth-of-private-cloud-economics/17244\",\"internal\":true,\"reflection\":false,\"title\":\"Busting
+        the myth of private cloud economics\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/do-vmware-ao-charmed-openstack/18165\",\"internal\":true,\"reflection\":false,\"title\":\"Do
+        VMware ao Charmed OpenStack\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/red-hat-openstack-platform-vs-canonicals-charmed-openstack/18159\",\"internal\":true,\"reflection\":false,\"title\":\"Red
+        Hat OpenStack Platform vs Canonical's Charmed OpenStack\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/building-powerful-customer-solutions/18481\",\"internal\":true,\"reflection\":false,\"title\":\"Building
+        powerful customer solutions\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/production-ai-from-data-lake-to-server-webinar/18163\",\"internal\":true,\"reflection\":false,\"title\":\"Production
+        AI from data lake to server webinar\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/5-strategies-to-accelerate-kubernetes-deployment-in-the-enterprise/18161\",\"internal\":true,\"reflection\":false,\"title\":\"5
+        strategies to accelerate Kubernetes deployment in the enterprise\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/da-vmware-a-openstack/18164\",\"internal\":true,\"reflection\":false,\"title\":\"Da
+        VMware a OpenStack\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/gmo-pepabo-ubuntu/18476\",\"internal\":true,\"reflection\":false,\"title\":\"GMO
+        Pepabo \\u0026 Ubuntu\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/da-vmware-a-charmed-openstack/18478\",\"internal\":true,\"reflection\":false,\"title\":\"Da
+        VMware a Charmed Openstack\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/guia-para-la-implementacion-de-openstack/18480\",\"internal\":true,\"reflection\":false,\"title\":\"Gu\xEDa
+        para la implementaci\xF3n de OpenStack\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/transforming-telco-infrastructure/18162\",\"internal\":true,\"reflection\":false,\"title\":\"Transforming
+        telco infrastructure\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/extend-your-openstack-cloud-with-native-backup-and-recover/18911\",\"internal\":true,\"reflection\":false,\"title\":\"Extend
+        your OpenStack cloud with native backup and recover\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/cloud-gaming-for-android/18757\",\"internal\":true,\"reflection\":false,\"title\":\"Cloud
+        gaming for Android\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/watch-the-raspberry-pi-ubuntu-desktop-intro-video/18577\",\"internal\":true,\"reflection\":false,\"title\":\"Watch
+        the Raspberry Pi Ubuntu Desktop intro video\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/ubuntu-20-10-what-s-new/19050\",\"internal\":true,\"reflection\":false,\"title\":\"Ubuntu
+        20.10: What\u2019s new?\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/open-digital-platforms-for-the-industrial-edge-cloud-in-2020/19068\",\"internal\":true,\"reflection\":false,\"title\":\"Open
+        digital platforms for the industrial edge cloud in 2020\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/optimised-authentication-methods-for-ubuntu-desktop/19133\",\"internal\":true,\"reflection\":false,\"title\":\"Optimised
+        authentication methods for Ubuntu Desktop\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/comparando-la-plataforma-openstack-de-red-hat-y-la-charmed-openstack-de-canonical/19194\",\"internal\":true,\"reflection\":false,\"title\":\"Comparando
+        la plataforma OpenStack de Red Hat y la Charmed OpenStack de Canonical\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/cinco-estrategias-para-acelerar-el-despliegue-de-kubernetes/19208\",\"internal\":true,\"reflection\":false,\"title\":\"Cinco
+        estrategias para acelerar el despliegue de Kubernetes\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/9-out-of-top-10-us-european-financial-institutions-use-ubuntu/19304\",\"internal\":true,\"reflection\":false,\"title\":\"9
+        out of top 10 US \\u0026 European financial institutions use Ubuntu\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/vergleich-von-red-hat-openstack-platform-und-charmed-openstack-von-canonical/19285\",\"internal\":true,\"reflection\":false,\"title\":\"Vergleich
+        von Red Hat OpenStack Platform und Charmed OpenStack von Canonical\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/funf-strategien-zur-beschleunigung-von-kubernetes-in-unternehmen/19284\",\"internal\":true,\"reflection\":false,\"title\":\"F\xFCnf
+        Strategien zur Beschleunigung von Kubernetes in Unternehmen\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/guide-pour-reussir-ladoption-et-le-deploiement-dopenstack/19361\",\"internal\":true,\"reflection\":false,\"title\":\"Guide
+        pour r\xE9ussir l'adoption et le d\xE9ploiement d'OpenStack\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/confronto-fra-red-hats-openstack-platform-e-charmed-openstack-di-canonical/19362\",\"internal\":true,\"reflection\":false,\"title\":\"Confronto
+        fra \\\"Red Hat's Openstack platform\\\" e Charmed Openstack di Canonical\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/cinque-strategie-per-accelerare-limplementazione-di-kubernetes-nellimpresa/19381\",\"internal\":true,\"reflection\":false,\"title\":\"Cinque
+        strategie per accelerare l'implementazione di Kubernetes nell'impresa\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/micro-clouds/19424\",\"internal\":true,\"reflection\":false,\"title\":\"Micro
+        clouds:\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/ubuntu-16-04-lts-moving-to-extended-security-maintenance/19598\",\"internal\":true,\"reflection\":false,\"title\":\"Ubuntu
+        16.04 LTS moving to Extended Security Maintenance\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/ubuntu-pro-for-aws/19600\",\"internal\":true,\"reflection\":false,\"title\":\"Ubuntu
+        Pro for AWS\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/agility-and-innovation-in-financial-services-with-open-source/19601\",\"internal\":true,\"reflection\":false,\"title\":\"Agility
+        and innovation in Financial Services with open source\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/ai-deployment-and-inference/19692\",\"internal\":true,\"reflection\":false,\"title\":\"AI
+        deployment and inference:\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/lightweight-kubernetes-in-the-enterprise/19716\",\"internal\":true,\"reflection\":false,\"title\":\"Lightweight
+        Kubernetes in the enterprise\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/suse-openstack-cloud-to-be-discontinued/19765\",\"internal\":true,\"reflection\":false,\"title\":\"SUSE
+        OpenStack Cloud to be discontinued\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/workstations-ai/19766\",\"internal\":true,\"reflection\":false,\"title\":\"Workstations
+        AI\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/in-weniger-als-6-monaten-kommt-ubuntu-16-04-esm-6-punkte-fur-ihre-vorbereitung/19895\",\"internal\":true,\"reflection\":false,\"title\":\"In
+        weniger als 6 Monaten kommt Ubuntu 16.04 ESM: 6 Punkte f\xFCr Ihre Vorbereitung\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/menos-de-6-meses-para-16-04-esm-seis-aspectos-a-tener-en-cuenta/19925\",\"internal\":true,\"reflection\":false,\"title\":\"Menos
+        de 6 meses para 16.04 ESM: seis aspectos a tener en cuenta\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/staying-compliant-while-delivering-innovation-in-government-services/19960\",\"internal\":true,\"reflection\":false,\"title\":\"Staying
+        compliant while delivering innovation in government services\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/android-in-the-cloud-on-arm-native-servers/20015\",\"internal\":true,\"reflection\":false,\"title\":\"Android
+        in the cloud on Arm native servers\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/cloud-native-driving-agility-and-innovation-in-financial-services/20244\",\"internal\":true,\"reflection\":false,\"title\":\"Cloud-native
+        driving agility and innovation in financial services\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/automation-through-open-source-operators/20215\",\"internal\":true,\"reflection\":false,\"title\":\"Automation
+        through open source operators\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/comparaison-de-red-hat-openstack-platform-et-de-charmed-openstack-de-canonical/20432\",\"internal\":true,\"reflection\":false,\"title\":\"Comparaison
+        de Red Hat OpenStack Platform et de Charmed OpenStack de Canonical\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/industrial-process-transformation-with-machine-learning-using-kubeflow/20436\",\"internal\":true,\"reflection\":false,\"title\":\"Industrial
+        process transformation with Machine Learning using Kubeflow\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/kubeflow-reference-architecture/20467\",\"internal\":true,\"reflection\":false,\"title\":\"Kubeflow
+        reference architecture\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/an-introduction-to-ubuntu-core-20/20687\",\"internal\":true,\"reflection\":false,\"title\":\"An
+        introduction to Ubuntu Core 20\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/embedded-linux-make-or-buy/20696\",\"internal\":true,\"reflection\":false,\"title\":\"Embedded
+        Linux: make or buy?\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/end-to-end-wiring-using-kubeflow-kafka-and-elasticsearch/20704\",\"internal\":true,\"reflection\":false,\"title\":\"End-to-end
+        wiring using Kubeflow, Kafka and ElasticSearch\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/integrazione-di-ubuntu-desktop-con-microsoft-active-directory/20746\",\"internal\":true,\"reflection\":false,\"title\":\"Integrazione
+        di Ubuntu Desktop con Microsoft Active Directory\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/mantenimiento-de-seguridad-extendido/20747\",\"internal\":true,\"reflection\":false,\"title\":\"Mantenimiento
+        de Seguridad Extendido\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/open-source-in-government/20843\",\"internal\":true,\"reflection\":false,\"title\":\"Open
+        source in Government\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/edge-use-cases-enabled-by-mec-and-5g/20873\",\"internal\":true,\"reflection\":false,\"title\":\"Edge
+        use-cases enabled by MEC and 5G\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/secure-container-orchestration-at-the-edge/20965\",\"internal\":true,\"reflection\":false,\"title\":\"Secure
+        container orchestration at the edge\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/enterprise-kubernetes-a-buyer-s-guide/20979\",\"internal\":true,\"reflection\":false,\"title\":\"Enterprise
+        Kubernetes: A buyer\u2019s guide\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/simplifying-ai-ml-adoption-in-telco-with-modern-operations-practices/20996\",\"internal\":true,\"reflection\":false,\"title\":\"Simplifying
+        AI/ML adoption in telco with modern operations practices\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/migration-vers-ubuntu-lts-six-points-cles-pour-les-utilisateurs-de-centos/21054\",\"internal\":true,\"reflection\":false,\"title\":\"Migration
+        vers Ubuntu LTS: six points cl\xE9s pour les utilisateurs de CentOS\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/ubuntu-16-04-esm-6-choses-a-preparer/21058\",\"internal\":true,\"reflection\":false,\"title\":\"Ubuntu
+        16.04 ESM: 6 choses \xE0 pr\xE9parer\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/a-technical-introduction-to-ubuntu-core-20/21068\",\"internal\":true,\"reflection\":false,\"title\":\"A
+        technical introduction to Ubuntu Core 20\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/whats-next-for-centos-users/21090\",\"internal\":true,\"reflection\":false,\"title\":\"What's
+        next for CentOS users?\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/migrar-a-ubuntu-lts-seis-factores-a-tener-en-cuenta-para-los-usuarios-de-centos/21315\",\"internal\":true,\"reflection\":false,\"title\":\"Migrar
+        a Ubuntu LTS: seis factores a tener en cuenta para los usuarios de CentOS\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/securing-open-source-from-cloud-to-edge/21394\",\"internal\":true,\"reflection\":false,\"title\":\"Securing
+        open source from cloud to edge\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/esm-garantisce-la-sicurezza-dei-sistemi-interana-anche-durante-laggiornamento/21378\",\"internal\":true,\"reflection\":false,\"title\":\"ESM
+        garantisce la sicurezza dei sistemi Interana anche durante l'aggiornamento\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/model-driven-audit-trail-logs-infrastructure-for-telco-vnfs/21500\",\"internal\":true,\"reflection\":false,\"title\":\"Model-driven
+        Audit Trail Logs infrastructure for Telco VNFs\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/canonical-ubuntu-at-nvidia-gtc-2021-digital/21524\",\"internal\":true,\"reflection\":false,\"title\":\"Canonical
+        \\u0026 Ubuntu at NVIDIA GTC 2021 Digital\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/data-science-workstations/21739\",\"internal\":true,\"reflection\":false,\"title\":\"Data
+        Science Workstations\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/telecom-ai-a-guide-for-data-teams/21740\",\"internal\":true,\"reflection\":false,\"title\":\"Telecom
+        AI: a guide for data teams\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/elkhart-lake/21775\",\"internal\":true,\"reflection\":false,\"title\":\"Elkhart
+        Lake\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/the-value-of-open-source-in-2021/21790\",\"internal\":true,\"reflection\":false,\"title\":\"The
+        Value of Open Source in 2021\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/what-s-new-in-ubuntu-server-21-04/21802\",\"internal\":true,\"reflection\":false,\"title\":\"What\u2019s
+        new in Ubuntu Server 21.04?\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/unleashing-z-workstations-by-hp-powered-by-ubuntu/21825\",\"internal\":true,\"reflection\":false,\"title\":\"Unleashing
+        Z Workstations by HP Powered by Ubuntu\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/data-science-workstations-journey/21828\",\"internal\":true,\"reflection\":false,\"title\":\"Data
+        Science Workstations Journey\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/infrastruttura-multi-cloud-in-italia/21894\",\"internal\":true,\"reflection\":false,\"title\":\"Infrastruttura
+        multi-cloud in Italia\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/meno-di-6-mesi-a-ubuntu-16-04-esm-6-cose-da-preparare/21958\",\"internal\":true,\"reflection\":false,\"title\":\"Meno
+        di 6 mesi a Ubuntu 16.04 ESM: 6 cose da preparare\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/migrare-a-ubuntu-lts-sei-fatti-per-gli-utenti-centos/21959\",\"internal\":true,\"reflection\":false,\"title\":\"Migrare
+        a Ubuntu LTS: sei fatti per gli utenti CentOS\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/ros-kinetic-end-of-life/21952\",\"internal\":true,\"reflection\":false,\"title\":\"ROS
+        Kinetic End-Of-Life\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/a-business-guide-to-hybrid-cloud/22092\",\"internal\":true,\"reflection\":false,\"title\":\"A
+        business guide to hybrid cloud\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/a-business-guide-to-multi-cloud/22093\",\"internal\":true,\"reflection\":false,\"title\":\"A
+        business guide to multi-cloud\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/simplifying-kubernetes-across-the-clouds/22260\",\"internal\":true,\"reflection\":false,\"title\":\"Simplifying
+        Kubernetes across the clouds\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/building-and-orchestrating-network-functions/22269\",\"internal\":true,\"reflection\":false,\"title\":\"Building
+        and orchestrating network functions\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/suse-openstack-cloud-wird-eingestellt/22283\",\"internal\":true,\"reflection\":false,\"title\":\"SUSE
+        OpenStack Cloud wird eingestellt\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/kubernetes-at-the-edge-easy-as-pi/22342\",\"internal\":true,\"reflection\":false,\"title\":\"Kubernetes
+        at the edge: easy as Pi\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/open-source-private-5g-and-lte-networks/22346\",\"internal\":true,\"reflection\":false,\"title\":\"Open
+        source private 5G and LTE networks\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/canonical-at-mwc-2021/22348\",\"internal\":true,\"reflection\":false,\"title\":\"Canonical
+        at MWC 2021\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/private-cloud-for-financial-services/22500\",\"internal\":true,\"reflection\":false,\"title\":\"Private
+        cloud for Financial Services\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/kubernetes-e-ubuntu-in-italia/22562\",\"internal\":true,\"reflection\":false,\"title\":\"Kubernetes
+        e Ubuntu in Italia\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/guida-cio-alle-operazioni-multi-cloud/22564\",\"internal\":true,\"reflection\":false,\"title\":\"Guida
+        CIO alle operazioni multi-cloud\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/data-lab-architectures/22247\",\"internal\":true,\"reflection\":false,\"title\":\"Data
+        Lab Architectures\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/preparing-for-the-suse-openstack-cloud-end-of-life/22587\",\"internal\":true,\"reflection\":false,\"title\":\"Preparing
+        for the SUSE OpenStack Cloud end-of-life\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/ros-support-with-ros-esm/22595\",\"internal\":true,\"reflection\":false,\"title\":\"ROS
+        Support with ROS ESM\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/openstack-public-cloud-implementation/22648\",\"internal\":true,\"reflection\":false,\"title\":\"OpenStack
+        public cloud implementation\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/enterprise-mlops-in-hybrid-cloud-scenarios-best-practices/22650\",\"internal\":true,\"reflection\":false,\"title\":\"Enterprise
+        MLOps in hybrid-cloud scenarios: best practices\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/ubuntu-pro-on-azure/22674\",\"internal\":true,\"reflection\":false,\"title\":\"Ubuntu
+        Pro on Azure\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/che-cose-il-mec-il-telco-edge/22748\",\"internal\":true,\"reflection\":false,\"title\":\"Che
+        cos'\xE8 il MEC? Il telco edge\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/a-technical-introduction-to-the-snap-store-proxy/22762\",\"internal\":true,\"reflection\":false,\"title\":\"A
+        technical introduction to the Snap Store Proxy\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/das-wellcome-sanger-institute-ermoglicht-weltweite-zusammenarbeit-in-der-genomforschung-mit-von-canonical-unterstutztem-ceph-speicher/22811\",\"internal\":true,\"reflection\":false,\"title\":\"Das
+        Wellcome Sanger Institute erm\xF6glicht weltweite Zusammenarbeit in der Genomforschung
+        mit von Canonical unterst\xFCtztem Ceph-Speicher\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/kaust-selects-canonicals-openstack-cloud/22858\",\"internal\":true,\"reflection\":false,\"title\":\"KAUST
+        selects Canonical's OpenStack cloud\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/atresmedia-accede-a-una-alta-disponibilidad-y-productividad-sin-precedentes-con-charmed-kubernetes/23125\",\"internal\":true,\"reflection\":false,\"title\":\"Atresmedia
+        accede a una alta disponibilidad y productividad sin precedentes con Charmed
+        Kubernetes\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/handlungsoptionen-nach-dem-endof-life-der-suse-openstack-cloud/23173\",\"internal\":true,\"reflection\":false,\"title\":\"Handlungsoptionen
+        nach dem Endof-life der SUSE OpenStack Cloud\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/a-small-to-medium-size-business-guide-to-cybersecurity/23274\",\"internal\":true,\"reflection\":false,\"title\":\"A
+        small to medium-size business guide to cybersecurity\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/sbi-group-sblocca-lautomazione-dellinfrastruttura-con-un-cloud-openstack-sicuro-e-on-premises/23286\",\"internal\":true,\"reflection\":false,\"title\":\"SBI
+        Group sblocca l'automazione dell'infrastruttura con un cloud OpenStack sicuro
+        e on-premises\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/free-cloud-pricing-report-2021/23455\",\"internal\":true,\"reflection\":false,\"title\":\"Free
+        cloud pricing report 2021\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/atresmedia-accesses-high-availability-and-unprecedented-productivity-with-charmed-kubernetes/23693\",\"internal\":true,\"reflection\":false,\"title\":\"Atresmedia
+        accesses high availability and unprecedented productivity with Charmed Kubernetes\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/applied-ai-for-fraud-prevention-and-detection/23734\",\"internal\":true,\"reflection\":false,\"title\":\"Applied
+        AI for fraud prevention and detection\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/running-enterprise-grade-edge-applications-with-edgex-on-ubuntu-core/23773\",\"internal\":true,\"reflection\":false,\"title\":\"Running
+        enterprise-grade edge applications with EdgeX on Ubuntu Core\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/helping-developers-reach-new-heights/23873\",\"internal\":true,\"reflection\":false,\"title\":\"Helping
+        developers reach new heights\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/containers-as-a-service-deploy-kubernetes-faster-with-canonical-and-portainer/23970\",\"internal\":true,\"reflection\":false,\"title\":\"Containers-as-a-service:
+        Deploy Kubernetes faster with Canonical and Portainer\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/kubernetes-platform-comparison-red-hat-openshift-suse-rancher-and-canonical-kubernetes/23982\",\"internal\":true,\"reflection\":false,\"title\":\"Kubernetes
+        platform comparison: Red Hat OpenShift, SUSE Rancher and Canonical Kubernetes\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/how-to-manage-risks-with-the-top-1-managed-service-providers/23983\",\"internal\":true,\"reflection\":false,\"title\":\"How
+        to manage risks with the top 1% Managed Service Providers\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/atresmedia-domine-le-marche-des-medias-en-espagne-avec-l-architecture-de-microservices-charmed-kubernetes/24009\",\"internal\":true,\"reflection\":false,\"title\":\"Atresmedia
+        domine le march\xE9 des m\xE9dias en Espagne avec l\u2019architecture de microservices
+        Charmed Kubernetes\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/self-healing-kubernetes-at-the-edge-microk8s-raspberry-pis-and-portainer/24070\",\"internal\":true,\"reflection\":false,\"title\":\"Self-healing
+        Kubernetes at the edge: MicroK8s, Raspberry Pis and Portainer\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/its-like-a-jungle-out-there-how-to-adapt-your-it-strategy-for-changing-markets/24077\",\"internal\":true,\"reflection\":false,\"title\":\"It's
+        like a jungle out there: how to adapt your IT strategy for changing markets\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/building-graphical-applications-in-embedded-devices/24167\",\"internal\":true,\"reflection\":false,\"title\":\"Building
+        graphical applications in embedded devices\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/canonical-ubuntu-at-arm-dev-summit-2021/24204\",\"internal\":true,\"reflection\":false,\"title\":\"Canonical
+        \\u0026 Ubuntu at ARM Dev Summit 2021\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/beat-disruption-how-to-adapt-your-it-strategy-for-changing-markets/24237\",\"internal\":true,\"reflection\":false,\"title\":\"Beat
+        disruption: how to adapt your IT strategy for changing markets\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/managed-it-services-overcoming-cios-biggest-challenges/24285\",\"internal\":true,\"reflection\":false,\"title\":\"Managed
+        IT Services: Overcoming CIOs Biggest Challenges\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/edge-kubernetes-what-s-brewing/24492\",\"internal\":true,\"reflection\":false,\"title\":\"Edge
+        Kubernetes: what\u2019s brewing?\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/canonical-ubuntu-at-nvidia-gtc-2021/24671\",\"internal\":true,\"reflection\":false,\"title\":\"Canonical
+        \\u0026 Ubuntu at Nvidia GTC 2021\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/enterprise-kubernetes-use-cases-4-real-world-stories/24588\",\"internal\":true,\"reflection\":false,\"title\":\"Enterprise
+        Kubernetes use cases: 4 real-world stories\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/finserv-open-source-infrastructure-powers-hybrid-cloud-strategy/24008\",\"internal\":true,\"reflection\":false,\"title\":\"Finserv
+        open source infrastructure powers hybrid cloud strategy\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/driving-robotics-innovation/24442\",\"internal\":true,\"reflection\":false,\"title\":\"Driving
+        robotics innovation\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/workstations-on-the-ai-journey-deploying-your-model/24401\",\"internal\":true,\"reflection\":false,\"title\":\"Workstations
+        on the AI Journey | Deploying Your Model\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/ctos-guide-to-micro-clouds/24533\",\"internal\":true,\"reflection\":false,\"title\":\"CTOs'
+        Guide to Micro Clouds\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/7-approaches-to-accelerating-apache-kafka-on-k8s/24711\",\"internal\":true,\"reflection\":false,\"title\":\"7
+        Approaches to Accelerating Apache Kafka on K8s\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/architecting-price-performance-private-cloud/24721\",\"internal\":true,\"reflection\":false,\"title\":\"Architecting
+        price performance Private Cloud\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/openstack-upgrades-with-minimal-downtime/24756\",\"internal\":true,\"reflection\":false,\"title\":\"OpenStack
+        Upgrades with Minimal Downtime\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/ubuntu-16-04-lts-verso-la-manutenzione-estesa-della-sicurezza/24781\",\"internal\":true,\"reflection\":false,\"title\":\"Ubuntu
+        16.04 LTS verso la Manutenzione Estesa della Sicurezza\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/smartdrone-fast-tracks-drone-infrastructure-revolution-with-ubuntu-core/24821\",\"internal\":true,\"reflection\":false,\"title\":\"SmartDrone
+        fast-tracks drone infrastructure revolution with Ubuntu Core\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/secure-ai-models-deployment-at-the-edge-with-openvino-on-ubuntu-containers/24894\",\"internal\":true,\"reflection\":false,\"title\":\"Secure
+        AI models deployment at the edge with OpenVINO\u2122 on Ubuntu containers\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/atresmedia-domina-il-mercato-spagnolo-dei-media-ott-con-larchitettura-di-microservizi-charmed-kubernetes/24897\",\"internal\":true,\"reflection\":false,\"title\":\"Atresmedia
+        domina il mercato spagnolo dei media OTT con l'architettura di microservizi
+        Charmed Kubernetes\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/cybersecurity-and-compliance-with-ubuntu/24933\",\"internal\":true,\"reflection\":false,\"title\":\"Cybersecurity
+        and Compliance with Ubuntu\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/telecom-infrastructure-the-open-source-way/25038\",\"internal\":true,\"reflection\":false,\"title\":\"Telecom
+        infrastructure the open source way\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/ceph-in-the-modern-data-center/25046\",\"internal\":true,\"reflection\":false,\"title\":\"Ceph
+        in the modern data center\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/ubuntu-desktop/25158\",\"internal\":true,\"reflection\":false,\"title\":\"\u958B\u767C\u8005\u9078\u64C7
+        Ubuntu Desktop \u7684\u516D\u5927\u7406\u7531\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/finserv-it-infrastructure-migrating-from-vmware-to-openstack/25179\",\"internal\":true,\"reflection\":false,\"title\":\"Finserv
+        IT infrastructure: Migrating from VMWare to OpenStack\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/microk8s-on-ibm-z-minimal-footprint-meets-zero-downtime/25183\",\"internal\":true,\"reflection\":false,\"title\":\"MicroK8s
+        on IBM Z \u2014 minimal footprint meets zero downtime\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/introducing-sql-server-on-ubuntu-pro-for-azure-part-1/25193\",\"internal\":true,\"reflection\":false,\"title\":\"Introducing
+        SQL Server on Ubuntu Pro for Azure Part 1\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/getting-started-with-shells-custom-ubuntu-pro-image-on-azure/25267\",\"internal\":true,\"reflection\":false,\"title\":\"Getting
+        started with Shell's custom Ubuntu Pro image on Azure\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/ceph-for-enterprise/25305\",\"internal\":true,\"reflection\":false,\"title\":\"Ceph
+        for Enterprise\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/nayatel-builds-public-cloud-service-with-charmed-openstack/25331\",\"internal\":true,\"reflection\":false,\"title\":\"Nayatel
+        builds public cloud service with Charmed OpenStack\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/building-cost-efficient-open-source-cloud-operations/25347\",\"internal\":true,\"reflection\":false,\"title\":\"Building
+        cost-efficient open source cloud operations\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/introducing-sql-server-on-ubuntu-pro-for-azure-part-2/25350\",\"internal\":true,\"reflection\":false,\"title\":\"Introducing
+        SQL Server on Ubuntu Pro for Azure Part 2\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/ubuntu-pro-en-azure/25388\",\"internal\":true,\"reflection\":false,\"title\":\"Ubuntu
+        Pro en Azure\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/docker-ros-when-all-you-have-is-a-hammer-everything-looks-like-a-nail/25389\",\"internal\":true,\"reflection\":false,\"title\":\"Docker
+        \\u0026 ROS: When all you have is a hammer, everything looks like a nail\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/ubuntu-pro-em-microsoft-azure/25392\",\"internal\":true,\"reflection\":false,\"title\":\"Ubuntu
+        Pro em Microsoft Azure\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/nfv-orchestration-for-open-source-telco/25422\",\"internal\":true,\"reflection\":false,\"title\":\"NFV
+        Orchestration For Open Source Telco\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/how-to-increase-developer-productivity-with-ubuntu-desktop/25426\",\"internal\":true,\"reflection\":false,\"title\":\"How
+        to increase developer productivity with Ubuntu Desktop\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/migrating-to-ubuntu-lts-six-facts-for-centos-users/25585\",\"internal\":true,\"reflection\":false,\"title\":\"Migrating
+        to Ubuntu LTS: six facts for CentOS users\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/evaluating-microsoft-sql-server-options-for-azure/25594\",\"internal\":true,\"reflection\":false,\"title\":\"Evaluating
+        Microsoft SQL Server Options for Azure\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/bare-metal-provisioning-what-s-new-in-maas-3-1/25607\",\"internal\":true,\"reflection\":false,\"title\":\"Bare
+        metal provisioning: What\u2019s new in MAAS 3.1?\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/embedded-kubernetes-for-secure-iot-edge/25635\",\"internal\":true,\"reflection\":false,\"title\":\"Embedded
+        Kubernetes for secure IoT Edge\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/costruire-infrastrutture-multi-cloud-con-ubuntu-e-kubernetes/21247\",\"internal\":true,\"reflection\":false,\"title\":\"Costruire
+        infrastrutture multi-cloud con Ubuntu e Kubernetes\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/suse-openstack-cloud-arrive-en-fin-de-vie/21096\",\"internal\":true,\"reflection\":false,\"title\":\"SUSE
+        OpenStack Cloud arrive en fin de vie\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/kubeflow-operations-guide/21213\",\"internal\":true,\"reflection\":false,\"title\":\"Kubeflow
+        operations guide\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/from-yocto-buildroot-to-ubuntu-core-20/21248\",\"internal\":true,\"reflection\":false,\"title\":\"From
+        Yocto \\u0026 Buildroot to Ubuntu Core 20\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/linux/24602\",\"internal\":true,\"reflection\":false,\"title\":\"\u5D4C\u5165\u5F0FLinux\uFF1A\u81EA\u88FD\u6216\u5916\u8CFC?\",\"clicks\":0}],\"read\":true,\"user_title\":null,\"bookmarked\":false,\"actions_summary\":[{\"id\":3,\"can_act\":true},{\"id\":4,\"can_act\":true},{\"id\":8,\"can_act\":true},{\"id\":7,\"can_act\":true}],\"moderator\":false,\"admin\":true,\"staff\":true,\"user_id\":9642,\"hidden\":false,\"trust_level\":3,\"deleted_at\":null,\"user_deleted\":false,\"edit_reason\":null,\"can_view_edit_history\":true,\"wiki\":false,\"reviewable_id\":0,\"reviewable_score_count\":0,\"reviewable_score_pending_count\":0,\"can_accept_answer\":false,\"can_unaccept_answer\":false,\"accepted_answer\":false}],\"stream\":[50258]},\"timeline_lookup\":[[1,472]],\"suggested_topics\":[{\"id\":19808,\"title\":\"Image
+        building\",\"fancy_title\":\"Image building\",\"slug\":\"image-building\",\"posts_count\":6,\"reply_count\":4,\"highest_post_number\":6,\"image_url\":null,\"created_at\":\"2020-12-11T12:06:10.284Z\",\"last_posted_at\":\"2021-05-14T10:50:28.370Z\",\"bumped\":true,\"bumped_at\":\"2021-05-14T10:50:28.370Z\",\"archetype\":\"regular\",\"unseen\":false,\"last_read_post_number\":1,\"unread\":0,\"new_posts\":5,\"pinned\":false,\"unpinned\":null,\"visible\":true,\"closed\":false,\"archived\":false,\"notification_level\":3,\"bookmarked\":false,\"liked\":false,\"tags\":[],\"like_count\":5,\"views\":2005,\"category_id\":47,\"featured_link\":null,\"has_accepted_answer\":false,\"posters\":[{\"extras\":null,\"description\":\"Original
+        Poster\",\"user\":{\"id\":9642,\"username\":\"carkod\",\"name\":\"Carlos Wu
+        Fei\",\"avatar_template\":\"/letter_avatar/carkod/{size}/5_6d6f4cde2641c35611d5cac2fb97c77e.png\"}},{\"extras\":null,\"description\":\"Frequent
+        Poster\",\"user\":{\"id\":14088,\"username\":\"rzr\",\"name\":\"\",\"avatar_template\":\"/user_avatar/discourse.ubuntu.com/rzr/{size}/12642_2.png\"}},{\"extras\":null,\"description\":\"Frequent
+        Poster\",\"user\":{\"id\":9578,\"username\":\"degville\",\"name\":\"Graham
+        Morrison\",\"avatar_template\":\"/user_avatar/discourse.ubuntu.com/degville/{size}/9336_2.png\"}},{\"extras\":\"latest\",\"description\":\"Most
+        Recent Poster\",\"user\":{\"id\":1046,\"username\":\"ogra\",\"name\":\"Oliver
+        Grawert\",\"avatar_template\":\"/user_avatar/discourse.ubuntu.com/ogra/{size}/8750_2.png\"}}]},{\"id\":19806,\"title\":\"System
+        requirements\",\"fancy_title\":\"System requirements\",\"slug\":\"system-requirements\",\"posts_count\":5,\"reply_count\":2,\"highest_post_number\":5,\"image_url\":null,\"created_at\":\"2020-12-11T11:58:38.369Z\",\"last_posted_at\":\"2021-01-12T17:22:21.406Z\",\"bumped\":true,\"bumped_at\":\"2021-01-12T17:22:21.406Z\",\"archetype\":\"regular\",\"unseen\":false,\"last_read_post_number\":4,\"unread\":0,\"new_posts\":1,\"pinned\":false,\"unpinned\":null,\"visible\":true,\"closed\":false,\"archived\":false,\"notification_level\":3,\"bookmarked\":false,\"liked\":false,\"tags\":[],\"like_count\":1,\"views\":2018,\"category_id\":47,\"featured_link\":null,\"has_accepted_answer\":false,\"posters\":[{\"extras\":null,\"description\":\"Original
+        Poster\",\"user\":{\"id\":9642,\"username\":\"carkod\",\"name\":\"Carlos Wu
+        Fei\",\"avatar_template\":\"/letter_avatar/carkod/{size}/5_6d6f4cde2641c35611d5cac2fb97c77e.png\"}},{\"extras\":null,\"description\":\"Frequent
+        Poster\",\"user\":{\"id\":1046,\"username\":\"ogra\",\"name\":\"Oliver Grawert\",\"avatar_template\":\"/user_avatar/discourse.ubuntu.com/ogra/{size}/8750_2.png\"}},{\"extras\":\"latest\",\"description\":\"Most
+        Recent Poster\",\"user\":{\"id\":9578,\"username\":\"degville\",\"name\":\"Graham
+        Morrison\",\"avatar_template\":\"/user_avatar/discourse.ubuntu.com/degville/{size}/9336_2.png\"}}]},{\"id\":11322,\"title\":\"Introduction\",\"fancy_title\":\"Introduction\",\"slug\":\"introduction\",\"posts_count\":19,\"reply_count\":13,\"highest_post_number\":19,\"image_url\":null,\"created_at\":\"2019-06-19T20:48:28.000Z\",\"last_posted_at\":\"2021-12-07T19:55:08.830Z\",\"bumped\":true,\"bumped_at\":\"2021-12-07T19:55:08.830Z\",\"archetype\":\"regular\",\"unseen\":false,\"last_read_post_number\":12,\"unread\":0,\"new_posts\":7,\"pinned\":false,\"unpinned\":true,\"visible\":true,\"closed\":false,\"archived\":false,\"notification_level\":2,\"bookmarked\":false,\"liked\":false,\"tags\":[],\"like_count\":13,\"views\":32236,\"category_id\":26,\"featured_link\":null,\"has_accepted_answer\":false,\"posters\":[{\"extras\":null,\"description\":\"Original
+        Poster\",\"user\":{\"id\":37,\"username\":\"powersj\",\"name\":\"Joshua Powers\",\"avatar_template\":\"/user_avatar/discourse.ubuntu.com/powersj/{size}/10180_2.png\"}},{\"extras\":null,\"description\":\"Frequent
+        Poster\",\"user\":{\"id\":3783,\"username\":\"paelzer\",\"name\":\"Christian
+        Ehrhardt\",\"avatar_template\":\"/user_avatar/discourse.ubuntu.com/paelzer/{size}/8804_2.png\"}},{\"extras\":null,\"description\":\"Frequent
+        Poster\",\"user\":{\"id\":16120,\"username\":\"jrmyck\",\"name\":\"Jeremy
+        Cook\",\"avatar_template\":\"/user_avatar/discourse.ubuntu.com/jrmyck/{size}/14019_2.png\"}},{\"extras\":null,\"description\":\"Frequent
+        Poster\",\"user\":{\"id\":7676,\"username\":\"bryce\",\"name\":\"Bryce Harrington\",\"avatar_template\":\"/user_avatar/discourse.ubuntu.com/bryce/{size}/6071_2.png\"}},{\"extras\":\"latest\",\"description\":\"Most
+        Recent Poster\",\"user\":{\"id\":8605,\"username\":\"dsmythies\",\"name\":\"Doug
+        Smythies\",\"avatar_template\":\"/user_avatar/discourse.ubuntu.com/dsmythies/{size}/6700_2.png\"}}]},{\"id\":25710,\"title\":\"An
+        Introduction to Ubuntu Desktop\",\"fancy_title\":\"An Introduction to Ubuntu
+        Desktop\",\"slug\":\"an-introduction-to-ubuntu-desktop\",\"posts_count\":1,\"reply_count\":0,\"highest_post_number\":1,\"image_url\":null,\"created_at\":\"2021-12-10T11:37:11.283Z\",\"last_posted_at\":\"2021-12-10T11:37:11.517Z\",\"bumped\":true,\"bumped_at\":\"2021-12-10T11:37:11.517Z\",\"archetype\":\"regular\",\"unseen\":true,\"pinned\":false,\"unpinned\":null,\"visible\":true,\"closed\":false,\"archived\":false,\"bookmarked\":null,\"liked\":null,\"tags\":[\"desktop\"],\"like_count\":0,\"views\":15,\"category_id\":51,\"featured_link\":null,\"has_accepted_answer\":false,\"posters\":[{\"extras\":\"latest
+        single\",\"description\":\"Original Poster, Most Recent Poster\",\"user\":{\"id\":15862,\"username\":\"prk9987\",\"name\":\"Prk9987\",\"avatar_template\":\"/letter_avatar/prk9987/{size}/5_6d6f4cde2641c35611d5cac2fb97c77e.png\"}}]},{\"id\":25707,\"title\":\"\u201Cbackup\u201D
+        network to access instance when interface is down\",\"fancy_title\":\"\u201Cbackup\u201D
+        network to access instance when interface is down\",\"slug\":\"backup-network-to-access-instance-when-interface-is-down\",\"posts_count\":2,\"reply_count\":0,\"highest_post_number\":2,\"image_url\":null,\"created_at\":\"2021-12-10T10:01:16.206Z\",\"last_posted_at\":\"2021-12-10T10:58:11.545Z\",\"bumped\":true,\"bumped_at\":\"2021-12-10T10:58:11.545Z\",\"archetype\":\"regular\",\"unseen\":true,\"pinned\":false,\"unpinned\":null,\"visible\":true,\"closed\":false,\"archived\":false,\"bookmarked\":null,\"liked\":null,\"tags\":[],\"like_count\":0,\"views\":23,\"category_id\":21,\"featured_link\":null,\"has_accepted_answer\":false,\"posters\":[{\"extras\":null,\"description\":\"Original
+        Poster\",\"user\":{\"id\":12399,\"username\":\"glancr\",\"name\":\"Tobias\",\"avatar_template\":\"/user_avatar/discourse.ubuntu.com/glancr/{size}/9017_2.png\"}},{\"extras\":\"latest\",\"description\":\"Most
+        Recent Poster\",\"user\":{\"id\":167,\"username\":\"saviq\",\"name\":\"Micha\u0142
+        Sawicz\",\"avatar_template\":\"/user_avatar/discourse.ubuntu.com/saviq/{size}/8770_2.png\"}}]}],\"tags\":[],\"id\":18033,\"title\":\"Engage
+        pages for ubuntu.com\",\"fancy_title\":\"Engage pages for ubuntu.com\",\"posts_count\":1,\"created_at\":\"2020-08-25T11:17:26.006Z\",\"views\":219,\"reply_count\":0,\"like_count\":0,\"last_posted_at\":\"2020-08-25T11:17:26.382Z\",\"visible\":true,\"closed\":false,\"archived\":false,\"has_summary\":false,\"archetype\":\"regular\",\"slug\":\"engage-pages-for-ubuntu-com\",\"category_id\":51,\"word_count\":11981,\"deleted_at\":null,\"user_id\":9642,\"featured_link\":null,\"pinned_globally\":false,\"pinned_at\":null,\"pinned_until\":null,\"image_url\":null,\"slow_mode_seconds\":0,\"draft\":null,\"draft_key\":\"topic_18033\",\"draft_sequence\":180,\"posted\":true,\"unpinned\":null,\"pinned\":false,\"current_post_number\":1,\"highest_post_number\":1,\"last_read_post_number\":1,\"last_read_post_id\":50258,\"deleted_by\":null,\"has_deleted\":false,\"actions_summary\":[{\"id\":4,\"count\":0,\"hidden\":false,\"can_act\":true},{\"id\":8,\"count\":0,\"hidden\":false,\"can_act\":true},{\"id\":7,\"count\":0,\"hidden\":false,\"can_act\":true}],\"chunk_size\":20,\"bookmarked\":false,\"topic_timer\":null,\"message_bus_last_id\":7,\"participant_count\":1,\"queued_posts_count\":0,\"show_read_indicator\":false,\"thumbnails\":null,\"details\":{\"notification_level\":3,\"notifications_reason_id\":1,\"can_move_posts\":true,\"can_edit\":true,\"can_delete\":true,\"can_remove_allowed_users\":true,\"can_invite_to\":true,\"can_create_post\":true,\"can_reply_as_new_topic\":true,\"can_flag_topic\":true,\"can_convert_topic\":true,\"can_review_topic\":true,\"can_close_topic\":true,\"can_archive_topic\":true,\"can_split_merge_topic\":true,\"can_edit_staff_notes\":true,\"can_moderate_category\":true,\"can_remove_self_id\":9642,\"participants\":[{\"id\":9642,\"username\":\"carkod\",\"name\":\"Carlos
+        Wu Fei\",\"avatar_template\":\"/letter_avatar/carkod/{size}/5_6d6f4cde2641c35611d5cac2fb97c77e.png\",\"post_count\":1,\"primary_group_name\":\"Canonical\",\"primary_group_flair_url\":\"/uploads/short-url/paWz8RxxmKxiYXUmH2ABvqKp0Gg.png\",\"primary_group_flair_color\":\"\",\"primary_group_flair_bg_color\":\"\"}],\"created_by\":{\"id\":9642,\"username\":\"carkod\",\"name\":\"Carlos
+        Wu Fei\",\"avatar_template\":\"/letter_avatar/carkod/{size}/5_6d6f4cde2641c35611d5cac2fb97c77e.png\"},\"last_poster\":{\"id\":9642,\"username\":\"carkod\",\"name\":\"Carlos
+        Wu Fei\",\"avatar_template\":\"/letter_avatar/carkod/{size}/5_6d6f4cde2641c35611d5cac2fb97c77e.png\"},\"links\":[{\"url\":\"https://ubuntu.com/engage\",\"title\":\"Ubuntu
+        case studies, whitepapers and webinars | Ubuntu\",\"internal\":false,\"attachment\":false,\"reflection\":false,\"clicks\":3,\"user_id\":9642,\"domain\":\"ubuntu.com\",\"root_domain\":\"ubuntu.com\"}]},\"pending_posts\":[]}"
     headers:
       Access-Control-Allow-Credentials:
       - 'true'
       Access-Control-Allow-Headers:
-      - Content-Type, Cache-Control, X-Requested-With, X-CSRF-Token, Discourse-Visible,
-        User-Api-Key, User-Api-Client-Id
+      - Content-Type, Cache-Control, X-Requested-With, X-CSRF-Token, Discourse-Present,
+        User-Api-Key, User-Api-Client-Id, Authorization
       Access-Control-Allow-Methods:
       - POST, PUT, GET, OPTIONS, DELETE
       Access-Control-Allow-Origin:
       - https://didrocks.fr
       Cache-Control:
       - no-cache, no-store
-      Connection:
-      - Keep-Alive
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 19 Nov 2020 12:28:42 GMT
-      Keep-Alive:
-      - timeout=5, max=100
+      - Fri, 10 Dec 2021 12:45:41 GMT
       Referrer-Policy:
       - strict-origin-when-cross-origin
       Server:
@@ -2259,10 +1400,10 @@ interactions:
       - chunked
       X-Content-Type-Options:
       - nosniff
-      X-Discourse-Cached:
-      - 'true'
       X-Discourse-Route:
       - topics/show
+      X-Discourse-Username:
+      - carkod
       X-Download-Options:
       - noopen
       X-Frame-Options:
@@ -2270,9 +1411,9 @@ interactions:
       X-Permitted-Cross-Domain-Policies:
       - none
       X-Request-Id:
-      - 358eb0d0-cba4-4674-83a7-11d58d3eba36
+      - 5bba4f68-4049-4308-bf90-910209edcf2a
       X-Runtime:
-      - '0.002626'
+      - '0.211810'
       X-XSS-Protection:
       - 1; mode=block
     status:

--- a/tests/cassettes/TestRoutes.test_engage_index_with_preview_flag_sees_inactive_pages.yaml
+++ b/tests/cassettes/TestRoutes.test_engage_index_with_preview_flag_sees_inactive_pages.yaml
@@ -1,2256 +1,1397 @@
 interactions:
 - request:
     body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - python-requests/2.24.0
+    headers: {}
     method: GET
-    uri: https://discourse.ubuntu.com/t/17229.json
+    uri: https://discourse.ubuntu.com/t/18033.json
   response:
     body:
-      string: "{\"post_stream\":{\"posts\":[{\"id\":48547,\"name\":\"Peter Mahnke\"\
-        ,\"username\":\"peterm-ubuntu\",\"avatar_template\":\"/user_avatar/discourse.ubuntu.com/peterm-ubuntu/{size}/7873_2.png\"\
-        ,\"created_at\":\"2020-07-14T09:57:15.584Z\",\"cooked\":\"\\u003ch1\\u003eEngage\
-        \ pages\\u003c/h1\\u003e\\n\\u003cp\\u003eThe content of topics in this category\
-        \ are displayed at \\u003ca href=\\\"https://ubuntu.com/engage\\\" rel=\\\"\
-        nofollow noopener\\\"\\u003ehttps://ubuntu.com/engage\\u003c/a\\u003e.\\u003c/p\\\
-        u003e\\n\\u003ch2\\u003eMetadata\\u003c/h2\\u003e\\n\\u003cdetails\\u003e\\\
-        n\\u003csummary\\u003e\\nMapping table\\u003c/summary\\u003e\\n\\u003cdiv\
-        \ class=\\\"md-table\\\"\\u003e\\n\\u003ctable\\u003e\\n\\u003cthead\\u003e\\\
-        n\\u003ctr\\u003e\\n\\u003cth\\u003etopic\\u003c/th\\u003e\\n\\u003cth\\u003epath\\\
-        u003c/th\\u003e\\n\\u003cth\\u003etype\\u003c/th\\u003e\\n\\u003cth\\u003etags\\\
-        u003c/th\\u003e\\n\\u003cth\\u003epublish_date\\u003c/th\\u003e\\n\\u003cth\\\
-        u003elanguage\\u003c/th\\u003e\\n\\u003cth\\u003esubtitle\\u003c/th\\u003e\\\
-        n\\u003cth\\u003eactive\\u003c/th\\u003e\\n\\u003c/tr\\u003e\\n\\u003c/thead\\\
-        u003e\\n\\u003ctbody\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca\
-        \ href=\\\"https://discourse.ubuntu.com/t/cinque-strategie-per-accelerare-limplementazione-di-kubernetes-nellimpresa/19381\\\
-        \"\\u003eCinque strategie per accelerare l\u2019implementazione di Kubernetes\
-        \ nell\u2019impresa\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/it/deployment-azienda-manuale\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003eenterprise\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-11-17\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003eit\\u003c/td\\u003e\\n\\u003ctd\\u003eCome scegliere\
-        \ il miglior approccio Kubernetes per la tua azienda\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003efalse\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
-        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/confronto-fra-red-hats-openstack-platform-e-charmed-openstack-di-canaonical/19362\\\
-        \"\\u003eConfronto fra \u201CRed Hat\u2019s Openstack platform\u201D e Charmed\
-        \ Openstack di Canaonical\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/it/redhat-openstack-confronto-manuale\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003eRed Hat\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-11-16\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003eit\\u003c/td\\u003e\\n\\u003ctd\\u003eCharmed Openstack riduce\
-        \ significativamente il costo totale di propriet\xE0\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
-        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/confronto-fra-red-hats-openstack-platform-e-charmed-openstack-di-canaonical/19361\\\
-        \"\\u003eGuide pour r\xE9ussir l\u2019adoption et le d\xE9ploiement d\u2019\
-        OpenStack\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/fr/guide-adoption-openstack\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003eopenstack\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-11-16\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003efr\\u003c/td\\u003e\\n\\u003ctd\\u003eD\xE9couvrez l\u2019\
-        \xE9prouv\xE9 processus d\u2019impl\xE9mentation OpenStack de Canonical\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\\
-        n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/funf-strategien-zur-beschleunigung-von-kubernetes-in-unternehmen/19284\\\
-        \"\\u003eF\xFCnf Strategien zur Beschleunigung von Kubernetes in Unternehmen\\\
-        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/de/kubernetes-implementierung-fur-unternehmen\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003eenterprise\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-11-11\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003ede\\u003c/td\\u003e\\n\\u003ctd\\u003eEntscheidungskriterien\
-        \ zur optimalen Herangehensweise an Kubernetes f\xFCr Ihr Unternehmen\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\\
-        u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/vergleich-von-red-hat-openstack-platform-und-charmed-openstack-von-canonical/19285\\\
-        \"\\u003eVergleich von Red Hat OpenStack Platform und Charmed OpenStack von\
-        \ Canonical\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/de/redhat-openstack-vergleich\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003eRed Hat\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-11-11\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003ede\\u003c/td\\u003e\\n\\u003ctd\\u003eSenken Sie Ihre Gesamtkosten\
-        \ deutlich mit Charmed OpenStack\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\\
-        u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\\
-        u003ca href=\\\"https://discourse.ubuntu.com/t/9-out-of-top-10-us-financial-institutions-use-ubuntu/19304\\\
-        \"\\u003e9 out of top 10 US \\u0026amp; European financial institutions use\
-        \ Ubuntu\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/finance\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003efinance\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-11-11\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eFind out why multi-cloud\
-        \ is fundamental to financial services transformation\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
-        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/cinco-estrategias-para-acelerar-a-los-kubernetes-en-la-empresa/19208\\\
-        \"\\u003eCinco estrategias para acelerar a los Kubernetes en la empresa\\\
-        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/es/kubernetes-despliegue-empresa-manual\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003eenterprise, kubernetes\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-11-04\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003ees\\u003c/td\\u003e\\n\\u003ctd\\u003eC\xF3\
-        mo elegir el mejor enfoque de Kubernetes para su negocio\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
-        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/comparando-la-plataforma-openstack-de-red-hat-y-la-charmed-openstack-de-canonical/19194\\\
-        \"\\u003eComparando la plataforma OpenStack de Red Hat y la Charmed OpenStack\
-        \ de Canonical\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/es/redhat-openstack-comparacion-manual\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003eopenstack\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-11-03\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003ees\\u003c/td\\u003e\\n\\u003ctd\\u003eReducir significativamente\
-        \ el coste total de propiedad con Charmed OpenStack\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
-        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/optimised-authentication-methods-for-ubuntu-desktop/19133\\\
-        \"\\u003eOptimised authentication methods for Ubuntu Desktop\\u003c/a\\u003e\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/desktop-authentication-whitepaper\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003edesktop, security\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-08-07\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eSecuring enterprise\
-        \ desktops with modern authentication options\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\\
-        u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/open-digital-platforms-for-the-industrial-edge-cloud-in-2020/19068\\\
-        \"\\u003eOpen digital platforms for the industrial edge cloud in 2020\\u003c/a\\\
-        u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/pac-radar\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003epac-radar\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e2020-10-27\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eThe next wave of cloud-native innovations\
-        \ at the edge\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\\
-        u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/ubuntu-20-10-what-s-new/19050\\\
-        \"\\u003eUbuntu 20.10: What\u2019s new?\\u003c/a\\u003e\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003e/engage/ubuntu-20.10\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003eubuntu server, maas, kubernetes\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e2020-10-26\\u003c/td\\u003e\\n\\u003ctd\\u003een\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003eLearn about new features in Ubuntu Server,\
-        \ MAAS, Charmed OpenStack and Charmed Kubernetes\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\\
-        u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/ubuntu-for-raspberry-pi-live-on-youtube/18577\\\
-        \"\\u003eUbuntu for Raspberry Pi intro video\\u003c/a\\u003e\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003e/engage/raspberry-pi-livestream\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eraspberry-pi, desktop\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e2020-10-21\\u003c/td\\u003e\\n\\u003ctd\\u003een\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\\
-        u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\\
-        u003ca href=\\\"https://discourse.ubuntu.com/t/cloud-gaming-for-android/18757\\\
-        \"\\u003eCloud gaming for Android\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003e/engage/anbox-cloud-gaming-whitepaper\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eanbox, gaming\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e2020-01-21\\u003c/td\\u003e\\n\\u003ctd\\u003een\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003eBuilding a high performing and scalable\
-        \ platform\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\\
-        u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/extend-your-openstack-cloud-with-native-backup-and-recover/18911\\\
-        \"\\u003eExtend your OpenStack cloud with native backup and recovery\\u003c/a\\\
-        u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/trilio-backup-recovery\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e2020-09-31\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eLearn how TrilioVault can be easily\
-        \ deployed in a Charmed OpenStack environment\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\\
-        u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/transforming-telco-infrastructure-a-virtual-event/18162\\\
-        \"\\u003eTransforming telco infrastructure\\u003c/a\\u003e\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003e/engage/telco-virtual-event\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003eevent\\u003c/td\\u003e\\n\\u003ctd\\u003eopen-source\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003e2020-09-24\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003eCanonical\u2019s experts explore the telecommunication\
-        \ industry\u2019s latest technologies. Join us live on 24 September 2020.\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\\
-        n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/guia-para-la-implementacion-de-openstack/18480\\\
-        \"\\u003eGu\xEDa para la implementaci\xF3n de OpenStack\\u003c/a\\u003e\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/es/guia-para-la-implementacion-de-openstack\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003eopenstack\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-09-16\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003ees\\u003c/td\\u003e\\n\\u003ctd\\u003eDescubre el probado\
-        \ proceso de implementaci\xF3n de OpenStack de Canonical\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
-        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/da-vmware-a-charmed-openstack/18478\\\
-        \"\\u003eDa VMware a Charmed Openstack\\u003c/a\\u003e\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003e/engage/it/da-vmware-a-charmed-openstack\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e2020-09-15\\u003c/td\\u003e\\n\\u003ctd\\u003eit\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003eCome la migrazione a Charmed OpenStack pu\xF2\
-        \ ridurre significativamente il TCO\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\\
-        u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\\
-        u003ca href=\\\"https://discourse.ubuntu.com/t/gmo-pepabo-ubuntu/18476\\\"\
-        \\u003eGMO Pepabo \\u0026amp; Ubuntu\\u003c/a\\u003e\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003e/engage/case-study-gmo-pepabo\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003ecase study\\u003c/td\\u003e\\n\\u003ctd\\u003eserver, kubernetes,ubuntu-advantage\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e2020-09-14\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eGMO Pepabo cuts OPEX costs with\
-        \ live kernel patching and saves 2,500 hours of manual work\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
-        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/da-vmware-a-openstack/18164\\\
-        \"\\u003eDa VMware a OpenStack\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003e/engage/it/da-vmware-a-openstack\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003eopenstack\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003e2020-09-04\\u003c/td\\u003e\\n\\u003ctd\\u003eit\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003eCome la migrazione a Charmed OpenStack pu\xF2 ridurre significativamente\
-        \ il TCO\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\\
-        u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/five-strategies-to-accelerate-kubernetes-deployment-in-the-enterprise/18161\\\
-        \"\\u003eFive strategies to accelerate Kubernetes in the enterprise\\u003c/a\\\
-        u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/kubernetes-deployment-enterprise-whitepaper\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003ekubernetes\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-09-02\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eHow to choose\
-        \ the best approach to Kubernetes for your business\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
-        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/production-ai-from-data-lake-to-server-webinar/18163\\\
-        \"\\u003eProduction AI from data lake to server\\u003c/a\\u003e\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e/engage/data-lake_2_server_webinar\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eai\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e2020-08-13\\u003c/td\\u003e\\n\\u003ctd\\u003een\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003eSolving hardware challenges in ML environments\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\\
-        n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/building-powerful-customer-solutions/18481\\\
-        \"\\u003eBuilding powerful customer solutions\\u003c/a\\u003e\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e/engage/gsi-webinar-series\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003ecloud, kubernetes\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e2020-07-31\\u003c/td\\u003e\\n\\u003ctd\\u003een\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003eA webinar series for GSIs seizing new models\
-        \ for scalable, automated and repeatable deployments\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
-        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/comparing-red-hat-openstack-platform-and-canonicals-charmed-openstack/18159\\\
-        \"\\u003eComparing Red Hat OpenStack Platform and Canonical\u2019s Charmed\
-        \ OpenStack\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/redhat-openstack-comparison-whitepaper\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003eopenstack\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-07-29\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eImprove security and\
-        \ efficiency at a reduced total cost of ownership with Charmed OpenStack\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\\
-        n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/do-vmware-ao-charmed-openstack/18165\\\
-        \"\\u003eDo VMware ao Charmed OpenStack\\u003c/a\\u003e\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003e/engage/pt/vmware-para-o-openstack\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e2020-07-22\\u003c/td\\u003e\\n\\u003ctd\\u003ept\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003eReduza os custos e aumente a efici\xEAncia\
-        \ da sua infraestrutura com ado\xE7\xE3o de c\xF3digo aberto\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
-        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/busting-the-myth-of-private-cloud-economics/17244\\\
-        \"\\u003eBusting the myth of private cloud economics\\u003c/a\\u003e\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e/engage/cloud-economics\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003ecase-study\\u003c/td\\u003e\\n\\u003ctd\\u003ecloud, openstack\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e2019-07-12\\u003c/td\\u003e\\n\\u003ctd\\u003een\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\\
-        u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\\
-        u003ca href=\\\"https://discourse.ubuntu.com/t/scale-android-applications-economically-in-the-cloud-with-anbox-cloud/17401\\\
-        \"\\u003eScale Android applications economically in the cloud with Anbox Cloud\\\
-        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/intro-to-anbox-cloud-whitepaper\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003ecloud\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-07-08\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eDiscover Canonical\u2019\
-        s scalable, hardware-agnostic mobile cloud computing platform\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\\
-        u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/accelerating-iot-device-time-to-market/17399\\\
-        \"\\u003eAccelerating IoT device time to market\\u003c/a\\u003e\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e/engage/smart-start-whitepaper\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eiot\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e2020-07-03\\u003c/td\\u003e\\n\\u003ctd\\u003een\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003eIntroducing a packaged solution to condense\
-        \ IoT decision-making into a 2-week, fixed cost process\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
-        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/kubernetes-from-cloud-to-edge/17398\\\
-        \"\\u003eKubernetes from Cloud to Edge\\u003c/a\\u003e\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003e/engage/kubernetes-event-us\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003ekubernetes, cloud, edge\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e2020-06-24\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eHow to streamline your Kubernetes\
-        \ deployment and operations from Canonical\u2019s experts.\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
-        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/scaling-on-azure-with-ubuntu-pro/17397\\\
-        \"\\u003eScaling on Azure with Ubuntu Pro\\u003c/a\\u003e\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003e/engage/scaling-securely-ubuntu-azure\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003eeBook\\u003c/td\\u003e\\n\\u003ctd\\u003eopen-source, cloud\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e2020-06-17\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eScale your open-source infrastructure\
-        \ with speed, security, and compliance\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\\
-        u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\\
-        u003ca href=\\\"https://discourse.ubuntu.com/t/a-technical-intro-to-ubuntu-pro/17396\\\
-        \"\\u003eA technical intro to Ubuntu Pro\\u003c/a\\u003e\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003e/engage/ubuntu-pro-intro\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003eopen-source\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003e2020-06-16\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\\
-        n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"\
-        https://discourse.ubuntu.com/t/migrating-your-infrastructure-to-ubuntu-20-04-lts/17395\\\
-        \"\\u003eMigrating your infrastructure to Ubuntu 20.04 LTS\\u003c/a\\u003e\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/migrating-to-20.04\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eopen-source\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e2020-06-11\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eHow, when and why?\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\\
-        u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/utilising-cloud-init-on-microsoft-azure/17394\\\
-        \"\\u003eUtilising cloud-init on Microsoft Azure\\u003c/a\\u003e\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e/engage/azure-cloud-init-whitepaper\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003ecloud\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e2020-06-03\\u003c/td\\u003e\\n\\u003ctd\\u003een\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003eSimplify cloud instance deployment with\
-        \ Ubuntu on Azure\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\\
-        n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"\
-        https://discourse.ubuntu.com/t/standardising-machine-learning-from-workstation-to-production/17393\\\
-        \"\\u003eStandardising machine learning \u2014 from workstation to production\\\
-        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/ml-dell-webinar\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eai,\
-        \ ml, kubernetes\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-06-02\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\\
-        u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/kafka-in-production/17392\\\
-        \"\\u003eKafka in production\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003e/engage/kafka-in-production\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003ekafka\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-05-28\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eMaking\
-        \ sure your deployment is fast, reliable and secure\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
-        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/solving-the-software-update-challenge-for-iot-devices/17391\\\
-        \"\\u003eSolving the software update challenge for IoT devices\\u003c/a\\\
-        u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/snapd-whitepaper\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eiot,\
-        \ ubuntu-core, snaps\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-05-15\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eHow Ubuntu Core\
-        \ transforms over-the-air software updates\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\\
-        u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/secure-iot-device-management/17390\\\
-        \"\\u003eSecure IoT device management\\u003c/a\\u003e\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003e/engage/iot-device-management-whitepaper\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eiot, security,\
-        \ ubuntu-core\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-05-13\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eBuild and deploy a\
-        \ central IoT management solution\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\\
-        u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\\
-        u003ca href=\\\"https://discourse.ubuntu.com/t/leveraging-open-source-with-ubuntu-pro-on-azure/17389\\\
-        \"\\u003eLeveraging open source with Ubuntu Pro on Azure\\u003c/a\\u003e\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/azure-webinar\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eopen-source\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e2020-05-12\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eEconomics, velocity and security\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\\
-        n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/streamlined-kubernetes-from-cloud-to-edge/17388\\\
-        \"\\u003eStreamlined Kubernetes, from Cloud to Edge\\u003c/a\\u003e\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e/engage/eu-kubernetes-event\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003ekubernetes, cloud,\
-        \ edge\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-05-11\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eInnovating and scaling\
-        \ efficiently, with Charmed Kubernetes and MicroK8s\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
-        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/embracing-the-open-source-mandate/17387\\\
-        \"\\u003eEmbracing the open source mandate\\u003c/a\\u003e\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003e/engage/moving-to-opensource-whitepaper\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eopen-source\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e2020-04-28\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e85% of enterprises have an open\
-        \ source mandate, preference or are exploring\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\\
-        u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/what-s-new-in-ubuntu-20-04-lts/17386\\\
-        \"\\u003eWhat\u2019s new in Ubuntu 20.04 LTS?\\u003c/a\\u003e\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e/engage/20.04-webinars\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003edesktop, server\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e2020-04-16\\u003c/td\\u003e\\n\\u003ctd\\u003een\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003eTwo webinars to help you understand what\
-        \ makes 20.04 our most secure and reliable release to date\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
-        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/maintaining-business-focus-in-a-cloud-native-world-with-managed-apps/17385\\\
-        \"\\u003eMaintaining business focus in a cloud-native world with Managed Apps\\\
-        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/managed-apps-webinar\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003ecloud\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e2020-04-09\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\\
-        u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/ubuntu-core-a-cybersecurity-analysis/17381\\\
-        \"\\u003eUbuntu Core: a cybersecurity analysis\\u003c/a\\u003e\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e/engage/ubuntu-core-security-audit\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eubuntu-core,\
-        \ security, iot\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-03-31\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eAn independent\
-        \ evaluation of Ubuntu Core\u2019s security capabilities\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
-        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/openstack-deployment-guide/17384\\\
-        \"\\u003eOpenStack deployment guide\\u003c/a\\u003e\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003e/engage/openstack-deployment-guide\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003e2020-03-31\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003eDiscover Canonical\u2019s proven OpenStack implementation\
-        \ process\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\\
-        u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/installez-et-mettez-openstack-a-lechelle-en-toute-simplicite/17418\\\
-        \"\\u003eInstallez et mettez OpenStack \xE0 l\u2019\xE9chelle en toute simplicit\xE9\
-        \\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/fr/openstack-made-easy\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003eeBook\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e2020-03-29\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003efr\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\\
-        u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/virtual-event-microk8s-kubernetes/17380\\\
-        \"\\u003eVirtual event: MicroK8s \\u0026amp; Kubernetes\\u003c/a\\u003e\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/pre-kubecon-event\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003eevent\\u003c/td\\u003e\\n\\u003ctd\\u003ekubernetes\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e2020-03-24\\u003c/td\\u003e\\n\\u003ctd\\u003een\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003eJoin our virtual event to learn more about\
-        \ MicroK8s, what it is and why you should use it. This event will also include\
-        \ discussions on Kubernetes, an introduction to Canonical and much more!\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\\
-        n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/rigado-cuts-customers-time-to-market/17379\\\
-        \"\\u003eRigado cuts customers\u2019 time-to-market\\u003c/a\\u003e\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e/engage/case-study-rigado\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003ecase study\\u003c/td\\u003e\\n\\u003ctd\\u003eiot, ubuntu-core, snaps\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e2020-03-19\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003een\\u003c/td\\u003e\\n\\u003ctd\\u003ewith Ubuntu Core and AWS\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\\
-        u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/securing-ros-robotics-platforms/17378\\\
-        \"\\u003eSecuring ROS robotics platforms\\u003c/a\\u003e\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003e/engage/securing-ros-on-robotics-platforms-whitepaper\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003erobotics,\
-        \ security\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-03-11\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eSteps to maximise robotics\
-        \ security with Ubuntu\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\\
-        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\
-        \"https://discourse.ubuntu.com/t/smart-card-login-on-ubuntu/17377\\\"\\u003eSmart\
-        \ card login on Ubuntu\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/smart-card-whitepaper\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003esecurity\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-03-09\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eConfigure Ubuntu 18.04\
-        \ LTS for smart card operation\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\\
-        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\
-        \"https://discourse.ubuntu.com/t/hosted-private-cloud-infrastructure-a-cost-analysis/17375\\\
-        \"\\u003eHosted private cloud infrastructure: a cost analysis\\u003c/a\\u003e\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/private-cloud-cost-analysis-webinar\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack,\
-        \ cloud, kubernetes, maas\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-03-02\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eAccelerate\
-        \ initial deployment and reduce operational costs by outsourcing private cloud\
-        \ infrastructure management\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\\
-        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\
-        \"https://discourse.ubuntu.com/t/an-introduction-to-anbox-cloud/17374\\\"\\\
-        u003eAccelerating IoT device time to market\\u003c/a\\u003e\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003e/engage/smart-start-webinar\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eiot\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003e2020-02-26\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003eChallenges and solutions for IoT execution\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\\
-        u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/an-introduction-to-anbox-cloud/17374\\\
-        \"\\u003eAn introduction to Anbox Cloud\\u003c/a\\u003e\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003e/engage/anbox-cloud-webinar\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003ecloud\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003e2020-02-25\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003eScalable Android\u2122 in the cloud\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
-        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/esm-maintains-interanas-system-security-while-upgrading/17376\\\
-        \"\\u003eESM maintains Interana\u2019s system security while upgrading\\u003c/a\\\
-        u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/interana-casestudy\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003ecase study\\u003c/td\\u003e\\n\\u003ctd\\u003esecurity\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e2020-02-17\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\\
-        u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/artificial-intelligence-at-the-edge-in-a-5g-world/17372\\\
-        \"\\u003eArtificial Intelligence at the edge in a 5G world\\u003c/a\\u003e\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/ai-edge-webinar\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eai, ml, edge\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e2020-02-07\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eDeploying AI/ML solutions in latency-sensitive\
-        \ environments requires a new solution architecture approach\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
-        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/deploy-kubernetes-in-your-data-centre/17373\\\
-        \"\\u003eDeploy Kubernetes in your data centre\\u003c/a\\u003e\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e/engage/dell-kubernetes-webinar\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003ekubernetes\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e2020-02-07\\u003c/td\\u003e\\n\\u003ctd\\u003een\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\\
-        u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\\
-        u003ca href=\\\"https://discourse.ubuntu.com/t/migration-von-vmware-zu-openstack/17370\\\
-        \"\\u003eMigration von VMware zu OpenStack\\u003c/a\\u003e\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003e/engage/de/migration-von-vmware-zu-openstack\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e2020-02-04\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003ede\\u003c/td\\u003e\\n\\u003ctd\\u003eWie ein Umstieg auf Charmed OpenStack\
-        \ die Gesamtkosten sp\xFCrbar senken kann\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\\
-        u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\\
-        u003ca href=\\\"https://discourse.ubuntu.com/t/de-vmware-a-charmed-openstack/17371\\\
-        \"\\u003eDe VMware a Charmed OpenStack\\u003c/a\\u003e\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003e/engage/es/vmware-a-charmed-openstack\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e2020-02-04\\u003c/td\\u003e\\n\\u003ctd\\u003ees\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003eC\xF3mo la migraci\xF3n a Charmed OpenStack\
-        \ puede reducir significativamente el TCO\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\\
-        u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\\
-        u003ca href=\\\"https://discourse.ubuntu.com/t/kubernetes-a-secure-flexible-and-automated-edge-for-iot-developers/17369\\\
-        \"\\u003eKubernetes: a secure, flexible and automated edge for IoT developers\\\
-        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/microk8s-451research\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003ekubernetes, edge, iot\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-01-10\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eThe\
-        \ factors for implementing Kubernetes successfully at the edge\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\\
-        u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/an-intro-to-microk8s/17367\\\
-        \"\\u003eAn intro to MicroK8s\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003e/engage/intro-to-microk8s-webinar\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003ekubernetes\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003e2019-12-19\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003eReliable, fast, small and upstream Kubernetes\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
-        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/ubuntu-desktop-for-the-enterprise/17368\\\
-        \"\\u003eUbuntu Desktop for the enterprise\\u003c/a\\u003e\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003e/engage/linux-enterprise-whitepaper\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003edesktop\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e2019-12-19\\u003c/td\\u003e\\n\\u003ctd\\u003een\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003eLearn why enterprises are beginning to adopt\
-        \ Linux as a desktop operating system\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\\
-        u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\\
-        u003ca href=\\\"https://discourse.ubuntu.com/t/cyberdyne-keeps-cleaning-robots-up-to-date-in-the-field-with-snaps/17366\\\
-        \"\\u003eCyberdyne keeps cleaning robots up-to-date in the field with snaps\\\
-        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/cyberdyne\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003ecase study\\u003c/td\\u003e\\n\\u003ctd\\u003erobotics,\
-        \ iot\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-12-18\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
-        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/sbi-group-unlocks-infrastructure-automation-with-secure-on-premises-openstack-cloud/17364\\\
-        \"\\u003eSBI Group unlocks infrastructure automation with secure, on-premises\
-        \ OpenStack cloud\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/sbi-casestudy\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003ecase study\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003eopenstack\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-12-06\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
-        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/register-for-wslconf/17365\\\
-        \"\\u003eRegister for WSLConf\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003e/engage/wslconf\\u003c/td\\u003e\\n\\u003ctd\\u003eevent\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003ewsl\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-12-06\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\\
-        n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/build-smart-display-devices-with-mir-fast-to-production-secure-open-source/17363\\\
-        \"\\u003eBuild smart display devices with Mir: fast to production, secure,\
-        \ open-source\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/build-smart-devices-with-mir-whitepaper\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003eiot\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-11-27\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
-        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/linux-security-with-ubuntu/17362\\\
-        \"\\u003eLinux security with Ubuntu\\u003c/a\\u003e\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003e/engage/linux_security_webinar\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003esecurity\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003e2019-11-14\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003eSecuring Ubuntu systems for reduced downtime and optimum\
-        \ CVE coverage.\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\\
-        n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"\
-        https://discourse.ubuntu.com/t/lessons-learned-from-100-private-cloud-builds/17361\\\
-        \"\\u003eLessons learned from 100+ Private cloud builds\\u003c/a\\u003e\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/private-cloud-build-webinar\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack,\
-        \ cloud\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-11-12\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eReducing the complexities\
-        \ of building a private cloud on OpenStack\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\\
-        u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/the-wellcome-sanger-institute-turns-to-canonical-for-high-level-ceph-support/17360\\\
-        \"\\u003eThe Wellcome Sanger Institute turns to Canonical for high level Ceph\
-        \ support\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/wellcome-sanger-case-study\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003ecase study\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003eceph, openstack\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-11-04\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\\
-        u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/ensuring-security-and-isolation-in-kubernetes-with-kata-containers/17359\\\
-        \"\\u003eEnsuring security and isolation in Kubernetes with Kata Containers\\\
-        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/kata-containers-webinar\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003esecurity\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e2019-11-01\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\\
-        u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/tim-ensures-system-security-and-client-confidence-with-esm/17358\\\
-        \"\\u003eTIM ensures system security and client confidence with ESM\\u003c/a\\\
-        u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/case-study-acuris\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003ecase study\\u003c/td\\u003e\\n\\u003ctd\\u003esecurity,\
-        \ ubuntu-advantage\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-10-22\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\\
-        u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/what-s-new-in-ubuntu-19-10/17357\\\
-        \"\\u003eWhat\u2019s new in Ubuntu 19.10\\u003c/a\\u003e\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003e/engage/19-10-webinar\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003edesktop\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-10-17\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eUbuntu\
-        \ 19.10 includes enhanced K8s capabilities for edge and AI/ML, OpenStack Train\
-        \ live-migration extensions for easier infrastructure deployments and more.\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\\
-        n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/how-domotz-streamlined-provisioning-of-iot-devices/17356\\\
-        \"\\u003eHow Domotz streamlined provisioning of IoT devices\\u003c/a\\u003e\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/domotz-case-study\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003ecase study\\u003c/td\\u003e\\n\\u003ctd\\u003eubuntu-core,\
-        \ snaps, iot\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-10-10\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eLearn how Ubuntu Core\
-        \ and snaps gives Domotz a competitive advantage\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\\
-        u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/yahoo-japan-builds-their-iaas-environment-with-canonical/17355\\\
-        \"\\u003eYahoo! Japan builds their IaaS environment with Canonical\\u003c/a\\\
-        u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/yahoo-japan-case-study\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003ecase study\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003eopenstack, maas, juju, ubuntu-advantage, security\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003e2019-10-08\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\\
-        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\
-        \"https://discourse.ubuntu.com/t/accelerating-deep-tech-with-ubuntu/17354\\\
-        \"\\u003eAccelerating deep tech with Ubuntu\\u003c/a\\u003e\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003e/engage/deeptech\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003eiot, robotics\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003e2019-10-02\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\\
-        n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"\
-        https://discourse.ubuntu.com/t/from-vmware-to-charmed-openstack/17343\\\"\\\
-        u003eFrom VMWare To Charmed OpenStack\\u003c/a\\u003e\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003e/engage/vmware-to-charmed-openstack\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003e2019-09-04\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003eReduce costs and increase the efficiency of your infrastructure\
-        \ with open source adoption\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\\
-        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\
-        \"https://discourse.ubuntu.com/t/machine-learning-operations-mlops/17353\\\
-        \"\\u003eMachine Learning Operations (MLOps)\\u003c/a\\u003e\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003e/engage/get-started-with-ai-part-2\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eai, ml\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e2019-09-11\\u003c/td\\u003e\\n\\u003ctd\\u003een\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003eDeploy at scale\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\\
-        u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/how-to-manage-snaps-in-an-enterprise-environment/17352\\\
-        \"\\u003eHow to manage snaps in an enterprise environment\\u003c/a\\u003e\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/enterprise-snap-management\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003esnaps,\
-        \ security\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-08-20\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eHow the Snap Store\
-        \ Proxy overcomes challenges presented by restricted networks and management\
-        \ policies\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\\
-        u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/a-guide-to-developing-android-apps-on-ubuntu/17351\\\
-        \"\\u003eA guide to developing Android apps on Ubuntu\\u003c/a\\u003e\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e/engage/developing-android-on-ubuntu\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003edesktop, apps\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e2019-08-13\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\\
-        u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/creating-a-cloud-like-bare-metal-experience-in-the-data-centre/17348\\\
-        \"\\u003eCreating a cloud-like bare metal experience in the data centre\\\
-        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/maas-hardware-testing\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003emaas\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-08-08\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
-        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/creating-accurate-ai-models-with-data/17349\\\
-        \"\\u003eCreating accurate AI models with data\\u003c/a\\u003e\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e/engage/data-pipelines-kubeflow\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003ekubeflow, ai\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e2019-08-08\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eHow Kubeflow and machine learning\
-        \ help you get the most out of your data\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\\
-        u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\\
-        u003ca href=\\\"https://discourse.ubuntu.com/t/ims-evolve-adopts-ubuntu-core-to-provide-iot-enabled-business-intelligence-in-the-supply-chain/17284\\\
-        \"\\u003eIMS Evolve adopts Ubuntu Core to provide IoT-enabled business intelligence\
-        \ in the supply chain\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/casestudy-imsevolve\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003ecase study\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003eiot\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-17\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
-        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/rocket-chat-communication-platform-enables-simplicity-through-snaps/17288\\\
-        \"\\u003eRocket.Chat communication platform enables simplicity through snaps\\\
-        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/casestudy-rocketchat\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003ecase study\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003esnaps, apps\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-17\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\\
-        u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/server-provisioning-what-network-admins-it-pros-need-to-know/17307\\\
-        \"\\u003eServer Provisioning: What Network Admins \\u0026amp; IT Pros Need\
-        \ to Know\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/ebook-maas\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003eeBook\\u003c/td\\u003e\\n\\u003ctd\\u003eserver\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-17\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\\
-        u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/building-a-private-cloud-take-the-leap/17331\\\
-        \"\\u003eBuilding a private cloud? Take the leap!\\u003c/a\\u003e\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e/engage/private-cloud\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003eeBook\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack, cloud\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e2019-07-17\\u003c/td\\u003e\\n\\u003ctd\\u003een\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\\
-        u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\\
-        u003ca href=\\\"https://discourse.ubuntu.com/t/make-it-rain-public-cloud-on-ubuntu-openstack/17332\\\
-        \"\\u003eMake IT rain: public cloud on Ubuntu OpenStack\\u003c/a\\u003e\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/public-cloud\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003eeBook\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack, cloud\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-17\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\\
-        u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/learn-whats-new-in-ubuntu-server-14-04-lts/17344\\\
-        \"\\u003eLearn What\u2019s New In Ubuntu Server 14.04 LTS\\u003c/a\\u003e\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/whats-new-ubuntu-14-04-lts\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eserver,\
-        \ openstack\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-17\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
-        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/how-ubuntu-helped-innovapos-revolutionise-the-vending-machine-industry/17285\\\
-        \"\\u003eHow Ubuntu helped InnovaPOS revolutionise the vending machine industry\\\
-        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/casestudy-innovapos\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003ecase study\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003eiot\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-16\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
-        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/nexiona-collaborates-with-canonical-and-dell-to-create-miimetiq-edge/17287\\\
-        \"\\u003eNEXIONA collaborates with Canonical and Dell to create MIIMETIQ EDGE\\\
-        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/casestudy-nexiona\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003ecase study\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003eiot\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-16\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
-        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/azeti-uses-ubuntu-core-to-improve-deployment-and-security/17278\\\
-        \"\\u003eAzeti uses Ubuntu Core to improve deployment and security\\u003c/a\\\
-        u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/casestudy-azeti\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003ecase study\\u003c/td\\u003e\\n\\u003ctd\\u003esecurity,\
-        \ iot\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-16\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
-        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/azlogica-utilise-ubuntu-core-for-customised-iot-agricultural-solutions/17279\\\
-        \"\\u003eAZLOGICA utilise Ubuntu Core for customised IoT agricultural solutions\\\
-        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/casestudy-azlogica\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003ecase study\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003eiot\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-16\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
-        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/botsandus-builds-a-social-robot-on-ubuntu/17280\\\
-        \"\\u003eBotsAndUs builds a social robot on Ubuntu\\u003c/a\\u003e\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e/engage/casestudy-botsandus\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003ecase study\\u003c/td\\u003e\\n\\u003ctd\\u003erobotics\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e2019-07-16\\u003c/td\\u003e\\n\\u003ctd\\u003een\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\\
-        u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\\
-        u003ca href=\\\"https://discourse.ubuntu.com/t/cinergy-makes-significant-digital-signage-saving-with-screenly-pro-and-ubuntu-core/17281\\\
-        \"\\u003eCinergy makes significant digital signage saving with Screenly Pro\
-        \ and Ubuntu Core\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/casestudy-cinergy\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003ecase study\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003edigital-signage\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-16\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\\
-        u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/commercetools-uses-ubuntu-server-to-power-its-next-generation-ecommerce-platform/17283\\\
-        \"\\u003eCommercetools uses Ubuntu Server to power its next-generation ecommerce\
-        \ platform\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/casestudy-commercetools\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003ecase study\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003eserver, e-commerce\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-16\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\\
-        u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/for-ctos-the-no-nonsense-way-to-accelerate-your-business-with-containers/17345\\\
-        \"\\u003eFor CTOs: the no-nonsense way to accelerate your business with containers\\\
-        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/whitepaper-containers\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003etelco\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-16\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
-        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/taking-charge-of-the-iots-security-vulnerabilities/17346\\\
-        \"\\u003eTaking charge of the IoT\u2019s security vulnerabilities\\u003c/a\\\
-        u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/whitepaper-iot-security\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003eiot, security\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-16\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\\
-        u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/the-essential-guide-for-telecoms-and-service-providers-adopting-big-data-solutions/17309\\\
-        \"\\u003eThe essential guide for Telecoms and Service Providers adopting big\
-        \ data solutions\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/essential-guide-big-data-solutions\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003eeBook\\u003c/td\\u003e\\n\\u003ctd\\u003etelco,\
-        \ openstack\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-15\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
-        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/city-network-brings-openstack-cloud-hosting-to-the-financial-services-sector-with-canonical/17282\\\
-        \"\\u003eCity Network brings OpenStack cloud hosting to the financial services\
-        \ sector with Canonical\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/casestudy-city-network\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003ecase study\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003ecloud\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-15\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
-        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/cto-s-guide-to-sdn-nfv-vnf/17293\\\
-        \"\\u003eCTO\u2019s guide to SDN, NFV \\u0026amp; VNF\\u003c/a\\u003e\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e/engage/cto-guide-sdn-nfv-vnf\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003eeBook\\u003c/td\\u003e\\n\\u003ctd\\u003enetworking\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e2019-07-15\\u003c/td\\u003e\\n\\u003ctd\\u003een\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003eWhy is the transition happening and why\
-        \ is it important?\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\\
-        n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"\
-        https://discourse.ubuntu.com/t/sensape-uses-landscape-to-remotely-support-revolutionary-interactive-retail-displays/17289\\\
-        \"\\u003eSensape uses Landscape to remotely support revolutionary interactive\
-        \ retail displays\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/casestudy-sensape\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003ecase study\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003edigital-signage\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-15\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\\
-        u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/how-to-face-the-challenges-of-becoming-a-cloud-operator/17290\\\
-        \"\\u003eHow to face the challenges of becoming a cloud operator\\u003c/a\\\
-        u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/cloud-fray\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003eeBook\\u003c/td\\u003e\\n\\u003ctd\\u003ecloud, openstack,\
-        \ telco\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-15\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
-        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/low-latency-and-real-time-kernels-for-telco-and-nfv/17321\\\
-        \"\\u003eLow latency and real time kernels for telco and NFV\\u003c/a\\u003e\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/low-latency-report\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003etelco\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e2019-07-15\\u003c/td\\u003e\\n\\u003ctd\\u003een\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\\
-        u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\\
-        u003ca href=\\\"https://discourse.ubuntu.com/t/how-to-escape-stuckstack-and-profit-from-your-openstack-investment/17337\\\
-        \"\\u003eHow to escape StuckStack and profit from your OpenStack investment\\\
-        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/stuckstack-ebook\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003eeBook\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-15\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\\
-        u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/carrier-cloudification-what-every-telecom-executive-needs-to-know/17338\\\
-        \"\\u003eCarrier Cloudification: What every telecom executive needs to know\\\
-        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/telco-cloudification-ebook\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003eeBook\\u003c/td\\u003e\\n\\u003ctd\\u003etelco,\
-        \ cloud, openstack\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-15\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\\
-        u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/nfv-and-sdn-on-openstack/17326\\\
-        \"\\u003eNFV and SDN on OpenStack\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003e/engage/nfv-sdn-openstack\\u003c/td\\u003e\\n\\u003ctd\\u003eeBook\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003eopenstack, networking\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003e2019-07-12\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\\
-        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\
-        \"https://discourse.ubuntu.com/t/openstack-made-easy/17328\\\"\\u003eOpenStack\
-        \ made easy\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/openstack-made-easy\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003eeBook\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-12\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eWith the right tools, OpenStack\
-        \ can be easy\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\\
-        u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/telcos-and-service-providers-expect-near-100-uptime/17330\\\
-        \"\\u003eTelcos and Service Providers expect near 100% uptime\\u003c/a\\u003e\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/openstack-telco-clouds\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003eeBook\\u003c/td\\u003e\\n\\u003ctd\\u003etelco, openstack,\
-        \ cloud\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-12\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eThis requires a proven\
-        \ cloud platform that minimises time-to-revenue and ensures predictable costs.\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\\
-        n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/a-shift-to-the-linux-app-store-experience/17347\\\
-        \"\\u003eA shift to the Linux app store experience\\u003c/a\\u003e\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e/engage/shift-to-app-store-experience\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eapps,\
-        \ snaps\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-11\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eThe key to optimising\
-        \ software distribution in a fragmented environment.\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
-        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/le-support-d-ubuntu-14-04-lts-est-maintenant-passe-a-esm/17413\\\
-        \"\\u003eLe support d\u2019Ubuntu 14.04 LTS est maintenant pass\xE9 \xE0 ESM\\\
-        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/fr/esm_1404\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003eblog\\u003c/td\\u003e\\n\\u003ctd\\u003esecurity\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e2019-06-28\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003efr\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\\
-        u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/a-guide-to-edge-computing-and-the-tools-you-need/17308\\\
-        \"\\u003eA guide to edge computing and the tools you need\\u003c/a\\u003e\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/edge-month\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eedge, cloud, kubernetes,\
-        \ maas\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-06-27\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eLearn how edge computing\
-        \ provides enterprises with real-time data processing, cost-effective security\
-        \ and scalability.\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\\
-        n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"\
-        https://discourse.ubuntu.com/t/sicherheit-in-der-private-cloud/17411\\\"\\\
-        u003eSicherheit in der Private Cloud\\u003c/a\\u003e\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003e/engage/de/openstack-security-de\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack, cloud\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e2019-06-19\\u003c/td\\u003e\\n\\u003ctd\\u003ede\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003eH\xF6chste Anforderungen in Unternehmensumgebungen\
-        \ mit OpenStack erf\xFCllen.\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\\
-        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\
-        \"https://discourse.ubuntu.com/t/how-to-get-started-and-progress-with-an-ai-program/17245\\\
-        \"\\u003eHow to get started and progress with an AI program\\u003c/a\\u003e\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/ai-gettingstarted\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eai, ml\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e2019-06-11\\u003c/td\\u003e\\n\\u003ctd\\u003een\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\\
-        u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\\
-        u003ca href=\\\"https://discourse.ubuntu.com/t/the-future-of-mobile-connectivity/17342\\\
-        \"\\u003eThe future of mobile connectivity\\u003c/a\\u003e\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003e/engage/ubuntu-lime-telco\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003etelco\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003e2019-06-12\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003eMajor mobile operators are adopting open source versus\
-        \ proprietary technologies to reduce costs.\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\\
-        u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/north-america-s-first-autonomous-runway-snowplough/17327\\\
-        \"\\u003eNorth America\u2018s first autonomous runway snowplough\\u003c/a\\\
-        u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/northstar\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003ecase study\\u003c/td\\u003e\\n\\u003ctd\\u003erobotics, iot\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e2019-06-05\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eThe robots helping to address off-highway\
-        \ labour shortages\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\\
-        n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"\
-        https://discourse.ubuntu.com/t/small-robot-company-sows-the-seeds-for-autonomous-and-more-profitable-farming/17334\\\
-        \"\\u003eSmall Robot Company sows the seeds for autonomous and more profitable\
-        \ farming\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/small-robot-company\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003ecase study\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003erobotics, ai\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-06-04\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\\
-        u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/how-to-integrate-ubuntu-desktop-with-active-directory/17323\\\
-        \"\\u003eHow to integrate Ubuntu Desktop with Active Directory\\u003c/a\\\
-        u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/microsoft-active-directory\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003edesktop, active-directory\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-06-04\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\\
-        n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/connected-cars-and-autonomous-driving/17243\\\
-        \"\\u003eConnected cars and autonomous driving\\u003c/a\\u003e\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e/engage/451-automotive\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eiot\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003e2019-05-31\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003eAddressing risk and complexity with software\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\\
-        u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/why-ubuntu-core-is-the-most-secure-choice-for-iot/17292\\\
-        \"\\u003eWhy Ubuntu Core is the most secure choice for IoT\\u003c/a\\u003e\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/core18-security\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003esecurity, iot,\
-        \ ubuntu-core\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-05-29\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
-        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/getting-started-with-ai/17336\\\
-        \"\\u003eGetting started with AI\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003e/engage/starting-with-ai\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003eai, ml\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-05-11\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\\
-        n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/the-transformation-of-the-devops-journey-in-iot/17422\\\
-        \"\\u003eThe transformation of the DevOps journey in IoT\\u003c/a\\u003e\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/iot-devops\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eiot\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e2019-05-07\\u003c/td\\u003e\\n\\u003ctd\\u003een\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\\
-        u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\\
-        u003ca href=\\\"https://discourse.ubuntu.com/t/cloud-init/17291\\\"\\u003eCloud\
-        \ init\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/cloud-init-whitepaper\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003ecloud\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-05-01\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
-        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/how-to-build-a-lightweight-system-container-cluster/17322\\\
-        \"\\u003eHow to build a lightweight system container cluster\\u003c/a\\u003e\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/lxd-whitepaper\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003elxd\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e2019-04-30\\u003c/td\\u003e\\n\\u003ctd\\u003een\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003eYou will learn how working in this environment:\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\\
-        n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/the-transformation-of-the-devops-journey-in-iot-webinar/17306\\\
-        \"\\u003eThe transformation of the DevOps journey in IoT Webinar\\u003c/a\\\
-        u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/devops-iot-webinar\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eiot\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e2019-04-29\\u003c/td\\u003e\\n\\u003ctd\\u003een\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\\
-        u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\\
-        u003ca href=\\\"https://discourse.ubuntu.com/t/private-cloud-security-webinar/17329\\\
-        \"\\u003ePrivate cloud security Webinar\\u003c/a\\u003e\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003e/engage/openstack-security-webinar\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack, security\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e2019-04-24\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eHow Charmed OpenStack is decreasing\
-        \ common security concerns\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\\
-        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\
-        \"https://discourse.ubuntu.com/t/private-cloud-security/17421\\\"\\u003ePrivate\
-        \ cloud security\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/openstack-security-whitepaper\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003eopenstack, security\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-04-24\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eMeeting the\
-        \ highest levels of enterprise requirements with OpenStack\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
-        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/hiri-successfully-monetises-their-snap/17314\\\
-        \"\\u003eHiri successfully monetises their snap\\u003c/a\\u003e\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e/engage/hiri-case-study\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003ecase study\\u003c/td\\u003e\\n\\u003ctd\\u003eapps, snaps\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e2019-04-25\\u003c/td\\u003e\\n\\u003ctd\\u003een\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\\
-        u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\\
-        u003ca href=\\\"https://discourse.ubuntu.com/t/whats-new-in-ubuntu-19-04/17240\\\
-        \"\\u003eWhat\u2019s new in Ubuntu 19.04?\\u003c/a\\u003e\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003e/engage/19-04-webinar\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003eopenstack, kubernetes, ceph, iot, desktop\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e2019-04-18\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eJoin Canonical Product Director\
-        \ Stephan Fabel and Ubuntu Product Managers to discuss everything new in Ubuntu\
-        \ 19.04 \u2018Disco Dingo\u2019\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\\
-        u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\\
-        u003ca href=\\\"https://discourse.ubuntu.com/t/optimising-iot-bandwidth-with-delta-updates/17335\\\
-        \"\\u003eOptimising IoT bandwidth with delta updates\\u003c/a\\u003e\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e/engage/snap-deltas\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eiot, snaps\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e2019-03-16\\u003c/td\\u003e\\n\\u003ctd\\u003een\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003eLearn how snap deltas\u2019 over-the-air\
-        \ updates are efficient and effective.\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\\
-        u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\\
-        u003ca href=\\\"https://discourse.ubuntu.com/t/an-introduction-to-apparmor/17277\\\
-        \"\\u003eAn introduction to AppArmor\\u003c/a\\u003e\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003e/engage/apparmor-intro\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003esecurity\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003e2019-03-16\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003eAn explanation of AppArmor and its key features.\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\\
-        u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/get-started-with-devops-best-practices-ci-cd/17305\\\
-        \"\\u003eGet started with DevOps best practices: CI/CD\\u003c/a\\u003e\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e/engage/devops-cicd-webinar\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003ekubernetes\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e2019-03-07\\u003c/td\\u003e\\n\\u003ctd\\u003een\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\\
-        u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\\
-        u003ca href=\\\"https://discourse.ubuntu.com/t/esm-for-ubuntu-14-04-lts-trusty-tahr/17275\\\
-        \"\\u003eESM for Ubuntu 14.04 LTS Trusty Tahr\\u003c/a\\u003e\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e/engage/14-04-esm\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003esecurity\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003e2019-02-21\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003eLearn how to maintain ongoing security compliance for your 14.04\
-        \ systems.\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\\
-        u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/securing-iot-device-data-against-physical-access/17318\\\
-        \"\\u003eSecuring IoT device data against physical access\\u003c/a\\u003e\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/iot-disk-encryption\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eiot,\
-        \ security, ubuntu-core\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-02-11\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eA technical\
-        \ overview of how Ubuntu Core with full disk encryption and secure boot can\
-        \ be implemented to harden IoT devices\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\\
-        u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\\
-        u003ca href=\\\"https://discourse.ubuntu.com/t/multi-cloud-fundamental-to-financial-services-transformation/17312\\\
-        \"\\u003eMulti-cloud fundamental to financial services transformation\\u003c/a\\\
-        u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/finserv-multi-cloud\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003ecloud,\
-        \ finance, ai\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-02-04\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
-        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/extension-securite-et-maintenance-pour-ubuntu-14-04/17414\\\
-        \"\\u003eExtension S\xE9curit\xE9 et Maintenance pour Ubuntu 14.04\\u003c/a\\\
-        u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/fr/esm\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003eblog\\u003c/td\\u003e\\n\\u003ctd\\u003esecurity\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e2019-01-31\\u003c/td\\u003e\\n\\u003ctd\\u003efr\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\\
-        u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\\
-        u003ca href=\\\"https://discourse.ubuntu.com/t/utiliser-des-gpus-avec-kubernetes/17419\\\
-        \"\\u003eUtiliser des GPUs avec Kubernetes\\u003c/a\\u003e\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003e/engage/fr/utiliser-gpgpus-avec-kubernetes\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003eblog\\u003c/td\\u003e\\n\\u003ctd\\u003ekubernetes\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e2018-12-20\\u003c/td\\u003e\\n\\u003ctd\\u003efr\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\\
-        u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\\
-        u003ca href=\\\"https://discourse.ubuntu.com/t/apellix-engineers-safer-work-environments-with-ubuntu-powered-aerial-robotics/17315\\\
-        \"\\u003eApellix engineers safer work environments with Ubuntu powered aerial\
-        \ robotics\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/industrial-drones-case-study\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003ecase study\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003erobotics, iot\\u003c/td\\u003e\\n\\u003ctd\\u003e2018-12-14\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\\
-        u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/allan-gray-unlocks-unprecedented-availability-and-productivity-with-charmed-kubernetes/17319\\\
-        \"\\u003eAllan Gray unlocks unprecedented availability and productivity with\
-        \ Charmed Kubernetes\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/k8s-allan-gray\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003ecase study\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003efinance, kubernetes\\u003c/td\\u003e\\n\\u003ctd\\u003e2018-12-13\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\\
-        u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/six-reasons-why-developers-choose-ubuntu-desktop/17304\\\
-        \"\\u003eSix reasons why developers choose Ubuntu Desktop\\u003c/a\\u003e\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/developer-desktop\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003edesktop\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e2018-11-23\\u003c/td\\u003e\\n\\u003ctd\\u003een\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\\
-        u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\\
-        u003ca href=\\\"https://discourse.ubuntu.com/t/modernise-your-cloud/17324\\\
-        \"\\u003eModernise your cloud\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003e/engage/modern-cloud\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003ecloud\\u003c/td\\u003e\\n\\u003ctd\\u003e2018-11-22\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eDiscover\
-        \ how Trilio and Canonical help organisations transition to new, maintainable\
-        \ cloud architecture in just weeks.\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\\
-        u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\\
-        u003ca href=\\\"https://discourse.ubuntu.com/t/precision-drones-on-ubuntu-flying-at-the-edge-of-innovation/17316\\\
-        \"\\u003ePrecision drones on Ubuntu: flying at the edge of innovation\\u003c/a\\\
-        u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/industrial-drones\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003erobotics,\
-        \ iot\\u003c/td\\u003e\\n\\u003ctd\\u003e2018-11-20\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eHow Apellix uses Ubuntu\
-        \ on drones to replace human workers in potentially dangerous scenarios.\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\\
-        n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/securing-the-enterprise-how-ubuntu-is-at-the-forefront-of-security-and-compliance/17340\\\
-        \"\\u003eSecuring the enterprise: how Ubuntu is at the forefront of security\
-        \ and compliance\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/ubuntu-compliance\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003esecurity\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e2018-11-12\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\\
-        u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/itstrategen-keeps-legacy-applications-secure-with-extended-security-maintenance/17286\\\
-        \"\\u003eITstrategen keeps legacy applications secure with Extended Security\
-        \ Maintenance\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/ITstrategen-case-study\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003ecase study\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003esecurity\\u003c/td\\u003e\\n\\u003ctd\\u003e2018-10-29\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
-        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/what-s-new-in-ubuntu-18-10/17339\\\
-        \"\\u003eWhat\u2019s New in Ubuntu 18.10\\u003c/a\\u003e\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003e/engage/ubuntu-18-10\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003edesktop, server\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003e2018-10-29\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003eCanonical product managers discuss the new Ubuntu 18.10 release\
-        \ features in this on-demand webinar\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\\
-        u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\\
-        u003ca href=\\\"https://discourse.ubuntu.com/t/ubuntu-core-and-kura-a-framework-for-iot-gateways/17341\\\
-        \"\\u003eUbuntu Core and Kura: A framework for IoT gateways\\u003c/a\\u003e\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/ubuntu-core-and-kura\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eubuntu-core,\
-        \ iot, edge, snaps\\u003c/td\\u003e\\n\\u003ctd\\u003e2018-10-23\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\\
-        u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/keep-up-with-evolving-software/17310\\\
-        \"\\u003eKeep up with evolving software\\u003c/a\\u003e\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003e/engage/evolving-software\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003ejuju, cloud\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e2018-10-22\\u003c/td\\u003e\\n\\u003ctd\\u003een\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003eLearn how Juju can help solve software management\
-        \ complexity.\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\\
-        u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/wofur-konnen-sie-kubernetes-einsetzen/17410\\\
-        \"\\u003eWof\xFCr k\xF6nnen Sie Kubernetes einsetzen?\\u003c/a\\u003e\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e/engage/de/what-can-you-do-with-kubernetes\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003ekubernetes\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e2018-10-19\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003ede\\u003c/td\\u003e\\n\\u003ctd\\u003eDieses Webinar liefert Ihnen alles\
-        \ Wichtige zum Einstieg.\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\\
-        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\
-        \"https://discourse.ubuntu.com/t/low-latency-and-real-time-kernels-for-telco-and-nfv/17320\\\
-        \"\\u003eLow latency and real-time kernels for telco and NFV\\u003c/a\\u003e\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/kernel-telco-nfv\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003etelco\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e2018-10-08\\u003c/td\\u003e\\n\\u003ctd\\u003een\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\\
-        u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\\
-        u003ca href=\\\"https://discourse.ubuntu.com/t/future-proofing-fingbox-the-iot-home-network-monitoring-device/17313\\\
-        \"\\u003eFuture-proofing Fingbox, the IoT home network monitoring device\\\
-        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/future-proof-iot\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eiot,\
-        \ ubuntu-core\\u003c/td\\u003e\\n\\u003ctd\\u003e2018-10-02\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
-        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/how-to-build-and-deploy-your-first-ai-ml-model-on-ubuntu/17294\\\
-        \"\\u003eHow to build and deploy your first AI/ML model on Ubuntu\\u003c/a\\\
-        u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/deploy-ai-ml-model\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eai, ml,\
-        \ kubeflow, kubernetes\\u003c/td\\u003e\\n\\u003ctd\\u003e2018-09-26\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eAn introduction\
-        \ to AI and ML workloads on Ubuntu workstations, servers and in the cloud\
-        \ on a Kubernetes stack.\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\\
-        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\
-        \"https://discourse.ubuntu.com/t/openstack-problemlos-installieren-und-skalieren/17409\\\
-        \"\\u003eOpenStack problemlos installieren und skalieren\\u003c/a\\u003e\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/de/openstack-made-easy\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003eeBook\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e2018-09-05\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003ede\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\\
-        u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/key-considerations-when-choosing-a-robot-s-operating-system/17333\\\
-        \"\\u003eKey considerations when choosing a robot\u2019s operating system\\\
-        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/robot-operating-system-choice\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003erobotics\\u003c/td\\u003e\\n\\u003ctd\\u003e2018-09-05\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
-        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/cio-guide-to-multi-cloud-operations/17325\\\
-        \"\\u003eCIO guide to multi-cloud operations\\u003c/a\\u003e\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003e/engage/multi-cloud-guide\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003ecloud, kubernetes, container\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e2018-09-03\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\\
-        u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/canonical-presents-financial-services-month/17241\\\
-        \"\\u003eCanonical presents Financial Services Month\\u003c/a\\u003e\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e/engage/financial-services-month\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003efinance, ai, ml\
-        \ cloud\\u003c/td\\u003e\\n\\u003ctd\\u003e2018-09-03\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eFilmed at the London Stock\
-        \ exchange with representatives from Canonical, 451 Research, IBM, and a former\
-        \ Deutsche Bank storage CTO, Canonical took a deep dive look in to the rise\
-        \ of multi-cloud in the financial services industry.\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
-        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/establishing-a-software-defined-iot-business-model/17317\\\
-        \"\\u003eEstablishing a software defined IoT business model\\u003c/a\\u003e\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/iot-business-model\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eiot\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e2018-08-24\\u003c/td\\u003e\\n\\u003ctd\\u003een\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\\
-        u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\\
-        u003ca href=\\\"https://discourse.ubuntu.com/t/artificial-intelligence-machine-learning-and-ubuntu/17276\\\
-        \"\\u003eArtificial intelligence, machine learning and Ubuntu\\u003c/a\\u003e\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/ai-ml-ubuntu\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eai, ml, kubernetes\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e2018-08-16\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\\
-        u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/von-vmware-zu-canonical-openstack/17408\\\
-        \"\\u003eVon VMware zu Canonical OpenStack\\u003c/a\\u003e\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003e/engage/de/vmware-to-openstack\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003e2018-08-06\\u003c/td\\u003e\\n\\u003ctd\\u003ede\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\\
-        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\
-        \"https://discourse.ubuntu.com/t/fing-serves-30-000-customers-with-a-secure-future-proof-iot-device/17311\\\
-        \"\\u003eFing serves 30,000 customers with a secure, future-proof IoT device\\\
-        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/fingbox-case-study\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003eiot, ubuntu-core, snaps\\u003c/td\\u003e\\n\\u003ctd\\u003e2018-06-25\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\\
-        n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/canonical-integre-containerd-a-ubuntu-kubernetes/17412\\\
-        \"\\u003eCanonical int\xE8gre containerd \xE0 Ubuntu Kubernetes\\u003c/a\\\
-        u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/fr/canonical-ajoute-containerd-a-ubuntu-kubernetes\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003eblog\\u003c/td\\u003e\\n\\u003ctd\\u003ekubernetes\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e2020-05-22\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003efr\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\\
-        u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/guide-du-dsi-pour-les-operations-multicloud/17415\\\
-        \"\\u003eGUIDE DU DSI pour les op\xE9rations multicloud\\u003c/a\\u003e\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/fr/guide-du-DSI-pour-les-operations-multicloud\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003ecloud, kubernetes\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-05-22\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003efr\\u003c/td\\u003e\\n\\u003ctd\\u003eChoisir une\
-        \ architecture cloud rentable\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\\
-        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\
-        \"https://discourse.ubuntu.com/t/canonical-annonce-managed-apps-linfogerance-des-applications-sur-votre-cloud/17416\\\
-        \"\\u003eCanonical annonce Managed Apps: l\u2019infog\xE9rance des applications\
-        \ sur votre cloud.\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/fr/managed-apps\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003eblog\\u003c/td\\u003e\\n\\u003ctd\\u003eapps\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e2020-05-18\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003efr\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\\
-        u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/migrer-de-vmware-a-openstack/17417\\\
-        \"\\u003eMigrer de VMWare \xE0 OpenStack\\u003c/a\\u003e\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003e/engage/fr/migrer-de-vmware-a-openstack\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e2020-05-18\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003efr\\u003c/td\\u003e\\n\\u003ctd\\u003ePassez \xE0 Charmed OpenStack et\
-        \ r\xE9duisez consid\xE9rablement vos co\xFBts\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\\
-        u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/migrer-de-vmware-a-openstack-webinaire/17420\\\
-        \"\\u003eMigrer de VMware \xE0 Openstack Webinaire\\u003c/a\\u003e\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e/engage/fr/vmware-to-openstack\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e2020-05-18\\u003c/td\\u003e\\n\\u003ctd\\u003efr\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003eApprenez comment migrer d\u2019un environnement\
-        \ traditionnel et propri\xE9taire \xE0 un cloud OpenStack\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
-        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/charmed-kubernetes-reference-architecture/19159\\\
-        \"\\u003eCharmed Kubernetes reference architecture\\u003c/a\\u003e\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e/engage/dell-k8s-reference-architecture\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003ekubernetes\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e2019-11-07\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eIntegration with VxFlex OS delivered\
-        \ by Dell EMC and Canonical.\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\\
-        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\
-        \"https://discourse.ubuntu.com/t/charmed-openstack-reference-architecture/19160\\\
-        \"\\u003eCharmed OpenStack reference architecture\\u003c/a\\u003e\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e/engage/dell-openstack-reference-architecture\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e2019-11-07\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eWith Dell EMC PowerEdge servers\
-        \ for workloads and storage and Dell EMC Networking and Canonical.\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\\
-        u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/at-t-private-offer-on-azure-ubuntu-pro-support/19161\\\
-        \"\\u003eAT\\u0026amp;T Private Offer on Azure - Ubuntu Pro + Support\\u003c/a\\\
-        u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/at\\u0026amp;t-azure-webinar\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eubuntu-advantage\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e2020-06-30\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eSecure, updated Ubuntu with 24x7\
-        \ support special pricing and SLAs for AT\\u0026amp;T.\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003c/tbody\\\
-        u003e\\n\\u003c/table\\u003e\\n\\u003c/div\\u003e\\u003c/details\\u003e\\\
-        n\\u003ch2\\u003eTakeovers\\u003c/h2\\u003e\\n\\u003cdetails\\u003e\\n\\u003csummary\\\
-        u003e\\nMapping table\\u003c/summary\\u003e\\n\\u003cdiv class=\\\"md-table\\\
-        \"\\u003e\\n\\u003ctable\\u003e\\n\\u003cthead\\u003e\\n\\u003ctr\\u003e\\\
-        n\\u003cth\\u003etitle\\u003c/th\\u003e\\n\\u003cth\\u003esubtitle\\u003c/th\\\
-        u003e\\n\\u003cth\\u003epublish_date\\u003c/th\\u003e\\n\\u003cth\\u003elang\\\
-        u003c/th\\u003e\\n\\u003cth\\u003elang_skip\\u003c/th\\u003e\\n\\u003cth\\\
-        u003eclass\\u003c/th\\u003e\\n\\u003cth\\u003eimage\\u003c/th\\u003e\\n\\\
-        u003cth\\u003eimage_width\\u003c/th\\u003e\\n\\u003cth\\u003eimage_height\\\
-        u003c/th\\u003e\\n\\u003cth\\u003eprimary_cta\\u003c/th\\u003e\\n\\u003cth\\\
-        u003eprimary_url\\u003c/th\\u003e\\n\\u003cth\\u003esecondary_cta\\u003c/th\\\
-        u003e\\n\\u003cth\\u003esecondary_url\\u003c/th\\u003e\\n\\u003cth\\u003eactive\\\
-        u003c/th\\u003e\\n\\u003cth\\u003eequal_cols\\u003c/th\\u003e\\n\\u003c/tr\\\
-        u003e\\n\\u003c/thead\\u003e\\n\\u003ctbody\\u003e\\n\\u003ctr\\u003e\\n\\\
-        u003ctd\\u003eUbuntu Masters 4\\u003c/td\\u003e\\n\\u003ctd\\u003eA virtual\
-        \ event on open source innovation, featuring leaders from Bosch, Oracle, and\
-        \ more.\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-11-17\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003egrad\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://assets.ubuntu.com/v1/7757c907-ubuntu-masters-logo-wht.svg\\\
-        \" rel=\\\"nofollow noopener\\\"\\u003ehttps://assets.ubuntu.com/v1/7757c907-ubuntu-masters-logo-wht.svg\\\
-        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e270\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003e270\\u003c/td\\u003e\\n\\u003ctd\\u003eBrowse sessions\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e/masters-conference?utm_source=Takeover\\u0026amp;utm_medium=Takeover\\\
-        u0026amp;utm_campaign=CY20_DC_Kubernetes_VEVT_EU2020\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003etrue\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\\
-        u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003eCinque strategie per accelerare\
-        \ l\u2019implementazione di Kubernetes nell\u2019impresa\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003eCome scegliere il miglior approccio Kubernetes per la tua\
-        \ azienda\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-11-17\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003eit\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003edark\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"\
-        https://assets.ubuntu.com/v1/11d594e7-K8s+logo+white+outline.svg\\\" rel=\\\
-        \"nofollow noopener\\\"\\u003ehttps://assets.ubuntu.com/v1/11d594e7-K8s+logo+white+outline.svg\\\
-        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e240\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003e234\\u003c/td\\u003e\\n\\u003ctd\\u003eScarica il whitepaper\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/it/deployment-azienda-manuale?utm_source=Takeover\\\
-        u0026amp;utm_medium=Takeover\\u0026amp;utm_campaign=CY20_DC_Kubernetes_IT_Whitepaper_K8sEnterpriseChallenges\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\\
-        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003eConfronto fra\
-        \ \u201CRed Hat\u2019s Openstack platform\u201D e Charmed Openstack di Canaonical\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003eCharmed Openstack riduce significativamente\
-        \ il costo totale di propriet\xE0\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-11-16\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003eit\\u003c/td\\u003e\\n\\u003ctd\\u003e\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003edark\\u003c/td\\u003e\\n\\u003ctd\\u003e\\\
-        u003ca href=\\\"https://assets.ubuntu.com/v1/2d935f28-openstack-cloud.svg\\\
-        \" rel=\\\"nofollow noopener\\\"\\u003ehttps://assets.ubuntu.com/v1/2d935f28-openstack-cloud.svg\\\
-        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e280\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003e280\\u003c/td\\u003e\\n\\u003ctd\\u003eScarica il whitepaper\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/it/redhat-openstack-confronto-manuale?utm_source=Takeover\\\
-        u0026amp;utm_medium=Takeover\\u0026amp;utm_campaign=7013z000001Wld9AAC\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\\
-        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003eGuide pour\
-        \ r\xE9ussir l\u2019adoption et le d\xE9ploiement d\u2019OpenStack\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003eD\xE9couvrez l\u2019\xE9prouv\xE9 processus d\u2019\
-        impl\xE9mentation OpenStack de Canonical\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-11-16\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003efr\\u003c/td\\u003e\\n\\u003ctd\\u003e\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003edark\\u003c/td\\u003e\\n\\u003ctd\\u003e\\\
-        u003ca href=\\\"https://assets.ubuntu.com/v1/2d935f28-openstack-cloud.svg\\\
-        \" rel=\\\"nofollow noopener\\\"\\u003ehttps://assets.ubuntu.com/v1/2d935f28-openstack-cloud.svg\\\
-        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e250\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003e250\\u003c/td\\u003e\\n\\u003ctd\\u003eT\xE9l\xE9charger guide\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/fr/guide-adoption-openstack?utm_source=Takeover\\\
-        u0026amp;\\u0026amp;utm_medium=Takeover\\u0026amp;utm_campaign=7013z000001WjOjAAK\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\\
-        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003eF\xFCnf Strategien\
-        \ zur Beschleunigung von Kubernetes in Unternehmen\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003eEntscheidungskriterien zur optimalen Herangehensweise an Kubernetes f\xFC\
-        r Ihr Unternehmen\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-11-11\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003ede\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003edark\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\
-        \"https://assets.ubuntu.com/v1/11d594e7-K8s+logo+white+outline.svg\\\" rel=\\\
-        \"nofollow noopener\\\"\\u003ehttps://assets.ubuntu.com/v1/11d594e7-K8s+logo+white+outline.svg\\\
-        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e240\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003e234\\u003c/td\\u003e\\n\\u003ctd\\u003eLaden Sie das White Paper\
-        \ herunter\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/de/kubernetes-implementierung-fur-unternehmen\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\\
-        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003eVergleich von\
-        \ Red Hat OpenStack Platform und Charmed OpenStack von Canonical\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003eSenken Sie Ihre Gesamtkosten deutlich mit Charmed\
-        \ OpenStack\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-11-11\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003ede\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003edark\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"\
-        https://assets.ubuntu.com/v1/2d935f28-openstack-cloud.svg\\\" rel=\\\"nofollow\
-        \ noopener\\\"\\u003ehttps://assets.ubuntu.com/v1/2d935f28-openstack-cloud.svg\\\
-        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e250\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003e250\\u003c/td\\u003e\\n\\u003ctd\\u003eLaden Sie das White Paper\
-        \ herunter\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/de/redhat-openstack-vergleich\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\\
-        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003eCinco estrategias\
-        \ para acelerar a los Kubernetes en la empresa\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003eC\xF3mo elegir el mejor enfoque de Kubernetes para su negocio\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e2020-11-04\\u003c/td\\u003e\\n\\u003ctd\\u003ees\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003edark\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://assets.ubuntu.com/v1/11d594e7-K8s+logo+white+outline.svg\\\
-        \" rel=\\\"nofollow noopener\\\"\\u003ehttps://assets.ubuntu.com/v1/11d594e7-K8s+logo+white+outline.svg\\\
-        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e240\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003e234\\u003c/td\\u003e\\n\\u003ctd\\u003eDescargar el manual\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/es/kubernetes-despliegue-empresa-manual?utm_source=Takeover\\\
-        u0026amp;utm_medium=Takeover\\u0026amp;utm_campaign=7013z000001WkLAAA0\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\\
-        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003eComparando\
-        \ la plataforma OpenStack de Red Hat y la Charmed OpenStack de Canonical\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003eReducir significativamente el coste total\
-        \ de propiedad con Charmed OpenStack\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-11-03\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003ees\\u003c/td\\u003e\\n\\u003ctd\\u003e\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003edark\\u003c/td\\u003e\\n\\u003ctd\\u003e\\\
-        u003ca href=\\\"https://assets.ubuntu.com/v1/2d935f28-openstack-cloud.svg\\\
-        \" rel=\\\"nofollow noopener\\\"\\u003ehttps://assets.ubuntu.com/v1/2d935f28-openstack-cloud.svg\\\
-        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e300\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003e230\\u003c/td\\u003e\\n\\u003ctd\\u003eDescargar el manual\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/es/redhat-openstack-comparacion-manual?utm_source=Takeover\\\
-        u0026amp;utm_medium=Takeover\\u0026amp;utm_campaign=7013z000001WkRmAAK\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\\
-        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003eSecurity, cloud\
-        \ native \\u0026amp; confidential computing\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003eA deep dive into securing against the threats of cyber attacks and data\
-        \ breaches\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-10-23\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003egrad\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://assets.ubuntu.com/v1/cea1e4c7-IBM-Z-logo-white.png\\\
-        \" rel=\\\"nofollow noopener\\\"\\u003ehttps://assets.ubuntu.com/v1/cea1e4c7-IBM-Z-logo-white.png\\\
-        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e180\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003e180\\u003c/td\\u003e\\n\\u003ctd\\u003eRegister for the webinar\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://www.brighttalk.com/webcast/6793/440529?utm_source=Takeover\\\
-        u0026amp;utm_medium=Takeover\\u0026amp;utm_campaign=7013z000001G3QyAAK\\\"\
-        \ rel=\\\"nofollow noopener\\\"\\u003ehttps://www.brighttalk.com/webcast/6793/440529?utm_source=Takeover\\\
-        u0026amp;utm_medium=Takeover\\u0026amp;utm_campaign=7013z000001G3QyAAK\\u003c/a\\\
-        u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\\
-        u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003eWhat\u2019\
-        s new in\\u003cbr\\u003eUbuntu 20.10?\\u003c/td\\u003e\\n\\u003ctd\\u003eIntroducing\
-        \ the Ubuntu Desktop for Raspberry Pi, the latest desktop features and micro\
-        \ clouds.\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-10-22\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003egrad\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://assets.ubuntu.com/v1/fe951eda-20.10_Groovy+Gorilla_RPi_Sketch.svg\\\
-        \" rel=\\\"nofollow noopener\\\"\\u003ehttps://assets.ubuntu.com/v1/fe951eda-20.10_Groovy+Gorilla_RPi_Sketch.svg\\\
-        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e250\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003e388\\u003c/td\\u003e\\n\\u003ctd\\u003eGet Ubuntu 20.10\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e/download\\u003c/td\\u003e\\n\\u003ctd\\u003eLearn\
-        \ more about Ubuntu on the Raspberry Pi\\u003c/td\\u003e\\n\\u003ctd\\u003e/raspberry-pi\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\\
-        u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003eHow\
-        \ to manage risk with secure managed service providers\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003eLearn the standards and control objects that should be met\
-        \ through a certified MSP provide\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-10-23\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003egrad\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\
-        \"https://assets.ubuntu.com/v1/0a819c9c-managed-private-cloud_wht_lrg.svg\\\
-        \" rel=\\\"nofollow noopener\\\"\\u003ehttps://assets.ubuntu.com/v1/0a819c9c-managed-private-cloud_wht_lrg.svg\\\
-        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e220\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003e220\\u003c/td\\u003e\\n\\u003ctd\\u003eRegister for the webinar\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://www.brighttalk.com/webcast/6793/440499?utm_source=Takeover\\\
-        u0026amp;utm_medium=Takeover\\u0026amp;utm_campaign=7013z000001G3QyAAK\\\"\
-        \ rel=\\\"nofollow noopener\\\"\\u003ehttps://www.brighttalk.com/webcast/6793/440499?utm_source=Takeover\\\
-        u0026amp;utm_medium=Takeover\\u0026amp;utm_campaign=7013z000001G3QyAAK\\u003c/a\\\
-        u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003efalse\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\\
-        u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003eCassandra\
-        \ in production\\u003c/td\\u003e\\n\\u003ctd\\u003eReliability and scalability\
-        \ for Cassandra deployments\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-09-31\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003edark\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\
-        \"https://assets.ubuntu.com/v1/f880a3bd-Enterprise+support.svg\\\" rel=\\\"\
-        nofollow noopener\\\"\\u003ehttps://assets.ubuntu.com/v1/f880a3bd-Enterprise+support.svg\\\
-        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e250\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003e250\\u003c/td\\u003e\\n\\u003ctd\\u003eRegister for the webinar\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://www.brighttalk.com/webcast/6793/439718?utm_source=Takeover\\\
-        \" rel=\\\"nofollow noopener\\\"\\u003ehttps://www.brighttalk.com/webcast/6793/439718?utm_source=Takeover\\\
-        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003e\\u003c/td\\u003e\\n\\u003ctd\\u003efalse\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\\
-        u003eStill running Ubuntu 14.04 LTS?\\u003c/td\\u003e\\n\\u003ctd\\u003eLearn\
-        \ how to maintain ongoing security compliance for your Ubuntu 14.04 LTS systems.\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e2019-02-27\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003edark\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://assets.ubuntu.com/v1/2217d1c8-Security.svg\\\
-        \" rel=\\\"nofollow noopener\\\"\\u003ehttps://assets.ubuntu.com/v1/2217d1c8-Security.svg\\\
-        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e154\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003e154\\u003c/td\\u003e\\n\\u003ctd\\u003eWatch the webinar\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e/engage/14-04-esm?utm_source=takeover\\u0026amp;utm_campaign=CY19_DC_UA_WBN_ESM14-04\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003efalse\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\\
-        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003eConnected cars\
-        \ and autonomous driving\\u003c/td\\u003e\\n\\u003ctd\\u003eManaging software\
-        \ for the ultimate edge device including development, extensibility, risk\
-        \ mitigation and security factors.\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-05-31\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003edark\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\
-        \"https://assets.ubuntu.com/v1/5096c143-451-research-vector-white-logo.svg\\\
-        \" rel=\\\"nofollow noopener\\\"\\u003ehttps://assets.ubuntu.com/v1/5096c143-451-research-vector-white-logo.svg\\\
-        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e250\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003e250\\u003c/td\\u003e\\n\\u003ctd\\u003eWatch the webinar\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e/engage/451-automotive?utm_source=Takeover\\u0026amp;utm_medium=Takeover\\\
-        u0026amp;utm_campaign=CY19_IOT_Automotive_WBN_451\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003efalse\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\\
-        n\\u003ctr\\u003e\\n\\u003ctd\\u003eKubernetes for IoT developers\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003eSecurity, flexibility and automation - implementing\
-        \ Kubernetes at the edge.\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-01-10\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003egrad\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\
-        \"https://assets.ubuntu.com/v1/5096c143-451-research-vector-white-logo.svg\\\
-        \" rel=\\\"nofollow noopener\\\"\\u003ehttps://assets.ubuntu.com/v1/5096c143-451-research-vector-white-logo.svg\\\
-        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e311\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003e116\\u003c/td\\u003e\\n\\u003ctd\\u003eDownload the report\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/microk8s-451research?utm_source=Takeover\\\
-        u0026amp;utm_medium=Takeover\\u0026amp;utm_campaign=3)CY20_DC_Kubernetes_Whitepaper_MicroK8s_451Research\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003efalse\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\\
-        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003eUbuntu 17.04\
-        \ has arrived\\u003c/td\\u003e\\n\\u003ctd\\u003eFrom the smallest device\
-        \ to the largest cloud.\\u003c/td\\u003e\\n\\u003ctd\\u003e2017-04-31\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003egrad\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"\
-        https://assets.ubuntu.com/v1/5096c143-451-research-vector-white-logo.svg\\\
-        \" rel=\\\"nofollow noopener\\\"\\u003ehttps://assets.ubuntu.com/v1/5096c143-451-research-vector-white-logo.svg\\\
-        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e311\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003e116\\u003c/td\\u003e\\n\\u003ctd\\u003eGet Ubuntu 17.04\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e/download\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003efalse\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\\
-        u003e\\n\\u003ctd\\u003eUbuntu 17.10\\u003c/td\\u003e\\n\\u003ctd\\u003eBrand\
-        \ new Ubuntu desktop!\\u003c/td\\u003e\\n\\u003ctd\\u003e2017-04-31\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003elight\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\
-        \"https://assets.ubuntu.com/v1/b0b06642-Laptop.png?w=654\\\" rel=\\\"nofollow\
-        \ noopener\\\"\\u003ehttps://assets.ubuntu.com/v1/b0b06642-Laptop.png?w=654\\\
-        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e311\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003e116\\u003c/td\\u003e\\n\\u003ctd\\u003eGet Ubuntu 17.04\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e/download\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003efalse\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\\
-        u003e\\n\\u003ctd\\u003eCloud gaming for Android\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003eBuilding a high performing and scalable platform.\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003e2020-01-31\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003egrad\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://assets.ubuntu.com/v1/b0b06642-Laptop.png?w=654\\\
-        \" rel=\\\"nofollow noopener\\\"\\u003ehttps://assets.ubuntu.com/v1/b0b06642-Laptop.png?w=654\\\
-        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e338\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003e246\\u003c/td\\u003e\\n\\u003ctd\\u003eDownload the whitepaper\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/anbox-cloud-gaming-whitepaper?utm_source=Takeover\\\
-        u0026amp;utm_medium=Takeover\\u0026amp;utm_campaign=CY20_IOT_Mobile_Whitepaper_AnboxCloud\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003efalse\\u003c/td\\u003e\\n\\u003ctd\\u003efalse\\u003c/td\\\
-        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003eAn introduction\
-        \ to Anbox Cloud\\u003c/td\\u003e\\n\\u003ctd\\u003eScalable Android in the\
-        \ cloud\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-01-31\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003egrad\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://assets.ubuntu.com/v1/7e3bd1ed-Anbox-Cloud+computing_outline.svg\\\
-        \" rel=\\\"nofollow noopener\\\"\\u003ehttps://assets.ubuntu.com/v1/7e3bd1ed-Anbox-Cloud+computing_outline.svg\\\
-        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e338\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003e246\\u003c/td\\u003e\\n\\u003ctd\\u003eDownload the whitepaper\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/anbox-cloud-webinar?utm_source=Takeover\\\
-        u0026amp;utm_medium=Takeover\\u0026amp;utm_campaign=CY20_DC_AnboxCloud_WBN_IntrotoAnboxCloud\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003efalse\\u003c/td\\u003e\\n\\u003ctd\\u003efalse\\u003c/td\\\
-        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003ePrecision drone\
-        \ flights at the edge of innovation\\u003c/td\\u003e\\n\\u003ctd\\u003eDiscover\
-        \ how Apellix has designed revolutionary software to solve industrial IoT\
-        \ challenges.\\u003c/td\\u003e\\n\\u003ctd\\u003e2017-04-31\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003egrad\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://assets.ubuntu.com/v1/7e3bd1ed-Anbox-Cloud+computing_outline.svg\\\
-        \" rel=\\\"nofollow noopener\\\"\\u003ehttps://assets.ubuntu.com/v1/7e3bd1ed-Anbox-Cloud+computing_outline.svg\\\
-        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e338\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003e246\\u003c/td\\u003e\\n\\u003ctd\\u003eDownload the whitepaper\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/anbox-cloud-webinar?utm_source=Takeover\\\
-        u0026amp;utm_medium=Takeover\\u0026amp;utm_campaign=CY20_DC_AnboxCloud_WBN_IntrotoAnboxCloud\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003efalse\\u003c/td\\u003e\\n\\u003ctd\\u003efalse\\u003c/td\\\
-        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003eComparing Red\
-        \ Hat OpenStack Platform and Canonical\u2019s Charmed OpenStack\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003eSignificantly reduce TCO with Charmed OpenStack\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e2020-07-29\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003egrad\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://assets.ubuntu.com/v1/2d935f28-openstack-cloud.svg\\\
-        \" rel=\\\"nofollow noopener\\\"\\u003ehttps://assets.ubuntu.com/v1/2d935f28-openstack-cloud.svg\\\
-        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e300\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003e300\\u003c/td\\u003e\\n\\u003ctd\\u003eDownload the whitepaper\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/redhat-openstack-comparison-whitepaper?utm_source=Takeover\\\
-        u0026amp;utm_medium=Takeover\\u0026amp;utm_campaign=CY20_DC_Openstack_Whitepaper_RedHatComparison\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003efalse\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\\
-        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003eFive strategies\
-        \ to\\u003cbr\\u003eaccelerate Kubernetes\\u003cbr\\u003ein the enterprise\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003eHow to choose the best approach to Kubernetes\\\
-        u003cbr\\u003efor your business\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-09-02\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003edark\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\
-        \"https://assets.ubuntu.com/v1/11d594e7-K8s+logo+white+outline.svg\\\" rel=\\\
-        \"nofollow noopener\\\"\\u003ehttps://assets.ubuntu.com/v1/11d594e7-K8s+logo+white+outline.svg\\\
-        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e240\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003e234\\u003c/td\\u003e\\n\\u003ctd\\u003eDownload the whitepaper\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e//engage/kubernetes-deployment-enterprise-whitepaper?utm_source=Takeover\\\
-        u0026amp;utm_medium=Takeover\\u0026amp;utm_campaign=CY20_DC_Kubernetes_Whitepaper_K8sEnterpriseChallenges\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003efalse\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\\
-        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003eFIPS certification\
-        \ and CIS compliance with Ubuntu\\u003c/td\\u003e\\n\\u003ctd\\u003eLearn\
-        \ about Ubuntu CIS and FIPS certified components to enable operating under\
-        \ compliance regimes like FedRAMP, HIPAA, PCI and ISO.\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003e2020-09-02\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003elight\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://assets.ubuntu.com/v1/b576398c-compliance-wht.svg\\\
-        \" rel=\\\"nofollow noopener\\\"\\u003ehttps://assets.ubuntu.com/v1/b576398c-compliance-wht.svg\\\
-        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e400\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003e234\\u003c/td\\u003e\\n\\u003ctd\\u003eRegister for the webinar\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://www.brighttalk.com/webcast/6793/432536?utm_source=Takeover\\\
-        \" rel=\\\"nofollow noopener\\\"\\u003ehttps://www.brighttalk.com/webcast/6793/432536?utm_source=Takeover\\\
-        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003e\\u003c/td\\u003e\\n\\u003ctd\\u003efalse\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\\
-        u003eUbuntu Security: Security and compliance for the full stack\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003eThe full Ubuntu security story. Learn how our teams\
-        \ are securing all your open source, from cloud to edge.\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003e2020-10-01\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003egrad\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://assets.ubuntu.com/v1/1899df43-ubuntu-advantage-circular_white.svg\\\
-        \" rel=\\\"nofollow noopener\\\"\\u003ehttps://assets.ubuntu.com/v1/1899df43-ubuntu-advantage-circular_white.svg\\\
-        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e280\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003e280\\u003c/td\\u003e\\n\\u003ctd\\u003eLearn more\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e/security-series?utm_source=Takeover\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003efalse\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\\
-        n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003eExtend your OpenStack\
-        \ cloud with native backup and recovery\\u003c/td\\u003e\\n\\u003ctd\\u003eLearn\
-        \ how TrilioVault can be easily deployed in a Charmed OpenStack environment\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e2020-09-30\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003edark\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://assets.ubuntu.com/v1/469b4b31-Trilio-openstack-canonical.svg\\\
-        \" rel=\\\"nofollow noopener\\\"\\u003ehttps://assets.ubuntu.com/v1/469b4b31-Trilio-openstack-canonical.svg\\\
-        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e350\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eRegister for the webinar\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/trilio-backup-recovery?utm_source=Takeover\\\
-        u0026amp;utm_medium=Takeover\\u0026amp;utm_campaign=CY20_DC_WBN_OpenStack_Trilio\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003efalse\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\\
-        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003eChoisir une\
-        \ architecture cloud rentable\\u003c/td\\u003e\\n\\u003ctd\\u003eD\xE9couvrez\
-        \ les diff\xE9rentes architectures clouds et comment choisir une architecture\
-        \ rentable\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-03-29\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003efr\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003edark\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"\
-        https://assets.ubuntu.com/v1/2acca081-choosingacloud-white.svg\\\" rel=\\\"\
-        nofollow noopener\\\"\\u003ehttps://assets.ubuntu.com/v1/2acca081-choosingacloud-white.svg\\\
-        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e393\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003e345\\u003c/td\\u003e\\n\\u003ctd\\u003eLire le whitepaper\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/fr/guide-du-DSI-pour-les-operations-multicloud?utm_source=Takeover\\\
-        u0026amp;utm_medium=Takeover\\u0026amp;utm_campaign=7013z000001GHleAAG\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003efalse\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\\
-        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003eMigrer de VMWare\
-        \ \xE0 Openstack\\u003c/td\\u003e\\n\\u003ctd\\u003eApprenez comment migrer\
-        \ d\u2019un environnement traditionnel et propri\xE9taire \xE0 un cloud OpenStack\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e2020-03-29\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003efr\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003elight\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://assets.ubuntu.com/v1/35515576-openstack-cloud.svg\\\
-        \" rel=\\\"nofollow noopener\\\"\\u003ehttps://assets.ubuntu.com/v1/35515576-openstack-cloud.svg\\\
-        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e393\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003e345\\u003c/td\\u003e\\n\\u003ctd\\u003eS\u2019inscrire au webinar\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/fr/vmware-to-openstack?utm_source=Takeover\\\
-        u0026amp;utm_medium=Takeover\\u0026amp;utm_campaign=CY19_DC_France_Openstack_WBN_VmwaretoOpenstack\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003efalse\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\\
-        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003eDo VMware ao\
-        \ Charmed OpenStack\\u003c/td\\u003e\\n\\u003ctd\\u003eReduza os custos e\
-        \ aumente a efici\xEAncia da sua infraestrutura com ado\xE7\xE3o de c\xF3\
-        digo aberto\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-07-22\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003ept\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003edark\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"\
-        https://assets.ubuntu.com/v1/2d935f28-openstack-cloud.svg\\\" rel=\\\"nofollow\
-        \ noopener\\\"\\u003ehttps://assets.ubuntu.com/v1/2d935f28-openstack-cloud.svg\\\
-        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e300\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eLeia o documento t\xE9cnico\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/pt/vmware-para-o-openstack?utm_source=Takeover\\\
-        u0026amp;utm_medium=Takeover\\u0026amp;utm_campaign=7013z000001WaxFAAS\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003efalse\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\\
-        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003eDa VMware a\
-        \ OpenStack\\u003c/td\\u003e\\n\\u003ctd\\u003eCome la migrazione a Charmed\
-        \ OpenStack pu\xF2 ridurre significativamente il TCO\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003e2020-09-02\\u003c/td\\u003e\\n\\u003ctd\\u003eit\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003edark\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://assets.ubuntu.com/v1/2d935f28-openstack-cloud.svg\\\
-        \" rel=\\\"nofollow noopener\\\"\\u003ehttps://assets.ubuntu.com/v1/2d935f28-openstack-cloud.svg\\\
-        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e300\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eScarica il whitepaper\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/it/da-vmware-a-openstack?utm_source=Takeover\\\
-        u0026amp;utm_medium=Takeover\\u0026amp;utm_campaign=CY20_DC_OpenStack_IT_Whitepaper_VMwaretoOpenstack\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003efalse\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\\
-        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003eDa VMware a\
-        \ Charmed Openstack\\u003c/td\\u003e\\n\\u003ctd\\u003eCome la migrazione\
-        \ pu\xF2 tagliare i costi\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-09-15\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003eit\\u003c/td\\u003e\\n\\u003ctd\\u003e\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003edark\\u003c/td\\u003e\\n\\u003ctd\\u003e\\\
-        u003ca href=\\\"https://assets.ubuntu.com/v1/2d935f28-openstack-cloud.svg\\\
-        \" rel=\\\"nofollow noopener\\\"\\u003ehttps://assets.ubuntu.com/v1/2d935f28-openstack-cloud.svg\\\
-        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e300\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eRegistrati al webinar\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/it/da-vmware-a-charmed-openstack?utm_source=Takeover\\\
-        u0026amp;utm_medium=Takeover\\u0026amp;utm_campaign=2)CY20_DC_OpenStack_IT_WBN_VMwaretoOpenstack\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003efalse\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\\
-        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003eUna gu\xED\
-        a para la adopci\xF3n y el despliegue satisfactorios de OpenStack\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003eSuperar los desaf\xEDos de la adopci\xF3n de OpenStack\
-        \ siguiendo un proceso de adopci\xF3n probado\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003e2020-09-15\\u003c/td\\u003e\\n\\u003ctd\\u003ees\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003edark\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003e\\u003ca href=\\\"https://assets.ubuntu.com/v1/dcb2963c-openstack+cloud+outlines.svg\\\
-        \" rel=\\\"nofollow noopener\\\"\\u003ehttps://assets.ubuntu.com/v1/dcb2963c-openstack+cloud+outlines.svg\\\
-        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e320\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eDescargar el manual\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e/engage/es/guia-implementacion-openstack?utm_source=Takeover\\\
-        u0026amp;utm_medium=Takeover\\u0026amp;utm_campaign=7013z000001WhDoAAK\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003efalse\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\\
-        u003e\\n\\u003c/tr\\u003e\\n\\u003c/tbody\\u003e\\n\\u003c/table\\u003e\\\
-        n\\u003c/div\\u003e\\u003c/details\\u003e\",\"post_number\":1,\"post_type\"\
-        :1,\"updated_at\":\"2020-11-18T22:50:16.694Z\",\"reply_count\":0,\"reply_to_post_number\"\
-        :null,\"quote_count\":0,\"incoming_link_count\":23,\"reads\":21,\"score\"\
-        :119.2,\"yours\":false,\"topic_id\":17229,\"topic_slug\":\"engage-pages-and-takeovers\"\
-        ,\"display_username\":\"Peter Mahnke\",\"primary_group_name\":\"Canonical\"\
-        ,\"primary_group_flair_url\":\"https://launchpadlibrarian.net/68730579/64.png\"\
-        ,\"primary_group_flair_bg_color\":\"\",\"primary_group_flair_color\":\"\"\
-        ,\"version\":26,\"can_edit\":false,\"can_delete\":false,\"can_recover\":false,\"\
-        can_wiki\":false,\"link_counts\":[{\"url\":\"https://ubuntu.com/engage\",\"\
-        internal\":false,\"reflection\":false,\"title\":\"Ubuntu case studies, whitepapers\
-        \ and webinars | Ubuntu\",\"clicks\":5},{\"url\":\"https://discourse.ubuntu.com/t/do-vmware-ao-charmed-openstack/18165\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Do VMware ao Charmed OpenStack\"\
-        ,\"clicks\":3},{\"url\":\"https://discourse.ubuntu.com/t/openstack-deployment-guide/17384\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"OpenStack deployment guide\"\
-        ,\"clicks\":2},{\"url\":\"https://discourse.ubuntu.com/t/five-strategies-to-accelerate-kubernetes-deployment-in-the-enterprise/18161\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Five strategies to accelerate\
-        \ Kubernetes deployment in the enterprise\",\"clicks\":2},{\"url\":\"https://discourse.ubuntu.com/t/sensape-uses-landscape-to-remotely-support-revolutionary-interactive-retail-displays/17289\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Sensape uses Landscape\
-        \ to remotely support revolutionary interactive retail displays\",\"clicks\"\
-        :1},{\"url\":\"https://discourse.ubuntu.com/t/kubernetes-from-cloud-to-edge/17398\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Kubernetes from Cloud\
-        \ to Edge\",\"clicks\":1},{\"url\":\"https://discourse.ubuntu.com/t/extension-securite-et-maintenance-pour-ubuntu-14-04/17414\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Extension S\xE9curit\xE9\
-        \ et Maintenance pour Ubuntu 14.04\",\"clicks\":1},{\"url\":\"https://discourse.ubuntu.com/t/cloud-gaming-for-android/18757\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Cloud gaming for Android\"\
-        ,\"clicks\":1},{\"url\":\"https://assets.ubuntu.com/v1/1899df43-ubuntu-advantage-circular_white.svg\"\
-        ,\"internal\":false,\"reflection\":false,\"title\":\"1899df43-ubuntu-advantage-circular_white.svg\"\
-        ,\"clicks\":1},{\"url\":\"https://discourse.ubuntu.com/t/ubuntu-20-10-what-s-new/19050\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Ubuntu 20.10: What\u2019\
-        s new?\",\"clicks\":1},{\"url\":\"https://discourse.ubuntu.com/t/transforming-telco-infrastructure-a-virtual-event/18162\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Transforming telco infrastructure:\
-        \ A virtual event\",\"clicks\":1},{\"url\":\"https://discourse.ubuntu.com/t/keep-up-with-evolving-software/17310\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Keep up with evolving\
-        \ software\",\"clicks\":1},{\"url\":\"https://discourse.ubuntu.com/t/botsandus-builds-a-social-robot-on-ubuntu/17280\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"BotsAndUs builds a social\
-        \ robot on Ubuntu\",\"clicks\":1},{\"url\":\"https://discourse.ubuntu.com/t/openstack-problemlos-installieren-und-skalieren/17409\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"OpenStack problemlos installieren\
-        \ und skalieren\",\"clicks\":1},{\"url\":\"https://discourse.ubuntu.com/t/cinco-estrategias-para-acelerar-a-los-kubernetes-en-la-empresa/19208\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Cinco estrategias para\
-        \ acelerar a los Kubernetes en la empresa\",\"clicks\":1},{\"url\":\"https://discourse.ubuntu.com/t/an-introduction-to-apparmor/17277\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"An introduction to AppArmor\"\
-        ,\"clicks\":1},{\"url\":\"https://discourse.ubuntu.com/t/whats-new-in-ubuntu-19-04/17240\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"What's new in Ubuntu 19.04?\"\
-        ,\"clicks\":1},{\"url\":\"https://discourse.ubuntu.com/t/how-to-build-and-deploy-your-first-ai-ml-model-on-ubuntu/17294\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"How to build and deploy\
-        \ your first AI/ML model on Ubuntu\",\"clicks\":1},{\"url\":\"https://discourse.ubuntu.com/t/confronto-fra-red-hats-openstack-platform-e-charmed-openstack-di-canaonical/19362\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Confronto fra \\\"Red\
-        \ Hat's Openstack platform\\\" e Charmed Openstack di Canaonical\",\"clicks\"\
-        :1},{\"url\":\"https://discourse.ubuntu.com/t/cinque-strategie-per-accelerare-limplementazione-di-kubernetes-nellimpresa/19381\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Cinque strategie per accelerare\
-        \ l'implementazione di Kubernetes nell'impresa\",\"clicks\":1},{\"url\":\"\
-        https://discourse.ubuntu.com/t/da-vmware-a-openstack/18164\",\"internal\"\
-        :true,\"reflection\":false,\"title\":\"Da VMware a OpenStack\",\"clicks\"\
-        :1},{\"url\":\"https://discourse.ubuntu.com/t/how-to-face-the-challenges-of-becoming-a-cloud-operator/17290\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"How to face the challenges\
-        \ of becoming a cloud operator\",\"clicks\":1},{\"url\":\"https://assets.ubuntu.com/v1/11d594e7-K8s+logo+white+outline.svg\"\
-        ,\"internal\":false,\"reflection\":false,\"title\":\"11d594e7-K8s+logo+white+outline.svg\"\
-        ,\"clicks\":0},{\"url\":\"https://assets.ubuntu.com/v1/7e3bd1ed-Anbox-Cloud+computing_outline.svg\"\
-        ,\"internal\":false,\"reflection\":false,\"title\":\"7e3bd1ed-Anbox-Cloud+computing_outline.svg\"\
-        ,\"clicks\":0},{\"url\":\"https://assets.ubuntu.com/v1/2d935f28-openstack-cloud.svg\"\
-        ,\"internal\":false,\"reflection\":false,\"title\":\"2d935f28-openstack-cloud.svg\"\
-        ,\"clicks\":0},{\"url\":\"https://assets.ubuntu.com/v1/b0b06642-Laptop.png?w=654\"\
-        ,\"internal\":false,\"reflection\":false,\"clicks\":0},{\"url\":\"https://assets.ubuntu.com/v1/5096c143-451-research-vector-white-logo.svg\"\
-        ,\"internal\":false,\"reflection\":false,\"title\":\"5096c143-451-research-vector-white-logo.svg\"\
-        ,\"clicks\":0},{\"url\":\"https://assets.ubuntu.com/v1/2217d1c8-Security.svg\"\
-        ,\"internal\":false,\"reflection\":false,\"title\":\"2217d1c8-Security.svg\"\
-        ,\"clicks\":0},{\"url\":\"https://assets.ubuntu.com/v1/f880a3bd-Enterprise+support.svg\"\
-        ,\"internal\":false,\"reflection\":false,\"title\":\"f880a3bd-Enterprise+support.svg\"\
-        ,\"clicks\":0},{\"url\":\"https://assets.ubuntu.com/v1/fe951eda-20.10_Groovy+Gorilla_RPi_Sketch.svg\"\
-        ,\"internal\":false,\"reflection\":false,\"title\":\"fe951eda-20.10_Groovy+Gorilla_RPi_Sketch.svg\"\
-        ,\"clicks\":0},{\"url\":\"https://www.brighttalk.com/webcast/6793/440529?utm_source=Takeover\\\
-        u0026utm_medium=Takeover\\u0026utm_campaign=7013z000001G3QyAAK\",\"internal\"\
-        :false,\"reflection\":false,\"clicks\":0},{\"url\":\"https://assets.ubuntu.com/v1/cea1e4c7-IBM-Z-logo-white.png\"\
-        ,\"internal\":false,\"reflection\":false,\"title\":\"cea1e4c7-IBM-Z-logo-white.png\"\
-        ,\"clicks\":0},{\"url\":\"https://www.brighttalk.com/webcast/6793/440499?utm_source=Takeover\\\
-        u0026utm_medium=Takeover\\u0026utm_campaign=7013z000001G3QyAAK\",\"internal\"\
-        :false,\"reflection\":false,\"clicks\":0},{\"url\":\"https://assets.ubuntu.com/v1/0a819c9c-managed-private-cloud_wht_lrg.svg\"\
-        ,\"internal\":false,\"reflection\":false,\"title\":\"0a819c9c-managed-private-cloud_wht_lrg.svg\"\
-        ,\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/open-digital-platforms-for-the-industrial-edge-cloud-in-2020/19068\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Open digital platforms\
-        \ for the industrial edge cloud in 2020\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/watch-the-raspberry-pi-ubuntu-desktop-intro-video/18577\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Watch the Raspberry Pi\
-        \ Ubuntu Desktop intro video\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/extend-your-openstack-cloud-with-native-backup-and-recover/18911\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Extend your OpenStack\
-        \ cloud with native backup and recover\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/busting-the-myth-of-private-cloud-economics/17244\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Busting the myth of private\
-        \ cloud economics\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/building-powerful-customer-solutions/18481\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Building powerful customer\
-        \ solutions\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/gmo-pepabo-ubuntu/18476\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"GMO Pepabo \\u0026 Ubuntu\"\
-        ,\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/da-vmware-a-charmed-openstack/18478\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Da VMware a Charmed Openstack\"\
-        ,\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/guia-para-la-implementacion-de-openstack/18480\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Gu\xEDa para la implementaci\xF3\
-        n de OpenStack\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/comparing-red-hat-openstack-platform-and-canonicals-charmed-openstack/18159\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Comparing Red Hat OpenStack\
-        \ Platform and Canonical's Charmed OpenStack\",\"clicks\":0},{\"url\":\"https://www.brighttalk.com/webcast/6793/439718?utm_source=Takeover\"\
-        ,\"internal\":false,\"reflection\":false,\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/nfv-and-sdn-on-openstack-for-network-operators/17326\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"NFV and SDN on OpenStack\
-        \ for network operators\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/still-running-ubuntu-14-04/17275\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Still running Ubuntu 14.04?\"\
-        ,\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/production-ai-from-data-lake-to-server-webinar/18163\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Production AI from data\
-        \ lake to server webinar\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/utiliser-des-gpus-avec-kubernetes/17419\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Utiliser des GPUs avec\
-        \ Kubernetes\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/installez-et-mettez-openstack-a-lechelle-en-toute-simplicite/17418\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Installez et mettez OpenStack\
-        \ \xE0 l'\xE9chelle en toute simplicit\xE9\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/le-support-d-ubuntu-14-04-lts-est-maintenant-passe-a-esm/17413\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Le support d\u2019Ubuntu\
-        \ 14.04 LTS est maintenant pass\xE9 \xE0 ESM\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/sicherheit-in-der-private-cloud/17411\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Sicherheit in der Private\
-        \ Cloud\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/wofur-konnen-sie-kubernetes-einsetzen/17410\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Wof\xFCr k\xF6nnen Sie\
-        \ Kubernetes einsetzen?\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/von-vmware-zu-canonical-openstack/17408\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Von VMware zu Canonical\
-        \ OpenStack\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/scale-android-applications-economically-in-the-cloud-with-anbox-cloud/17401\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Scale Android applications\
-        \ economically in the cloud with Anbox Cloud\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/accelerating-iot-device-time-to-market/17399\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Accelerating IoT device\
-        \ time to market\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/scaling-on-azure-with-ubuntu-pro/17397\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Scaling on Azure with\
-        \ Ubuntu Pro\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/a-technical-intro-to-ubuntu-pro/17396\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"A technical intro to Ubuntu\
-        \ Pro\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/migrating-your-infrastructure-to-ubuntu-20-04-lts/17395\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Migrating your infrastructure\
-        \ to Ubuntu 20.04 LTS\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/utilising-cloud-init-on-microsoft-azure/17394\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Utilising cloud-init on\
-        \ Microsoft Azure\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/standardising-machine-learning-from-workstation-to-production/17393\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Standardising machine\
-        \ learning \u2014 from workstation to production\",\"clicks\":0},{\"url\"\
-        :\"https://discourse.ubuntu.com/t/kafka-in-production/17392\",\"internal\"\
-        :true,\"reflection\":false,\"title\":\"Kafka in production\",\"clicks\":0},{\"\
-        url\":\"https://discourse.ubuntu.com/t/solving-the-software-update-challenge-for-iot-devices/17391\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Solving the software update\
-        \ challenge for IoT devices\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/secure-iot-device-management/17390\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Secure IoT device management\"\
-        ,\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/leveraging-open-source-with-ubuntu-pro-on-azure/17389\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Leveraging open source\
-        \ with Ubuntu Pro on Azure\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/streamlined-kubernetes-from-cloud-to-edge/17388\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Streamlined Kubernetes,\
-        \ from Cloud to Edge\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/embracing-the-open-source-mandate/17387\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Embracing the open source\
-        \ mandate\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/what-s-new-in-ubuntu-20-04-lts/17386\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"What\u2019s new in Ubuntu\
-        \ 20.04 LTS?\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/maintaining-business-focus-in-a-cloud-native-world-with-managed-apps/17385\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Maintaining business focus\
-        \ in a cloud-native world with Managed Apps\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/ubuntu-core-a-cybersecurity-analysis/17381\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Ubuntu Core: a cybersecurity\
-        \ analysis\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/virtual-event-microk8s-kubernetes/17380\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Virtual event: MicroK8s\
-        \ \\u0026 Kubernetes\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/rigado-cuts-customers-time-to-market/17379\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Rigado cuts customers'\
-        \ time-to-market\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/securing-ros-robotics-platforms/17378\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Securing ROS robotics\
-        \ platforms\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/smart-card-login-on-ubuntu/17377\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Smart card login on Ubuntu\"\
-        ,\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/esm-maintains-interanas-system-security-while-upgrading/17376\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"ESM maintains Interana's\
-        \ system security while upgrading\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/hosted-private-cloud-infrastructure-a-cost-analysis/17375\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Hosted private cloud infrastructure:\
-        \ a cost analysis\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/an-introduction-to-anbox-cloud/17374\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"An introduction to Anbox\
-        \ Cloud\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/deploy-kubernetes-in-your-data-centre/17373\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Deploy Kubernetes in your\
-        \ data centre\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/artificial-intelligence-at-the-edge-in-a-5g-world/17372\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Artificial Intelligence\
-        \ at the edge in a 5G world\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/de-vmware-a-charmed-openstack/17371\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"De VMware a Charmed OpenStack\"\
-        ,\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/migration-von-vmware-zu-openstack/17370\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Migration von VMware zu\
-        \ OpenStack\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/kubernetes-a-secure-flexible-and-automated-edge-for-iot-developers/17369\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Kubernetes: a secure,\
-        \ flexible and automated edge for IoT developers\",\"clicks\":0},{\"url\"\
-        :\"https://discourse.ubuntu.com/t/ubuntu-desktop-for-the-enterprise/17368\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Ubuntu Desktop for the\
-        \ enterprise\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/an-intro-to-microk8s/17367\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"An intro to MicroK8s\"\
-        ,\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/cyberdyne-keeps-cleaning-robots-up-to-date-in-the-field-with-snaps/17366\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Cyberdyne keeps cleaning\
-        \ robots up-to-date in the field with snaps\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/register-for-wslconf/17365\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Register for WSLConf\"\
-        ,\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/sbi-group-unlocks-infrastructure-automation-with-secure-on-premises-openstack-cloud/17364\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"SBI Group unlocks infrastructure\
-        \ automation with secure, on-premises OpenStack cloud\",\"clicks\":0},{\"\
-        url\":\"https://discourse.ubuntu.com/t/build-smart-display-devices-with-mir-fast-to-production-secure-open-source/17363\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Build smart display devices\
-        \ with Mir: fast to production, secure, open-source\",\"clicks\":0},{\"url\"\
-        :\"https://discourse.ubuntu.com/t/linux-security-with-ubuntu/17362\",\"internal\"\
-        :true,\"reflection\":false,\"title\":\"Linux security with Ubuntu\",\"clicks\"\
-        :0},{\"url\":\"https://discourse.ubuntu.com/t/lessons-learned-from-100-private-cloud-builds/17361\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Lessons learned from 100+\
-        \ Private cloud builds\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/the-wellcome-sanger-institute-turns-to-canonical-for-high-level-ceph-support/17360\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"The Wellcome Sanger Institute\
-        \ turns to Canonical for high level Ceph support\",\"clicks\":0},{\"url\"\
-        :\"https://discourse.ubuntu.com/t/ensuring-security-and-isolation-in-kubernetes-with-kata-containers/17359\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Ensuring security and\
-        \ isolation in Kubernetes with Kata Containers\",\"clicks\":0},{\"url\":\"\
-        https://discourse.ubuntu.com/t/tim-ensures-system-security-and-client-confidence-with-esm/17358\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"TIM ensures system security\
-        \ and client confidence with ESM\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/what-s-new-in-ubuntu-19-10/17357\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"What\u2019s new in Ubuntu\
-        \ 19.10\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/how-domotz-streamlined-provisioning-of-iot-devices/17356\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"How Domotz streamlined\
-        \ provisioning of IoT devices\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/yahoo-japan-builds-their-iaas-environment-with-canonical/17355\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Yahoo! Japan builds their\
-        \ IaaS environment with Canonical\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/accelerating-deep-tech-with-ubuntu/17354\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Accelerating deep tech\
-        \ with Ubuntu\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/machine-learning-operations-mlops/17353\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Machine Learning Operations\
-        \ (MLOps)\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/how-to-manage-snaps-in-an-enterprise-environment/17352\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"How to manage snaps in\
-        \ an enterprise environment\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/a-guide-to-developing-android-apps-on-ubuntu/17351\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"A guide to developing\
-        \ Android apps on Ubuntu\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/creating-accurate-ai-models-with-data/17349\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Creating accurate AI models\
-        \ with data\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/creating-a-cloud-like-bare-metal-experience-in-the-data-centre/17348\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Creating a cloud-like\
-        \ bare metal experience in the data centre\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/a-shift-to-the-linux-app-store-experience/17347\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"A shift to the Linux app\
-        \ store experience\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/taking-charge-of-the-iots-security-vulnerabilities/17346\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Taking charge of the IoT's\
-        \ security vulnerabilities\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/for-ctos-the-no-nonsense-way-to-accelerate-your-business-with-containers/17345\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"For CTOs: the no-nonsense\
-        \ way to accelerate your business with containers\",\"clicks\":0},{\"url\"\
-        :\"https://discourse.ubuntu.com/t/learn-whats-new-in-ubuntu-server-14-04-lts/17344\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Learn What's New In Ubuntu\
-        \ Server 14.04 LTS\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/from-vmware-to-charmed-openstack/17343\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"From VMWare To Charmed\
-        \ OpenStack\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/the-future-of-mobile-connectivity/17342\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"The future of mobile connectivity\"\
-        ,\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/ubuntu-core-and-kura-a-framework-for-iot-gateways/17341\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Ubuntu Core and Kura:\
-        \ A framework for IoT gateways\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/securing-the-enterprise-how-ubuntu-is-at-the-forefront-of-security-and-compliance/17340\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Securing the enterprise:\
-        \ how Ubuntu is at the forefront of security and compliance\",\"clicks\":0},{\"\
-        url\":\"https://discourse.ubuntu.com/t/what-s-new-in-ubuntu-18-10/17339\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"What\u2019s New in Ubuntu\
-        \ 18.10\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/carrier-cloudification-what-every-telecom-executive-needs-to-know/17338\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Carrier Cloudification:\
-        \ What every telecom executive needs to know\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/how-to-escape-stuckstack-and-profit-from-your-openstack-investment/17337\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"How to escape StuckStack\
-        \ and profit from your OpenStack investment\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/getting-started-with-ai/17336\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Getting started with AI\"\
-        ,\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/optimising-iot-bandwidth-with-delta-updates/17335\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Optimising IoT bandwidth\
-        \ with delta updates\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/small-robot-company-sows-the-seeds-for-autonomous-and-more-profitable-farming/17334\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Small Robot Company sows\
-        \ the seeds for autonomous and more profitable farming\",\"clicks\":0},{\"\
-        url\":\"https://discourse.ubuntu.com/t/key-considerations-when-choosing-a-robot-s-operating-system/17333\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Key considerations when\
-        \ choosing a robot\u2019s operating system\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/make-it-rain-public-cloud-on-ubuntu-openstack/17332\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Make IT rain: public cloud\
-        \ on Ubuntu OpenStack\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/building-a-private-cloud-take-the-leap/17331\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Building a private cloud?\
-        \ Take the leap!\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/telcos-and-service-providers-expect-near-100-uptime/17330\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Telcos and Service Providers\
-        \ expect near 100% uptime\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/private-cloud-security/17421\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Private cloud security\"\
-        ,\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/private-cloud-security-webinar/17329\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Private cloud security\
-        \ Webinar\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/openstack-made-easy/17328\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"OpenStack made easy\"\
-        ,\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/north-america-s-first-autonomous-runway-snowplough/17327\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"North America\u2018s first\
-        \ autonomous runway snowplough\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/cio-guide-to-multi-cloud-operations/17325\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"CIO guide to multi-cloud\
-        \ operations\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/modernise-your-cloud/17324\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Modernise your cloud\"\
-        ,\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/how-to-integrate-ubuntu-desktop-with-active-directory/17323\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"How to integrate Ubuntu\
-        \ Desktop with Active Directory\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/how-to-build-a-lightweight-system-container-cluster/17322\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"How to build a lightweight\
-        \ system container cluster\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/low-latency-and-real-time-kernels-for-telco-and-nfv/17321\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Low latency and real time\
-        \ kernels for telco and NFV\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/low-latency-and-real-time-kernels-for-telco-and-nfv/17320\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Low latency and real-time\
-        \ kernels for telco and NFV\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/allan-gray-unlocks-unprecedented-availability-and-productivity-with-charmed-kubernetes/17319\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Allan Gray unlocks unprecedented\
-        \ availability and productivity with Charmed Kubernetes\",\"clicks\":0},{\"\
-        url\":\"https://discourse.ubuntu.com/t/securing-iot-device-data-against-physical-access/17318\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Securing IoT device data\
-        \ against physical access\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/the-transformation-of-the-devops-journey-in-iot/17422\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"The transformation of\
-        \ the DevOps journey in IoT\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/establishing-a-software-defined-iot-business-model/17317\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Establishing a software\
-        \ defined IoT business model\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/precision-drones-on-ubuntu-flying-at-the-edge-of-innovation/17316\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Precision drones on Ubuntu:\
-        \ flying at the edge of innovation\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/apellix-engineers-safer-work-environments-with-ubuntu-powered-aerial-robotics/17315\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Apellix engineers safer\
-        \ work environments with Ubuntu powered aerial robotics\",\"clicks\":0},{\"\
-        url\":\"https://discourse.ubuntu.com/t/hiri-successfully-monetises-their-snap/17314\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Hiri successfully monetises\
-        \ their snap\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/future-proofing-fingbox-the-iot-home-network-monitoring-device/17313\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Future-proofing Fingbox,\
-        \ the IoT home network monitoring device\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/multi-cloud-fundamental-to-financial-services-transformation/17312\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Multi-cloud fundamental\
-        \ to financial services transformation\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/fing-serves-30-000-customers-with-a-secure-future-proof-iot-device/17311\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Fing serves 30,000 customers\
-        \ with a secure, future-proof IoT device\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/canonical-presents-financial-services-month/17241\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Canonical presents Financial\
-        \ Services Month\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/the-essential-guide-for-telecoms-and-service-providers-adopting-big-data-solutions/17309\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"The essential guide for\
-        \ Telecoms and Service Providers adopting big data solutions\",\"clicks\"\
-        :0},{\"url\":\"https://discourse.ubuntu.com/t/a-guide-to-edge-computing-and-the-tools-you-need/17308\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"A guide to edge computing\
-        \ and the tools you need\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/server-provisioning-what-network-admins-it-pros-need-to-know/17307\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Server Provisioning: What\
-        \ Network Admins \\u0026 IT Pros Need to Know\",\"clicks\":0},{\"url\":\"\
-        https://discourse.ubuntu.com/t/the-transformation-of-the-devops-journey-in-iot-webinar/17306\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"The transformation of\
-        \ the DevOps journey in IoT Webinar\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/get-started-with-devops-best-practices-ci-cd/17305\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Get started with DevOps\
-        \ best practices: CI/CD\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/cto-s-guide-to-sdn-nfv-vnf/17293\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"CTO\u2019s guide to SDN,\
-        \ NFV \\u0026 VNF\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/why-ubuntu-core-is-the-most-secure-choice-for-iot/17292\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Why Ubuntu Core is the\
-        \ most secure choice for IoT\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/cloud-init/17291\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Cloud init\",\"clicks\"\
-        :0},{\"url\":\"https://discourse.ubuntu.com/t/rocket-chat-communication-platform-enables-simplicity-through-snaps/17288\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Rocket.Chat communication\
-        \ platform enables simplicity through snaps\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/nexiona-collaborates-with-canonical-and-dell-to-create-miimetiq-edge/17287\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"NEXIONA collaborates with\
-        \ Canonical and Dell to create MIIMETIQ EDGE\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/itstrategen-keeps-legacy-applications-secure-with-extended-security-maintenance/17286\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"ITstrategen keeps legacy\
-        \ applications secure with Extended Security Maintenance\",\"clicks\":0},{\"\
-        url\":\"https://discourse.ubuntu.com/t/how-ubuntu-helped-innovapos-revolutionise-the-vending-machine-industry/17285\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"How Ubuntu helped InnovaPOS\
-        \ revolutionise the vending machine industry\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/ims-evolve-adopts-ubuntu-core-to-provide-iot-enabled-business-intelligence-in-the-supply-chain/17284\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"IMS Evolve adopts Ubuntu\
-        \ Core to provide IoT-enabled business intelligence in the supply chain\"\
-        ,\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/commercetools-uses-ubuntu-server-to-power-its-next-generation-ecommerce-platform/17283\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Commercetools uses Ubuntu\
-        \ Server to power its next-generation ecommerce platform\",\"clicks\":0},{\"\
-        url\":\"https://discourse.ubuntu.com/t/city-network-brings-openstack-cloud-hosting-to-the-financial-services-sector-with-canonical/17282\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"City Network brings OpenStack\
-        \ cloud hosting to the financial services sector with Canonical\",\"clicks\"\
-        :0},{\"url\":\"https://discourse.ubuntu.com/t/cinergy-makes-significant-digital-signage-saving-with-screenly-pro-and-ubuntu-core/17281\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Cinergy makes significant\
-        \ digital signage saving with Screenly Pro and Ubuntu Core\",\"clicks\":0},{\"\
-        url\":\"https://discourse.ubuntu.com/t/azlogica-utilise-ubuntu-core-for-customised-iot-agricultural-solutions/17279\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"AZLOGICA utilise Ubuntu\
-        \ Core for customised IoT agricultural solutions\",\"clicks\":0},{\"url\"\
-        :\"https://discourse.ubuntu.com/t/azeti-uses-ubuntu-core-to-improve-deployment-and-security/17278\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Azeti uses Ubuntu Core\
-        \ to improve deployment and security\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/artificial-intelligence-machine-learning-and-ubuntu/17276\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Artificial intelligence,\
-        \ machine learning and Ubuntu\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/how-to-get-started-and-progress-with-an-ai-program/17245\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"How to get started and\
-        \ progress with an AI program\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/connected-cars-and-autonomous-driving/17243\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Connected cars and autonomous\
-        \ driving\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/six-reasons-why-developers-choose-ubuntu-desktop/17304\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Six reasons why developers\
-        \ choose Ubuntu Desktop\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/9-out-of-top-10-us-european-financial-institutions-use-ubuntu/19304\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"9 out of top 10 US \\\
-        u0026 European financial institutions use Ubuntu\",\"clicks\":0},{\"url\"\
-        :\"https://assets.ubuntu.com/v1/7757c907-ubuntu-masters-logo-wht.svg\",\"\
-        internal\":false,\"reflection\":false,\"title\":\"7757c907-ubuntu-masters-logo-wht.svg\"\
-        ,\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/guide-pour-reussir-ladoption-et-le-deploiement-dopenstack/19361\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Guide pour r\xE9ussir\
-        \ l'adoption et le d\xE9ploiement d'OpenStack\",\"clicks\":0},{\"url\":\"\
-        https://discourse.ubuntu.com/t/funf-strategien-zur-beschleunigung-von-kubernetes-in-unternehmen/19284\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"F\xFCnf Strategien zur\
-        \ Beschleunigung von Kubernetes in Unternehmen\",\"clicks\":0},{\"url\":\"\
-        https://discourse.ubuntu.com/t/vergleich-von-red-hat-openstack-platform-und-charmed-openstack-von-canonical/19285\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Vergleich von Red Hat\
-        \ OpenStack Platform und Charmed OpenStack von Canonical\",\"clicks\":0},{\"\
-        url\":\"https://discourse.ubuntu.com/t/comparando-la-plataforma-openstack-de-red-hat-y-la-charmed-openstack-de-canonical/19194\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Comparando la plataforma\
-        \ OpenStack de Red Hat y la Charmed OpenStack de Canonical\",\"clicks\":0},{\"\
-        url\":\"https://discourse.ubuntu.com/t/at-t-private-offer-on-azure-ubuntu-pro-support/19161\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"AT\\u0026T Private Offer\
-        \ on Azure - Ubuntu Pro + Support\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/charmed-openstack-reference-architecture/19160\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Charmed OpenStack reference\
-        \ architecture\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/charmed-kubernetes-reference-architecture/19159\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Charmed Kubernetes reference\
-        \ architecture\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/migrer-de-vmware-a-openstack-webinaire/17420\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Migrer de VMware \xE0\
-        \ Openstack Webinaire\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/migrer-de-vmware-a-openstack/17417\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Migrer de VMWare \xE0\
-        \ OpenStack\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/canonical-annonce-managed-apps-linfogerance-des-applications-sur-votre-cloud/17416\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Canonical annonce Managed\
-        \ Apps: l'infog\xE9rance des applications sur votre cloud\",\"clicks\":0},{\"\
-        url\":\"https://discourse.ubuntu.com/t/guide-du-dsi-pour-les-operations-multicloud/17415\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"GUIDE DU DSI pour les\
-        \ op\xE9rations multicloud\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/canonical-integre-containerd-a-ubuntu-kubernetes/17412\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Canonical int\xE8gre containerd\
-        \ \xE0 Ubuntu Kubernetes\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/optimised-authentication-methods-for-ubuntu-desktop/19133\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Optimised authentication\
-        \ methods for Ubuntu Desktop\",\"clicks\":0},{\"url\":\"https://assets.ubuntu.com/v1/dcb2963c-openstack+cloud+outlines.svg\"\
-        ,\"internal\":false,\"reflection\":false,\"title\":\"dcb2963c-openstack+cloud+outlines.svg\"\
-        ,\"clicks\":0},{\"url\":\"https://assets.ubuntu.com/v1/35515576-openstack-cloud.svg\"\
-        ,\"internal\":false,\"reflection\":false,\"title\":\"35515576-openstack-cloud.svg\"\
-        ,\"clicks\":0},{\"url\":\"https://assets.ubuntu.com/v1/2acca081-choosingacloud-white.svg\"\
-        ,\"internal\":false,\"reflection\":false,\"title\":\"2acca081-choosingacloud-white.svg\"\
-        ,\"clicks\":0},{\"url\":\"https://assets.ubuntu.com/v1/469b4b31-Trilio-openstack-canonical.svg\"\
-        ,\"internal\":false,\"reflection\":false,\"title\":\"469b4b31-Trilio-openstack-canonical.svg\"\
-        ,\"clicks\":0},{\"url\":\"https://www.brighttalk.com/webcast/6793/432536?utm_source=Takeover\"\
-        ,\"internal\":false,\"reflection\":false,\"clicks\":0},{\"url\":\"https://assets.ubuntu.com/v1/b576398c-compliance-wht.svg\"\
-        ,\"internal\":false,\"reflection\":false,\"title\":\"b576398c-compliance-wht.svg\"\
-        ,\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/how-to-add-engage-pages/18185\"\
-        ,\"internal\":true,\"reflection\":true,\"title\":\"How to add engage pages\"\
-        ,\"clicks\":4}],\"read\":true,\"user_title\":null,\"actions_summary\":[],\"\
-        moderator\":false,\"admin\":true,\"staff\":true,\"user_id\":320,\"hidden\"\
-        :false,\"trust_level\":2,\"deleted_at\":null,\"user_deleted\":false,\"edit_reason\"\
-        :null,\"can_view_edit_history\":true,\"wiki\":false,\"can_accept_answer\"\
-        :false,\"can_unaccept_answer\":false,\"accepted_answer\":false}],\"stream\"\
-        :[48547]},\"timeline_lookup\":[[1,128]],\"suggested_topics\":[{\"id\":17306,\"\
-        title\":\"The transformation of the DevOps journey in IoT Webinar\",\"fancy_title\"\
-        :\"The transformation of the DevOps journey in IoT Webinar\",\"slug\":\"the-transformation-of-the-devops-journey-in-iot-webinar\"\
-        ,\"posts_count\":1,\"reply_count\":0,\"highest_post_number\":1,\"image_url\"\
-        :null,\"created_at\":\"2020-07-17T12:27:22.792Z\",\"last_posted_at\":\"2020-07-17T12:27:22.947Z\"\
-        ,\"bumped\":true,\"bumped_at\":\"2020-07-17T16:56:51.056Z\",\"unseen\":false,\"\
-        pinned\":false,\"unpinned\":null,\"visible\":true,\"closed\":false,\"archived\"\
-        :false,\"bookmarked\":null,\"liked\":null,\"tags\":[],\"archetype\":\"regular\"\
-        ,\"like_count\":0,\"views\":117,\"category_id\":51,\"featured_link\":null,\"\
-        has_accepted_answer\":false,\"posters\":[{\"extras\":\"latest single\",\"\
-        description\":\"Original Poster, Most Recent Poster\",\"user\":{\"id\":320,\"\
-        username\":\"peterm-ubuntu\",\"name\":\"Peter Mahnke\",\"avatar_template\"\
-        :\"/user_avatar/discourse.ubuntu.com/peterm-ubuntu/{size}/7873_2.png\"}}]},{\"\
-        id\":17332,\"title\":\"Make IT rain: public cloud on Ubuntu OpenStack\",\"\
-        fancy_title\":\"Make IT rain: public cloud on Ubuntu OpenStack\",\"slug\"\
-        :\"make-it-rain-public-cloud-on-ubuntu-openstack\",\"posts_count\":1,\"reply_count\"\
-        :0,\"highest_post_number\":1,\"image_url\":null,\"created_at\":\"2020-07-17T13:03:03.490Z\"\
-        ,\"last_posted_at\":\"2020-07-17T13:03:03.626Z\",\"bumped\":true,\"bumped_at\"\
-        :\"2020-07-17T13:03:03.626Z\",\"unseen\":false,\"pinned\":false,\"unpinned\"\
-        :null,\"visible\":true,\"closed\":false,\"archived\":false,\"bookmarked\"\
-        :null,\"liked\":null,\"tags\":[],\"archetype\":\"regular\",\"like_count\"\
-        :0,\"views\":125,\"category_id\":51,\"featured_link\":null,\"has_accepted_answer\"\
-        :false,\"posters\":[{\"extras\":\"latest single\",\"description\":\"Original\
-        \ Poster, Most Recent Poster\",\"user\":{\"id\":11720,\"username\":\"owenrm\"\
-        ,\"name\":\"Owenrm\",\"avatar_template\":\"/letter_avatar/owenrm/{size}/5_6d6f4cde2641c35611d5cac2fb97c77e.png\"\
-        }}]},{\"id\":17244,\"title\":\"Busting the myth of private cloud economics\"\
-        ,\"fancy_title\":\"Busting the myth of private cloud economics\",\"slug\"\
-        :\"busting-the-myth-of-private-cloud-economics\",\"posts_count\":1,\"reply_count\"\
-        :0,\"highest_post_number\":1,\"image_url\":null,\"created_at\":\"2020-07-15T09:07:34.144Z\"\
-        ,\"last_posted_at\":\"2020-07-15T09:07:34.394Z\",\"bumped\":true,\"bumped_at\"\
-        :\"2020-07-17T10:23:30.186Z\",\"unseen\":false,\"pinned\":false,\"unpinned\"\
-        :null,\"visible\":true,\"closed\":false,\"archived\":false,\"bookmarked\"\
-        :null,\"liked\":null,\"tags\":[],\"archetype\":\"regular\",\"like_count\"\
-        :0,\"views\":156,\"category_id\":51,\"featured_link\":null,\"has_accepted_answer\"\
-        :false,\"posters\":[{\"extras\":\"latest single\",\"description\":\"Original\
-        \ Poster, Most Recent Poster\",\"user\":{\"id\":11720,\"username\":\"owenrm\"\
-        ,\"name\":\"Owenrm\",\"avatar_template\":\"/letter_avatar/owenrm/{size}/5_6d6f4cde2641c35611d5cac2fb97c77e.png\"\
-        }}]},{\"id\":17276,\"title\":\"Artificial intelligence, machine learning and\
-        \ Ubuntu\",\"fancy_title\":\"Artificial intelligence, machine learning and\
-        \ Ubuntu\",\"slug\":\"artificial-intelligence-machine-learning-and-ubuntu\"\
-        ,\"posts_count\":1,\"reply_count\":0,\"highest_post_number\":1,\"image_url\"\
-        :null,\"created_at\":\"2020-07-17T10:25:55.722Z\",\"last_posted_at\":\"2020-07-17T10:25:55.868Z\"\
-        ,\"bumped\":true,\"bumped_at\":\"2020-07-17T10:25:55.868Z\",\"unseen\":false,\"\
-        pinned\":false,\"unpinned\":null,\"visible\":true,\"closed\":false,\"archived\"\
-        :false,\"bookmarked\":null,\"liked\":null,\"tags\":[],\"archetype\":\"regular\"\
-        ,\"like_count\":0,\"views\":139,\"category_id\":51,\"featured_link\":null,\"\
-        has_accepted_answer\":false,\"posters\":[{\"extras\":\"latest single\",\"\
-        description\":\"Original Poster, Most Recent Poster\",\"user\":{\"id\":11720,\"\
-        username\":\"owenrm\",\"name\":\"Owenrm\",\"avatar_template\":\"/letter_avatar/owenrm/{size}/5_6d6f4cde2641c35611d5cac2fb97c77e.png\"\
-        }}]},{\"id\":18159,\"title\":\"Comparing Red Hat OpenStack Platform and Canonical's\
-        \ Charmed OpenStack\",\"fancy_title\":\"Comparing Red Hat OpenStack Platform\
-        \ and Canonical\\u0026rsquo;s Charmed OpenStack\",\"slug\":\"comparing-red-hat-openstack-platform-and-canonicals-charmed-openstack\"\
-        ,\"posts_count\":1,\"reply_count\":0,\"highest_post_number\":1,\"image_url\"\
-        :null,\"created_at\":\"2020-09-04T15:54:39.187Z\",\"last_posted_at\":\"2020-09-04T15:54:39.319Z\"\
-        ,\"bumped\":true,\"bumped_at\":\"2020-09-04T16:22:44.182Z\",\"unseen\":false,\"\
-        pinned\":false,\"unpinned\":null,\"visible\":true,\"closed\":false,\"archived\"\
-        :false,\"bookmarked\":null,\"liked\":null,\"tags\":[],\"archetype\":\"regular\"\
-        ,\"like_count\":0,\"views\":146,\"category_id\":51,\"featured_link\":null,\"\
-        has_accepted_answer\":false,\"posters\":[{\"extras\":\"latest single\",\"\
-        description\":\"Original Poster, Most Recent Poster\",\"user\":{\"id\":9642,\"\
-        username\":\"carkod\",\"name\":\"Carlos Wu Fei\",\"avatar_template\":\"/letter_avatar/carkod/{size}/5_6d6f4cde2641c35611d5cac2fb97c77e.png\"\
-        }}]}],\"tags\":[],\"id\":17229,\"title\":\"Engage pages and Takeovers\",\"\
-        fancy_title\":\"Engage pages and Takeovers\",\"posts_count\":1,\"created_at\"\
-        :\"2020-07-14T09:57:15.561Z\",\"views\":350,\"reply_count\":0,\"like_count\"\
-        :0,\"last_posted_at\":null,\"visible\":true,\"closed\":false,\"archived\"\
-        :false,\"has_summary\":false,\"archetype\":\"regular\",\"slug\":\"engage-pages-and-takeovers\"\
-        ,\"category_id\":51,\"word_count\":7985,\"deleted_at\":null,\"user_id\":320,\"\
-        featured_link\":null,\"pinned_globally\":false,\"pinned_at\":\"2020-07-14T09:57:15.469Z\"\
-        ,\"pinned_until\":null,\"draft\":null,\"draft_key\":\"topic_17229\",\"draft_sequence\"\
-        :null,\"unpinned\":null,\"pinned\":true,\"current_post_number\":1,\"highest_post_number\"\
-        :1,\"deleted_by\":null,\"actions_summary\":[{\"id\":4,\"count\":0,\"hidden\"\
-        :false,\"can_act\":false},{\"id\":8,\"count\":0,\"hidden\":false,\"can_act\"\
-        :false},{\"id\":7,\"count\":0,\"hidden\":false,\"can_act\":false}],\"chunk_size\"\
-        :20,\"bookmarked\":null,\"topic_timer\":null,\"message_bus_last_id\":227,\"\
-        participant_count\":1,\"details\":{\"notification_level\":1,\"participants\"\
-        :[{\"id\":320,\"username\":\"peterm-ubuntu\",\"name\":\"Peter Mahnke\",\"\
-        avatar_template\":\"/user_avatar/discourse.ubuntu.com/peterm-ubuntu/{size}/7873_2.png\"\
-        ,\"post_count\":1,\"primary_group_name\":\"Canonical\",\"primary_group_flair_url\"\
-        :\"https://launchpadlibrarian.net/68730579/64.png\",\"primary_group_flair_color\"\
-        :\"\",\"primary_group_flair_bg_color\":\"\"}],\"created_by\":{\"id\":320,\"\
-        username\":\"peterm-ubuntu\",\"name\":\"Peter Mahnke\",\"avatar_template\"\
-        :\"/user_avatar/discourse.ubuntu.com/peterm-ubuntu/{size}/7873_2.png\"},\"\
-        last_poster\":{\"id\":320,\"username\":\"peterm-ubuntu\",\"name\":\"Peter\
-        \ Mahnke\",\"avatar_template\":\"/user_avatar/discourse.ubuntu.com/peterm-ubuntu/{size}/7873_2.png\"\
-        },\"links\":[{\"url\":\"https://ubuntu.com/engage\",\"title\":\"Ubuntu case\
-        \ studies, whitepapers and webinars | Ubuntu\",\"internal\":false,\"attachment\"\
-        :false,\"reflection\":false,\"clicks\":5,\"user_id\":320,\"domain\":\"ubuntu.com\"\
-        ,\"root_domain\":\"ubuntu.com\"},{\"url\":\"https://discourse.ubuntu.com/t/how-to-add-engage-pages/18185\"\
-        ,\"title\":\"How to add engage pages\",\"internal\":true,\"attachment\":false,\"\
-        reflection\":true,\"clicks\":4,\"user_id\":9642,\"domain\":\"discourse.ubuntu.com\"\
-        ,\"root_domain\":\"ubuntu.com\"},{\"url\":\"https://discourse.ubuntu.com/t/do-vmware-ao-charmed-openstack/18165\"\
-        ,\"title\":\"Do VMware ao Charmed OpenStack\",\"internal\":true,\"attachment\"\
-        :false,\"reflection\":false,\"clicks\":3,\"user_id\":320,\"domain\":\"discourse.ubuntu.com\"\
-        ,\"root_domain\":\"ubuntu.com\"},{\"url\":\"https://discourse.ubuntu.com/t/five-strategies-to-accelerate-kubernetes-deployment-in-the-enterprise/18161\"\
-        ,\"title\":\"Five strategies to accelerate Kubernetes deployment in the enterprise\"\
-        ,\"internal\":true,\"attachment\":false,\"reflection\":false,\"clicks\":2,\"\
-        user_id\":320,\"domain\":\"discourse.ubuntu.com\",\"root_domain\":\"ubuntu.com\"\
-        },{\"url\":\"https://discourse.ubuntu.com/t/openstack-deployment-guide/17384\"\
-        ,\"title\":\"OpenStack deployment guide\",\"internal\":true,\"attachment\"\
-        :false,\"reflection\":false,\"clicks\":2,\"user_id\":320,\"domain\":\"discourse.ubuntu.com\"\
-        ,\"root_domain\":\"ubuntu.com\"},{\"url\":\"https://discourse.ubuntu.com/t/cloud-gaming-for-android/18757\"\
-        ,\"title\":\"Cloud gaming for Android\",\"internal\":true,\"attachment\":false,\"\
-        reflection\":false,\"clicks\":1,\"user_id\":320,\"domain\":\"discourse.ubuntu.com\"\
-        ,\"root_domain\":\"ubuntu.com\"},{\"url\":\"https://discourse.ubuntu.com/t/confronto-fra-red-hats-openstack-platform-e-charmed-openstack-di-canaonical/19362\"\
-        ,\"title\":\"Confronto fra \\\"Red Hat's Openstack platform\\\" e Charmed\
-        \ Openstack di Canaonical\",\"internal\":true,\"attachment\":false,\"reflection\"\
-        :false,\"clicks\":1,\"user_id\":320,\"domain\":\"discourse.ubuntu.com\",\"\
-        root_domain\":\"ubuntu.com\"},{\"url\":\"https://discourse.ubuntu.com/t/da-vmware-a-openstack/18164\"\
-        ,\"title\":\"Da VMware a OpenStack\",\"internal\":true,\"attachment\":false,\"\
-        reflection\":false,\"clicks\":1,\"user_id\":320,\"domain\":\"discourse.ubuntu.com\"\
-        ,\"root_domain\":\"ubuntu.com\"},{\"url\":\"https://discourse.ubuntu.com/t/extension-securite-et-maintenance-pour-ubuntu-14-04/17414\"\
-        ,\"title\":\"Extension S\xE9curit\xE9 et Maintenance pour Ubuntu 14.04\",\"\
-        internal\":true,\"attachment\":false,\"reflection\":false,\"clicks\":1,\"\
-        user_id\":320,\"domain\":\"discourse.ubuntu.com\",\"root_domain\":\"ubuntu.com\"\
-        },{\"url\":\"https://assets.ubuntu.com/v1/1899df43-ubuntu-advantage-circular_white.svg\"\
-        ,\"title\":\"1899df43-ubuntu-advantage-circular_white.svg\",\"internal\":false,\"\
-        attachment\":false,\"reflection\":false,\"clicks\":1,\"user_id\":320,\"domain\"\
-        :\"assets.ubuntu.com\",\"root_domain\":\"ubuntu.com\"},{\"url\":\"https://discourse.ubuntu.com/t/how-to-build-and-deploy-your-first-ai-ml-model-on-ubuntu/17294\"\
-        ,\"title\":\"How to build and deploy your first AI/ML model on Ubuntu\",\"\
-        internal\":true,\"attachment\":false,\"reflection\":false,\"clicks\":1,\"\
-        user_id\":320,\"domain\":\"discourse.ubuntu.com\",\"root_domain\":\"ubuntu.com\"\
-        },{\"url\":\"https://discourse.ubuntu.com/t/how-to-face-the-challenges-of-becoming-a-cloud-operator/17290\"\
-        ,\"title\":\"How to face the challenges of becoming a cloud operator\",\"\
-        internal\":true,\"attachment\":false,\"reflection\":false,\"clicks\":1,\"\
-        user_id\":320,\"domain\":\"discourse.ubuntu.com\",\"root_domain\":\"ubuntu.com\"\
-        },{\"url\":\"https://discourse.ubuntu.com/t/keep-up-with-evolving-software/17310\"\
-        ,\"title\":\"Keep up with evolving software\",\"internal\":true,\"attachment\"\
-        :false,\"reflection\":false,\"clicks\":1,\"user_id\":320,\"domain\":\"discourse.ubuntu.com\"\
-        ,\"root_domain\":\"ubuntu.com\"},{\"url\":\"https://discourse.ubuntu.com/t/kubernetes-from-cloud-to-edge/17398\"\
-        ,\"title\":\"Kubernetes from Cloud to Edge\",\"internal\":true,\"attachment\"\
-        :false,\"reflection\":false,\"clicks\":1,\"user_id\":320,\"domain\":\"discourse.ubuntu.com\"\
-        ,\"root_domain\":\"ubuntu.com\"},{\"url\":\"https://discourse.ubuntu.com/t/openstack-problemlos-installieren-und-skalieren/17409\"\
-        ,\"title\":\"OpenStack problemlos installieren und skalieren\",\"internal\"\
-        :true,\"attachment\":false,\"reflection\":false,\"clicks\":1,\"user_id\":320,\"\
-        domain\":\"discourse.ubuntu.com\",\"root_domain\":\"ubuntu.com\"},{\"url\"\
-        :\"https://discourse.ubuntu.com/t/sensape-uses-landscape-to-remotely-support-revolutionary-interactive-retail-displays/17289\"\
-        ,\"title\":\"Sensape uses Landscape to remotely support revolutionary interactive\
-        \ retail displays\",\"internal\":true,\"attachment\":false,\"reflection\"\
-        :false,\"clicks\":1,\"user_id\":320,\"domain\":\"discourse.ubuntu.com\",\"\
-        root_domain\":\"ubuntu.com\"},{\"url\":\"https://discourse.ubuntu.com/t/transforming-telco-infrastructure-a-virtual-event/18162\"\
-        ,\"title\":\"Transforming telco infrastructure: A virtual event\",\"internal\"\
-        :true,\"attachment\":false,\"reflection\":false,\"clicks\":1,\"user_id\":320,\"\
-        domain\":\"discourse.ubuntu.com\",\"root_domain\":\"ubuntu.com\"},{\"url\"\
-        :\"https://discourse.ubuntu.com/t/ubuntu-20-10-what-s-new/19050\",\"title\"\
-        :\"Ubuntu 20.10: What\u2019s new?\",\"internal\":true,\"attachment\":false,\"\
-        reflection\":false,\"clicks\":1,\"user_id\":320,\"domain\":\"discourse.ubuntu.com\"\
-        ,\"root_domain\":\"ubuntu.com\"},{\"url\":\"https://discourse.ubuntu.com/t/whats-new-in-ubuntu-19-04/17240\"\
-        ,\"title\":\"What's new in Ubuntu 19.04?\",\"internal\":true,\"attachment\"\
-        :false,\"reflection\":false,\"clicks\":1,\"user_id\":320,\"domain\":\"discourse.ubuntu.com\"\
-        ,\"root_domain\":\"ubuntu.com\"},{\"url\":\"https://discourse.ubuntu.com/t/botsandus-builds-a-social-robot-on-ubuntu/17280\"\
-        ,\"title\":\"BotsAndUs builds a social robot on Ubuntu\",\"internal\":true,\"\
-        attachment\":false,\"reflection\":false,\"clicks\":1,\"user_id\":320,\"domain\"\
-        :\"discourse.ubuntu.com\",\"root_domain\":\"ubuntu.com\"},{\"url\":\"https://discourse.ubuntu.com/t/an-introduction-to-apparmor/17277\"\
-        ,\"title\":\"An introduction to AppArmor\",\"internal\":true,\"attachment\"\
-        :false,\"reflection\":false,\"clicks\":1,\"user_id\":320,\"domain\":\"discourse.ubuntu.com\"\
-        ,\"root_domain\":\"ubuntu.com\"},{\"url\":\"https://discourse.ubuntu.com/t/cinco-estrategias-para-acelerar-a-los-kubernetes-en-la-empresa/19208\"\
-        ,\"title\":\"Cinco estrategias para acelerar a los Kubernetes en la empresa\"\
-        ,\"internal\":true,\"attachment\":false,\"reflection\":false,\"clicks\":1,\"\
-        user_id\":320,\"domain\":\"discourse.ubuntu.com\",\"root_domain\":\"ubuntu.com\"\
-        },{\"url\":\"https://discourse.ubuntu.com/t/cinque-strategie-per-accelerare-limplementazione-di-kubernetes-nellimpresa/19381\"\
-        ,\"title\":\"Cinque strategie per accelerare l'implementazione di Kubernetes\
-        \ nell'impresa\",\"internal\":true,\"attachment\":false,\"reflection\":false,\"\
-        clicks\":1,\"user_id\":320,\"domain\":\"discourse.ubuntu.com\",\"root_domain\"\
-        :\"ubuntu.com\"}]}}"
+      string: "{\"post_stream\":{\"posts\":[{\"id\":50258,\"name\":\"Carlos Wu Fei\",\"username\":\"carkod\",\"avatar_template\":\"/letter_avatar/carkod/{size}/5_6d6f4cde2641c35611d5cac2fb97c77e.png\",\"created_at\":\"2020-08-25T11:17:26.382Z\",\"cooked\":\"\\u003ch1\\u003eEngage
+        pages\\u003c/h1\\u003e\\n\\u003cp\\u003eThe content of topics in this category
+        are displayed at \\u003ca href=\\\"https://ubuntu.com/engage\\\"\\u003ehttps://ubuntu.com/engage\\u003c/a\\u003e.\\u003c/p\\u003e\\n\\u003ch2\\u003eMetadata\\u003c/h2\\u003e\\n\\u003cdetails\\u003e\\n\\u003csummary\\u003e\\nMapping
+        table\\u003c/summary\\u003e\\n\\u003cdiv class=\\\"md-table\\\"\\u003e\\n\\u003ctable\\u003e\\n\\u003cthead\\u003e\\n\\u003ctr\\u003e\\n\\u003cth\\u003etopic\\u003c/th\\u003e\\n\\u003cth\\u003epath\\u003c/th\\u003e\\n\\u003cth\\u003etype\\u003c/th\\u003e\\n\\u003cth\\u003etags\\u003c/th\\u003e\\n\\u003cth\\u003epublish_date\\u003c/th\\u003e\\n\\u003cth\\u003elanguage\\u003c/th\\u003e\\n\\u003cth\\u003esubtitle\\u003c/th\\u003e\\n\\u003cth\\u003eactive\\u003c/th\\u003e\\n\\u003c/tr\\u003e\\n\\u003c/thead\\u003e\\n\\u003ctbody\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/embedded-kubernetes-for-secure-iot-edge/25635\\\"\\u003eEmbedded
+        Kubernetes for secure IoT Edge\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/embedded-kubernetes-for-secure-iot-edge-webinar\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar,
+        internet of things, ubuntu core, embedded\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-12-06\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eMicroK8s
+        on Ubuntu Core\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/bare-metal-provisioning-what-s-new-in-maas-3-1/25607\\\"\\u003eBare
+        metal provisioning: What\u2019s new in MAAS 3.1?\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/maas-whats-new-3-1\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eMaas,
+        bare metal, bare metal cloud, bare metal provisioning\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-12-03\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eThe
+        latest and greatest news about bare metal provisioning with MAAS\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/evaluating-microsoft-sql-server-options-for-azure/25594\\\"\\u003eEvaluating
+        Microsoft SQL Server Options for Azure\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/Evaluating-MSFT-SQL-Server-whitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eManaged
+        Apps\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-12-01\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eThis
+        white paper provides an in-depth examination of the most popular approaches
+        to running SQL Server on Azure, including SQL Server on Ubuntu Pro for Azure.\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/migrating-to-ubuntu-lts-six-facts-for-centos-users/25585\\\"\\u003eMigrating
+        to Ubuntu LTS: six facts for CentOS users\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/migrating-to-ubuntu-lts-six-facts-for-centos-users\\u003c/td\\u003e\\n\\u003ctd\\u003etakeover
+        only\\u003c/td\\u003e\\n\\u003ctd\\u003ecentos , Compliance , developers ,
+        hpc , livepatch , Migration , Open source , OpenStack , Security , Support\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eConsidering
+        migrating to Ubuntu from other Linux platforms, such as CentOS?\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/how-to-increase-developer-productivity-with-ubuntu-desktop/25426\\\"\\u003eHow
+        to increase developer productivity with Ubuntu Desktop\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/developer-desktop-productivity-whitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eubuntu,
+        desktop, enterprise, ubuntu advantage,\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-11-23\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eA
+        guide for CTOs, IT managers and sysadmins\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/nfv-orchestration-for-open-source-telco-integrating-and-managing-open-source-network-functions/25422\\\"\\u003eNFV
+        Orchestration For Open Source Telco\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/nfv-management-and-orchestration-charmed-open-source-mano\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eosm,
+        gsi, cloud, open source, orchestration\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eIntegrating
+        And Managing Open Source Network Functions\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/ubuntu-pro-no-microsoft-azure/25392\\\"\\u003eUbuntu
+        Pro em Azure\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/ubuntu-pro-azure-webinar-Portuguese\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eManaged
+        Apps, cloud, pro\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-10-29\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eExplore
+        recursos como seguran\xE7a estendida, conformidade certificada e prote\xE7\xE3o
+        para Ubuntu Pro em Azure.\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/docker-ros-when-all-you-have-is-a-hammer-everything-looks-like-a-nail/25389\\\"\\u003eDocker
+        \\u0026amp; ROS: When all you have is a hammer, everything looks like a nail\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/dockerandros\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003erobotics,
+        whitepaper, iot\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-11-22\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eKey
+        Docker limitations for ROS and the snap alternative\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/ubunto-pro-en-azure-sp-wbn/25388\\\"\\u003eUbunto
+        Pro en Azure \\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/ubuntu-pro-azure-webinar-spanish\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eManaged
+        Apps, cloud, pro\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-10-29\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eExplora
+        caracter\xEDsticas como seguridad extendida, cumplimiento certificado y refuerzo
+        para Ubuntu Pro en Azure.\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/introducing-sql-server-on-ubuntu-pro-for-azure-part-2/25350\\\"\\u003eIntroducing
+        SQL Server on Ubuntu Pro for Azure Part 2\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/SQLServerWebinarPart2\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eManaged
+        Apps, SQL\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-10-29\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eIn
+        this talk will deep dive on the anatomy of the performance features of SQL
+        Server on Ubuntu Pro and setting up AD.\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/webinar-building-cost-efficient-open-source-cloud-operations/25347\\\"\\u003eBuilding
+        cost-efficient open source cloud operations\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/cost-efficient-open-source-cloud-operations\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eManaged
+        IT Services, Managed Cloud Services, OpenStack, Kubernetes, Ceph\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/nayatel-builds-public-cloud-service-with-charmed-openstack/25331\\\"\\u003eNayatel
+        builds public cloud service with Charmed OpenStack\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/nayatel-casestudy-charmed-openstack\\u003c/td\\u003e\\n\\u003ctd\\u003ecase
+        study\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eLearn
+        how Nayatel partnered with Canonical to build Pakistan\u2019s first cost-effective
+        enterprise-grade public cloud\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/ceph-for-enterprise/25305\\\"\\u003eCeph
+        for Enterprise\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/enterprise-ceph\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eceph,
+        managed services\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eThe
+        best open-source enterprise storage solution\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/getting-started-with-shells-custom-ubuntu-pro-image-on-azure/25267\\\"\\u003eGetting
+        started with Shell\u2019s custom Ubuntu Pro image on Azure\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/ShellOnboarding\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eAzure,
+        Ubuntu Pro, Security\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-11-15\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eIn
+        this technical video you\u2019ll learn how to get started with Shell\u2019s
+        custom images of Ubuntu Pro with Support on Azure.\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/introducing-sql-server-on-ubuntu-pro-for-azure-part-1/25193\\\"\\u003eIntroducing
+        SQL Server on Ubuntu Pro for Azure Part 1\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/SQLServerWebinarPart1\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eManaged
+        Apps, SQL\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-10-29\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eIn
+        this talk we will introduce SQL Server on Ubuntu Pro for Azure and deep dive
+        on patching regimes and high availability clustering for SQL Server on Ubuntu
+        Pro.\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/microk8s-on-z-minimal-footprint-meets-zero-downtime/25183\\\"\\u003eMicroK8s
+        on IBM Z \u2014 minimal footprint meets zero downtime\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/webinar-microk8s-on-z\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003emicrok8s,
+        kubernetes, ibm\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-11-09\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eA
+        low-ops, minimal production Kubernetes on Ubuntu for your IBM Z / LinuxONE
+        system.\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/finserv-it-infrastructure-migrating-from-vmware-to-openstack/25179\\\"\\u003eFinserv
+        IT infrastructure: Migrating from VMWare to OpenStack\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/finserv-vmware-to-openstack\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eCIOs\u2019
+        guide to migrating your private cloud infrastructure to a more cost effective
+        solution\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/ubuntu/25158\\\"\\u003e\u958B\u767C\u8005\u9078\u64C7Ubuntu\u7684\u516D\u5927\u7406\u7531\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/developer-desktop-tw\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003edesktop,
+        ubuntu\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-11-08\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\u6700\u6D41\u884C\u7684linux
+        os \u64CD\u4F5C\u7CFB\u7D71\uFF0C\u9078\u64C7Ubuntu\u7684\u516D\u5927\u7406\u7531\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/ceph-in-the-modern-data-center/25046\\\"\\u003eCeph
+        in the modern data center\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/webinar-ceph-modern-data-center\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eceph,
+        storage, poweredge\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-11-18\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eManage
+        exponential data growth with Canonical Charmed Ceph and Dell PowerEdge Servers\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/telecom-infrastructure-the-open-source-way/25038\\\"\\u003eTelecom
+        infrastructure the open source way\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/open-source-telco-infrastructure-whitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003etelco,
+        telecommunications, 5G, cloud\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-10-02\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eAutomated,
+        secure and cloud native telco\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/cybersecurity-compliance-with-ubuntu/24933\\\"\\u003eCybersecurity
+        and Compliance with Ubuntu\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/ubuntu-cybersecurity-webinar\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003ecybersecurity\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-10-28\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eJoin
+        the live webinar\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/atresmedia-domina-il-mercato-spagnolo-dei-media-ott-con-larchitettura-di-microservizi-charmed-kubernetes/24897\\\"\\u003eAtresmedia
+        domina il mercato spagnolo dei media OTT con l\u2019architettura di microservizi
+        Charmed Kubernetes\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/it/atresmedia-charmed-kubernetes-case-study\\u003c/td\\u003e\\n\\u003ctd\\u003ecase
+        study\\u003c/td\\u003e\\n\\u003ctd\\u003eKubernetes, K8s\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-10-27\\u003c/td\\u003e\\n\\u003ctd\\u003eit\\u003c/td\\u003e\\n\\u003ctd\\u003eCome
+        l\u2019azienda ha ottenuto un\u2019alta disponibilit\xE0 e una produttivit\xE0
+        senza precedenti\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/secure-ai-models-deployment-at-the-edge-with-openvino-on-ubuntu-containers/24894\\\"\\u003eSecure
+        AI models deployment at the edge with OpenVINO on Ubuntu containers\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/webinar-ai-containers-edge-deployment\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar,
+        containers, AI,\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-10-27\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eJoin
+        Intel and Canonical for a webinar on Nov. 17\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/smartdrone-fast-tracks-drone-infrastructure-revolution-with-ubuntu-core/24821\\\"\\u003eSmartDrone
+        fast-tracks drone infrastructure revolution with Ubuntu Core\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/drone-infrastructure-case-study-smartdrone\\u003c/td\\u003e\\n\\u003ctd\\u003ecase
+        study\\u003c/td\\u003e\\n\\u003ctd\\u003erobotics, case study, iot\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-10-25\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/ubuntu-16-04-lts-verso-la-manutenzione-estesa-della-sicurezza/24781\\\"\\u003eUbuntu
+        16.04 LTS verso la Manutenzione Estesa della Sicurezza\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/ubuntu-16.04-esm-webinar\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eesm,
+        ubuntu 16.04, ubuntu lts\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eit\\u003c/td\\u003e\\n\\u003ctd\\u003eSei
+        aspetti da considerare nella pianificazione della migrazione\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/openstack-upgrades-with-minimal-downtime/24756\\\"\\u003eOpenStack
+        Upgrades with Minimal Downtime\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/openstack-upgrades-webinar\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack,
+        publiccloud\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/architecting-price-performance-private-cloud/24721\\\"\\u003eArchitecting
+        price-performance Private Cloud\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/architecting-price-performance-private-cloud\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack,
+        privatecloud\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eLearn
+        how to build the most cost-efficient private cloud infrastructure using open
+        source technologies\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/7-approaches-to-accelerating-apache-kafka-on-k8s/24711\\\"\\u003e7
+        approaches to accelerating Apache Kafka on K8s\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/7-approaches-accelerating-kafka-whitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eManaged
+        Apps\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-08-31\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eIn
+        this white paper, we will review seven techniques that can help to reduce
+        latency in high volume, low criticality Kafka solutions running on Kubernetes.\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/ctos-guide-to-micro-clouds/24533\\\"\\u003eCTOs\u2019
+        Guide to Micro Clouds\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/CTO-guide-to-micro-clouds-2021\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eedge,
+        microclouds, edgecomputing\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eMicro
+        Clouds an Edge Computing Solution\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/workstations-on-the-ai-journey-deploying-your-model/24401\\\"\\u003eWorkstations
+        on the AI Journey - Deploying Your Model\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/webinar-ai-journey-deploying-your-model\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eworkstations,
+        AI, dell, webinar\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-10-12\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eIn
+        the fourth and final part of this webinar series, Canonical and Dell will
+        talk about inference engines deployment.\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/driving-robotics-innovation/24442\\\"\\u003eDriving
+        robotics innovation\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/rosworld2021\\u003c/td\\u003e\\n\\u003ctd\\u003eevent\\u003c/td\\u003e\\n\\u003ctd\\u003eevent\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-09-16\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eCanonical
+        \\u0026amp; Ubuntu at ROS World 2021\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/embedded-linux-make-or-buy-tw/24602\\\"\\u003e
+        \u5D4C\u5165\u5F0FLinux\uFF1A\u81EA\u88FD\u6216\u5916\u8CFC\uFF1F\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/embedded-linux-make-or-buy-tw\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eCore\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-10-13\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\u5169\u96E3\u7684\u9078\u64C7\uFF1A\u5546\u696D\u652F\u63F4VS\u81EA\u7814\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/enterprise-kubernetes-use-cases-4-real-world-stories/24588\\\"\\u003eEnterprise
+        Kubernetes use cases: 4 real-world stories\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/kubernetes-use-cases-webinar\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eK8s,
+        Kubernetes\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-10-12\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eJoin
+        the live webinar\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/canonical-ubuntu-at-nvidia-gtc-2021/24671\\\"\\u003eCanonical
+        \\u0026amp; Ubuntu at Nvidia GTC 2021\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/gtc_nvidia_2021\\u003c/td\\u003e\\n\\u003ctd\\u003eevent\\u003c/td\\u003e\\n\\u003ctd\\u003eevent\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-10-15\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eJoin
+        us on November 8-11!\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/edge-kubernetes-what-s-brewing/24492\\\"\\u003eEdge
+        Kubernetes: what\u2019s brewing?\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/edge-kubernetes-coffee-webinar\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eK8s,
+        kubernetes, containerization, cloud\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-10-05\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/managed-it-services/24285\\\"\\u003eManaged
+        IT Services\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/managed-services-overcoming-cio-challenges-2021\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-09-17\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eHow
+        to build a strategic IT model that drives innovation while cutting down operational
+        costs\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/beat-disruption-white-paper/24237\\\"\\u003eBeat
+        disruption: how to adapt your IT strategy for changing markets\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/beat-disruption-wp\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eManaged
+        Apps\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-08-31\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eRead
+        our whitepaper to learn more about the fast changing modern business landscape
+        - cloud \\u0026amp; SaaS, agile, and outsourcing - and learn about a strategy
+        to help navigate through the jungle.\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/canonical-ubuntu-at-arm-dev-summit-2021/24204\\\"\\u003eCanonical
+        \\u0026amp; Ubuntu at ARM Dev Summit 2021\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/armdevsummit2021\\u003c/td\\u003e\\n\\u003ctd\\u003eevent\\u003c/td\\u003e\\n\\u003ctd\\u003eevent\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-09-16\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eJoin
+        us virtually on October 19-21, 2021\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/building-graphical-applications-in-embedded-devices/24167\\\"\\u003eBuilding
+        graphical applications in embedded devices\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/webinarintrotoframe\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003edigital
+        signage, mir, ubuntu frame\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-09-14\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eJoin
+        us for a webinar introducing Ubuntu Frame on November 3rd at 5pm BST and 12pm
+        ET\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/its-like-a-jungle-out-there-how-to-adapt-your-it-strategy-for-changing-markets/24077\\\"\\u003eIt\u2019s
+        like a jungle out there\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/adapt-your-it-strategy\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar
+        , Managed Apps\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-08-31\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eLearn
+        strategies to help you navigate the fast changing modern business landscape
+        - cloud and SaaS, agile and outsourcing\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/self-healing-kubernetes-at-the-edge-microk8s-raspberry-pis-and-portainer/24070\\\"\\u003eSelf-healing
+        Kubernetes at the edge: MicroK8s, Raspberry Pis and Portainer\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/self-healing-edge-kubernetes-webinar\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003ek8s,
+        kubernetes, edge, MicroK8s\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-09-97\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/atresmedia-domine-le-marche-des-medias-en-espagne-avec-l-architecture-de-microservices-charmed-kubernetes/24009\\\"\\u003eAtresmedia
+        domine le march\xE9 des m\xE9dia en Espagne avec l\u2019architecture de microservices
+        Charmed Kubernetes\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/fr/atresmedia-charmed-kubernetes\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003ekubernetes,
+        k8s\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-09-02\\u003c/td\\u003e\\n\\u003ctd\\u003efr\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/how-to-manage-risks-with-the-top-1-managed-service-providers/23983\\\"\\u003eHow
+        to manage risks with the top 1% Managed Service Providers\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/MSPAlliance-Canonical-Webinar\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar
+        , Managed Service\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-08-31\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eJoin
+        our webinar to learn more about Canonical\u2019s MSP Alliance security verification,
+        and how the top 1% managed service providers help minimise your security risks
+        and optimise your clouds.\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/kubernetes-platform-comparison-red-hat-openshift-suse-rancher-and-canonical-kubernetes/23982\\\"\\u003eKubernetes
+        platform comparison: Red Hat OpenShift, SUSE Rancher and Canonical Kubernetes\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/enterprise-kubernetes-comparison\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003ekubernetes,
+        k8s, containerization, cloud\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-08-31\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eHow
+        to choose the right Kubernetes distribution for your business\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/containers-as-a-service/23970\\\"\\u003eContainers-as-a-service:
+        Deploy faster with Canonical and Portainer\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/containers-as-a-service-webinar\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003ekubernetes,
+        k8s, cloud\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-08-31\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/helping-developers-reach-new-heights/23873\\\"\\u003eHelping
+        developers reach new heights \\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/px4devsummit\\u003c/td\\u003e\\n\\u003ctd\\u003eevent\\u003c/td\\u003e\\n\\u003ctd\\u003eevent,
+        devsummit, drones, iot\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-08-24\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eCanonical
+        \\u0026amp; Ubuntu at PX4 Developer Summit\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/running-enterprise-grade-edge-applications-with-edgex-on-ubuntu-core/23773\\\"\\u003eRunning
+        enterprise-grade edge applications with EdgeX on Ubuntu Core\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/webinarcoreedgex\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar,
+        internet of things, ubuntu core, edgex\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-08-17\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eJoin
+        us for a webinar on September 29th 5AM BST \\u0026amp; 12PM ET\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/applied-ai-for-fraud-prevention-and-detection/23734\\\"\\u003eApplied
+        AI for fraud prevention and detection\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/ai-fraud-prevention-finserv\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003efinserv\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-08-16\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eHow
+        open source AI/ML solutions can assist banks\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/atresmedia-accesses-high-availability-and-unprecedented-productivity-with-charmed-kubernetes/23693\\\"\\u003eAtresmedia
+        dominates the OTT services market with Charmed Kubernetes\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/atresmedia-charmed-kubernetes-case-study\\u003c/td\\u003e\\n\\u003ctd\\u003ecase
+        study\\u003c/td\\u003e\\n\\u003ctd\\u003eKubernetes, K8s\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-08-12\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eHow
+        the company accessed high availability and unprecedented productivity\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/free-cloud-pricing-report-2021/23455\\\"\\u003eCloud
+        pricing report 2021\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/cloud-pricing-report-2021\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003ecloud\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-07-26\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eGet
+        the report to compare cloud pricing across leading public and private cloud
+        platforms, including AWS, Azure, Google, VMWare and OpenStack\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/sbi-group-sblocca-lautomazione-dellinfrastruttura-con-un-cloud-openstack-sicuro-e-on-premises/23286\\\"\\u003eSBI
+        Group sblocca l\u2019automazione dell\u2019infrastruttura con un cloud OpenStack
+        sicuro e on-premises \\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/it/sbi-casestudy\\u003c/td\\u003e\\n\\u003ctd\\u003ecase
+        study\\u003c/td\\u003e\\n\\u003ctd\\u003eOpenstack, private cloud\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-07-15\\u003c/td\\u003e\\n\\u003ctd\\u003eit\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/a-small-to-medium-size-business-guide-to-cybersecurity/23274\\\"\\u003eA
+        business guide to cybersecurity\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/a-small-to-medium-size-business-guide-to-cybersecurity\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003esecurity,
+        cybersecurity\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-07-14\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/handlungsoptionen-nach-dem-endof-life-der-suse-openstack-cloud/23173\\\"\\u003eHandlungsoptionen
+        nach dem Endof-life der SUSE OpenStack Cloud\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/de/suse-openstack-whitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eOpenStack\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-07-07\\u003c/td\\u003e\\n\\u003ctd\\u003ede\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/atresmedia-accede-a-una-alta-disponibilidad-y-productividad-sin-precedentes-con-charmed-kubernetes/23125\\\"\\u003eAtresmedia
+        domina el mercado de servicios OTT \\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/es/atresmedia-charmed-kubernetes-caso-de-estudio\\u003c/td\\u003e\\n\\u003ctd\\u003ecase
+        study\\u003c/td\\u003e\\n\\u003ctd\\u003eKubernetes\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-07-05\\u003c/td\\u003e\\n\\u003ctd\\u003ees\\u003c/td\\u003e\\n\\u003ctd\\u003eCon
+        la arquitectura de microservicios Charmed Kubernetes\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/kaust-selects-canonicals-openstack-cloud/22858\\\"\\u003eKAUST
+        selects Canonical\u2019s OpenStack cloud\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/openstack-cloud-kaust\\u003c/td\\u003e\\n\\u003ctd\\u003ecase
+        study\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack, private cloud, cloud\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-06-24\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eNew
+        OpenStack and Kubernetes deployments improve computing performance for researchers,
+        easing management pains for IT staff\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/das-wellcome-sanger-institute-ermoglicht-weltweite-zusammenarbeit-in-der-genomforschung-mit-von-canonical-unterstutztem-ceph-speicher/22811\\\"\\u003eDas
+        Wellcome Sanger Institute erm\xF6glicht weltweite Zusammenarbeit in der Genomforschung
+        mit von Canonical unterst\xFCtztem Ceph-Speicher\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/de/wellcome-sanger-case-study\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eceph\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-06-03\\u003c/td\\u003e\\n\\u003ctd\\u003ede\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/a-technical-introduction-to-the-snap-store-proxy/22762\\\"\\u003eA
+        technical introduction to the Snap Store Proxy\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/snap-store-proxy-intro-webinar\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eiot,
+        edge\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-06-18\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/che-cose-il-mec-il-telco-edge/22748\\\"\\u003eChe
+        cos\u2019\xE8 il MEC? Il telco edge.\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/it/mec-telco-edge\\u003c/td\\u003e\\n\\u003ctd\\u003eblog\\u003c/td\\u003e\\n\\u003ctd\\u003etelco,
+        edge\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eit\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/ubuntu-pro-on-azure/22674\\\"\\u003eUbuntu
+        Pro on Azure \\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/ubuntu-pro-azure-latam\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eubuntu
+        pro, microsoft, azure, cloud, security, latam\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-06-09\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eExplore
+        features like extended security, certified compliance and hardening for Ubuntu
+        Pro on Azure.\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/enterprise-mlops-in-hybrid-cloud-scenarios-best-practices/22650\\\"\\u003eEnterprise
+        MLOps in hybrid-cloud scenarios: best practices\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/enterprise-mlops-in-hybrid-cloud-scenarios-best-practices\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eelo,
+        hybrid-cloud, enterprise, kubeflow\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-06-07\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eLearn
+        about architectural best practices that have recently emerged\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/openstack-public-cloud-implementation/22648\\\"\\u003eOpenStack
+        public cloud implementation\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/public-cloud-openstack-implementation\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack,
+        public-cloud\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-06-02\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eReduce
+        total cost of ownership with local public cloud infrastructure\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/ros-support-with-ros-esm/22595\\\"\\u003eROS
+        Support\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/ros-support\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eros\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-06-04\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eSecurity
+        maintenance and enterprise support for your ROS environment\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/preparing-for-the-suse-openstack-cloud-end-of-life/22587\\\"\\u003eSUSE
+        OpenStack Cloud end-of-life\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/suse-openstack-cloud-eol\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack,
+        cloud, suse\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-06-03\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eA
+        preparation guide\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/data-lab-architectures/22247\\\"\\u003eData
+        Lab Architectures\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/data-lab-architectures-whitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003ebig
+        data, data driven, AI, ML\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-06-02\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eA
+        field practitioner guide to building and accelerating data lab initiatives\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/guida-cio-alle-operazioni-multi-cloud/22564\\\"\\u003eGuida
+        CIO alle operazioni multi-cloud\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/it/operazioni-multi-cloud\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003emulti-cloud,
+        finance\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-10-05\\u003c/td\\u003e\\n\\u003ctd\\u003eit\\u003c/td\\u003e\\n\\u003ctd\\u003eCome
+        scegliere un\u2019architettura cloud conveniente\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/kubernetes-e-ubuntu-in-italia/22562\\\"\\u003eKubernetes
+        e Ubuntu in Italia\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/it/kubernetes-e-ubuntu-in-italia\\u003c/td\\u003e\\n\\u003ctd\\u003eblog\\u003c/td\\u003e\\n\\u003ctd\\u003ekubernetes,
+        ubuntu, openstack\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-06-02\\u003c/td\\u003e\\n\\u003ctd\\u003eit\\u003c/td\\u003e\\n\\u003ctd\\u003eUn\u2019esplorazione
+        tecnica delle ultime tecnologie di infrastruttura\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/private-cloud-for-financial-services/22500\\\"\\u003ePrivate
+        cloud for Financial Services\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/private-cloud-financial-services\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003efinserv,
+        openstack\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-05-28\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eComparing
+        Red Hat OpenStack Platform and Canonical\u2019s Charmed OpenStack\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/canonical-at-mwc-2021/22348\\\"\\u003eCanonical
+        at MWC 2021\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/canonical-ubuntu-mwc-2021\\u003c/td\\u003e\\n\\u003ctd\\u003eblog\\u003c/td\\u003e\\n\\u003ctd\\u003etelco,
+        telecommunications, 5G, events\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-05-18\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/open-source-private-5g-and-lte-networks/22346\\\"\\u003eOpen
+        source private 5G and LTE networks\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/5g-and-lte-networks-webinar\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003etelco,
+        telecommunications, 5G\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-05-18\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eUse-cases,
+        tools and technologies\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/kubernetes-at-the-edge-easy-as-pi/22342\\\"\\u003eKubernetes
+        at the edge: easy as Pi\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/edge-kubernetes-raspberry-pi-webinar\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eKubernetes,
+        K8s, edge\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-05-18\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/suse-openstack-cloud-wird-eingestellt/22283\\\"\\u003eSUSE
+        OpenStack Cloud wird eingestellt.\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/de/suse-openstack-webinar\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003esuse,
+        openstack\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-05-13\\u003c/td\\u003e\\n\\u003ctd\\u003ede\\u003c/td\\u003e\\n\\u003ctd\\u003eSind
+        Sie vorbereitet?\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/building-and-orchestrating-network-functions/22269\\\"\\u003eBuilding
+        and orchestrating network functions\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/telco-network-functions-whitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003etelco,
+        telecommunications, 5G, OSM\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-05-12\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eAccelerate
+        migration towards NFV with Open Source MANO\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/simplifying-kubernetes-across-the-clouds-microk8s-on-nvidia-tech-stack/22260\\\"\\u003eSimplifying
+        Kubernetes across the Clouds \\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/microk8s-nvidia-tech-stack\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003emicrok8s,
+        edge, kubernetes, k8s\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-05-11\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eMicroK8s
+        on NVIDIA Tech Stack\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/data-lab-architectures/22247\\\"\\u003eData
+        Lab Architectures\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/data-lab-architectures-whitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003ebig
+        data, data driven, AI, ML\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-05-10\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eA
+        field practitioner guide to building and accelerating data lab initiatives\\u003c/td\\u003e\\n\\u003ctd\\u003efalse\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/a-business-guide-to-multi-cloud/22093\\\"\\u003eA
+        business guide to multi-cloud\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/multi-cloud-business-guide\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-04-30\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eA
+        cost-effective extension to the public cloud infrastructure\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/a-business-guide-to-hybrid-cloud/22092\\\"\\u003eA
+        business guide to hybrid cloud\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/hybrid-cloud-business-guide\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-04-30\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eA
+        cost-effective extension to the public cloud infrastructure\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/ros-kinetic-end-of-life/21952\\\"\\u003eROS
+        Kinetic End-Of-Life\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/ros-kinetic-eol\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003erobotics\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-04-20\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eKeep
+        your robots secure with ROS ESM\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/migrare-a-ubuntu-lts-sei-fatti-per-gli-utenti-centos/21959\\\"\\u003eMigrare
+        ad Ubuntu LTS: 6 fatti per gli utenti CentOS\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/it/migrare-a-ubuntu-lts-centos\\u003c/td\\u003e\\n\\u003ctd\\u003eblog\\u003c/td\\u003e\\n\\u003ctd\\u003ecentos\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eit\\u003c/td\\u003e\\n\\u003ctd\\u003eState
+        pensando di migrare a Ubuntu da altre piattaforme Linux, come CentOS?\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/meno-di-6-mesi-a-ubuntu-16-04-esm-6-cose-da-preparare/21958\\\"\\u003eMeno
+        di 6 mesi a Ubuntu 16.04 ESM: 6 cose da preparare\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/it/ubuntu-16-04-esm\\u003c/td\\u003e\\n\\u003ctd\\u003eblog\\u003c/td\\u003e\\n\\u003ctd\\u003eubuntu,
+        esm\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eit\\u003c/td\\u003e\\n\\u003ctd\\u003eQuesto
+        articolo spiega come funziona il periodo ESM e fornisce una guida a sei considerazioni
+        chiave per la pianificazione di un percorso di migrazione da Ubuntu 16.04
+        LTS.\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/infrastruttura-multi-cloud-in-italia/21894\\\"\\u003eInfrastruttura
+        multi-cloud in Italia\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/it/infrastruttura-multi-cloud\\u003c/td\\u003e\\n\\u003ctd\\u003eblog\\u003c/td\\u003e\\n\\u003ctd\\u003emulti-cloud,
+        kubernetes\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eL\u2019evento,
+        della durata di 2 ore, si terr\xE0 il 12 maggio 2021 su BrightTalk. Dai live
+        talk dei nostri speaker alle sessioni di Q\\u0026amp;A.\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/data-science-workstations-journey/21828\\\"\\u003eData
+        Science Workstations\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/workstations-journey-to-ai\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eAI/ML\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-04-15\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eTake
+        a deep dive into how workstations enable the AI journey in part 2 of our series\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/unleashing-z-workstations-by-hp-powered-by-ubuntu/21825\\\"\\u003eUnleashing
+        Z by HP Workstation Power with Ubuntu\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/Z-Workstation-Ubuntu\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eOpen
+        Source, Linux, Data Science, AI, Machine Learning, HP\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-04-15\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eExplore
+        key solutions for AI, Machine Learning, and Data Science Workflows\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/what-s-new-in-ubuntu-server-21-04/21802\\\"\\u003eWhat\u2019s
+        new in Ubuntu Server 21.04?\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/ubuntu-21.04-release-webinar\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eserver\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-04-14\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eIntroducing
+        native integration with Microsoft SQL Server\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/the-value-of-open-source-in-2021/21790\\\"\\u003eThe
+        Value of Open Source in 2021\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/open-source-value\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eOpen
+        Source, Kubernetes, Dell, OpenStack, Edge\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-04-12\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eExplore
+        the latest open source market trends and dive into OpenStack, Kubernetes and
+        Edge solutions from Dell and Canonical.\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/elkhart-lake/21775\\\"\\u003eElkhart
+        Lake\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/iot-elkhart-lake\\u003c/td\\u003e\\n\\u003ctd\\u003eblog\\u003c/td\\u003e\\n\\u003ctd\\u003eintel,
+        iot\\u003c/td\\u003e\\n\\u003ctd\\u003e4/16/2021\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eEmbedded
+        silicon from Intel focusing on IoT features for the next generation of edge
+        devices.\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/elkhart-lake/21775\\\"\\u003eElkhart
+        Lake\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/elkhart-lake\\u003c/td\\u003e\\n\\u003ctd\\u003eblog\\u003c/td\\u003e\\n\\u003ctd\\u003eintel,
+        iot\\u003c/td\\u003e\\n\\u003ctd\\u003e4/16/2021\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eEmbedded
+        silicon from Intel focusing on IoT features for the next generation of edge
+        devices.\\u003c/td\\u003e\\n\\u003ctd\\u003efalse\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/telecom-ai-a-guide-for-data-teams/21740\\\"\\u003eTelecom
+        AI: a guide for data teams\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/telecom-ai-guide\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eAI/ML,
+        telco, telecommunications\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-04-09\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eOptimising
+        AI for production in the telco space\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/data-science-workstations/21739\\\"\\u003eData
+        Science Workstations\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/data-science-workstations\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eAI/ML\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-04-09\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eTake
+        a deep dive into how workstations enable the AI journey in this four-part
+        webinar series\\u003c/td\\u003e\\n\\u003ctd\\u003efalse\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/canonical-ubuntu-at-nvidia-gtc-2021-digital/21524\\\"\\u003eCanonical
+        \\u0026amp; Ubuntu at NVIDIA GTC 2021 Digital\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/ubuntu-at-nvidia-gtc-2021\\u003c/td\\u003e\\n\\u003ctd\\u003eblog\\u003c/td\\u003e\\n\\u003ctd\\u003eAI/ML,
+        MicroK8s, edge\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-03-24\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eMeet
+        us there on April 12-16\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/model-driven-audit-trail-logs-infrastructure-for-telco-vnfs/21500\\\"\\u003eModel-driven
+        Audit Trail Logs infrastructure for Telco VNFs\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/audit-trail-logs-for-telco\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003etelecommunications\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-03-23\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eLive
+        webinar on April 15th\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/esm-garantisce-la-sicurezza-dei-sistemi-interana-anche-durante-laggiornamento/21378\\\"\\u003eESM
+        garantisce la sicurezza dei sistemi Interana anche durante l\u2019aggiornamento\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/it/interana-casestudy\\u003c/td\\u003e\\n\\u003ctd\\u003ecase
+        study\\u003c/td\\u003e\\n\\u003ctd\\u003eesm, security, interana\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-03-16\\u003c/td\\u003e\\n\\u003ctd\\u003eit\\u003c/td\\u003e\\n\\u003ctd\\u003eCaso
+        di studio - Interana\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/securing-open-source-from-cloud-to-edge/21394\\\"\\u003eSecuring
+        open source from cloud to edge\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/open-source-security-cloud-edge-webinar\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003esecurity,
+        ubuntu pro\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-03-16\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eGet
+        the full Ubuntu security story and see how our teams are securing Ubuntu systems
+        across cloud, device and edge environments.\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/migrar-a-ubuntu-lts-seis-factores-a-tener-en-cuenta-para-los-usuarios-de-centos/21315\\\"\\u003eMigrar
+        a Ubuntu LTS: seis factores a tener en cuenta para los usuarios de CentOS\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/es/migrar-de-centos-a-ubuntu-lts\\u003c/td\\u003e\\n\\u003ctd\\u003eblog\\u003c/td\\u003e\\n\\u003ctd\\u003eserver,
+        ubuntu\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-03-09\\u003c/td\\u003e\\n\\u003ctd\\u003ees\\u003c/td\\u003e\\n\\u003ctd\\u003e\xBFEst\xE1
+        considerando migrar a Ubuntu desde otras plataformas Linux, como CentOS?\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/from-yocto-buildroot-to-ubuntu-core-20/21248\\\"\\u003eFrom
+        Yocto \\u0026amp; Buildroot to Ubuntu Core 20\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/yocto-buildroot-to-ubuntu-core\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eubuntu-core\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-03-05\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eThe
+        path to enterprise-grade embedded Linux\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/costruire-infrastrutture-multi-cloud-con-ubuntu-e-kubernetes/21247\\\"\\u003eCostruire
+        infrastrutture multi-cloud con Ubuntu e Kubernetes\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/it/multi-cloud-infrastrutture-kubernetes-italy\\u003c/td\\u003e\\n\\u003ctd\\u003eevent\\u003c/td\\u003e\\n\\u003ctd\\u003emulti-cloud,
+        infrastructure, kubernetes\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eit\\u003c/td\\u003e\\n\\u003ctd\\u003eUn\u2019esplorazione
+        tecnica delle ultime tecnologie di infrastruttura\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/kubeflow-operations-guide/21213\\\"\\u003eKubeflow
+        operations guide\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/kubeflow-operations-guide\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003ekubeflow,
+        machine learning, AI/ML\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eAutomating
+        day-0 to day-2 with Kubernetes operators\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/suse-openstack-cloud-arrive-en-fin-de-vie/21096\\\"\\u003eSUSE
+        OpenStack Cloud arrive en fin de vie\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/fr/suse-openstack-fin-de-vie\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003esuse,
+        openstack\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-02-25\\u003c/td\\u003e\\n\\u003ctd\\u003efr\\u003c/td\\u003e\\n\\u003ctd\\u003ePreparez
+        pour votre migration d\u2019OpenStack\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/whats-next-for-centos-users/21090\\\"\\u003eWhat\u2019s
+        next for CentOS users?\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/centos-live-q\\u0026amp;A\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-02-24\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eLive
+        Q\\u0026amp;A with Ubuntu\u2019s technical experts\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/a-technical-introduction-to-ubuntu-core-20/21068\\\"\\u003eA
+        technical introduction to Ubuntu Core 20\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/technical-intro-to-ubuntu-core-20\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eubuntu-core\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-02-23\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eFull-disk
+        encryption, secure boot, device recovery and more\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/ubuntu-16-04-esm-6-choses-a-preparer/21058\\\"\\u003eUbuntu
+        16.04 ESM: 6 choses \xE0 pr\xE9parer\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/fr/ubuntu-1604-esm\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003esecurity\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-02-22\\u003c/td\\u003e\\n\\u003ctd\\u003efr\\u003c/td\\u003e\\n\\u003ctd\\u003eUn
+        guide de migration\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/migration-vers-ubuntu-lts-six-points-cles-pour-les-utilisateurs-de-centos/21054\\\"\\u003eMigration
+        vers Ubuntu LTS: six points cl\xE9s pour les utilisateurs de CentOS\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/centos-vers-ubuntu\\u003c/td\\u003e\\n\\u003ctd\\u003eblog\\u003c/td\\u003e\\n\\u003ctd\\u003esecurity\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-02-22\\u003c/td\\u003e\\n\\u003ctd\\u003efr\\u003c/td\\u003e\\n\\u003ctd\\u003ePr\xE9parez
+        vos prochaines \xE9tapes\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/simplifying-ai-ml-adoption-in-telco-with-modern-operations-practices/20996\\\"\\u003eSimplifying
+        AI/ML adoption in telco with modern operations practices\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/ai-ml-telco-modern-operations\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eAI/ML,
+        telecommunications\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-02-17\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eLeveraging
+        open source software for optimal TCO\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/enterprise-kubernetes-a-buyer-s-guide/20979\\\"\\u003eEnterprise
+        Kubernetes: A buyer\u2019s guide\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/enterprise-kubernetes-guide\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eKubernetes,
+        K8s, Cloud\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-02-16\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eFind
+        the right Kubernetes for your business\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/secure-container-orchestration-at-the-edge/20965\\\"\\u003eSecure
+        container orchestration at the edge\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/container-orchestration-edge\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eKubernetes,
+        edge, MicroK8s\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-02-15\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eDevelop
+        your cloud-native apps with micro clouds\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/edge-use-cases-enabled-by-mec-and-5g/20873\\\"\\u003eEdge
+        use-cases enabled by MEC and 5G\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/mec-5g-use-cases\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eTelecommunications,
+        5G\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-02-10\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eLeveraging
+        open source software in the telco space\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/open-source-in-government/20843\\\"\\u003eOpen
+        source in Government\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/gov-webinar\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-02-09\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eThe
+        Public Sector team discusses adoption and procurement of secure open source
+        tech, tooling and support.\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/mantenimiento-de-seguridad-extendido/20747\\\"\\u003eMantenimiento
+        de Seguridad Extendido\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/es/esm\\u003c/td\\u003e\\n\\u003ctd\\u003eblog\\u003c/td\\u003e\\n\\u003ctd\\u003eesm\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-02-04\\u003c/td\\u003e\\n\\u003ctd\\u003ees\\u003c/td\\u003e\\n\\u003ctd\\u003eActualizaciones
+        de seguridad para Ubuntu 16.04 LTS hasta el 2024 y Ubuntu 14.04 LTS hasta
+        el 2022.\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/integrazione-di-ubuntu-desktop-con-microsoft-active-directory/20746\\\"\\u003eIntegrazione
+        di Ubuntu Desktop con Microsoft Active Directory\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/it/ubuntu-desktop-active-directory\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eactive
+        directory, desktop\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-02-04\\u003c/td\\u003e\\n\\u003ctd\\u003eit\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/end-to-end-wiring-using-kubeflow-kafka-and-elasticsearch/20704\\\"\\u003eEnd-to-end
+        wiring using Kubeflow, Kafka and ElasticSearch\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/end-to-end-wiring-with-kubeflow-kafka-elasticsearch\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eAI/ML,
+        Kubeflow\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-02-03\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eOur
+        latest webinar provides real world application and demo for end-to-end wiring
+        using Kubeflow, Kafka and ElasticSearch.\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/embedded-linux-make-or-buy/20696\\\"\\u003eEmbedded
+        Linux: make or buy?\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/embedded-linux-make-or-buy\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-02-02\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eCommercial
+        support vs roll your own: a dilemma\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/an-introduction-to-ubuntu-core-20/20687\\\"\\u003eAn
+        introduction to Ubuntu Core 20\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/ubuntu-core-20-webinar\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003ecore,
+        iot, embedded, security\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-02-02\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eImproving
+        usability, security and time-to-market\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/kubeflow-reference-architecture/20467\\\"\\u003eKubeflow
+        reference architecture\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/dell-kubeflow-reference-architecture\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003ekubeflow,
+        ai/ml, dell\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-01-21\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/industrial-process-transformation-with-machine-learning-using-kubeflow/20436\\\"\\u003eIndustrial
+        process transformation with Machine Learning using Kubeflow\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/industrial-process-ml-kubeflow\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eAI/ML,
+        Kubeflow\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-01-18\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eAccelerate
+        the time from model development to deployment\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/comparaison-de-red-hat-openstack-platform-et-de-charmed-openstack-de-canonical/20432\\\"\\u003eComparaison
+        entre Red Hat OpenStack et Charmed OpenStack de Canonical\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/fr/red-hat-canonical-openstack-comparaison\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eOpenStack\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-01-29\\u003c/td\\u003e\\n\\u003ctd\\u003efr\\u003c/td\\u003e\\n\\u003ctd\\u003eAm\xE9liorez
+        la s\xE9curit\xE9 et l\u2019efficacit\xE9 \xE0 un co\xFBt total de possession
+        r\xE9duit avec Charmed OpenStack\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/automation-through-open-source-operators/20215\\\"\\u003eAutomation
+        through open source operators \\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/automation-through-open-source-operators\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eapps,
+        Juju, Forrester\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-01-08\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eA
+        Forrester Consulting study on the state of infrastructure and application
+        deployment\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/cloud-native-driving-agility-and-innovation-in-financial-services/20244\\\"\\u003eCloud-native
+        driving agility and innovation in financial services\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/cloud-native-agility-financial-services\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003ecloud-native,
+        finance\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-01-07\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eAdapt,
+        innovate and transform\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/android-in-the-cloud-on-arm-native-servers/20015\\\"\\u003eAndroid
+        in the cloud on Arm native servers\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/android-on-arm-whitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eandroid\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-12-18\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eHigh
+        performance. Power efficiency. Hardware rooted security.\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/staying-compliant-while-delivering-innovation-in-government-services/19960\\\"\\u003eStaying
+        compliant while delivering innovation in government services\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/azure-ubuntu-pro-fips-whitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eazure,
+        ubuntu pro, fips\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-12-17\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eHow
+        Ubuntu Pro FIPS on Microsoft Azure gives government agencies and contractors
+        new ways to control costs and boost innovation while maintaining FIPS compliance.\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/menos-de-6-meses-para-16-04-esm-seis-aspectos-a-tener-en-cuenta/19925\\\"\\u003eMenos
+        de 6 meses para 16.04 ESM: seis aspectos a tener en cuenta\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/es/ubuntu-16-04-esm\\u003c/td\\u003e\\n\\u003ctd\\u003eblog\\u003c/td\\u003e\\n\\u003ctd\\u003eesm,
+        security, ubuntu advantage\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-12-17\\u003c/td\\u003e\\n\\u003ctd\\u003ees\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/in-weniger-als-6-monaten-kommt-ubuntu-16-04-esm-6-punkte-fur-ihre-vorbereitung/19895\\\"\\u003eIn
+        weniger als 6 Monaten kommt Ubuntu 16.04 ESM: 6 Punkte f\xFCr Ihre Vorbereitung\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/de/ubuntu-16-04-esm\\u003c/td\\u003e\\n\\u003ctd\\u003eblog\\u003c/td\\u003e\\n\\u003ctd\\u003eesm,
+        security, ubuntu advantage\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-12-17\\u003c/td\\u003e\\n\\u003ctd\\u003ede\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/workstations-ai/19766\\\"\\u003eWorkstations
+        AI\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/it/workstation-ai\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003ekubeflow\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-12-09\\u003c/td\\u003e\\n\\u003ctd\\u003eit\\u003c/td\\u003e\\n\\u003ctd\\u003eCome
+        e perch\xE9 Kubeflow migliora i workflow AI\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/suse-openstack-cloud-to-be-discontinued/19765\\\"\\u003eSUSE
+        OpenStack Cloud to be discontinued\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/suse-openstack-webinar\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack,
+        cloud, suse\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-12-23\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eAre
+        you prepared?\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/lightweight-kubernetes-in-the-enterprise/19716\\\"\\u003eLightweight
+        Kubernetes in the enterprise\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/451-research-microk8s-high-availability\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003ekubernetes,
+        451, microk8s\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-12-09\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eProduction
+        workloads in cloud and server deployments made faster than ever\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/ai-deployment-and-inference/19692\\\"\\u003eAI
+        deployment and inference\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/ai-deployment-and-inference\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003einference\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-12-07\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eReliable
+        infrastructure and streamlined operations\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/agility-and-innovation-in-financial-services-with-open-source/19601\\\"\\u003eAgility
+        and innovation in Financial Services with open source \\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/open-source-financial-services\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003efinance\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-12-01\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eLearn
+        how managed open source can help financial institutions deliver business value.\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/ubuntu-pro-for-aws/19600\\\"\\u003eUbuntu
+        Pro for AWS\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/ubuntu-pro-for-aws\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eaws,
+        Ubuntu Pro\\u003c/td\\u003e\\n\\u003ctd\\u003e2020 -12 01\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eFIPS
+        compliance made easy\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/ubuntu-16-04-lts-moving-to-extended-security-maintenance/19598\\\"\\u003eUbuntu
+        16.04 LTS moving to Extended Security Maintenance\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/16-04-ESM-webinar\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eesm,
+        security, ubuntu advantage\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-12-01\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eSix
+        things to consider when migration planning\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/micro-clouds/19424\\\"\\u003eMicro
+        clouds\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/micro-clouds\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eedge\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-11-19\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eBuilding
+        your Kubernetes edge computing strategy\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/cinque-strategie-per-accelerare-limplementazione-di-kubernetes-nellimpresa/19381\\\"\\u003eCinque
+        strategie per accelerare l\u2019implementazione di Kubernetes nell\u2019impresa\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/it/deployment-azienda-manuale\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eenterprise\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-11-17\\u003c/td\\u003e\\n\\u003ctd\\u003eit\\u003c/td\\u003e\\n\\u003ctd\\u003eCome
+        scegliere il miglior approccio Kubernetes per la tua azienda\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/confronto-fra-red-hats-openstack-platform-e-charmed-openstack-di-canaonical/19362\\\"\\u003eConfronto
+        fra \u201CRed Hat\u2019s Openstack platform\u201D e Charmed Openstack di Canaonical\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/it/redhat-openstack-confronto-manuale\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eRed
+        Hat\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-11-16\\u003c/td\\u003e\\n\\u003ctd\\u003eit\\u003c/td\\u003e\\n\\u003ctd\\u003eCharmed
+        Openstack riduce significativamente il costo totale di propriet\xE0\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/confronto-fra-red-hats-openstack-platform-e-charmed-openstack-di-canaonical/19361\\\"\\u003eGuide
+        pour r\xE9ussir l\u2019adoption et le d\xE9ploiement d\u2019OpenStack\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/fr/guide-adoption-openstack\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-11-16\\u003c/td\\u003e\\n\\u003ctd\\u003efr\\u003c/td\\u003e\\n\\u003ctd\\u003eD\xE9couvrez
+        l\u2019\xE9prouv\xE9 processus d\u2019impl\xE9mentation OpenStack de Canonical\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/funf-strategien-zur-beschleunigung-von-kubernetes-in-unternehmen/19284\\\"\\u003eF\xFCnf
+        Strategien zur Beschleunigung von Kubernetes in Unternehmen\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/de/kubernetes-implementierung-fur-unternehmen\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eenterprise\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-11-11\\u003c/td\\u003e\\n\\u003ctd\\u003ede\\u003c/td\\u003e\\n\\u003ctd\\u003eEntscheidungskriterien
+        zur optimalen Herangehensweise an Kubernetes f\xFCr Ihr Unternehmen\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/vergleich-von-red-hat-openstack-platform-und-charmed-openstack-von-canonical/19285\\\"\\u003eVergleich
+        von Red Hat OpenStack Platform und Charmed OpenStack von Canonical\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/de/redhat-openstack-vergleich\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eRed
+        Hat\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-11-11\\u003c/td\\u003e\\n\\u003ctd\\u003ede\\u003c/td\\u003e\\n\\u003ctd\\u003eSenken
+        Sie Ihre Gesamtkosten deutlich mit Charmed OpenStack\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/9-out-of-top-10-us-financial-institutions-use-ubuntu/19304\\\"\\u003e9
+        out of top 10 US \\u0026amp; European financial institutions use Ubuntu\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/ubuntu-finance-sector-whitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003efinance\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-11-11\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eFind
+        out why multi-cloud is fundamental to financial services transformation\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/cinco-estrategias-para-acelerar-el-despliegue-de-kubernetes/19208\\\"\\u003eCinco
+        estrategias para acelerar el despliegue de Kubernetes\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/es/kubernetes-despliegue-empresa-manual\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eenterprise,
+        kubernetes\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-11-04\\u003c/td\\u003e\\n\\u003ctd\\u003ees\\u003c/td\\u003e\\n\\u003ctd\\u003eC\xF3mo
+        elegir el mejor enfoque de Kubernetes para su negocio\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/comparando-la-plataforma-openstack-de-red-hat-y-la-charmed-openstack-de-canonical/19194\\\"\\u003eComparando
+        la plataforma OpenStack de Red Hat y la Charmed OpenStack de Canonical\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/es/redhat-openstack-comparacion-manual\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-11-03\\u003c/td\\u003e\\n\\u003ctd\\u003ees\\u003c/td\\u003e\\n\\u003ctd\\u003eReducir
+        significativamente el coste total de propiedad con Charmed OpenStack\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/optimised-authentication-methods-for-ubuntu-desktop/19133\\\"\\u003eOptimised
+        authentication methods for Ubuntu Desktop\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/desktop-authentication-whitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003edesktop,
+        security\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-08-07\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eSecuring
+        enterprise desktops with modern authentication options\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/open-digital-platforms-for-the-industrial-edge-cloud-in-2020/19068\\\"\\u003eOpen
+        digital platforms for the industrial edge cloud in 2020\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/pac-radar\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003epac-radar\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-10-27\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eThe
+        next wave of cloud-native innovations at the edge\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/ubuntu-20-10-what-s-new/19050\\\"\\u003eUbuntu
+        20.10: What\u2019s new?\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/ubuntu-20.10\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eubuntu
+        server, maas, kubernetes\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-10-26\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eLearn
+        about new features in Ubuntu Server, MAAS, Charmed OpenStack and Charmed Kubernetes\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/ubuntu-for-raspberry-pi-live-on-youtube/18577\\\"\\u003eUbuntu
+        for Raspberry Pi intro video\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/raspberry-pi-livestream\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eraspberry-pi,
+        desktop\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-10-21\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/cloud-gaming-for-android/18757\\\"\\u003eCloud
+        gaming for Android\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/anbox-cloud-gaming-whitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eanbox,
+        gaming\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-01-21\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eBuilding
+        a high performing and scalable platform\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/extend-your-openstack-cloud-with-native-backup-and-recover/18911\\\"\\u003eExtend
+        your OpenStack cloud with native backup and recovery\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/trilio-backup-recovery\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-09-31\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eLearn
+        how TrilioVault can be easily deployed in a Charmed OpenStack environment\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/transforming-telco-infrastructure-a-virtual-event/18162\\\"\\u003eTransforming
+        telco infrastructure\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/telco-virtual-event\\u003c/td\\u003e\\n\\u003ctd\\u003eevent\\u003c/td\\u003e\\n\\u003ctd\\u003eopen-source\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-09-24\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eCanonical\u2019s
+        experts explore the telecommunication industry\u2019s latest technologies.\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/guia-para-la-implementacion-de-openstack/18480\\\"\\u003eGu\xEDa
+        para la implementaci\xF3n de OpenStack\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/es/guia-para-la-implementacion-de-openstack\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-09-16\\u003c/td\\u003e\\n\\u003ctd\\u003ees\\u003c/td\\u003e\\n\\u003ctd\\u003eDescubre
+        el probado proceso de implementaci\xF3n de OpenStack de Canonical\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/da-vmware-a-charmed-openstack/18478\\\"\\u003eDa
+        VMware a Charmed Openstack\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/it/da-vmware-a-charmed-openstack\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-09-15\\u003c/td\\u003e\\n\\u003ctd\\u003eit\\u003c/td\\u003e\\n\\u003ctd\\u003eCome
+        la migrazione a Charmed OpenStack pu\xF2 ridurre significativamente il TCO\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/gmo-pepabo-ubuntu/18476\\\"\\u003eGMO
+        Pepabo \\u0026amp; Ubuntu\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/case-study-gmo-pepabo\\u003c/td\\u003e\\n\\u003ctd\\u003ecase
+        study\\u003c/td\\u003e\\n\\u003ctd\\u003eserver, kubernetes,ubuntu-advantage\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-09-14\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eGMO
+        Pepabo cuts OPEX costs with live kernel patching and saves 2,500 hours of
+        manual work\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/da-vmware-a-openstack/18164\\\"\\u003eDa
+        VMware a OpenStack\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/it/da-vmware-a-openstack\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-09-04\\u003c/td\\u003e\\n\\u003ctd\\u003eit\\u003c/td\\u003e\\n\\u003ctd\\u003eCome
+        la migrazione a Charmed OpenStack pu\xF2 ridurre significativamente il TCO\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/five-strategies-to-accelerate-kubernetes-deployment-in-the-enterprise/18161\\\"\\u003eFive
+        strategies to accelerate Kubernetes in the enterprise\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/kubernetes-deployment-enterprise-whitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003ekubernetes\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-09-02\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eHow
+        to choose the best approach to Kubernetes for your business\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/production-ai-from-data-lake-to-server-webinar/18163\\\"\\u003eProduction
+        AI from data lake to server\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/data-lake_2_server_webinar\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eai\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-08-13\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eSolving
+        hardware challenges in ML environments\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/building-powerful-customer-solutions/18481\\\"\\u003eBuilding
+        powerful customer solutions\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/gsi-webinar-series\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003ecloud,
+        kubernetes\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-07-31\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eA
+        webinar series for GSIs seizing new models for scalable, automated and repeatable
+        deployments\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/red-hat-openstack-platform-vs-canonicals-charmed-openstack/18159\\\"\\u003eRed
+        Hat OpenStack Platform vs Canonical\u2019s Charmed OpenStack\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/redhat-openstack-comparison-whitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-07-29\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eImprove
+        security and efficiency at a reduced total cost of ownership with Charmed
+        OpenStack\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/do-vmware-ao-charmed-openstack/18165\\\"\\u003eDo
+        VMware ao Charmed OpenStack\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/pt/vmware-para-o-openstack\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-07-22\\u003c/td\\u003e\\n\\u003ctd\\u003ept\\u003c/td\\u003e\\n\\u003ctd\\u003eReduza
+        os custos e aumente a efici\xEAncia da sua infraestrutura com ado\xE7\xE3o
+        de c\xF3digo aberto\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/busting-the-myth-of-private-cloud-economics/17244\\\"\\u003eBusting
+        the myth of private cloud economics\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/cloud-economics\\u003c/td\\u003e\\n\\u003ctd\\u003ecase
+        study\\u003c/td\\u003e\\n\\u003ctd\\u003ecloud, openstack\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-12\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/scale-android-applications-economically-in-the-cloud-with-anbox-cloud/17401\\\"\\u003eScale
+        Android applications economically in the cloud with Anbox Cloud\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/intro-to-anbox-cloud-whitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003ecloud\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-07-08\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eDiscover
+        Canonical\u2019s scalable, hardware-agnostic mobile cloud computing platform\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/accelerating-iot-device-time-to-market/17399\\\"\\u003eAccelerating
+        IoT device time to market\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/smart-start-whitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eiot\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-07-03\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eIntroducing
+        a packaged solution to condense IoT decision-making into a 2-week, fixed cost
+        process\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/kubernetes-from-cloud-to-edge/17398\\\"\\u003eKubernetes
+        from Cloud to Edge\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/kubernetes-event-us\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003ekubernetes,
+        cloud, edge\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-06-24\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eHow
+        to streamline your Kubernetes deployment and operations from Canonical\u2019s
+        experts.\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/scaling-on-azure-with-ubuntu-pro/17397\\\"\\u003eScaling
+        on Azure with Ubuntu Pro\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/scaling-securely-ubuntu-azure\\u003c/td\\u003e\\n\\u003ctd\\u003eeBook\\u003c/td\\u003e\\n\\u003ctd\\u003eopen-source,
+        cloud\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-06-17\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eScale
+        your open-source infrastructure with speed, security, and compliance\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/a-technical-intro-to-ubuntu-pro/17396\\\"\\u003eA
+        technical intro to Ubuntu Pro\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/ubuntu-pro-intro\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eopen-source\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-06-16\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/migrating-your-infrastructure-to-ubuntu-20-04-lts/17395\\\"\\u003eMigrating
+        your infrastructure to Ubuntu 20.04 LTS\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/migrating-to-20.04\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eopen-source\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-06-11\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eHow,
+        when and why?\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/utilising-cloud-init-on-microsoft-azure/17394\\\"\\u003eUtilising
+        cloud-init on Microsoft Azure\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/azure-cloud-init-whitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003ecloud\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-06-03\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eSimplify
+        cloud instance deployment with Ubuntu on Azure\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/standardising-machine-learning-from-workstation-to-production/17393\\\"\\u003eStandardising
+        machine learning \u2014 from workstation to production\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/ml-dell-webinar\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eai,
+        ml, kubernetes\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-06-02\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/kafka-in-production/17392\\\"\\u003eKafka
+        in production\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/kafka-in-production\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003ekafka\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-05-28\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eMaking
+        sure your deployment is fast, reliable and secure\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/solving-the-software-update-challenge-for-iot-devices/17391\\\"\\u003eSolving
+        the software update challenge for IoT devices\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/snapd-whitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eiot,
+        ubuntu-core, snaps\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-05-15\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eHow
+        Ubuntu Core transforms over-the-air software updates\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/secure-iot-device-management/17390\\\"\\u003eSecure
+        IoT device management\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/iot-device-management-whitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eiot,
+        security, ubuntu-core\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-05-13\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eBuild
+        and deploy a central IoT management solution\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/leveraging-open-source-with-ubuntu-pro-on-azure/17389\\\"\\u003eLeveraging
+        open source with Ubuntu Pro on Azure\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/azure-webinar\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eopen-source\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-05-12\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eEconomics,
+        velocity and security\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/streamlined-kubernetes-from-cloud-to-edge/17388\\\"\\u003eStreamlined
+        Kubernetes, from Cloud to Edge\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/eu-kubernetes-event\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003ekubernetes,
+        cloud, edge\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-05-11\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eInnovating
+        and scaling efficiently, with Charmed Kubernetes and MicroK8s\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/embracing-the-open-source-mandate/17387\\\"\\u003eEmbracing
+        the open source mandate\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/moving-to-opensource-whitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eopen-source\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-04-28\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e85%
+        of enterprises have an open source mandate, preference or are exploring\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/what-s-new-in-ubuntu-20-04-lts/17386\\\"\\u003eWhat\u2019s
+        new in Ubuntu 20.04 LTS?\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/20.04-webinars\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003edesktop,
+        server\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-04-16\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eTwo
+        webinars to help you understand what makes 20.04 our most secure and reliable
+        release to date\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/maintaining-business-focus-in-a-cloud-native-world-with-managed-apps/17385\\\"\\u003eMaintaining
+        business focus in a cloud-native world with Managed Apps\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/managed-apps-webinar\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003ecloud\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-04-09\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/ubuntu-core-a-cybersecurity-analysis/17381\\\"\\u003eUbuntu
+        Core: a cybersecurity analysis\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/ubuntu-core-security-audit\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eubuntu-core,
+        security, iot\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-03-31\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eAn
+        independent evaluation of Ubuntu Core\u2019s security capabilities\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/openstack-deployment-guide/17384\\\"\\u003eOpenStack
+        deployment guide\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/openstack-deployment-guide\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-03-31\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eDiscover
+        Canonical\u2019s proven OpenStack implementation process\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/installez-et-mettez-openstack-a-lechelle-en-toute-simplicite/17418\\\"\\u003eInstallez
+        et mettez OpenStack \xE0 l\u2019\xE9chelle en toute simplicit\xE9\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/fr/openstack-made-easy\\u003c/td\\u003e\\n\\u003ctd\\u003eeBook\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-03-29\\u003c/td\\u003e\\n\\u003ctd\\u003efr\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/virtual-event-microk8s-kubernetes/17380\\\"\\u003eVirtual
+        event: MicroK8s \\u0026amp; Kubernetes\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/pre-kubecon-event\\u003c/td\\u003e\\n\\u003ctd\\u003eevent\\u003c/td\\u003e\\n\\u003ctd\\u003ekubernetes\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-03-24\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eJoin
+        our virtual event to learn more about MicroK8s, what it is and why you should
+        use it. This event will also include discussions on Kubernetes, an introduction
+        to Canonical and much more!\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/rigado-cuts-customers-time-to-market/17379\\\"\\u003eRigado
+        cuts customers\u2019 time-to-market\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/case-study-rigado\\u003c/td\\u003e\\n\\u003ctd\\u003ecase
+        study\\u003c/td\\u003e\\n\\u003ctd\\u003eiot, ubuntu-core, snaps\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-03-19\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003ewith
+        Ubuntu Core and AWS\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/securing-ros-robotics-platforms/17378\\\"\\u003eSecuring
+        ROS robotics platforms\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/securing-ros-on-robotics-platforms-whitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003erobotics,
+        security\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-03-11\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eSteps
+        to maximise robotics security with Ubuntu\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/smart-card-login-on-ubuntu/17377\\\"\\u003eSmart
+        card login on Ubuntu\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/smart-card-whitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003esecurity\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-03-09\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eConfigure
+        Ubuntu 18.04 LTS for smart card operation\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/hosted-private-cloud-infrastructure-a-cost-analysis/17375\\\"\\u003eHosted
+        private cloud infrastructure: a cost analysis\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/private-cloud-cost-analysis-webinar\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack,
+        cloud, kubernetes, maas\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-03-02\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eAccelerate
+        initial deployment and reduce operational costs by outsourcing private cloud
+        infrastructure management\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/an-introduction-to-anbox-cloud/17374\\\"\\u003eAccelerating
+        IoT device time to market\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/smart-start-webinar\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eiot\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-02-26\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eChallenges
+        and solutions for IoT execution\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/an-introduction-to-anbox-cloud/17374\\\"\\u003eAn
+        introduction to Anbox Cloud\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/anbox-cloud-webinar\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003ecloud\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-02-25\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eScalable
+        Android\u2122 in the cloud\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/esm-maintains-interanas-system-security-while-upgrading/17376\\\"\\u003eESM
+        maintains Interana\u2019s system security while upgrading\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/interana-casestudy\\u003c/td\\u003e\\n\\u003ctd\\u003ecase
+        study\\u003c/td\\u003e\\n\\u003ctd\\u003esecurity\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-02-17\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/artificial-intelligence-at-the-edge-in-a-5g-world/17372\\\"\\u003eArtificial
+        Intelligence at the edge in a 5G world\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/ai-edge-webinar\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eai,
+        ml, edge\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-02-07\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eDeploying
+        AI/ML solutions in latency-sensitive environments requires a new solution
+        architecture approach\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/deploy-kubernetes-in-your-data-centre/17373\\\"\\u003eDeploy
+        Kubernetes in your data centre\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/dell-kubernetes-webinar\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003ekubernetes\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-02-07\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/migration-von-vmware-zu-openstack/17370\\\"\\u003eMigration
+        von VMware zu OpenStack\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/de/migration-von-vmware-zu-openstack\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-02-04\\u003c/td\\u003e\\n\\u003ctd\\u003ede\\u003c/td\\u003e\\n\\u003ctd\\u003eWie
+        ein Umstieg auf Charmed OpenStack die Gesamtkosten sp\xFCrbar senken kann\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/de-vmware-a-charmed-openstack/17371\\\"\\u003eDe
+        VMware a Charmed OpenStack\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/es/vmware-a-charmed-openstack\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-02-04\\u003c/td\\u003e\\n\\u003ctd\\u003ees\\u003c/td\\u003e\\n\\u003ctd\\u003eC\xF3mo
+        la migraci\xF3n a Charmed OpenStack puede reducir significativamente el TCO\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/kubernetes-a-secure-flexible-and-automated-edge-for-iot-developers/17369\\\"\\u003eKubernetes:
+        a secure, flexible and automated edge for IoT developers\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/microk8s-451research\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003ekubernetes,
+        edge, iot\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-01-10\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eThe
+        factors for implementing Kubernetes successfully at the edge\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/an-intro-to-microk8s/17367\\\"\\u003eAn
+        intro to MicroK8s\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/intro-to-microk8s-webinar\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003ekubernetes\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-12-19\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eReliable,
+        fast, small and upstream Kubernetes\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/ubuntu-desktop-for-the-enterprise/17368\\\"\\u003eUbuntu
+        Desktop for the enterprise\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/linux-enterprise-whitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003edesktop\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-12-19\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eLearn
+        why enterprises are beginning to adopt Linux as a desktop operating system\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/cyberdyne-keeps-cleaning-robots-up-to-date-in-the-field-with-snaps/17366\\\"\\u003eCyberdyne
+        keeps cleaning robots up-to-date in the field with snaps\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/cyberdyne\\u003c/td\\u003e\\n\\u003ctd\\u003ecase
+        study\\u003c/td\\u003e\\n\\u003ctd\\u003erobotics, iot\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-12-18\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/sbi-group-unlocks-infrastructure-automation-with-secure-on-premises-openstack-cloud/17364\\\"\\u003eSBI
+        Group unlocks infrastructure automation with secure, on-premises OpenStack
+        cloud\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/sbi-casestudy\\u003c/td\\u003e\\n\\u003ctd\\u003ecase
+        study\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-12-06\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/register-for-wslconf/17365\\\"\\u003eRegister
+        for WSLConf\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/wslconf\\u003c/td\\u003e\\n\\u003ctd\\u003eevent\\u003c/td\\u003e\\n\\u003ctd\\u003ewsl\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-12-06\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/build-smart-display-devices-with-mir-fast-to-production-secure-open-source/17363\\\"\\u003eBuild
+        smart display devices with Mir: fast to production, secure, open-source\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/build-smart-devices-with-mir-whitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eiot\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-11-27\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/linux-security-with-ubuntu/17362\\\"\\u003eLinux
+        security with Ubuntu\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/linux_security_webinar\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003esecurity\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-11-14\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eSecuring
+        Ubuntu systems for reduced downtime and optimum CVE coverage.\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/lessons-learned-from-100-private-cloud-builds/17361\\\"\\u003eLessons
+        learned from 100+ Private cloud builds\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/private-cloud-build-webinar\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack,
+        cloud\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-11-12\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eReducing
+        the complexities of building a private cloud on OpenStack\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/the-wellcome-sanger-institute-turns-to-canonical-for-high-level-ceph-support/17360\\\"\\u003eThe
+        Wellcome Sanger Institute turns to Canonical for high level Ceph support\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/wellcome-sanger-case-study\\u003c/td\\u003e\\n\\u003ctd\\u003ecase
+        study\\u003c/td\\u003e\\n\\u003ctd\\u003eceph, openstack\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-11-04\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/ensuring-security-and-isolation-in-kubernetes-with-kata-containers/17359\\\"\\u003eEnsuring
+        security and isolation in Kubernetes with Kata Containers\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/kata-containers-webinar\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003esecurity\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-11-01\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/tim-ensures-system-security-and-client-confidence-with-esm/17358\\\"\\u003eTIM
+        ensures system security and client confidence with ESM\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/case-study-acuris\\u003c/td\\u003e\\n\\u003ctd\\u003ecase
+        study\\u003c/td\\u003e\\n\\u003ctd\\u003esecurity, ubuntu-advantage\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-10-22\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/what-s-new-in-ubuntu-19-10/17357\\\"\\u003eWhat\u2019s
+        new in Ubuntu 19.10\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/19-10-webinar\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003edesktop\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-10-17\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eUbuntu
+        19.10 includes enhanced K8s capabilities for edge and AI/ML, OpenStack Train
+        live-migration extensions for easier infrastructure deployments and more.\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/how-domotz-streamlined-provisioning-of-iot-devices/17356\\\"\\u003eHow
+        Domotz streamlined provisioning of IoT devices\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/domotz-case-study\\u003c/td\\u003e\\n\\u003ctd\\u003ecase
+        study\\u003c/td\\u003e\\n\\u003ctd\\u003eubuntu-core, snaps, iot\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-10-10\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eLearn
+        how Ubuntu Core and snaps gives Domotz a competitive advantage\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/yahoo-japan-builds-their-iaas-environment-with-canonical/17355\\\"\\u003eYahoo!
+        Japan builds their IaaS environment with Canonical\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/yahoo-japan-case-study\\u003c/td\\u003e\\n\\u003ctd\\u003ecase
+        study\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack, maas, juju, ubuntu-advantage,
+        security\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-10-08\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/accelerating-deep-tech-with-ubuntu/17354\\\"\\u003eAccelerating
+        deep tech with Ubuntu\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/deeptech\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eiot,
+        robotics\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-10-02\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/from-vmware-to-charmed-openstack/17343\\\"\\u003eFrom
+        VMWare To Charmed OpenStack\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/vmware-to-charmed-openstack\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-09-04\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eReduce
+        costs and increase the efficiency of your infrastructure with open source
+        adoption\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/machine-learning-operations-mlops/17353\\\"\\u003eMachine
+        Learning Operations (MLOps)\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/get-started-with-ai-part-2\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eai,
+        ml\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-09-11\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eDeploy
+        at scale\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/how-to-manage-snaps-in-an-enterprise-environment/17352\\\"\\u003eHow
+        to manage snaps in an enterprise environment\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/enterprise-snap-management\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003esnaps,
+        security\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-08-20\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eHow
+        the Snap Store Proxy overcomes challenges presented by restricted networks
+        and management policies\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/a-guide-to-developing-android-apps-on-ubuntu/17351\\\"\\u003eA
+        guide to developing Android apps on Ubuntu\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/developing-android-on-ubuntu\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003edesktop,
+        apps\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-08-13\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/creating-a-cloud-like-bare-metal-experience-in-the-data-centre/17348\\\"\\u003eCreating
+        a cloud-like bare metal experience in the data centre\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/maas-hardware-testing\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003emaas\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-08-08\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/creating-accurate-ai-models-with-data/17349\\\"\\u003eCreating
+        accurate AI models with data\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/data-pipelines-kubeflow\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003ekubeflow,
+        ai\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-08-08\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eHow
+        Kubeflow and machine learning help you get the most out of your data\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/ims-evolve-adopts-ubuntu-core-to-provide-iot-enabled-business-intelligence-in-the-supply-chain/17284\\\"\\u003eIMS
+        Evolve adopts Ubuntu Core to provide IoT-enabled business intelligence in
+        the supply chain\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/casestudy-imsevolve\\u003c/td\\u003e\\n\\u003ctd\\u003ecase
+        study\\u003c/td\\u003e\\n\\u003ctd\\u003eiot\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-17\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/rocket-chat-communication-platform-enables-simplicity-through-snaps/17288\\\"\\u003eRocket.Chat
+        communication platform enables simplicity through snaps\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/casestudy-rocketchat\\u003c/td\\u003e\\n\\u003ctd\\u003ecase
+        study\\u003c/td\\u003e\\n\\u003ctd\\u003esnaps, apps\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-17\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/server-provisioning-what-network-admins-it-pros-need-to-know/17307\\\"\\u003eServer
+        Provisioning: What Network Admins \\u0026amp; IT Pros Need to Know\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/ebook-maas\\u003c/td\\u003e\\n\\u003ctd\\u003eeBook\\u003c/td\\u003e\\n\\u003ctd\\u003eserver\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-17\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/building-a-private-cloud-take-the-leap/17331\\\"\\u003eBuilding
+        a private cloud? Take the leap!\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/private-cloud\\u003c/td\\u003e\\n\\u003ctd\\u003eeBook\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack,
+        cloud\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-17\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/make-it-rain-public-cloud-on-ubuntu-openstack/17332\\\"\\u003eMake
+        IT rain: public cloud on Ubuntu OpenStack\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/public-cloud\\u003c/td\\u003e\\n\\u003ctd\\u003eeBook\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack,
+        cloud\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-17\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/learn-whats-new-in-ubuntu-server-14-04-lts/17344\\\"\\u003eLearn
+        What\u2019s New In Ubuntu Server 14.04 LTS\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/whats-new-ubuntu-14-04-lts\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eserver,
+        openstack\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-17\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/how-ubuntu-helped-innovapos-revolutionise-the-vending-machine-industry/17285\\\"\\u003eHow
+        Ubuntu helped InnovaPOS revolutionise the vending machine industry\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/casestudy-innovapos\\u003c/td\\u003e\\n\\u003ctd\\u003ecase
+        study\\u003c/td\\u003e\\n\\u003ctd\\u003eiot\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-16\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/nexiona-collaborates-with-canonical-and-dell-to-create-miimetiq-edge/17287\\\"\\u003eNEXIONA
+        collaborates with Canonical and Dell to create MIIMETIQ EDGE\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/casestudy-nexiona\\u003c/td\\u003e\\n\\u003ctd\\u003ecase
+        study\\u003c/td\\u003e\\n\\u003ctd\\u003eiot\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-16\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/azeti-uses-ubuntu-core-to-improve-deployment-and-security/17278\\\"\\u003eAzeti
+        uses Ubuntu Core to improve deployment and security\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/casestudy-azeti\\u003c/td\\u003e\\n\\u003ctd\\u003ecase
+        study\\u003c/td\\u003e\\n\\u003ctd\\u003esecurity, iot\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-16\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/azlogica-utilise-ubuntu-core-for-customised-iot-agricultural-solutions/17279\\\"\\u003eAZLOGICA
+        utilise Ubuntu Core for customised IoT agricultural solutions\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/casestudy-azlogica\\u003c/td\\u003e\\n\\u003ctd\\u003ecase
+        study\\u003c/td\\u003e\\n\\u003ctd\\u003eiot\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-16\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/botsandus-builds-a-social-robot-on-ubuntu/17280\\\"\\u003eBotsAndUs
+        builds a social robot on Ubuntu\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/casestudy-botsandus\\u003c/td\\u003e\\n\\u003ctd\\u003ecase
+        study\\u003c/td\\u003e\\n\\u003ctd\\u003erobotics\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-16\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/cinergy-makes-significant-digital-signage-saving-with-screenly-pro-and-ubuntu-core/17281\\\"\\u003eCinergy
+        makes significant digital signage saving with Screenly Pro and Ubuntu Core\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/casestudy-cinergy\\u003c/td\\u003e\\n\\u003ctd\\u003ecase
+        study\\u003c/td\\u003e\\n\\u003ctd\\u003edigital-signage\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-16\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/commercetools-uses-ubuntu-server-to-power-its-next-generation-ecommerce-platform/17283\\\"\\u003eCommercetools
+        uses Ubuntu Server to power its next-generation ecommerce platform\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/casestudy-commercetools\\u003c/td\\u003e\\n\\u003ctd\\u003ecase
+        study\\u003c/td\\u003e\\n\\u003ctd\\u003eserver, e-commerce\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-16\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/for-ctos-the-no-nonsense-way-to-accelerate-your-business-with-containers/17345\\\"\\u003eFor
+        CTOs: the no-nonsense way to accelerate your business with containers\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/whitepaper-containers\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003etelco\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-16\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/taking-charge-of-the-iots-security-vulnerabilities/17346\\\"\\u003eTaking
+        charge of the IoT\u2019s security vulnerabilities\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/whitepaper-iot-security\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eiot,
+        security\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-16\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/the-essential-guide-for-telecoms-and-service-providers-adopting-big-data-solutions/17309\\\"\\u003eThe
+        essential guide for Telecoms and Service Providers adopting big data solutions\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/essential-guide-big-data-solutions\\u003c/td\\u003e\\n\\u003ctd\\u003eeBook\\u003c/td\\u003e\\n\\u003ctd\\u003etelco,
+        openstack\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-15\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/city-network-brings-openstack-cloud-hosting-to-the-financial-services-sector-with-canonical/17282\\\"\\u003eCity
+        Network brings OpenStack cloud hosting to the financial services sector with
+        Canonical\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/casestudy-city-network\\u003c/td\\u003e\\n\\u003ctd\\u003ecase
+        study\\u003c/td\\u003e\\n\\u003ctd\\u003ecloud\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-15\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/cto-s-guide-to-sdn-nfv-vnf/17293\\\"\\u003eCTO\u2019s
+        guide to SDN, NFV \\u0026amp; VNF\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/cto-guide-sdn-nfv-vnf\\u003c/td\\u003e\\n\\u003ctd\\u003eeBook\\u003c/td\\u003e\\n\\u003ctd\\u003enetworking\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-15\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eWhy
+        is the transition happening and why is it important?\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/sensape-uses-landscape-to-remotely-support-revolutionary-interactive-retail-displays/17289\\\"\\u003eSensape
+        uses Landscape to remotely support revolutionary interactive retail displays\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/casestudy-sensape\\u003c/td\\u003e\\n\\u003ctd\\u003ecase
+        study\\u003c/td\\u003e\\n\\u003ctd\\u003edigital-signage\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-15\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/how-to-face-the-challenges-of-becoming-a-cloud-operator/17290\\\"\\u003eHow
+        to face the challenges of becoming a cloud operator\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/cloud-fray\\u003c/td\\u003e\\n\\u003ctd\\u003eeBook\\u003c/td\\u003e\\n\\u003ctd\\u003ecloud,
+        openstack, telco\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-15\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/low-latency-and-real-time-kernels-for-telco-and-nfv/17321\\\"\\u003eLow
+        latency and real time kernels for telco and NFV\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/low-latency-report\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003etelco\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-15\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/how-to-escape-stuckstack-and-profit-from-your-openstack-investment/17337\\\"\\u003eHow
+        to escape StuckStack and profit from your OpenStack investment\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/stuckstack-ebook\\u003c/td\\u003e\\n\\u003ctd\\u003eeBook\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-15\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/carrier-cloudification-what-every-telecom-executive-needs-to-know/17338\\\"\\u003eCarrier
+        Cloudification: What every telecom executive needs to know\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/telco-cloudification-ebook\\u003c/td\\u003e\\n\\u003ctd\\u003eeBook\\u003c/td\\u003e\\n\\u003ctd\\u003etelco,
+        cloud, openstack\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-15\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/nfv-and-sdn-on-openstack/17326\\\"\\u003eNFV
+        and SDN on OpenStack\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/nfv-sdn-openstack\\u003c/td\\u003e\\n\\u003ctd\\u003eeBook\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack,
+        networking\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-12\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/openstack-made-easy/17328\\\"\\u003eOpenStack
+        made easy\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/openstack-made-easy\\u003c/td\\u003e\\n\\u003ctd\\u003eeBook\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-12\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eWith
+        the right tools, OpenStack can be easy\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/telcos-and-service-providers-expect-near-100-uptime/17330\\\"\\u003eTelcos
+        and Service Providers expect near 100% uptime\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/openstack-telco-clouds\\u003c/td\\u003e\\n\\u003ctd\\u003eeBook\\u003c/td\\u003e\\n\\u003ctd\\u003etelco,
+        openstack, cloud\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-12\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eThis
+        requires a proven cloud platform that minimises time-to-revenue and ensures
+        predictable costs.\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/a-shift-to-the-linux-app-store-experience/17347\\\"\\u003eA
+        shift to the Linux app store experience\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/shift-to-app-store-experience\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eapps,
+        snaps\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-11\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eThe
+        key to optimising software distribution in a fragmented environment.\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/le-support-d-ubuntu-14-04-lts-est-maintenant-passe-a-esm/17413\\\"\\u003eLe
+        support d\u2019Ubuntu 14.04 LTS est maintenant pass\xE9 \xE0 ESM\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/fr/esm_1404\\u003c/td\\u003e\\n\\u003ctd\\u003eblog\\u003c/td\\u003e\\n\\u003ctd\\u003esecurity\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-06-28\\u003c/td\\u003e\\n\\u003ctd\\u003efr\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/a-guide-to-edge-computing-and-the-tools-you-need/17308\\\"\\u003eA
+        guide to edge computing and the tools you need\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/edge-month\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eedge,
+        cloud, kubernetes, maas\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-06-27\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eLearn
+        how edge computing provides enterprises with real-time data processing, cost-effective
+        security and scalability.\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/sicherheit-in-der-private-cloud/17411\\\"\\u003eSicherheit
+        in der Private Cloud\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/de/openstack-security-de\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack,
+        cloud\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-06-19\\u003c/td\\u003e\\n\\u003ctd\\u003ede\\u003c/td\\u003e\\n\\u003ctd\\u003eH\xF6chste
+        Anforderungen in Unternehmensumgebungen mit OpenStack erf\xFCllen.\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/how-to-get-started-and-progress-with-an-ai-program/17245\\\"\\u003eHow
+        to get started and progress with an AI program\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/ai-gettingstarted\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eai,
+        ml\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-06-11\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/the-future-of-mobile-connectivity/17342\\\"\\u003eThe
+        future of mobile connectivity\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/ubuntu-lime-telco\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003etelco\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-06-12\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eMajor
+        mobile operators are adopting open source versus proprietary technologies
+        to reduce costs.\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/north-america-s-first-autonomous-runway-snowplough/17327\\\"\\u003eNorth
+        America\u2018s first autonomous runway snowplough\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/northstar\\u003c/td\\u003e\\n\\u003ctd\\u003ecase
+        study\\u003c/td\\u003e\\n\\u003ctd\\u003erobotics, iot\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-06-05\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eThe
+        robots helping to address off-highway labour shortages\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/small-robot-company-sows-the-seeds-for-autonomous-and-more-profitable-farming/17334\\\"\\u003eSmall
+        Robot Company sows the seeds for autonomous and more profitable farming\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/small-robot-company\\u003c/td\\u003e\\n\\u003ctd\\u003ecase
+        study\\u003c/td\\u003e\\n\\u003ctd\\u003erobotics, ai\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-06-04\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/how-to-integrate-ubuntu-desktop-with-active-directory/17323\\\"\\u003eHow
+        to integrate Ubuntu Desktop with Active Directory\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/microsoft-active-directory\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003edesktop,
+        active-directory\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-06-04\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/connected-cars-and-autonomous-driving/17243\\\"\\u003eConnected
+        cars and autonomous driving\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/451-automotive\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eiot\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-05-31\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eAddressing
+        risk and complexity with software\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/why-ubuntu-core-is-the-most-secure-choice-for-iot/17292\\\"\\u003eWhy
+        Ubuntu Core is the most secure choice for IoT\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/core18-security\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003esecurity,
+        iot, ubuntu-core\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-05-29\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/getting-started-with-ai/17336\\\"\\u003eGetting
+        started with AI\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/starting-with-ai\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eai,
+        ml\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-05-11\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/the-transformation-of-the-devops-journey-in-iot/17422\\\"\\u003eThe
+        transformation of the DevOps journey in IoT\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/iot-devops\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eiot\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-05-07\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/cloud-init/17291\\\"\\u003eCloud init\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/cloud-init-whitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003ecloud\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-05-01\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/how-to-build-a-lightweight-system-container-cluster/17322\\\"\\u003eHow
+        to build a lightweight system container cluster\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/lxd-whitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003elxd\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-04-30\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eYou
+        will learn how working in this environment:\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/the-transformation-of-the-devops-journey-in-iot-webinar/17306\\\"\\u003eThe
+        transformation of the DevOps journey in IoT Webinar\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/devops-iot-webinar\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eiot\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-04-29\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/private-cloud-security-webinar/17329\\\"\\u003ePrivate
+        cloud security Webinar\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/openstack-security-webinar\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack,
+        security\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-04-24\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eHow
+        Charmed OpenStack is decreasing common security concerns\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/private-cloud-security/17421\\\"\\u003ePrivate
+        cloud security\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/openstack-security-whitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack,
+        security\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-04-24\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eMeeting
+        the highest levels of enterprise requirements with OpenStack\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/hiri-successfully-monetises-their-snap/17314\\\"\\u003eHiri
+        successfully monetises their snap\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/hiri-case-study\\u003c/td\\u003e\\n\\u003ctd\\u003ecase
+        study\\u003c/td\\u003e\\n\\u003ctd\\u003eapps, snaps\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-04-25\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/whats-new-in-ubuntu-19-04/17240\\\"\\u003eWhat\u2019s
+        new in Ubuntu 19.04?\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/19-04-webinar\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack,
+        kubernetes, ceph, iot, desktop\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-04-18\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eJoin
+        Canonical Product Director Stephan Fabel and Ubuntu Product Managers to discuss
+        everything new in Ubuntu 19.04 \u2018Disco Dingo\u2019\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/optimising-iot-bandwidth-with-delta-updates/17335\\\"\\u003eOptimising
+        IoT bandwidth with delta updates\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/snap-deltas\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eiot,
+        snaps\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-03-16\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eLearn
+        how snap deltas\u2019 over-the-air updates are efficient and effective.\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/an-introduction-to-apparmor/17277\\\"\\u003eAn
+        introduction to AppArmor\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/apparmor-intro\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003esecurity\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-03-16\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eAn
+        explanation of AppArmor and its key features.\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/get-started-with-devops-best-practices-ci-cd/17305\\\"\\u003eGet
+        started with DevOps best practices: CI/CD\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/devops-cicd-webinar\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003ekubernetes\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-03-07\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/esm-for-ubuntu-14-04-lts-trusty-tahr/17275\\\"\\u003eESM
+        for Ubuntu 14.04 LTS Trusty Tahr\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/14-04-esm\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003esecurity\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-02-21\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eLearn
+        how to maintain ongoing security compliance for your 14.04 systems.\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/securing-iot-device-data-against-physical-access/17318\\\"\\u003eSecuring
+        IoT device data against physical access\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/iot-disk-encryption\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eiot,
+        security, ubuntu-core\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-02-11\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eA
+        technical overview of how Ubuntu Core with full disk encryption and secure
+        boot can be implemented to harden IoT devices\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/multi-cloud-fundamental-to-financial-services-transformation/17312\\\"\\u003eMulti-cloud
+        fundamental to financial services transformation\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/finserv-multi-cloud\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003ecloud,
+        finance, ai\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-02-04\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/extension-securite-et-maintenance-pour-ubuntu-14-04/17414\\\"\\u003eExtension
+        S\xE9curit\xE9 et Maintenance pour Ubuntu 14.04\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/fr/esm\\u003c/td\\u003e\\n\\u003ctd\\u003eblog\\u003c/td\\u003e\\n\\u003ctd\\u003esecurity\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-01-31\\u003c/td\\u003e\\n\\u003ctd\\u003efr\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/utiliser-des-gpus-avec-kubernetes/17419\\\"\\u003eUtiliser
+        des GPUs avec Kubernetes\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/fr/utiliser-gpgpus-avec-kubernetes\\u003c/td\\u003e\\n\\u003ctd\\u003eblog\\u003c/td\\u003e\\n\\u003ctd\\u003ekubernetes\\u003c/td\\u003e\\n\\u003ctd\\u003e2018-12-20\\u003c/td\\u003e\\n\\u003ctd\\u003efr\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/apellix-engineers-safer-work-environments-with-ubuntu-powered-aerial-robotics/17315\\\"\\u003eApellix
+        engineers safer work environments with Ubuntu powered aerial robotics\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/industrial-drones-case-study\\u003c/td\\u003e\\n\\u003ctd\\u003ecase
+        study\\u003c/td\\u003e\\n\\u003ctd\\u003erobotics, iot\\u003c/td\\u003e\\n\\u003ctd\\u003e2018-12-14\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/allan-gray-unlocks-unprecedented-availability-and-productivity-with-charmed-kubernetes/17319\\\"\\u003eAllan
+        Gray unlocks unprecedented availability and productivity with Charmed Kubernetes\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/k8s-allan-gray\\u003c/td\\u003e\\n\\u003ctd\\u003ecase
+        study\\u003c/td\\u003e\\n\\u003ctd\\u003efinance, kubernetes\\u003c/td\\u003e\\n\\u003ctd\\u003e2018-12-13\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/six-reasons-why-developers-choose-ubuntu-desktop/17304\\\"\\u003eSix
+        reasons why developers choose Ubuntu Desktop\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/developer-desktop\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003edesktop\\u003c/td\\u003e\\n\\u003ctd\\u003e2018-11-23\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/modernise-your-cloud/17324\\\"\\u003eModernise
+        your cloud\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/modern-cloud\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003ecloud\\u003c/td\\u003e\\n\\u003ctd\\u003e2018-11-22\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eDiscover
+        how Trilio and Canonical help organisations transition to new, maintainable
+        cloud architecture in just weeks.\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/precision-drones-on-ubuntu-flying-at-the-edge-of-innovation/17316\\\"\\u003ePrecision
+        drones on Ubuntu: flying at the edge of innovation\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/industrial-drones\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003erobotics,
+        iot\\u003c/td\\u003e\\n\\u003ctd\\u003e2018-11-20\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eHow
+        Apellix uses Ubuntu on drones to replace human workers in potentially dangerous
+        scenarios.\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/securing-the-enterprise-how-ubuntu-is-at-the-forefront-of-security-and-compliance/17340\\\"\\u003eSecuring
+        the enterprise: how Ubuntu is at the forefront of security and compliance\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/ubuntu-compliance\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003esecurity\\u003c/td\\u003e\\n\\u003ctd\\u003e2018-11-12\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/itstrategen-keeps-legacy-applications-secure-with-extended-security-maintenance/17286\\\"\\u003eITstrategen
+        keeps legacy applications secure with Extended Security Maintenance\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/ITstrategen-case-study\\u003c/td\\u003e\\n\\u003ctd\\u003ecase
+        study\\u003c/td\\u003e\\n\\u003ctd\\u003esecurity\\u003c/td\\u003e\\n\\u003ctd\\u003e2018-10-29\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/what-s-new-in-ubuntu-18-10/17339\\\"\\u003eWhat\u2019s
+        New in Ubuntu 18.10\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/ubuntu-18-10\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003edesktop,
+        server\\u003c/td\\u003e\\n\\u003ctd\\u003e2018-10-29\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eCanonical
+        product managers discuss the new Ubuntu 18.10 release features in this on-demand
+        webinar\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/ubuntu-core-and-kura-a-framework-for-iot-gateways/17341\\\"\\u003eUbuntu
+        Core and Kura: A framework for IoT gateways\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/ubuntu-core-and-kura\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eubuntu-core,
+        iot, edge, snaps\\u003c/td\\u003e\\n\\u003ctd\\u003e2018-10-23\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/keep-up-with-evolving-software/17310\\\"\\u003eKeep
+        up with evolving software\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/evolving-software\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003ejuju,
+        cloud\\u003c/td\\u003e\\n\\u003ctd\\u003e2018-10-22\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eLearn
+        how Juju can help solve software management complexity.\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/wofur-konnen-sie-kubernetes-einsetzen/17410\\\"\\u003eWof\xFCr
+        k\xF6nnen Sie Kubernetes einsetzen?\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/de/what-can-you-do-with-kubernetes\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003ekubernetes\\u003c/td\\u003e\\n\\u003ctd\\u003e2018-10-19\\u003c/td\\u003e\\n\\u003ctd\\u003ede\\u003c/td\\u003e\\n\\u003ctd\\u003eDieses
+        Webinar liefert Ihnen alles Wichtige zum Einstieg.\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/low-latency-and-real-time-kernels-for-telco-and-nfv/17320\\\"\\u003eLow
+        latency and real-time kernels for telco and NFV\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/kernel-telco-nfv\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003etelco\\u003c/td\\u003e\\n\\u003ctd\\u003e2018-10-08\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/future-proofing-fingbox-the-iot-home-network-monitoring-device/17313\\\"\\u003eFuture-proofing
+        Fingbox, the IoT home network monitoring device\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/future-proof-iot\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eiot,
+        ubuntu-core\\u003c/td\\u003e\\n\\u003ctd\\u003e2018-10-02\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/how-to-build-and-deploy-your-first-ai-ml-model-on-ubuntu/17294\\\"\\u003eHow
+        to build and deploy your first AI/ML model on Ubuntu\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/deploy-ai-ml-model\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eai,
+        ml, kubeflow, kubernetes\\u003c/td\\u003e\\n\\u003ctd\\u003e2018-09-26\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eAn
+        introduction to AI and ML workloads on Ubuntu workstations, servers and in
+        the cloud on a Kubernetes stack.\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/openstack-problemlos-installieren-und-skalieren/17409\\\"\\u003eOpenStack
+        problemlos installieren und skalieren\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/de/openstack-made-easy\\u003c/td\\u003e\\n\\u003ctd\\u003eeBook\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack\\u003c/td\\u003e\\n\\u003ctd\\u003e2018-09-05\\u003c/td\\u003e\\n\\u003ctd\\u003ede\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/key-considerations-when-choosing-a-robot-s-operating-system/17333\\\"\\u003eKey
+        considerations when choosing a robot\u2019s operating system\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/robot-operating-system-choice\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003erobotics\\u003c/td\\u003e\\n\\u003ctd\\u003e2018-09-05\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/cio-guide-to-multi-cloud-operations/17325\\\"\\u003eCIO
+        guide to multi-cloud operations\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/multi-cloud-guide\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003ecloud,
+        kubernetes, container\\u003c/td\\u003e\\n\\u003ctd\\u003e2018-09-03\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/canonical-presents-financial-services-month/17241\\\"\\u003eCanonical
+        presents Financial Services Month\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/financial-services-month\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003efinance,
+        ai, ml cloud\\u003c/td\\u003e\\n\\u003ctd\\u003e2018-09-03\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eFilmed
+        at the London Stock exchange with representatives from Canonical, 451 Research,
+        IBM, and a former Deutsche Bank storage CTO, Canonical took a deep dive look
+        in to the rise of multi-cloud in the financial services industry.\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/establishing-a-software-defined-iot-business-model/17317\\\"\\u003eEstablishing
+        a software defined IoT business model\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/iot-business-model\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eiot\\u003c/td\\u003e\\n\\u003ctd\\u003e2018-08-24\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/artificial-intelligence-machine-learning-and-ubuntu/17276\\\"\\u003eArtificial
+        intelligence, machine learning and Ubuntu\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/ai-ml-ubuntu\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eai,
+        ml, kubernetes\\u003c/td\\u003e\\n\\u003ctd\\u003e2018-08-16\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/von-vmware-zu-canonical-openstack/17408\\\"\\u003eVon
+        VMware zu Canonical OpenStack\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/de/vmware-to-openstack\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack\\u003c/td\\u003e\\n\\u003ctd\\u003e2018-08-06\\u003c/td\\u003e\\n\\u003ctd\\u003ede\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/fing-serves-30-000-customers-with-a-secure-future-proof-iot-device/17311\\\"\\u003eFing
+        serves 30,000 customers with a secure, future-proof IoT device\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/fingbox-case-study\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eiot,
+        ubuntu-core, snaps\\u003c/td\\u003e\\n\\u003ctd\\u003e2018-06-25\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/canonical-integre-containerd-a-ubuntu-kubernetes/17412\\\"\\u003eCanonical
+        int\xE8gre containerd \xE0 Ubuntu Kubernetes\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/fr/canonical-ajoute-containerd-a-ubuntu-kubernetes\\u003c/td\\u003e\\n\\u003ctd\\u003eblog\\u003c/td\\u003e\\n\\u003ctd\\u003ekubernetes\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-05-22\\u003c/td\\u003e\\n\\u003ctd\\u003efr\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/guide-du-dsi-pour-les-operations-multicloud/17415\\\"\\u003eGUIDE
+        DU DSI pour les op\xE9rations multicloud\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/fr/guide-du-DSI-pour-les-operations-multicloud\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003ecloud,
+        kubernetes\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-05-22\\u003c/td\\u003e\\n\\u003ctd\\u003efr\\u003c/td\\u003e\\n\\u003ctd\\u003eChoisir
+        une architecture cloud rentable\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/canonical-annonce-managed-apps-linfogerance-des-applications-sur-votre-cloud/17416\\\"\\u003eCanonical
+        annonce Managed Apps: l\u2019infog\xE9rance des applications sur votre cloud.\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/fr/managed-apps\\u003c/td\\u003e\\n\\u003ctd\\u003eblog\\u003c/td\\u003e\\n\\u003ctd\\u003eapps\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-05-18\\u003c/td\\u003e\\n\\u003ctd\\u003efr\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/migrer-de-vmware-a-openstack/17417\\\"\\u003eMigrer
+        de VMWare \xE0 OpenStack\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/fr/migrer-de-vmware-a-openstack\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-05-18\\u003c/td\\u003e\\n\\u003ctd\\u003efr\\u003c/td\\u003e\\n\\u003ctd\\u003ePassez
+        \xE0 Charmed OpenStack et r\xE9duisez consid\xE9rablement vos co\xFBts\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/migrer-de-vmware-a-openstack-webinaire/17420\\\"\\u003eMigrer
+        de VMware \xE0 Openstack Webinaire\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/fr/vmware-to-openstack\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-05-18\\u003c/td\\u003e\\n\\u003ctd\\u003efr\\u003c/td\\u003e\\n\\u003ctd\\u003eApprenez
+        comment migrer d\u2019un environnement traditionnel et propri\xE9taire \xE0
+        un cloud OpenStack\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/charmed-kubernetes-reference-architecture/19159\\\"\\u003eCharmed
+        Kubernetes reference architecture\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/dell-k8s-reference-architecture\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003ekubernetes\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-11-07\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eIntegration
+        with VxFlex OS delivered by Dell EMC and Canonical.\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/charmed-openstack-reference-architecture/19160\\\"\\u003eCharmed
+        OpenStack reference architecture\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/dell-openstack-reference-architecture\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-11-07\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eWith
+        Dell EMC PowerEdge servers for workloads and storage and Dell EMC Networking
+        and Canonical.\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/at-t-private-offer-on-azure-ubuntu-pro-support/19161\\\"\\u003eAT\\u0026amp;T
+        Private Offer on Azure - Ubuntu Pro + Support\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/at\\u0026amp;t-azure-webinar\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eubuntu-advantage\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-06-30\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eSecure,
+        updated Ubuntu with 24x7 support special pricing and SLAs for AT\\u0026amp;T.\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/finserv-open-source-infrastructure-powers-hybrid-cloud-strategy/24008\\\"\\u003eFinserv
+        open source infrastructure powers hybrid cloud strategy\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/finserv-hybrid-cloud-webinar\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003efinancial
+        services, open source, openstack, cloud, hybrid cloud\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-09-02\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eAn
+        overview of how to simplify the deployment and management of an OpenStack
+        cloud.\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003c/tbody\\u003e\\n\\u003c/table\\u003e\\n\\u003c/div\\u003e\\u003c/details\\u003e\",\"post_number\":1,\"post_type\":1,\"updated_at\":\"2021-12-07T13:03:15.023Z\",\"reply_count\":0,\"reply_to_post_number\":null,\"quote_count\":0,\"incoming_link_count\":4,\"reads\":17,\"readers_count\":16,\"score\":13.2,\"yours\":true,\"topic_id\":18033,\"topic_slug\":\"engage-pages-for-ubuntu-com\",\"display_username\":\"Carlos
+        Wu Fei\",\"primary_group_name\":\"Canonical\",\"primary_group_flair_url\":\"/uploads/short-url/paWz8RxxmKxiYXUmH2ABvqKp0Gg.png\",\"primary_group_flair_bg_color\":\"\",\"primary_group_flair_color\":\"\",\"version\":50,\"can_edit\":true,\"can_delete\":false,\"can_recover\":false,\"can_wiki\":true,\"link_counts\":[{\"url\":\"https://ubuntu.com/engage\",\"internal\":false,\"reflection\":false,\"title\":\"Ubuntu
+        case studies, whitepapers and webinars | Ubuntu\",\"clicks\":3},{\"url\":\"https://discourse.ubuntu.com/t/at-t-private-offer-on-azure-ubuntu-pro-support/19161\",\"internal\":true,\"reflection\":false,\"title\":\"AT\\u0026T
+        Private Offer on Azure - Ubuntu Pro + Support\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/charmed-openstack-reference-architecture/19160\",\"internal\":true,\"reflection\":false,\"title\":\"Charmed
+        OpenStack reference architecture\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/charmed-kubernetes-reference-architecture/19159\",\"internal\":true,\"reflection\":false,\"title\":\"Charmed
+        Kubernetes reference architecture\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/migrer-de-vmware-a-openstack-webinaire/17420\",\"internal\":true,\"reflection\":false,\"title\":\"Migrer
+        de VMware \xE0 Openstack Webinaire\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/migrer-de-vmware-a-openstack/17417\",\"internal\":true,\"reflection\":false,\"title\":\"Migrer
+        de VMWare \xE0 OpenStack\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/canonical-annonce-managed-apps-linfogerance-des-applications-sur-votre-cloud/17416\",\"internal\":true,\"reflection\":false,\"title\":\"Canonical
+        annonce Managed Apps: l'infog\xE9rance des applications sur votre cloud\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/guide-du-dsi-pour-les-operations-multicloud/17415\",\"internal\":true,\"reflection\":false,\"title\":\"GUIDE
+        DU DSI pour les op\xE9rations multicloud\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/canonical-integre-containerd-a-ubuntu-kubernetes/17412\",\"internal\":true,\"reflection\":false,\"title\":\"Canonical
+        int\xE8gre containerd \xE0 Ubuntu Kubernetes\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/fing-serves-30-000-customers-with-a-secure-future-proof-iot-device/17311\",\"internal\":true,\"reflection\":false,\"title\":\"Fing
+        serves 30,000 customers with a secure, future-proof IoT device\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/von-vmware-zu-canonical-openstack/17408\",\"internal\":true,\"reflection\":false,\"title\":\"Von
+        VMware zu Canonical OpenStack\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/artificial-intelligence-machine-learning-and-ubuntu/17276\",\"internal\":true,\"reflection\":false,\"title\":\"Artificial
+        intelligence, machine learning and Ubuntu\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/establishing-a-software-defined-iot-business-model/17317\",\"internal\":true,\"reflection\":false,\"title\":\"Establishing
+        a software defined IoT business model\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/canonical-presents-financial-services-month/17241\",\"internal\":true,\"reflection\":false,\"title\":\"Canonical
+        presents Financial Services Month\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/cio-guide-to-multi-cloud-operations/17325\",\"internal\":true,\"reflection\":false,\"title\":\"CIO
+        guide to multi-cloud operations\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/key-considerations-when-choosing-a-robot-s-operating-system/17333\",\"internal\":true,\"reflection\":false,\"title\":\"Key
+        considerations when choosing a robot\u2019s operating system\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/openstack-problemlos-installieren-und-skalieren/17409\",\"internal\":true,\"reflection\":false,\"title\":\"OpenStack
+        problemlos installieren und skalieren\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/how-to-build-and-deploy-your-first-ai-ml-model-on-ubuntu/17294\",\"internal\":true,\"reflection\":false,\"title\":\"How
+        to build and deploy your first AI/ML model on Ubuntu\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/future-proofing-fingbox-the-iot-home-network-monitoring-device/17313\",\"internal\":true,\"reflection\":false,\"title\":\"Future-proofing
+        Fingbox, the IoT home network monitoring device\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/low-latency-and-real-time-kernels-for-telco-and-nfv/17320\",\"internal\":true,\"reflection\":false,\"title\":\"Low
+        latency and real-time kernels for telco and NFV\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/wofur-konnen-sie-kubernetes-einsetzen/17410\",\"internal\":true,\"reflection\":false,\"title\":\"Wof\xFCr
+        k\xF6nnen Sie Kubernetes einsetzen?\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/keep-up-with-evolving-software/17310\",\"internal\":true,\"reflection\":false,\"title\":\"Keep
+        up with evolving software\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/ubuntu-core-and-kura-a-framework-for-iot-gateways/17341\",\"internal\":true,\"reflection\":false,\"title\":\"Ubuntu
+        Core and Kura: A framework for IoT gateways\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/what-s-new-in-ubuntu-18-10/17339\",\"internal\":true,\"reflection\":false,\"title\":\"What\u2019s
+        New in Ubuntu 18.10\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/itstrategen-keeps-legacy-applications-secure-with-extended-security-maintenance/17286\",\"internal\":true,\"reflection\":false,\"title\":\"ITstrategen
+        keeps legacy applications secure with Extended Security Maintenance\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/securing-the-enterprise-how-ubuntu-is-at-the-forefront-of-security-and-compliance/17340\",\"internal\":true,\"reflection\":false,\"title\":\"Securing
+        the enterprise: how Ubuntu is at the forefront of security and compliance\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/precision-drones-on-ubuntu-flying-at-the-edge-of-innovation/17316\",\"internal\":true,\"reflection\":false,\"title\":\"Precision
+        drones on Ubuntu: flying at the edge of innovation\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/modernise-your-cloud/17324\",\"internal\":true,\"reflection\":false,\"title\":\"Modernise
+        your cloud\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/six-reasons-why-developers-choose-ubuntu-desktop/17304\",\"internal\":true,\"reflection\":false,\"title\":\"Six
+        reasons why developers choose Ubuntu Desktop\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/allan-gray-unlocks-unprecedented-availability-and-productivity-with-charmed-kubernetes/17319\",\"internal\":true,\"reflection\":false,\"title\":\"Allan
+        Gray unlocks unprecedented availability and productivity with Charmed Kubernetes\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/apellix-engineers-safer-work-environments-with-ubuntu-powered-aerial-robotics/17315\",\"internal\":true,\"reflection\":false,\"title\":\"Apellix
+        engineers safer work environments with Ubuntu powered aerial robotics\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/utiliser-des-gpus-avec-kubernetes/17419\",\"internal\":true,\"reflection\":false,\"title\":\"Utiliser
+        des GPUs avec Kubernetes\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/extension-securite-et-maintenance-pour-ubuntu-14-04/17414\",\"internal\":true,\"reflection\":false,\"title\":\"Extension
+        S\xE9curit\xE9 et Maintenance pour Ubuntu 14.04\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/multi-cloud-fundamental-to-financial-services-transformation/17312\",\"internal\":true,\"reflection\":false,\"title\":\"Multi-cloud
+        fundamental to financial services transformation\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/securing-iot-device-data-against-physical-access/17318\",\"internal\":true,\"reflection\":false,\"title\":\"Securing
+        IoT device data against physical access\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/still-running-ubuntu-14-04/17275\",\"internal\":true,\"reflection\":false,\"title\":\"Still
+        running Ubuntu 14.04?\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/get-started-with-devops-best-practices-ci-cd/17305\",\"internal\":true,\"reflection\":false,\"title\":\"Get
+        started with DevOps best practices: CI/CD\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/an-introduction-to-apparmor/17277\",\"internal\":true,\"reflection\":false,\"title\":\"An
+        introduction to AppArmor\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/optimising-iot-bandwidth-with-delta-updates/17335\",\"internal\":true,\"reflection\":false,\"title\":\"Optimising
+        IoT bandwidth with delta updates\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/whats-new-in-ubuntu-19-04/17240\",\"internal\":true,\"reflection\":false,\"title\":\"What's
+        new in Ubuntu 19.04?\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/hiri-successfully-monetises-their-snap/17314\",\"internal\":true,\"reflection\":false,\"title\":\"Hiri
+        successfully monetises their snap\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/private-cloud-security/17421\",\"internal\":true,\"reflection\":false,\"title\":\"Private
+        cloud security\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/private-cloud-security-webinar/17329\",\"internal\":true,\"reflection\":false,\"title\":\"Private
+        cloud security Webinar\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/the-transformation-of-the-devops-journey-in-iot-webinar/17306\",\"internal\":true,\"reflection\":false,\"title\":\"The
+        transformation of the DevOps journey in IoT Webinar\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/how-to-build-a-lightweight-system-container-cluster/17322\",\"internal\":true,\"reflection\":false,\"title\":\"How
+        to build a lightweight system container cluster\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/cloud-init/17291\",\"internal\":true,\"reflection\":false,\"title\":\"Cloud
+        init\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/the-transformation-of-the-devops-journey-in-iot/17422\",\"internal\":true,\"reflection\":false,\"title\":\"The
+        transformation of the DevOps journey in IoT\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/getting-started-with-ai/17336\",\"internal\":true,\"reflection\":false,\"title\":\"Getting
+        started with AI\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/why-ubuntu-core-is-the-most-secure-choice-for-iot/17292\",\"internal\":true,\"reflection\":false,\"title\":\"Why
+        Ubuntu Core is the most secure choice for IoT\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/connected-cars-and-autonomous-driving/17243\",\"internal\":true,\"reflection\":false,\"title\":\"Connected
+        cars and autonomous driving\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/how-to-integrate-ubuntu-desktop-with-active-directory/17323\",\"internal\":true,\"reflection\":false,\"title\":\"How
+        to integrate Ubuntu Desktop with Active Directory\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/small-robot-company-sows-the-seeds-for-autonomous-and-more-profitable-farming/17334\",\"internal\":true,\"reflection\":false,\"title\":\"Small
+        Robot Company sows the seeds for autonomous and more profitable farming\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/north-america-s-first-autonomous-runway-snowplough/17327\",\"internal\":true,\"reflection\":false,\"title\":\"North
+        America\u2018s first autonomous runway snowplough\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/the-future-of-mobile-connectivity/17342\",\"internal\":true,\"reflection\":false,\"title\":\"The
+        future of mobile connectivity\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/how-to-get-started-and-progress-with-an-ai-program/17245\",\"internal\":true,\"reflection\":false,\"title\":\"How
+        to get started and progress with an AI program\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/sicherheit-in-der-private-cloud/17411\",\"internal\":true,\"reflection\":false,\"title\":\"Sicherheit
+        in der Private Cloud\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/a-guide-to-edge-computing-and-the-tools-you-need/17308\",\"internal\":true,\"reflection\":false,\"title\":\"A
+        guide to edge computing and the tools you need\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/le-support-d-ubuntu-14-04-lts-est-maintenant-passe-a-esm/17413\",\"internal\":true,\"reflection\":false,\"title\":\"Le
+        support d\u2019Ubuntu 14.04 LTS est maintenant pass\xE9 \xE0 ESM\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/a-shift-to-the-linux-app-store-experience/17347\",\"internal\":true,\"reflection\":false,\"title\":\"A
+        shift to the Linux app store experience\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/telcos-and-service-providers-expect-near-100-uptime/17330\",\"internal\":true,\"reflection\":false,\"title\":\"Telcos
+        and Service Providers expect near 100% uptime\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/openstack-made-easy/17328\",\"internal\":true,\"reflection\":false,\"title\":\"OpenStack
+        made easy\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/nfv-and-sdn-on-openstack-for-network-operators/17326\",\"internal\":true,\"reflection\":false,\"title\":\"NFV
+        and SDN on OpenStack for network operators\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/carrier-cloudification-what-every-telecom-executive-needs-to-know/17338\",\"internal\":true,\"reflection\":false,\"title\":\"Carrier
+        Cloudification: What every telecom executive needs to know\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/how-to-escape-stuckstack-and-profit-from-your-openstack-investment/17337\",\"internal\":true,\"reflection\":false,\"title\":\"How
+        to escape StuckStack and profit from your OpenStack investment\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/low-latency-and-real-time-kernels-for-telco-and-nfv/17321\",\"internal\":true,\"reflection\":false,\"title\":\"Low
+        latency and real time kernels for telco and NFV\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/how-to-face-the-challenges-of-becoming-a-cloud-operator/17290\",\"internal\":true,\"reflection\":false,\"title\":\"How
+        to face the challenges of becoming a cloud operator\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/sensape-uses-landscape-to-remotely-support-revolutionary-interactive-retail-displays/17289\",\"internal\":true,\"reflection\":false,\"title\":\"Sensape
+        uses Landscape to remotely support revolutionary interactive retail displays\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/cto-s-guide-to-sdn-nfv-vnf/17293\",\"internal\":true,\"reflection\":false,\"title\":\"CTO\u2019s
+        guide to SDN, NFV \\u0026 VNF\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/city-network-brings-openstack-cloud-hosting-to-the-financial-services-sector-with-canonical/17282\",\"internal\":true,\"reflection\":false,\"title\":\"City
+        Network brings OpenStack cloud hosting to the financial services sector with
+        Canonical\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/the-essential-guide-for-telecoms-and-service-providers-adopting-big-data-solutions/17309\",\"internal\":true,\"reflection\":false,\"title\":\"The
+        essential guide for Telecoms and Service Providers adopting big data solutions\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/taking-charge-of-the-iots-security-vulnerabilities/17346\",\"internal\":true,\"reflection\":false,\"title\":\"Taking
+        charge of the IoT's security vulnerabilities\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/for-ctos-the-no-nonsense-way-to-accelerate-your-business-with-containers/17345\",\"internal\":true,\"reflection\":false,\"title\":\"For
+        CTOs: the no-nonsense way to accelerate your business with containers\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/commercetools-uses-ubuntu-server-to-power-its-next-generation-ecommerce-platform/17283\",\"internal\":true,\"reflection\":false,\"title\":\"Commercetools
+        uses Ubuntu Server to power its next-generation ecommerce platform\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/cinergy-makes-significant-digital-signage-saving-with-screenly-pro-and-ubuntu-core/17281\",\"internal\":true,\"reflection\":false,\"title\":\"Cinergy
+        makes significant digital signage saving with Screenly Pro and Ubuntu Core\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/botsandus-builds-a-social-robot-on-ubuntu/17280\",\"internal\":true,\"reflection\":false,\"title\":\"BotsAndUs
+        builds a social robot on Ubuntu\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/azlogica-utilise-ubuntu-core-for-customised-iot-agricultural-solutions/17279\",\"internal\":true,\"reflection\":false,\"title\":\"AZLOGICA
+        utilise Ubuntu Core for customised IoT agricultural solutions\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/azeti-uses-ubuntu-core-to-improve-deployment-and-security/17278\",\"internal\":true,\"reflection\":false,\"title\":\"Azeti
+        uses Ubuntu Core to improve deployment and security\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/nexiona-collaborates-with-canonical-and-dell-to-create-miimetiq-edge/17287\",\"internal\":true,\"reflection\":false,\"title\":\"NEXIONA
+        collaborates with Canonical and Dell to create MIIMETIQ EDGE\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/how-ubuntu-helped-innovapos-revolutionise-the-vending-machine-industry/17285\",\"internal\":true,\"reflection\":false,\"title\":\"How
+        Ubuntu helped InnovaPOS revolutionise the vending machine industry\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/learn-whats-new-in-ubuntu-server-14-04-lts/17344\",\"internal\":true,\"reflection\":false,\"title\":\"Learn
+        What's New In Ubuntu Server 14.04 LTS\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/make-it-rain-public-cloud-on-ubuntu-openstack/17332\",\"internal\":true,\"reflection\":false,\"title\":\"Make
+        IT rain: public cloud on Ubuntu OpenStack\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/building-a-private-cloud-take-the-leap/17331\",\"internal\":true,\"reflection\":false,\"title\":\"Building
+        a private cloud? Take the leap!\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/server-provisioning-what-network-admins-it-pros-need-to-know/17307\",\"internal\":true,\"reflection\":false,\"title\":\"Server
+        Provisioning: What Network Admins \\u0026 IT Pros Need to Know\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/rocket-chat-communication-platform-enables-simplicity-through-snaps/17288\",\"internal\":true,\"reflection\":false,\"title\":\"Rocket.Chat
+        communication platform enables simplicity through snaps\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/ims-evolve-adopts-ubuntu-core-to-provide-iot-enabled-business-intelligence-in-the-supply-chain/17284\",\"internal\":true,\"reflection\":false,\"title\":\"IMS
+        Evolve adopts Ubuntu Core to provide IoT-enabled business intelligence in
+        the supply chain\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/creating-accurate-ai-models-with-data/17349\",\"internal\":true,\"reflection\":false,\"title\":\"Creating
+        accurate AI models with data\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/creating-a-cloud-like-bare-metal-experience-in-the-data-centre/17348\",\"internal\":true,\"reflection\":false,\"title\":\"Creating
+        a cloud-like bare metal experience in the data centre\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/a-guide-to-developing-android-apps-on-ubuntu/17351\",\"internal\":true,\"reflection\":false,\"title\":\"A
+        guide to developing Android apps on Ubuntu\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/how-to-manage-snaps-in-an-enterprise-environment/17352\",\"internal\":true,\"reflection\":false,\"title\":\"How
+        to manage snaps in an enterprise environment\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/machine-learning-operations-mlops/17353\",\"internal\":true,\"reflection\":false,\"title\":\"Machine
+        Learning Operations (MLOps)\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/from-vmware-to-charmed-openstack/17343\",\"internal\":true,\"reflection\":false,\"title\":\"From
+        VMWare To Charmed OpenStack\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/accelerating-deep-tech-with-ubuntu/17354\",\"internal\":true,\"reflection\":false,\"title\":\"Accelerating
+        deep tech with Ubuntu\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/yahoo-japan-builds-their-iaas-environment-with-canonical/17355\",\"internal\":true,\"reflection\":false,\"title\":\"Yahoo!
+        Japan builds their IaaS environment with Canonical\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/how-domotz-streamlined-provisioning-of-iot-devices/17356\",\"internal\":true,\"reflection\":false,\"title\":\"How
+        Domotz streamlined provisioning of IoT devices\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/what-s-new-in-ubuntu-19-10/17357\",\"internal\":true,\"reflection\":false,\"title\":\"What\u2019s
+        new in Ubuntu 19.10\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/tim-ensures-system-security-and-client-confidence-with-esm/17358\",\"internal\":true,\"reflection\":false,\"title\":\"TIM
+        ensures system security and client confidence with ESM\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/ensuring-security-and-isolation-in-kubernetes-with-kata-containers/17359\",\"internal\":true,\"reflection\":false,\"title\":\"Ensuring
+        security and isolation in Kubernetes with Kata Containers\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/the-wellcome-sanger-institute-turns-to-canonical-for-high-level-ceph-support/17360\",\"internal\":true,\"reflection\":false,\"title\":\"The
+        Wellcome Sanger Institute turns to Canonical for high level Ceph support\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/lessons-learned-from-100-private-cloud-builds/17361\",\"internal\":true,\"reflection\":false,\"title\":\"Lessons
+        learned from 100+ Private cloud builds\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/linux-security-with-ubuntu/17362\",\"internal\":true,\"reflection\":false,\"title\":\"Linux
+        security with Ubuntu\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/build-smart-display-devices-with-mir-fast-to-production-secure-open-source/17363\",\"internal\":true,\"reflection\":false,\"title\":\"Build
+        smart display devices with Mir: fast to production, secure, open-source\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/register-for-wslconf/17365\",\"internal\":true,\"reflection\":false,\"title\":\"Register
+        for WSLConf\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/sbi-group-unlocks-infrastructure-automation-with-secure-on-premises-openstack-cloud/17364\",\"internal\":true,\"reflection\":false,\"title\":\"SBI
+        Group unlocks infrastructure automation with secure, on-premises OpenStack
+        cloud\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/cyberdyne-keeps-cleaning-robots-up-to-date-in-the-field-with-snaps/17366\",\"internal\":true,\"reflection\":false,\"title\":\"Cyberdyne
+        keeps cleaning robots up-to-date in the field with snaps\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/ubuntu-desktop-for-the-enterprise/17368\",\"internal\":true,\"reflection\":false,\"title\":\"Ubuntu
+        Desktop for the enterprise\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/an-intro-to-microk8s/17367\",\"internal\":true,\"reflection\":false,\"title\":\"An
+        intro to MicroK8s\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/kubernetes-a-secure-flexible-and-automated-edge-for-iot-developers/17369\",\"internal\":true,\"reflection\":false,\"title\":\"Kubernetes:
+        a secure, flexible and automated edge for IoT developers\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/de-vmware-a-charmed-openstack/17371\",\"internal\":true,\"reflection\":false,\"title\":\"De
+        VMware a Charmed OpenStack\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/migration-von-vmware-zu-openstack/17370\",\"internal\":true,\"reflection\":false,\"title\":\"Migration
+        von VMware zu OpenStack\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/deploy-kubernetes-in-your-data-centre/17373\",\"internal\":true,\"reflection\":false,\"title\":\"Deploy
+        Kubernetes in your data centre\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/artificial-intelligence-at-the-edge-in-a-5g-world/17372\",\"internal\":true,\"reflection\":false,\"title\":\"Artificial
+        Intelligence at the edge in a 5G world\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/esm-maintains-interanas-system-security-while-upgrading/17376\",\"internal\":true,\"reflection\":false,\"title\":\"ESM
+        maintains Interana's system security while upgrading\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/an-introduction-to-anbox-cloud/17374\",\"internal\":true,\"reflection\":false,\"title\":\"An
+        introduction to Anbox Cloud\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/hosted-private-cloud-infrastructure-a-cost-analysis/17375\",\"internal\":true,\"reflection\":false,\"title\":\"Hosted
+        private cloud infrastructure: a cost analysis\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/smart-card-login-on-ubuntu/17377\",\"internal\":true,\"reflection\":false,\"title\":\"Smart
+        card login on Ubuntu\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/securing-ros-robotics-platforms/17378\",\"internal\":true,\"reflection\":false,\"title\":\"Securing
+        ROS robotics platforms\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/rigado-cuts-customers-time-to-market/17379\",\"internal\":true,\"reflection\":false,\"title\":\"Rigado
+        cuts customers' time-to-market\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/virtual-event-microk8s-kubernetes/17380\",\"internal\":true,\"reflection\":false,\"title\":\"Virtual
+        event: MicroK8s \\u0026 Kubernetes\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/installez-et-mettez-openstack-a-lechelle-en-toute-simplicite/17418\",\"internal\":true,\"reflection\":false,\"title\":\"Installez
+        et mettez OpenStack \xE0 l'\xE9chelle en toute simplicit\xE9\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/openstack-deployment-guide/17384\",\"internal\":true,\"reflection\":false,\"title\":\"OpenStack
+        deployment guide\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/ubuntu-core-a-cybersecurity-analysis/17381\",\"internal\":true,\"reflection\":false,\"title\":\"Ubuntu
+        Core: a cybersecurity analysis\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/maintaining-business-focus-in-a-cloud-native-world-with-managed-apps/17385\",\"internal\":true,\"reflection\":false,\"title\":\"Maintaining
+        business focus in a cloud-native world with Managed Apps\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/what-s-new-in-ubuntu-20-04-lts/17386\",\"internal\":true,\"reflection\":false,\"title\":\"What\u2019s
+        new in Ubuntu 20.04 LTS?\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/embracing-the-open-source-mandate/17387\",\"internal\":true,\"reflection\":false,\"title\":\"Embracing
+        the open source mandate\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/streamlined-kubernetes-from-cloud-to-edge/17388\",\"internal\":true,\"reflection\":false,\"title\":\"Streamlined
+        Kubernetes, from Cloud to Edge\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/leveraging-open-source-with-ubuntu-pro-on-azure/17389\",\"internal\":true,\"reflection\":false,\"title\":\"Leveraging
+        open source with Ubuntu Pro on Azure\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/secure-iot-device-management/17390\",\"internal\":true,\"reflection\":false,\"title\":\"Secure
+        IoT device management\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/solving-the-software-update-challenge-for-iot-devices/17391\",\"internal\":true,\"reflection\":false,\"title\":\"Solving
+        the software update challenge for IoT devices\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/kafka-in-production/17392\",\"internal\":true,\"reflection\":false,\"title\":\"Kafka
+        in production\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/standardising-machine-learning-from-workstation-to-production/17393\",\"internal\":true,\"reflection\":false,\"title\":\"Standardising
+        machine learning \u2014 from workstation to production\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/utilising-cloud-init-on-microsoft-azure/17394\",\"internal\":true,\"reflection\":false,\"title\":\"Utilising
+        cloud-init on Microsoft Azure\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/migrating-your-infrastructure-to-ubuntu-20-04-lts/17395\",\"internal\":true,\"reflection\":false,\"title\":\"Migrating
+        your infrastructure to Ubuntu 20.04 LTS\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/a-technical-intro-to-ubuntu-pro/17396\",\"internal\":true,\"reflection\":false,\"title\":\"A
+        technical intro to Ubuntu Pro\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/scaling-on-azure-with-ubuntu-pro/17397\",\"internal\":true,\"reflection\":false,\"title\":\"Scaling
+        on Azure with Ubuntu Pro\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/kubernetes-from-cloud-to-edge/17398\",\"internal\":true,\"reflection\":false,\"title\":\"Kubernetes
+        from Cloud to Edge\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/accelerating-iot-device-time-to-market/17399\",\"internal\":true,\"reflection\":false,\"title\":\"Accelerating
+        IoT device time to market\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/scale-android-applications-economically-in-the-cloud-with-anbox-cloud/17401\",\"internal\":true,\"reflection\":false,\"title\":\"Scale
+        Android applications economically in the cloud with Anbox Cloud\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/busting-the-myth-of-private-cloud-economics/17244\",\"internal\":true,\"reflection\":false,\"title\":\"Busting
+        the myth of private cloud economics\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/do-vmware-ao-charmed-openstack/18165\",\"internal\":true,\"reflection\":false,\"title\":\"Do
+        VMware ao Charmed OpenStack\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/red-hat-openstack-platform-vs-canonicals-charmed-openstack/18159\",\"internal\":true,\"reflection\":false,\"title\":\"Red
+        Hat OpenStack Platform vs Canonical's Charmed OpenStack\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/building-powerful-customer-solutions/18481\",\"internal\":true,\"reflection\":false,\"title\":\"Building
+        powerful customer solutions\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/production-ai-from-data-lake-to-server-webinar/18163\",\"internal\":true,\"reflection\":false,\"title\":\"Production
+        AI from data lake to server webinar\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/5-strategies-to-accelerate-kubernetes-deployment-in-the-enterprise/18161\",\"internal\":true,\"reflection\":false,\"title\":\"5
+        strategies to accelerate Kubernetes deployment in the enterprise\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/da-vmware-a-openstack/18164\",\"internal\":true,\"reflection\":false,\"title\":\"Da
+        VMware a OpenStack\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/gmo-pepabo-ubuntu/18476\",\"internal\":true,\"reflection\":false,\"title\":\"GMO
+        Pepabo \\u0026 Ubuntu\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/da-vmware-a-charmed-openstack/18478\",\"internal\":true,\"reflection\":false,\"title\":\"Da
+        VMware a Charmed Openstack\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/guia-para-la-implementacion-de-openstack/18480\",\"internal\":true,\"reflection\":false,\"title\":\"Gu\xEDa
+        para la implementaci\xF3n de OpenStack\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/transforming-telco-infrastructure/18162\",\"internal\":true,\"reflection\":false,\"title\":\"Transforming
+        telco infrastructure\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/extend-your-openstack-cloud-with-native-backup-and-recover/18911\",\"internal\":true,\"reflection\":false,\"title\":\"Extend
+        your OpenStack cloud with native backup and recover\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/cloud-gaming-for-android/18757\",\"internal\":true,\"reflection\":false,\"title\":\"Cloud
+        gaming for Android\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/watch-the-raspberry-pi-ubuntu-desktop-intro-video/18577\",\"internal\":true,\"reflection\":false,\"title\":\"Watch
+        the Raspberry Pi Ubuntu Desktop intro video\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/ubuntu-20-10-what-s-new/19050\",\"internal\":true,\"reflection\":false,\"title\":\"Ubuntu
+        20.10: What\u2019s new?\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/open-digital-platforms-for-the-industrial-edge-cloud-in-2020/19068\",\"internal\":true,\"reflection\":false,\"title\":\"Open
+        digital platforms for the industrial edge cloud in 2020\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/optimised-authentication-methods-for-ubuntu-desktop/19133\",\"internal\":true,\"reflection\":false,\"title\":\"Optimised
+        authentication methods for Ubuntu Desktop\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/comparando-la-plataforma-openstack-de-red-hat-y-la-charmed-openstack-de-canonical/19194\",\"internal\":true,\"reflection\":false,\"title\":\"Comparando
+        la plataforma OpenStack de Red Hat y la Charmed OpenStack de Canonical\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/cinco-estrategias-para-acelerar-el-despliegue-de-kubernetes/19208\",\"internal\":true,\"reflection\":false,\"title\":\"Cinco
+        estrategias para acelerar el despliegue de Kubernetes\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/9-out-of-top-10-us-european-financial-institutions-use-ubuntu/19304\",\"internal\":true,\"reflection\":false,\"title\":\"9
+        out of top 10 US \\u0026 European financial institutions use Ubuntu\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/vergleich-von-red-hat-openstack-platform-und-charmed-openstack-von-canonical/19285\",\"internal\":true,\"reflection\":false,\"title\":\"Vergleich
+        von Red Hat OpenStack Platform und Charmed OpenStack von Canonical\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/funf-strategien-zur-beschleunigung-von-kubernetes-in-unternehmen/19284\",\"internal\":true,\"reflection\":false,\"title\":\"F\xFCnf
+        Strategien zur Beschleunigung von Kubernetes in Unternehmen\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/guide-pour-reussir-ladoption-et-le-deploiement-dopenstack/19361\",\"internal\":true,\"reflection\":false,\"title\":\"Guide
+        pour r\xE9ussir l'adoption et le d\xE9ploiement d'OpenStack\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/confronto-fra-red-hats-openstack-platform-e-charmed-openstack-di-canonical/19362\",\"internal\":true,\"reflection\":false,\"title\":\"Confronto
+        fra \\\"Red Hat's Openstack platform\\\" e Charmed Openstack di Canonical\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/cinque-strategie-per-accelerare-limplementazione-di-kubernetes-nellimpresa/19381\",\"internal\":true,\"reflection\":false,\"title\":\"Cinque
+        strategie per accelerare l'implementazione di Kubernetes nell'impresa\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/micro-clouds/19424\",\"internal\":true,\"reflection\":false,\"title\":\"Micro
+        clouds:\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/ubuntu-16-04-lts-moving-to-extended-security-maintenance/19598\",\"internal\":true,\"reflection\":false,\"title\":\"Ubuntu
+        16.04 LTS moving to Extended Security Maintenance\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/ubuntu-pro-for-aws/19600\",\"internal\":true,\"reflection\":false,\"title\":\"Ubuntu
+        Pro for AWS\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/agility-and-innovation-in-financial-services-with-open-source/19601\",\"internal\":true,\"reflection\":false,\"title\":\"Agility
+        and innovation in Financial Services with open source\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/ai-deployment-and-inference/19692\",\"internal\":true,\"reflection\":false,\"title\":\"AI
+        deployment and inference:\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/lightweight-kubernetes-in-the-enterprise/19716\",\"internal\":true,\"reflection\":false,\"title\":\"Lightweight
+        Kubernetes in the enterprise\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/suse-openstack-cloud-to-be-discontinued/19765\",\"internal\":true,\"reflection\":false,\"title\":\"SUSE
+        OpenStack Cloud to be discontinued\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/workstations-ai/19766\",\"internal\":true,\"reflection\":false,\"title\":\"Workstations
+        AI\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/in-weniger-als-6-monaten-kommt-ubuntu-16-04-esm-6-punkte-fur-ihre-vorbereitung/19895\",\"internal\":true,\"reflection\":false,\"title\":\"In
+        weniger als 6 Monaten kommt Ubuntu 16.04 ESM: 6 Punkte f\xFCr Ihre Vorbereitung\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/menos-de-6-meses-para-16-04-esm-seis-aspectos-a-tener-en-cuenta/19925\",\"internal\":true,\"reflection\":false,\"title\":\"Menos
+        de 6 meses para 16.04 ESM: seis aspectos a tener en cuenta\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/staying-compliant-while-delivering-innovation-in-government-services/19960\",\"internal\":true,\"reflection\":false,\"title\":\"Staying
+        compliant while delivering innovation in government services\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/android-in-the-cloud-on-arm-native-servers/20015\",\"internal\":true,\"reflection\":false,\"title\":\"Android
+        in the cloud on Arm native servers\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/cloud-native-driving-agility-and-innovation-in-financial-services/20244\",\"internal\":true,\"reflection\":false,\"title\":\"Cloud-native
+        driving agility and innovation in financial services\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/automation-through-open-source-operators/20215\",\"internal\":true,\"reflection\":false,\"title\":\"Automation
+        through open source operators\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/comparaison-de-red-hat-openstack-platform-et-de-charmed-openstack-de-canonical/20432\",\"internal\":true,\"reflection\":false,\"title\":\"Comparaison
+        de Red Hat OpenStack Platform et de Charmed OpenStack de Canonical\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/industrial-process-transformation-with-machine-learning-using-kubeflow/20436\",\"internal\":true,\"reflection\":false,\"title\":\"Industrial
+        process transformation with Machine Learning using Kubeflow\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/kubeflow-reference-architecture/20467\",\"internal\":true,\"reflection\":false,\"title\":\"Kubeflow
+        reference architecture\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/an-introduction-to-ubuntu-core-20/20687\",\"internal\":true,\"reflection\":false,\"title\":\"An
+        introduction to Ubuntu Core 20\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/embedded-linux-make-or-buy/20696\",\"internal\":true,\"reflection\":false,\"title\":\"Embedded
+        Linux: make or buy?\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/end-to-end-wiring-using-kubeflow-kafka-and-elasticsearch/20704\",\"internal\":true,\"reflection\":false,\"title\":\"End-to-end
+        wiring using Kubeflow, Kafka and ElasticSearch\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/integrazione-di-ubuntu-desktop-con-microsoft-active-directory/20746\",\"internal\":true,\"reflection\":false,\"title\":\"Integrazione
+        di Ubuntu Desktop con Microsoft Active Directory\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/mantenimiento-de-seguridad-extendido/20747\",\"internal\":true,\"reflection\":false,\"title\":\"Mantenimiento
+        de Seguridad Extendido\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/open-source-in-government/20843\",\"internal\":true,\"reflection\":false,\"title\":\"Open
+        source in Government\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/edge-use-cases-enabled-by-mec-and-5g/20873\",\"internal\":true,\"reflection\":false,\"title\":\"Edge
+        use-cases enabled by MEC and 5G\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/secure-container-orchestration-at-the-edge/20965\",\"internal\":true,\"reflection\":false,\"title\":\"Secure
+        container orchestration at the edge\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/enterprise-kubernetes-a-buyer-s-guide/20979\",\"internal\":true,\"reflection\":false,\"title\":\"Enterprise
+        Kubernetes: A buyer\u2019s guide\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/simplifying-ai-ml-adoption-in-telco-with-modern-operations-practices/20996\",\"internal\":true,\"reflection\":false,\"title\":\"Simplifying
+        AI/ML adoption in telco with modern operations practices\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/migration-vers-ubuntu-lts-six-points-cles-pour-les-utilisateurs-de-centos/21054\",\"internal\":true,\"reflection\":false,\"title\":\"Migration
+        vers Ubuntu LTS: six points cl\xE9s pour les utilisateurs de CentOS\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/ubuntu-16-04-esm-6-choses-a-preparer/21058\",\"internal\":true,\"reflection\":false,\"title\":\"Ubuntu
+        16.04 ESM: 6 choses \xE0 pr\xE9parer\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/a-technical-introduction-to-ubuntu-core-20/21068\",\"internal\":true,\"reflection\":false,\"title\":\"A
+        technical introduction to Ubuntu Core 20\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/whats-next-for-centos-users/21090\",\"internal\":true,\"reflection\":false,\"title\":\"What's
+        next for CentOS users?\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/migrar-a-ubuntu-lts-seis-factores-a-tener-en-cuenta-para-los-usuarios-de-centos/21315\",\"internal\":true,\"reflection\":false,\"title\":\"Migrar
+        a Ubuntu LTS: seis factores a tener en cuenta para los usuarios de CentOS\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/securing-open-source-from-cloud-to-edge/21394\",\"internal\":true,\"reflection\":false,\"title\":\"Securing
+        open source from cloud to edge\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/esm-garantisce-la-sicurezza-dei-sistemi-interana-anche-durante-laggiornamento/21378\",\"internal\":true,\"reflection\":false,\"title\":\"ESM
+        garantisce la sicurezza dei sistemi Interana anche durante l'aggiornamento\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/model-driven-audit-trail-logs-infrastructure-for-telco-vnfs/21500\",\"internal\":true,\"reflection\":false,\"title\":\"Model-driven
+        Audit Trail Logs infrastructure for Telco VNFs\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/canonical-ubuntu-at-nvidia-gtc-2021-digital/21524\",\"internal\":true,\"reflection\":false,\"title\":\"Canonical
+        \\u0026 Ubuntu at NVIDIA GTC 2021 Digital\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/data-science-workstations/21739\",\"internal\":true,\"reflection\":false,\"title\":\"Data
+        Science Workstations\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/telecom-ai-a-guide-for-data-teams/21740\",\"internal\":true,\"reflection\":false,\"title\":\"Telecom
+        AI: a guide for data teams\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/elkhart-lake/21775\",\"internal\":true,\"reflection\":false,\"title\":\"Elkhart
+        Lake\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/the-value-of-open-source-in-2021/21790\",\"internal\":true,\"reflection\":false,\"title\":\"The
+        Value of Open Source in 2021\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/what-s-new-in-ubuntu-server-21-04/21802\",\"internal\":true,\"reflection\":false,\"title\":\"What\u2019s
+        new in Ubuntu Server 21.04?\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/unleashing-z-workstations-by-hp-powered-by-ubuntu/21825\",\"internal\":true,\"reflection\":false,\"title\":\"Unleashing
+        Z Workstations by HP Powered by Ubuntu\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/data-science-workstations-journey/21828\",\"internal\":true,\"reflection\":false,\"title\":\"Data
+        Science Workstations Journey\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/infrastruttura-multi-cloud-in-italia/21894\",\"internal\":true,\"reflection\":false,\"title\":\"Infrastruttura
+        multi-cloud in Italia\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/meno-di-6-mesi-a-ubuntu-16-04-esm-6-cose-da-preparare/21958\",\"internal\":true,\"reflection\":false,\"title\":\"Meno
+        di 6 mesi a Ubuntu 16.04 ESM: 6 cose da preparare\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/migrare-a-ubuntu-lts-sei-fatti-per-gli-utenti-centos/21959\",\"internal\":true,\"reflection\":false,\"title\":\"Migrare
+        a Ubuntu LTS: sei fatti per gli utenti CentOS\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/ros-kinetic-end-of-life/21952\",\"internal\":true,\"reflection\":false,\"title\":\"ROS
+        Kinetic End-Of-Life\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/a-business-guide-to-hybrid-cloud/22092\",\"internal\":true,\"reflection\":false,\"title\":\"A
+        business guide to hybrid cloud\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/a-business-guide-to-multi-cloud/22093\",\"internal\":true,\"reflection\":false,\"title\":\"A
+        business guide to multi-cloud\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/simplifying-kubernetes-across-the-clouds/22260\",\"internal\":true,\"reflection\":false,\"title\":\"Simplifying
+        Kubernetes across the clouds\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/building-and-orchestrating-network-functions/22269\",\"internal\":true,\"reflection\":false,\"title\":\"Building
+        and orchestrating network functions\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/suse-openstack-cloud-wird-eingestellt/22283\",\"internal\":true,\"reflection\":false,\"title\":\"SUSE
+        OpenStack Cloud wird eingestellt\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/kubernetes-at-the-edge-easy-as-pi/22342\",\"internal\":true,\"reflection\":false,\"title\":\"Kubernetes
+        at the edge: easy as Pi\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/open-source-private-5g-and-lte-networks/22346\",\"internal\":true,\"reflection\":false,\"title\":\"Open
+        source private 5G and LTE networks\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/canonical-at-mwc-2021/22348\",\"internal\":true,\"reflection\":false,\"title\":\"Canonical
+        at MWC 2021\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/private-cloud-for-financial-services/22500\",\"internal\":true,\"reflection\":false,\"title\":\"Private
+        cloud for Financial Services\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/kubernetes-e-ubuntu-in-italia/22562\",\"internal\":true,\"reflection\":false,\"title\":\"Kubernetes
+        e Ubuntu in Italia\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/guida-cio-alle-operazioni-multi-cloud/22564\",\"internal\":true,\"reflection\":false,\"title\":\"Guida
+        CIO alle operazioni multi-cloud\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/data-lab-architectures/22247\",\"internal\":true,\"reflection\":false,\"title\":\"Data
+        Lab Architectures\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/preparing-for-the-suse-openstack-cloud-end-of-life/22587\",\"internal\":true,\"reflection\":false,\"title\":\"Preparing
+        for the SUSE OpenStack Cloud end-of-life\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/ros-support-with-ros-esm/22595\",\"internal\":true,\"reflection\":false,\"title\":\"ROS
+        Support with ROS ESM\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/openstack-public-cloud-implementation/22648\",\"internal\":true,\"reflection\":false,\"title\":\"OpenStack
+        public cloud implementation\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/enterprise-mlops-in-hybrid-cloud-scenarios-best-practices/22650\",\"internal\":true,\"reflection\":false,\"title\":\"Enterprise
+        MLOps in hybrid-cloud scenarios: best practices\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/ubuntu-pro-on-azure/22674\",\"internal\":true,\"reflection\":false,\"title\":\"Ubuntu
+        Pro on Azure\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/che-cose-il-mec-il-telco-edge/22748\",\"internal\":true,\"reflection\":false,\"title\":\"Che
+        cos'\xE8 il MEC? Il telco edge\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/a-technical-introduction-to-the-snap-store-proxy/22762\",\"internal\":true,\"reflection\":false,\"title\":\"A
+        technical introduction to the Snap Store Proxy\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/das-wellcome-sanger-institute-ermoglicht-weltweite-zusammenarbeit-in-der-genomforschung-mit-von-canonical-unterstutztem-ceph-speicher/22811\",\"internal\":true,\"reflection\":false,\"title\":\"Das
+        Wellcome Sanger Institute erm\xF6glicht weltweite Zusammenarbeit in der Genomforschung
+        mit von Canonical unterst\xFCtztem Ceph-Speicher\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/kaust-selects-canonicals-openstack-cloud/22858\",\"internal\":true,\"reflection\":false,\"title\":\"KAUST
+        selects Canonical's OpenStack cloud\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/atresmedia-accede-a-una-alta-disponibilidad-y-productividad-sin-precedentes-con-charmed-kubernetes/23125\",\"internal\":true,\"reflection\":false,\"title\":\"Atresmedia
+        accede a una alta disponibilidad y productividad sin precedentes con Charmed
+        Kubernetes\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/handlungsoptionen-nach-dem-endof-life-der-suse-openstack-cloud/23173\",\"internal\":true,\"reflection\":false,\"title\":\"Handlungsoptionen
+        nach dem Endof-life der SUSE OpenStack Cloud\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/a-small-to-medium-size-business-guide-to-cybersecurity/23274\",\"internal\":true,\"reflection\":false,\"title\":\"A
+        small to medium-size business guide to cybersecurity\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/sbi-group-sblocca-lautomazione-dellinfrastruttura-con-un-cloud-openstack-sicuro-e-on-premises/23286\",\"internal\":true,\"reflection\":false,\"title\":\"SBI
+        Group sblocca l'automazione dell'infrastruttura con un cloud OpenStack sicuro
+        e on-premises\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/free-cloud-pricing-report-2021/23455\",\"internal\":true,\"reflection\":false,\"title\":\"Free
+        cloud pricing report 2021\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/atresmedia-accesses-high-availability-and-unprecedented-productivity-with-charmed-kubernetes/23693\",\"internal\":true,\"reflection\":false,\"title\":\"Atresmedia
+        accesses high availability and unprecedented productivity with Charmed Kubernetes\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/applied-ai-for-fraud-prevention-and-detection/23734\",\"internal\":true,\"reflection\":false,\"title\":\"Applied
+        AI for fraud prevention and detection\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/running-enterprise-grade-edge-applications-with-edgex-on-ubuntu-core/23773\",\"internal\":true,\"reflection\":false,\"title\":\"Running
+        enterprise-grade edge applications with EdgeX on Ubuntu Core\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/helping-developers-reach-new-heights/23873\",\"internal\":true,\"reflection\":false,\"title\":\"Helping
+        developers reach new heights\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/containers-as-a-service-deploy-kubernetes-faster-with-canonical-and-portainer/23970\",\"internal\":true,\"reflection\":false,\"title\":\"Containers-as-a-service:
+        Deploy Kubernetes faster with Canonical and Portainer\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/kubernetes-platform-comparison-red-hat-openshift-suse-rancher-and-canonical-kubernetes/23982\",\"internal\":true,\"reflection\":false,\"title\":\"Kubernetes
+        platform comparison: Red Hat OpenShift, SUSE Rancher and Canonical Kubernetes\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/how-to-manage-risks-with-the-top-1-managed-service-providers/23983\",\"internal\":true,\"reflection\":false,\"title\":\"How
+        to manage risks with the top 1% Managed Service Providers\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/atresmedia-domine-le-marche-des-medias-en-espagne-avec-l-architecture-de-microservices-charmed-kubernetes/24009\",\"internal\":true,\"reflection\":false,\"title\":\"Atresmedia
+        domine le march\xE9 des m\xE9dias en Espagne avec l\u2019architecture de microservices
+        Charmed Kubernetes\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/self-healing-kubernetes-at-the-edge-microk8s-raspberry-pis-and-portainer/24070\",\"internal\":true,\"reflection\":false,\"title\":\"Self-healing
+        Kubernetes at the edge: MicroK8s, Raspberry Pis and Portainer\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/its-like-a-jungle-out-there-how-to-adapt-your-it-strategy-for-changing-markets/24077\",\"internal\":true,\"reflection\":false,\"title\":\"It's
+        like a jungle out there: how to adapt your IT strategy for changing markets\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/building-graphical-applications-in-embedded-devices/24167\",\"internal\":true,\"reflection\":false,\"title\":\"Building
+        graphical applications in embedded devices\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/canonical-ubuntu-at-arm-dev-summit-2021/24204\",\"internal\":true,\"reflection\":false,\"title\":\"Canonical
+        \\u0026 Ubuntu at ARM Dev Summit 2021\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/beat-disruption-how-to-adapt-your-it-strategy-for-changing-markets/24237\",\"internal\":true,\"reflection\":false,\"title\":\"Beat
+        disruption: how to adapt your IT strategy for changing markets\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/managed-it-services-overcoming-cios-biggest-challenges/24285\",\"internal\":true,\"reflection\":false,\"title\":\"Managed
+        IT Services: Overcoming CIOs Biggest Challenges\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/edge-kubernetes-what-s-brewing/24492\",\"internal\":true,\"reflection\":false,\"title\":\"Edge
+        Kubernetes: what\u2019s brewing?\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/canonical-ubuntu-at-nvidia-gtc-2021/24671\",\"internal\":true,\"reflection\":false,\"title\":\"Canonical
+        \\u0026 Ubuntu at Nvidia GTC 2021\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/enterprise-kubernetes-use-cases-4-real-world-stories/24588\",\"internal\":true,\"reflection\":false,\"title\":\"Enterprise
+        Kubernetes use cases: 4 real-world stories\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/finserv-open-source-infrastructure-powers-hybrid-cloud-strategy/24008\",\"internal\":true,\"reflection\":false,\"title\":\"Finserv
+        open source infrastructure powers hybrid cloud strategy\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/driving-robotics-innovation/24442\",\"internal\":true,\"reflection\":false,\"title\":\"Driving
+        robotics innovation\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/workstations-on-the-ai-journey-deploying-your-model/24401\",\"internal\":true,\"reflection\":false,\"title\":\"Workstations
+        on the AI Journey | Deploying Your Model\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/ctos-guide-to-micro-clouds/24533\",\"internal\":true,\"reflection\":false,\"title\":\"CTOs'
+        Guide to Micro Clouds\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/7-approaches-to-accelerating-apache-kafka-on-k8s/24711\",\"internal\":true,\"reflection\":false,\"title\":\"7
+        Approaches to Accelerating Apache Kafka on K8s\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/architecting-price-performance-private-cloud/24721\",\"internal\":true,\"reflection\":false,\"title\":\"Architecting
+        price performance Private Cloud\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/openstack-upgrades-with-minimal-downtime/24756\",\"internal\":true,\"reflection\":false,\"title\":\"OpenStack
+        Upgrades with Minimal Downtime\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/ubuntu-16-04-lts-verso-la-manutenzione-estesa-della-sicurezza/24781\",\"internal\":true,\"reflection\":false,\"title\":\"Ubuntu
+        16.04 LTS verso la Manutenzione Estesa della Sicurezza\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/smartdrone-fast-tracks-drone-infrastructure-revolution-with-ubuntu-core/24821\",\"internal\":true,\"reflection\":false,\"title\":\"SmartDrone
+        fast-tracks drone infrastructure revolution with Ubuntu Core\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/secure-ai-models-deployment-at-the-edge-with-openvino-on-ubuntu-containers/24894\",\"internal\":true,\"reflection\":false,\"title\":\"Secure
+        AI models deployment at the edge with OpenVINO\u2122 on Ubuntu containers\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/atresmedia-domina-il-mercato-spagnolo-dei-media-ott-con-larchitettura-di-microservizi-charmed-kubernetes/24897\",\"internal\":true,\"reflection\":false,\"title\":\"Atresmedia
+        domina il mercato spagnolo dei media OTT con l'architettura di microservizi
+        Charmed Kubernetes\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/cybersecurity-and-compliance-with-ubuntu/24933\",\"internal\":true,\"reflection\":false,\"title\":\"Cybersecurity
+        and Compliance with Ubuntu\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/telecom-infrastructure-the-open-source-way/25038\",\"internal\":true,\"reflection\":false,\"title\":\"Telecom
+        infrastructure the open source way\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/ceph-in-the-modern-data-center/25046\",\"internal\":true,\"reflection\":false,\"title\":\"Ceph
+        in the modern data center\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/ubuntu-desktop/25158\",\"internal\":true,\"reflection\":false,\"title\":\"\u958B\u767C\u8005\u9078\u64C7
+        Ubuntu Desktop \u7684\u516D\u5927\u7406\u7531\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/finserv-it-infrastructure-migrating-from-vmware-to-openstack/25179\",\"internal\":true,\"reflection\":false,\"title\":\"Finserv
+        IT infrastructure: Migrating from VMWare to OpenStack\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/microk8s-on-ibm-z-minimal-footprint-meets-zero-downtime/25183\",\"internal\":true,\"reflection\":false,\"title\":\"MicroK8s
+        on IBM Z \u2014 minimal footprint meets zero downtime\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/introducing-sql-server-on-ubuntu-pro-for-azure-part-1/25193\",\"internal\":true,\"reflection\":false,\"title\":\"Introducing
+        SQL Server on Ubuntu Pro for Azure Part 1\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/getting-started-with-shells-custom-ubuntu-pro-image-on-azure/25267\",\"internal\":true,\"reflection\":false,\"title\":\"Getting
+        started with Shell's custom Ubuntu Pro image on Azure\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/ceph-for-enterprise/25305\",\"internal\":true,\"reflection\":false,\"title\":\"Ceph
+        for Enterprise\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/nayatel-builds-public-cloud-service-with-charmed-openstack/25331\",\"internal\":true,\"reflection\":false,\"title\":\"Nayatel
+        builds public cloud service with Charmed OpenStack\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/building-cost-efficient-open-source-cloud-operations/25347\",\"internal\":true,\"reflection\":false,\"title\":\"Building
+        cost-efficient open source cloud operations\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/introducing-sql-server-on-ubuntu-pro-for-azure-part-2/25350\",\"internal\":true,\"reflection\":false,\"title\":\"Introducing
+        SQL Server on Ubuntu Pro for Azure Part 2\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/ubuntu-pro-en-azure/25388\",\"internal\":true,\"reflection\":false,\"title\":\"Ubuntu
+        Pro en Azure\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/docker-ros-when-all-you-have-is-a-hammer-everything-looks-like-a-nail/25389\",\"internal\":true,\"reflection\":false,\"title\":\"Docker
+        \\u0026 ROS: When all you have is a hammer, everything looks like a nail\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/ubuntu-pro-em-microsoft-azure/25392\",\"internal\":true,\"reflection\":false,\"title\":\"Ubuntu
+        Pro em Microsoft Azure\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/nfv-orchestration-for-open-source-telco/25422\",\"internal\":true,\"reflection\":false,\"title\":\"NFV
+        Orchestration For Open Source Telco\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/how-to-increase-developer-productivity-with-ubuntu-desktop/25426\",\"internal\":true,\"reflection\":false,\"title\":\"How
+        to increase developer productivity with Ubuntu Desktop\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/migrating-to-ubuntu-lts-six-facts-for-centos-users/25585\",\"internal\":true,\"reflection\":false,\"title\":\"Migrating
+        to Ubuntu LTS: six facts for CentOS users\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/evaluating-microsoft-sql-server-options-for-azure/25594\",\"internal\":true,\"reflection\":false,\"title\":\"Evaluating
+        Microsoft SQL Server Options for Azure\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/bare-metal-provisioning-what-s-new-in-maas-3-1/25607\",\"internal\":true,\"reflection\":false,\"title\":\"Bare
+        metal provisioning: What\u2019s new in MAAS 3.1?\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/embedded-kubernetes-for-secure-iot-edge/25635\",\"internal\":true,\"reflection\":false,\"title\":\"Embedded
+        Kubernetes for secure IoT Edge\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/costruire-infrastrutture-multi-cloud-con-ubuntu-e-kubernetes/21247\",\"internal\":true,\"reflection\":false,\"title\":\"Costruire
+        infrastrutture multi-cloud con Ubuntu e Kubernetes\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/suse-openstack-cloud-arrive-en-fin-de-vie/21096\",\"internal\":true,\"reflection\":false,\"title\":\"SUSE
+        OpenStack Cloud arrive en fin de vie\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/kubeflow-operations-guide/21213\",\"internal\":true,\"reflection\":false,\"title\":\"Kubeflow
+        operations guide\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/from-yocto-buildroot-to-ubuntu-core-20/21248\",\"internal\":true,\"reflection\":false,\"title\":\"From
+        Yocto \\u0026 Buildroot to Ubuntu Core 20\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/linux/24602\",\"internal\":true,\"reflection\":false,\"title\":\"\u5D4C\u5165\u5F0FLinux\uFF1A\u81EA\u88FD\u6216\u5916\u8CFC?\",\"clicks\":0}],\"read\":true,\"user_title\":null,\"bookmarked\":false,\"actions_summary\":[{\"id\":3,\"can_act\":true},{\"id\":4,\"can_act\":true},{\"id\":8,\"can_act\":true},{\"id\":7,\"can_act\":true}],\"moderator\":false,\"admin\":true,\"staff\":true,\"user_id\":9642,\"hidden\":false,\"trust_level\":3,\"deleted_at\":null,\"user_deleted\":false,\"edit_reason\":null,\"can_view_edit_history\":true,\"wiki\":false,\"reviewable_id\":0,\"reviewable_score_count\":0,\"reviewable_score_pending_count\":0,\"can_accept_answer\":false,\"can_unaccept_answer\":false,\"accepted_answer\":false}],\"stream\":[50258]},\"timeline_lookup\":[[1,472]],\"suggested_topics\":[{\"id\":19808,\"title\":\"Image
+        building\",\"fancy_title\":\"Image building\",\"slug\":\"image-building\",\"posts_count\":6,\"reply_count\":4,\"highest_post_number\":6,\"image_url\":null,\"created_at\":\"2020-12-11T12:06:10.284Z\",\"last_posted_at\":\"2021-05-14T10:50:28.370Z\",\"bumped\":true,\"bumped_at\":\"2021-05-14T10:50:28.370Z\",\"archetype\":\"regular\",\"unseen\":false,\"last_read_post_number\":1,\"unread\":0,\"new_posts\":5,\"pinned\":false,\"unpinned\":null,\"visible\":true,\"closed\":false,\"archived\":false,\"notification_level\":3,\"bookmarked\":false,\"liked\":false,\"tags\":[],\"like_count\":5,\"views\":2005,\"category_id\":47,\"featured_link\":null,\"has_accepted_answer\":false,\"posters\":[{\"extras\":null,\"description\":\"Original
+        Poster\",\"user\":{\"id\":9642,\"username\":\"carkod\",\"name\":\"Carlos Wu
+        Fei\",\"avatar_template\":\"/letter_avatar/carkod/{size}/5_6d6f4cde2641c35611d5cac2fb97c77e.png\"}},{\"extras\":null,\"description\":\"Frequent
+        Poster\",\"user\":{\"id\":14088,\"username\":\"rzr\",\"name\":\"\",\"avatar_template\":\"/user_avatar/discourse.ubuntu.com/rzr/{size}/12642_2.png\"}},{\"extras\":null,\"description\":\"Frequent
+        Poster\",\"user\":{\"id\":9578,\"username\":\"degville\",\"name\":\"Graham
+        Morrison\",\"avatar_template\":\"/user_avatar/discourse.ubuntu.com/degville/{size}/9336_2.png\"}},{\"extras\":\"latest\",\"description\":\"Most
+        Recent Poster\",\"user\":{\"id\":1046,\"username\":\"ogra\",\"name\":\"Oliver
+        Grawert\",\"avatar_template\":\"/user_avatar/discourse.ubuntu.com/ogra/{size}/8750_2.png\"}}]},{\"id\":19806,\"title\":\"System
+        requirements\",\"fancy_title\":\"System requirements\",\"slug\":\"system-requirements\",\"posts_count\":5,\"reply_count\":2,\"highest_post_number\":5,\"image_url\":null,\"created_at\":\"2020-12-11T11:58:38.369Z\",\"last_posted_at\":\"2021-01-12T17:22:21.406Z\",\"bumped\":true,\"bumped_at\":\"2021-01-12T17:22:21.406Z\",\"archetype\":\"regular\",\"unseen\":false,\"last_read_post_number\":4,\"unread\":0,\"new_posts\":1,\"pinned\":false,\"unpinned\":null,\"visible\":true,\"closed\":false,\"archived\":false,\"notification_level\":3,\"bookmarked\":false,\"liked\":false,\"tags\":[],\"like_count\":1,\"views\":2018,\"category_id\":47,\"featured_link\":null,\"has_accepted_answer\":false,\"posters\":[{\"extras\":null,\"description\":\"Original
+        Poster\",\"user\":{\"id\":9642,\"username\":\"carkod\",\"name\":\"Carlos Wu
+        Fei\",\"avatar_template\":\"/letter_avatar/carkod/{size}/5_6d6f4cde2641c35611d5cac2fb97c77e.png\"}},{\"extras\":null,\"description\":\"Frequent
+        Poster\",\"user\":{\"id\":1046,\"username\":\"ogra\",\"name\":\"Oliver Grawert\",\"avatar_template\":\"/user_avatar/discourse.ubuntu.com/ogra/{size}/8750_2.png\"}},{\"extras\":\"latest\",\"description\":\"Most
+        Recent Poster\",\"user\":{\"id\":9578,\"username\":\"degville\",\"name\":\"Graham
+        Morrison\",\"avatar_template\":\"/user_avatar/discourse.ubuntu.com/degville/{size}/9336_2.png\"}}]},{\"id\":11322,\"title\":\"Introduction\",\"fancy_title\":\"Introduction\",\"slug\":\"introduction\",\"posts_count\":19,\"reply_count\":13,\"highest_post_number\":19,\"image_url\":null,\"created_at\":\"2019-06-19T20:48:28.000Z\",\"last_posted_at\":\"2021-12-07T19:55:08.830Z\",\"bumped\":true,\"bumped_at\":\"2021-12-07T19:55:08.830Z\",\"archetype\":\"regular\",\"unseen\":false,\"last_read_post_number\":12,\"unread\":0,\"new_posts\":7,\"pinned\":false,\"unpinned\":true,\"visible\":true,\"closed\":false,\"archived\":false,\"notification_level\":2,\"bookmarked\":false,\"liked\":false,\"tags\":[],\"like_count\":13,\"views\":32236,\"category_id\":26,\"featured_link\":null,\"has_accepted_answer\":false,\"posters\":[{\"extras\":null,\"description\":\"Original
+        Poster\",\"user\":{\"id\":37,\"username\":\"powersj\",\"name\":\"Joshua Powers\",\"avatar_template\":\"/user_avatar/discourse.ubuntu.com/powersj/{size}/10180_2.png\"}},{\"extras\":null,\"description\":\"Frequent
+        Poster\",\"user\":{\"id\":3783,\"username\":\"paelzer\",\"name\":\"Christian
+        Ehrhardt\",\"avatar_template\":\"/user_avatar/discourse.ubuntu.com/paelzer/{size}/8804_2.png\"}},{\"extras\":null,\"description\":\"Frequent
+        Poster\",\"user\":{\"id\":16120,\"username\":\"jrmyck\",\"name\":\"Jeremy
+        Cook\",\"avatar_template\":\"/user_avatar/discourse.ubuntu.com/jrmyck/{size}/14019_2.png\"}},{\"extras\":null,\"description\":\"Frequent
+        Poster\",\"user\":{\"id\":7676,\"username\":\"bryce\",\"name\":\"Bryce Harrington\",\"avatar_template\":\"/user_avatar/discourse.ubuntu.com/bryce/{size}/6071_2.png\"}},{\"extras\":\"latest\",\"description\":\"Most
+        Recent Poster\",\"user\":{\"id\":8605,\"username\":\"dsmythies\",\"name\":\"Doug
+        Smythies\",\"avatar_template\":\"/user_avatar/discourse.ubuntu.com/dsmythies/{size}/6700_2.png\"}}]},{\"id\":25710,\"title\":\"An
+        Introduction to Ubuntu Desktop\",\"fancy_title\":\"An Introduction to Ubuntu
+        Desktop\",\"slug\":\"an-introduction-to-ubuntu-desktop\",\"posts_count\":1,\"reply_count\":0,\"highest_post_number\":1,\"image_url\":null,\"created_at\":\"2021-12-10T11:37:11.283Z\",\"last_posted_at\":\"2021-12-10T11:37:11.517Z\",\"bumped\":true,\"bumped_at\":\"2021-12-10T11:37:11.517Z\",\"archetype\":\"regular\",\"unseen\":true,\"pinned\":false,\"unpinned\":null,\"visible\":true,\"closed\":false,\"archived\":false,\"bookmarked\":null,\"liked\":null,\"tags\":[\"desktop\"],\"like_count\":0,\"views\":15,\"category_id\":51,\"featured_link\":null,\"has_accepted_answer\":false,\"posters\":[{\"extras\":\"latest
+        single\",\"description\":\"Original Poster, Most Recent Poster\",\"user\":{\"id\":15862,\"username\":\"prk9987\",\"name\":\"Prk9987\",\"avatar_template\":\"/letter_avatar/prk9987/{size}/5_6d6f4cde2641c35611d5cac2fb97c77e.png\"}}]},{\"id\":25707,\"title\":\"\u201Cbackup\u201D
+        network to access instance when interface is down\",\"fancy_title\":\"\u201Cbackup\u201D
+        network to access instance when interface is down\",\"slug\":\"backup-network-to-access-instance-when-interface-is-down\",\"posts_count\":2,\"reply_count\":0,\"highest_post_number\":2,\"image_url\":null,\"created_at\":\"2021-12-10T10:01:16.206Z\",\"last_posted_at\":\"2021-12-10T10:58:11.545Z\",\"bumped\":true,\"bumped_at\":\"2021-12-10T10:58:11.545Z\",\"archetype\":\"regular\",\"unseen\":true,\"pinned\":false,\"unpinned\":null,\"visible\":true,\"closed\":false,\"archived\":false,\"bookmarked\":null,\"liked\":null,\"tags\":[],\"like_count\":0,\"views\":23,\"category_id\":21,\"featured_link\":null,\"has_accepted_answer\":false,\"posters\":[{\"extras\":null,\"description\":\"Original
+        Poster\",\"user\":{\"id\":12399,\"username\":\"glancr\",\"name\":\"Tobias\",\"avatar_template\":\"/user_avatar/discourse.ubuntu.com/glancr/{size}/9017_2.png\"}},{\"extras\":\"latest\",\"description\":\"Most
+        Recent Poster\",\"user\":{\"id\":167,\"username\":\"saviq\",\"name\":\"Micha\u0142
+        Sawicz\",\"avatar_template\":\"/user_avatar/discourse.ubuntu.com/saviq/{size}/8770_2.png\"}}]}],\"tags\":[],\"id\":18033,\"title\":\"Engage
+        pages for ubuntu.com\",\"fancy_title\":\"Engage pages for ubuntu.com\",\"posts_count\":1,\"created_at\":\"2020-08-25T11:17:26.006Z\",\"views\":219,\"reply_count\":0,\"like_count\":0,\"last_posted_at\":\"2020-08-25T11:17:26.382Z\",\"visible\":true,\"closed\":false,\"archived\":false,\"has_summary\":false,\"archetype\":\"regular\",\"slug\":\"engage-pages-for-ubuntu-com\",\"category_id\":51,\"word_count\":11981,\"deleted_at\":null,\"user_id\":9642,\"featured_link\":null,\"pinned_globally\":false,\"pinned_at\":null,\"pinned_until\":null,\"image_url\":null,\"slow_mode_seconds\":0,\"draft\":null,\"draft_key\":\"topic_18033\",\"draft_sequence\":180,\"posted\":true,\"unpinned\":null,\"pinned\":false,\"current_post_number\":1,\"highest_post_number\":1,\"last_read_post_number\":1,\"last_read_post_id\":50258,\"deleted_by\":null,\"has_deleted\":false,\"actions_summary\":[{\"id\":4,\"count\":0,\"hidden\":false,\"can_act\":true},{\"id\":8,\"count\":0,\"hidden\":false,\"can_act\":true},{\"id\":7,\"count\":0,\"hidden\":false,\"can_act\":true}],\"chunk_size\":20,\"bookmarked\":false,\"topic_timer\":null,\"message_bus_last_id\":7,\"participant_count\":1,\"queued_posts_count\":0,\"show_read_indicator\":false,\"thumbnails\":null,\"details\":{\"notification_level\":3,\"notifications_reason_id\":1,\"can_move_posts\":true,\"can_edit\":true,\"can_delete\":true,\"can_remove_allowed_users\":true,\"can_invite_to\":true,\"can_create_post\":true,\"can_reply_as_new_topic\":true,\"can_flag_topic\":true,\"can_convert_topic\":true,\"can_review_topic\":true,\"can_close_topic\":true,\"can_archive_topic\":true,\"can_split_merge_topic\":true,\"can_edit_staff_notes\":true,\"can_moderate_category\":true,\"can_remove_self_id\":9642,\"participants\":[{\"id\":9642,\"username\":\"carkod\",\"name\":\"Carlos
+        Wu Fei\",\"avatar_template\":\"/letter_avatar/carkod/{size}/5_6d6f4cde2641c35611d5cac2fb97c77e.png\",\"post_count\":1,\"primary_group_name\":\"Canonical\",\"primary_group_flair_url\":\"/uploads/short-url/paWz8RxxmKxiYXUmH2ABvqKp0Gg.png\",\"primary_group_flair_color\":\"\",\"primary_group_flair_bg_color\":\"\"}],\"created_by\":{\"id\":9642,\"username\":\"carkod\",\"name\":\"Carlos
+        Wu Fei\",\"avatar_template\":\"/letter_avatar/carkod/{size}/5_6d6f4cde2641c35611d5cac2fb97c77e.png\"},\"last_poster\":{\"id\":9642,\"username\":\"carkod\",\"name\":\"Carlos
+        Wu Fei\",\"avatar_template\":\"/letter_avatar/carkod/{size}/5_6d6f4cde2641c35611d5cac2fb97c77e.png\"},\"links\":[{\"url\":\"https://ubuntu.com/engage\",\"title\":\"Ubuntu
+        case studies, whitepapers and webinars | Ubuntu\",\"internal\":false,\"attachment\":false,\"reflection\":false,\"clicks\":3,\"user_id\":9642,\"domain\":\"ubuntu.com\",\"root_domain\":\"ubuntu.com\"}]},\"pending_posts\":[]}"
     headers:
       Access-Control-Allow-Credentials:
       - 'true'
       Access-Control-Allow-Headers:
-      - Content-Type, Cache-Control, X-Requested-With, X-CSRF-Token, Discourse-Visible,
-        User-Api-Key, User-Api-Client-Id
+      - Content-Type, Cache-Control, X-Requested-With, X-CSRF-Token, Discourse-Present,
+        User-Api-Key, User-Api-Client-Id, Authorization
       Access-Control-Allow-Methods:
       - POST, PUT, GET, OPTIONS, DELETE
       Access-Control-Allow-Origin:
       - https://didrocks.fr
       Cache-Control:
       - no-cache, no-store
-      Connection:
-      - Keep-Alive
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 19 Nov 2020 12:42:04 GMT
-      Keep-Alive:
-      - timeout=5, max=100
+      - Fri, 10 Dec 2021 12:45:43 GMT
       Referrer-Policy:
       - strict-origin-when-cross-origin
       Server:
@@ -2259,10 +1400,10 @@ interactions:
       - chunked
       X-Content-Type-Options:
       - nosniff
-      X-Discourse-Cached:
-      - 'true'
       X-Discourse-Route:
       - topics/show
+      X-Discourse-Username:
+      - carkod
       X-Download-Options:
       - noopen
       X-Frame-Options:
@@ -2270,9 +1411,9 @@ interactions:
       X-Permitted-Cross-Domain-Policies:
       - none
       X-Request-Id:
-      - 607291a7-1cbf-4d49-ab02-d2ad327f305a
+      - 380f3de6-147a-4bb9-ac13-863166c3bf59
       X-Runtime:
-      - '0.002055'
+      - '0.209812'
       X-XSS-Protection:
       - 1; mode=block
     status:

--- a/tests/cassettes/TestRoutes.test_engage_index_without_preview_flag_cannot_see_inactive_page.yaml
+++ b/tests/cassettes/TestRoutes.test_engage_index_without_preview_flag_cannot_see_inactive_page.yaml
@@ -1,2256 +1,1397 @@
 interactions:
 - request:
     body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - python-requests/2.24.0
+    headers: {}
     method: GET
-    uri: https://discourse.ubuntu.com/t/17229.json
+    uri: https://discourse.ubuntu.com/t/18033.json
   response:
     body:
-      string: "{\"post_stream\":{\"posts\":[{\"id\":48547,\"name\":\"Peter Mahnke\"\
-        ,\"username\":\"peterm-ubuntu\",\"avatar_template\":\"/user_avatar/discourse.ubuntu.com/peterm-ubuntu/{size}/7873_2.png\"\
-        ,\"created_at\":\"2020-07-14T09:57:15.584Z\",\"cooked\":\"\\u003ch1\\u003eEngage\
-        \ pages\\u003c/h1\\u003e\\n\\u003cp\\u003eThe content of topics in this category\
-        \ are displayed at \\u003ca href=\\\"https://ubuntu.com/engage\\\" rel=\\\"\
-        nofollow noopener\\\"\\u003ehttps://ubuntu.com/engage\\u003c/a\\u003e.\\u003c/p\\\
-        u003e\\n\\u003ch2\\u003eMetadata\\u003c/h2\\u003e\\n\\u003cdetails\\u003e\\\
-        n\\u003csummary\\u003e\\nMapping table\\u003c/summary\\u003e\\n\\u003cdiv\
-        \ class=\\\"md-table\\\"\\u003e\\n\\u003ctable\\u003e\\n\\u003cthead\\u003e\\\
-        n\\u003ctr\\u003e\\n\\u003cth\\u003etopic\\u003c/th\\u003e\\n\\u003cth\\u003epath\\\
-        u003c/th\\u003e\\n\\u003cth\\u003etype\\u003c/th\\u003e\\n\\u003cth\\u003etags\\\
-        u003c/th\\u003e\\n\\u003cth\\u003epublish_date\\u003c/th\\u003e\\n\\u003cth\\\
-        u003elanguage\\u003c/th\\u003e\\n\\u003cth\\u003esubtitle\\u003c/th\\u003e\\\
-        n\\u003cth\\u003eactive\\u003c/th\\u003e\\n\\u003c/tr\\u003e\\n\\u003c/thead\\\
-        u003e\\n\\u003ctbody\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca\
-        \ href=\\\"https://discourse.ubuntu.com/t/cinque-strategie-per-accelerare-limplementazione-di-kubernetes-nellimpresa/19381\\\
-        \"\\u003eCinque strategie per accelerare l\u2019implementazione di Kubernetes\
-        \ nell\u2019impresa\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/it/deployment-azienda-manuale\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003eenterprise\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-11-17\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003eit\\u003c/td\\u003e\\n\\u003ctd\\u003eCome scegliere\
-        \ il miglior approccio Kubernetes per la tua azienda\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003efalse\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
-        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/confronto-fra-red-hats-openstack-platform-e-charmed-openstack-di-canaonical/19362\\\
-        \"\\u003eConfronto fra \u201CRed Hat\u2019s Openstack platform\u201D e Charmed\
-        \ Openstack di Canaonical\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/it/redhat-openstack-confronto-manuale\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003eRed Hat\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-11-16\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003eit\\u003c/td\\u003e\\n\\u003ctd\\u003eCharmed Openstack riduce\
-        \ significativamente il costo totale di propriet\xE0\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
-        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/confronto-fra-red-hats-openstack-platform-e-charmed-openstack-di-canaonical/19361\\\
-        \"\\u003eGuide pour r\xE9ussir l\u2019adoption et le d\xE9ploiement d\u2019\
-        OpenStack\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/fr/guide-adoption-openstack\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003eopenstack\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-11-16\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003efr\\u003c/td\\u003e\\n\\u003ctd\\u003eD\xE9couvrez l\u2019\
-        \xE9prouv\xE9 processus d\u2019impl\xE9mentation OpenStack de Canonical\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\\
-        n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/funf-strategien-zur-beschleunigung-von-kubernetes-in-unternehmen/19284\\\
-        \"\\u003eF\xFCnf Strategien zur Beschleunigung von Kubernetes in Unternehmen\\\
-        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/de/kubernetes-implementierung-fur-unternehmen\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003eenterprise\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-11-11\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003ede\\u003c/td\\u003e\\n\\u003ctd\\u003eEntscheidungskriterien\
-        \ zur optimalen Herangehensweise an Kubernetes f\xFCr Ihr Unternehmen\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\\
-        u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/vergleich-von-red-hat-openstack-platform-und-charmed-openstack-von-canonical/19285\\\
-        \"\\u003eVergleich von Red Hat OpenStack Platform und Charmed OpenStack von\
-        \ Canonical\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/de/redhat-openstack-vergleich\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003eRed Hat\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-11-11\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003ede\\u003c/td\\u003e\\n\\u003ctd\\u003eSenken Sie Ihre Gesamtkosten\
-        \ deutlich mit Charmed OpenStack\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\\
-        u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\\
-        u003ca href=\\\"https://discourse.ubuntu.com/t/9-out-of-top-10-us-financial-institutions-use-ubuntu/19304\\\
-        \"\\u003e9 out of top 10 US \\u0026amp; European financial institutions use\
-        \ Ubuntu\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/finance\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003efinance\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-11-11\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eFind out why multi-cloud\
-        \ is fundamental to financial services transformation\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
-        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/cinco-estrategias-para-acelerar-a-los-kubernetes-en-la-empresa/19208\\\
-        \"\\u003eCinco estrategias para acelerar a los Kubernetes en la empresa\\\
-        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/es/kubernetes-despliegue-empresa-manual\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003eenterprise, kubernetes\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-11-04\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003ees\\u003c/td\\u003e\\n\\u003ctd\\u003eC\xF3\
-        mo elegir el mejor enfoque de Kubernetes para su negocio\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
-        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/comparando-la-plataforma-openstack-de-red-hat-y-la-charmed-openstack-de-canonical/19194\\\
-        \"\\u003eComparando la plataforma OpenStack de Red Hat y la Charmed OpenStack\
-        \ de Canonical\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/es/redhat-openstack-comparacion-manual\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003eopenstack\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-11-03\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003ees\\u003c/td\\u003e\\n\\u003ctd\\u003eReducir significativamente\
-        \ el coste total de propiedad con Charmed OpenStack\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
-        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/optimised-authentication-methods-for-ubuntu-desktop/19133\\\
-        \"\\u003eOptimised authentication methods for Ubuntu Desktop\\u003c/a\\u003e\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/desktop-authentication-whitepaper\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003edesktop, security\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-08-07\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eSecuring enterprise\
-        \ desktops with modern authentication options\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\\
-        u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/open-digital-platforms-for-the-industrial-edge-cloud-in-2020/19068\\\
-        \"\\u003eOpen digital platforms for the industrial edge cloud in 2020\\u003c/a\\\
-        u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/pac-radar\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003epac-radar\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e2020-10-27\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eThe next wave of cloud-native innovations\
-        \ at the edge\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\\
-        u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/ubuntu-20-10-what-s-new/19050\\\
-        \"\\u003eUbuntu 20.10: What\u2019s new?\\u003c/a\\u003e\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003e/engage/ubuntu-20.10\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003eubuntu server, maas, kubernetes\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e2020-10-26\\u003c/td\\u003e\\n\\u003ctd\\u003een\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003eLearn about new features in Ubuntu Server,\
-        \ MAAS, Charmed OpenStack and Charmed Kubernetes\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\\
-        u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/ubuntu-for-raspberry-pi-live-on-youtube/18577\\\
-        \"\\u003eUbuntu for Raspberry Pi intro video\\u003c/a\\u003e\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003e/engage/raspberry-pi-livestream\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eraspberry-pi, desktop\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e2020-10-21\\u003c/td\\u003e\\n\\u003ctd\\u003een\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\\
-        u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\\
-        u003ca href=\\\"https://discourse.ubuntu.com/t/cloud-gaming-for-android/18757\\\
-        \"\\u003eCloud gaming for Android\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003e/engage/anbox-cloud-gaming-whitepaper\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eanbox, gaming\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e2020-01-21\\u003c/td\\u003e\\n\\u003ctd\\u003een\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003eBuilding a high performing and scalable\
-        \ platform\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\\
-        u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/extend-your-openstack-cloud-with-native-backup-and-recover/18911\\\
-        \"\\u003eExtend your OpenStack cloud with native backup and recovery\\u003c/a\\\
-        u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/trilio-backup-recovery\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e2020-09-31\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eLearn how TrilioVault can be easily\
-        \ deployed in a Charmed OpenStack environment\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\\
-        u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/transforming-telco-infrastructure-a-virtual-event/18162\\\
-        \"\\u003eTransforming telco infrastructure\\u003c/a\\u003e\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003e/engage/telco-virtual-event\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003eevent\\u003c/td\\u003e\\n\\u003ctd\\u003eopen-source\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003e2020-09-24\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003eCanonical\u2019s experts explore the telecommunication\
-        \ industry\u2019s latest technologies. Join us live on 24 September 2020.\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\\
-        n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/guia-para-la-implementacion-de-openstack/18480\\\
-        \"\\u003eGu\xEDa para la implementaci\xF3n de OpenStack\\u003c/a\\u003e\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/es/guia-para-la-implementacion-de-openstack\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003eopenstack\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-09-16\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003ees\\u003c/td\\u003e\\n\\u003ctd\\u003eDescubre el probado\
-        \ proceso de implementaci\xF3n de OpenStack de Canonical\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
-        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/da-vmware-a-charmed-openstack/18478\\\
-        \"\\u003eDa VMware a Charmed Openstack\\u003c/a\\u003e\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003e/engage/it/da-vmware-a-charmed-openstack\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e2020-09-15\\u003c/td\\u003e\\n\\u003ctd\\u003eit\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003eCome la migrazione a Charmed OpenStack pu\xF2\
-        \ ridurre significativamente il TCO\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\\
-        u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\\
-        u003ca href=\\\"https://discourse.ubuntu.com/t/gmo-pepabo-ubuntu/18476\\\"\
-        \\u003eGMO Pepabo \\u0026amp; Ubuntu\\u003c/a\\u003e\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003e/engage/case-study-gmo-pepabo\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003ecase study\\u003c/td\\u003e\\n\\u003ctd\\u003eserver, kubernetes,ubuntu-advantage\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e2020-09-14\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eGMO Pepabo cuts OPEX costs with\
-        \ live kernel patching and saves 2,500 hours of manual work\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
-        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/da-vmware-a-openstack/18164\\\
-        \"\\u003eDa VMware a OpenStack\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003e/engage/it/da-vmware-a-openstack\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003eopenstack\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003e2020-09-04\\u003c/td\\u003e\\n\\u003ctd\\u003eit\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003eCome la migrazione a Charmed OpenStack pu\xF2 ridurre significativamente\
-        \ il TCO\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\\
-        u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/five-strategies-to-accelerate-kubernetes-deployment-in-the-enterprise/18161\\\
-        \"\\u003eFive strategies to accelerate Kubernetes in the enterprise\\u003c/a\\\
-        u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/kubernetes-deployment-enterprise-whitepaper\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003ekubernetes\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-09-02\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eHow to choose\
-        \ the best approach to Kubernetes for your business\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
-        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/production-ai-from-data-lake-to-server-webinar/18163\\\
-        \"\\u003eProduction AI from data lake to server\\u003c/a\\u003e\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e/engage/data-lake_2_server_webinar\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eai\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e2020-08-13\\u003c/td\\u003e\\n\\u003ctd\\u003een\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003eSolving hardware challenges in ML environments\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\\
-        n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/building-powerful-customer-solutions/18481\\\
-        \"\\u003eBuilding powerful customer solutions\\u003c/a\\u003e\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e/engage/gsi-webinar-series\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003ecloud, kubernetes\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e2020-07-31\\u003c/td\\u003e\\n\\u003ctd\\u003een\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003eA webinar series for GSIs seizing new models\
-        \ for scalable, automated and repeatable deployments\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
-        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/comparing-red-hat-openstack-platform-and-canonicals-charmed-openstack/18159\\\
-        \"\\u003eComparing Red Hat OpenStack Platform and Canonical\u2019s Charmed\
-        \ OpenStack\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/redhat-openstack-comparison-whitepaper\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003eopenstack\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-07-29\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eImprove security and\
-        \ efficiency at a reduced total cost of ownership with Charmed OpenStack\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\\
-        n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/do-vmware-ao-charmed-openstack/18165\\\
-        \"\\u003eDo VMware ao Charmed OpenStack\\u003c/a\\u003e\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003e/engage/pt/vmware-para-o-openstack\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e2020-07-22\\u003c/td\\u003e\\n\\u003ctd\\u003ept\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003eReduza os custos e aumente a efici\xEAncia\
-        \ da sua infraestrutura com ado\xE7\xE3o de c\xF3digo aberto\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
-        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/busting-the-myth-of-private-cloud-economics/17244\\\
-        \"\\u003eBusting the myth of private cloud economics\\u003c/a\\u003e\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e/engage/cloud-economics\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003ecase-study\\u003c/td\\u003e\\n\\u003ctd\\u003ecloud, openstack\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e2019-07-12\\u003c/td\\u003e\\n\\u003ctd\\u003een\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\\
-        u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\\
-        u003ca href=\\\"https://discourse.ubuntu.com/t/scale-android-applications-economically-in-the-cloud-with-anbox-cloud/17401\\\
-        \"\\u003eScale Android applications economically in the cloud with Anbox Cloud\\\
-        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/intro-to-anbox-cloud-whitepaper\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003ecloud\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-07-08\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eDiscover Canonical\u2019\
-        s scalable, hardware-agnostic mobile cloud computing platform\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\\
-        u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/accelerating-iot-device-time-to-market/17399\\\
-        \"\\u003eAccelerating IoT device time to market\\u003c/a\\u003e\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e/engage/smart-start-whitepaper\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eiot\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e2020-07-03\\u003c/td\\u003e\\n\\u003ctd\\u003een\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003eIntroducing a packaged solution to condense\
-        \ IoT decision-making into a 2-week, fixed cost process\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
-        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/kubernetes-from-cloud-to-edge/17398\\\
-        \"\\u003eKubernetes from Cloud to Edge\\u003c/a\\u003e\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003e/engage/kubernetes-event-us\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003ekubernetes, cloud, edge\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e2020-06-24\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eHow to streamline your Kubernetes\
-        \ deployment and operations from Canonical\u2019s experts.\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
-        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/scaling-on-azure-with-ubuntu-pro/17397\\\
-        \"\\u003eScaling on Azure with Ubuntu Pro\\u003c/a\\u003e\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003e/engage/scaling-securely-ubuntu-azure\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003eeBook\\u003c/td\\u003e\\n\\u003ctd\\u003eopen-source, cloud\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e2020-06-17\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eScale your open-source infrastructure\
-        \ with speed, security, and compliance\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\\
-        u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\\
-        u003ca href=\\\"https://discourse.ubuntu.com/t/a-technical-intro-to-ubuntu-pro/17396\\\
-        \"\\u003eA technical intro to Ubuntu Pro\\u003c/a\\u003e\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003e/engage/ubuntu-pro-intro\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003eopen-source\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003e2020-06-16\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\\
-        n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"\
-        https://discourse.ubuntu.com/t/migrating-your-infrastructure-to-ubuntu-20-04-lts/17395\\\
-        \"\\u003eMigrating your infrastructure to Ubuntu 20.04 LTS\\u003c/a\\u003e\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/migrating-to-20.04\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eopen-source\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e2020-06-11\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eHow, when and why?\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\\
-        u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/utilising-cloud-init-on-microsoft-azure/17394\\\
-        \"\\u003eUtilising cloud-init on Microsoft Azure\\u003c/a\\u003e\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e/engage/azure-cloud-init-whitepaper\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003ecloud\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e2020-06-03\\u003c/td\\u003e\\n\\u003ctd\\u003een\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003eSimplify cloud instance deployment with\
-        \ Ubuntu on Azure\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\\
-        n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"\
-        https://discourse.ubuntu.com/t/standardising-machine-learning-from-workstation-to-production/17393\\\
-        \"\\u003eStandardising machine learning \u2014 from workstation to production\\\
-        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/ml-dell-webinar\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eai,\
-        \ ml, kubernetes\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-06-02\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\\
-        u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/kafka-in-production/17392\\\
-        \"\\u003eKafka in production\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003e/engage/kafka-in-production\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003ekafka\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-05-28\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eMaking\
-        \ sure your deployment is fast, reliable and secure\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
-        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/solving-the-software-update-challenge-for-iot-devices/17391\\\
-        \"\\u003eSolving the software update challenge for IoT devices\\u003c/a\\\
-        u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/snapd-whitepaper\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eiot,\
-        \ ubuntu-core, snaps\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-05-15\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eHow Ubuntu Core\
-        \ transforms over-the-air software updates\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\\
-        u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/secure-iot-device-management/17390\\\
-        \"\\u003eSecure IoT device management\\u003c/a\\u003e\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003e/engage/iot-device-management-whitepaper\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eiot, security,\
-        \ ubuntu-core\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-05-13\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eBuild and deploy a\
-        \ central IoT management solution\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\\
-        u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\\
-        u003ca href=\\\"https://discourse.ubuntu.com/t/leveraging-open-source-with-ubuntu-pro-on-azure/17389\\\
-        \"\\u003eLeveraging open source with Ubuntu Pro on Azure\\u003c/a\\u003e\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/azure-webinar\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eopen-source\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e2020-05-12\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eEconomics, velocity and security\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\\
-        n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/streamlined-kubernetes-from-cloud-to-edge/17388\\\
-        \"\\u003eStreamlined Kubernetes, from Cloud to Edge\\u003c/a\\u003e\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e/engage/eu-kubernetes-event\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003ekubernetes, cloud,\
-        \ edge\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-05-11\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eInnovating and scaling\
-        \ efficiently, with Charmed Kubernetes and MicroK8s\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
-        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/embracing-the-open-source-mandate/17387\\\
-        \"\\u003eEmbracing the open source mandate\\u003c/a\\u003e\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003e/engage/moving-to-opensource-whitepaper\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eopen-source\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e2020-04-28\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e85% of enterprises have an open\
-        \ source mandate, preference or are exploring\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\\
-        u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/what-s-new-in-ubuntu-20-04-lts/17386\\\
-        \"\\u003eWhat\u2019s new in Ubuntu 20.04 LTS?\\u003c/a\\u003e\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e/engage/20.04-webinars\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003edesktop, server\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e2020-04-16\\u003c/td\\u003e\\n\\u003ctd\\u003een\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003eTwo webinars to help you understand what\
-        \ makes 20.04 our most secure and reliable release to date\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
-        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/maintaining-business-focus-in-a-cloud-native-world-with-managed-apps/17385\\\
-        \"\\u003eMaintaining business focus in a cloud-native world with Managed Apps\\\
-        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/managed-apps-webinar\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003ecloud\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e2020-04-09\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\\
-        u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/ubuntu-core-a-cybersecurity-analysis/17381\\\
-        \"\\u003eUbuntu Core: a cybersecurity analysis\\u003c/a\\u003e\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e/engage/ubuntu-core-security-audit\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eubuntu-core,\
-        \ security, iot\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-03-31\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eAn independent\
-        \ evaluation of Ubuntu Core\u2019s security capabilities\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
-        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/openstack-deployment-guide/17384\\\
-        \"\\u003eOpenStack deployment guide\\u003c/a\\u003e\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003e/engage/openstack-deployment-guide\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003e2020-03-31\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003eDiscover Canonical\u2019s proven OpenStack implementation\
-        \ process\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\\
-        u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/installez-et-mettez-openstack-a-lechelle-en-toute-simplicite/17418\\\
-        \"\\u003eInstallez et mettez OpenStack \xE0 l\u2019\xE9chelle en toute simplicit\xE9\
-        \\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/fr/openstack-made-easy\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003eeBook\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e2020-03-29\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003efr\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\\
-        u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/virtual-event-microk8s-kubernetes/17380\\\
-        \"\\u003eVirtual event: MicroK8s \\u0026amp; Kubernetes\\u003c/a\\u003e\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/pre-kubecon-event\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003eevent\\u003c/td\\u003e\\n\\u003ctd\\u003ekubernetes\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e2020-03-24\\u003c/td\\u003e\\n\\u003ctd\\u003een\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003eJoin our virtual event to learn more about\
-        \ MicroK8s, what it is and why you should use it. This event will also include\
-        \ discussions on Kubernetes, an introduction to Canonical and much more!\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\\
-        n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/rigado-cuts-customers-time-to-market/17379\\\
-        \"\\u003eRigado cuts customers\u2019 time-to-market\\u003c/a\\u003e\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e/engage/case-study-rigado\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003ecase study\\u003c/td\\u003e\\n\\u003ctd\\u003eiot, ubuntu-core, snaps\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e2020-03-19\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003een\\u003c/td\\u003e\\n\\u003ctd\\u003ewith Ubuntu Core and AWS\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\\
-        u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/securing-ros-robotics-platforms/17378\\\
-        \"\\u003eSecuring ROS robotics platforms\\u003c/a\\u003e\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003e/engage/securing-ros-on-robotics-platforms-whitepaper\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003erobotics,\
-        \ security\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-03-11\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eSteps to maximise robotics\
-        \ security with Ubuntu\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\\
-        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\
-        \"https://discourse.ubuntu.com/t/smart-card-login-on-ubuntu/17377\\\"\\u003eSmart\
-        \ card login on Ubuntu\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/smart-card-whitepaper\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003esecurity\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-03-09\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eConfigure Ubuntu 18.04\
-        \ LTS for smart card operation\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\\
-        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\
-        \"https://discourse.ubuntu.com/t/hosted-private-cloud-infrastructure-a-cost-analysis/17375\\\
-        \"\\u003eHosted private cloud infrastructure: a cost analysis\\u003c/a\\u003e\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/private-cloud-cost-analysis-webinar\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack,\
-        \ cloud, kubernetes, maas\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-03-02\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eAccelerate\
-        \ initial deployment and reduce operational costs by outsourcing private cloud\
-        \ infrastructure management\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\\
-        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\
-        \"https://discourse.ubuntu.com/t/an-introduction-to-anbox-cloud/17374\\\"\\\
-        u003eAccelerating IoT device time to market\\u003c/a\\u003e\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003e/engage/smart-start-webinar\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eiot\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003e2020-02-26\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003eChallenges and solutions for IoT execution\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\\
-        u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/an-introduction-to-anbox-cloud/17374\\\
-        \"\\u003eAn introduction to Anbox Cloud\\u003c/a\\u003e\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003e/engage/anbox-cloud-webinar\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003ecloud\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003e2020-02-25\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003eScalable Android\u2122 in the cloud\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
-        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/esm-maintains-interanas-system-security-while-upgrading/17376\\\
-        \"\\u003eESM maintains Interana\u2019s system security while upgrading\\u003c/a\\\
-        u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/interana-casestudy\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003ecase study\\u003c/td\\u003e\\n\\u003ctd\\u003esecurity\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e2020-02-17\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\\
-        u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/artificial-intelligence-at-the-edge-in-a-5g-world/17372\\\
-        \"\\u003eArtificial Intelligence at the edge in a 5G world\\u003c/a\\u003e\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/ai-edge-webinar\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eai, ml, edge\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e2020-02-07\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eDeploying AI/ML solutions in latency-sensitive\
-        \ environments requires a new solution architecture approach\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
-        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/deploy-kubernetes-in-your-data-centre/17373\\\
-        \"\\u003eDeploy Kubernetes in your data centre\\u003c/a\\u003e\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e/engage/dell-kubernetes-webinar\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003ekubernetes\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e2020-02-07\\u003c/td\\u003e\\n\\u003ctd\\u003een\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\\
-        u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\\
-        u003ca href=\\\"https://discourse.ubuntu.com/t/migration-von-vmware-zu-openstack/17370\\\
-        \"\\u003eMigration von VMware zu OpenStack\\u003c/a\\u003e\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003e/engage/de/migration-von-vmware-zu-openstack\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e2020-02-04\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003ede\\u003c/td\\u003e\\n\\u003ctd\\u003eWie ein Umstieg auf Charmed OpenStack\
-        \ die Gesamtkosten sp\xFCrbar senken kann\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\\
-        u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\\
-        u003ca href=\\\"https://discourse.ubuntu.com/t/de-vmware-a-charmed-openstack/17371\\\
-        \"\\u003eDe VMware a Charmed OpenStack\\u003c/a\\u003e\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003e/engage/es/vmware-a-charmed-openstack\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e2020-02-04\\u003c/td\\u003e\\n\\u003ctd\\u003ees\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003eC\xF3mo la migraci\xF3n a Charmed OpenStack\
-        \ puede reducir significativamente el TCO\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\\
-        u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\\
-        u003ca href=\\\"https://discourse.ubuntu.com/t/kubernetes-a-secure-flexible-and-automated-edge-for-iot-developers/17369\\\
-        \"\\u003eKubernetes: a secure, flexible and automated edge for IoT developers\\\
-        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/microk8s-451research\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003ekubernetes, edge, iot\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-01-10\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eThe\
-        \ factors for implementing Kubernetes successfully at the edge\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\\
-        u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/an-intro-to-microk8s/17367\\\
-        \"\\u003eAn intro to MicroK8s\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003e/engage/intro-to-microk8s-webinar\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003ekubernetes\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003e2019-12-19\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003eReliable, fast, small and upstream Kubernetes\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
-        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/ubuntu-desktop-for-the-enterprise/17368\\\
-        \"\\u003eUbuntu Desktop for the enterprise\\u003c/a\\u003e\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003e/engage/linux-enterprise-whitepaper\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003edesktop\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e2019-12-19\\u003c/td\\u003e\\n\\u003ctd\\u003een\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003eLearn why enterprises are beginning to adopt\
-        \ Linux as a desktop operating system\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\\
-        u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\\
-        u003ca href=\\\"https://discourse.ubuntu.com/t/cyberdyne-keeps-cleaning-robots-up-to-date-in-the-field-with-snaps/17366\\\
-        \"\\u003eCyberdyne keeps cleaning robots up-to-date in the field with snaps\\\
-        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/cyberdyne\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003ecase study\\u003c/td\\u003e\\n\\u003ctd\\u003erobotics,\
-        \ iot\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-12-18\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
-        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/sbi-group-unlocks-infrastructure-automation-with-secure-on-premises-openstack-cloud/17364\\\
-        \"\\u003eSBI Group unlocks infrastructure automation with secure, on-premises\
-        \ OpenStack cloud\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/sbi-casestudy\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003ecase study\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003eopenstack\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-12-06\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
-        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/register-for-wslconf/17365\\\
-        \"\\u003eRegister for WSLConf\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003e/engage/wslconf\\u003c/td\\u003e\\n\\u003ctd\\u003eevent\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003ewsl\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-12-06\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\\
-        n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/build-smart-display-devices-with-mir-fast-to-production-secure-open-source/17363\\\
-        \"\\u003eBuild smart display devices with Mir: fast to production, secure,\
-        \ open-source\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/build-smart-devices-with-mir-whitepaper\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003eiot\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-11-27\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
-        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/linux-security-with-ubuntu/17362\\\
-        \"\\u003eLinux security with Ubuntu\\u003c/a\\u003e\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003e/engage/linux_security_webinar\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003esecurity\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003e2019-11-14\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003eSecuring Ubuntu systems for reduced downtime and optimum\
-        \ CVE coverage.\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\\
-        n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"\
-        https://discourse.ubuntu.com/t/lessons-learned-from-100-private-cloud-builds/17361\\\
-        \"\\u003eLessons learned from 100+ Private cloud builds\\u003c/a\\u003e\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/private-cloud-build-webinar\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack,\
-        \ cloud\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-11-12\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eReducing the complexities\
-        \ of building a private cloud on OpenStack\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\\
-        u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/the-wellcome-sanger-institute-turns-to-canonical-for-high-level-ceph-support/17360\\\
-        \"\\u003eThe Wellcome Sanger Institute turns to Canonical for high level Ceph\
-        \ support\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/wellcome-sanger-case-study\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003ecase study\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003eceph, openstack\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-11-04\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\\
-        u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/ensuring-security-and-isolation-in-kubernetes-with-kata-containers/17359\\\
-        \"\\u003eEnsuring security and isolation in Kubernetes with Kata Containers\\\
-        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/kata-containers-webinar\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003esecurity\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e2019-11-01\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\\
-        u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/tim-ensures-system-security-and-client-confidence-with-esm/17358\\\
-        \"\\u003eTIM ensures system security and client confidence with ESM\\u003c/a\\\
-        u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/case-study-acuris\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003ecase study\\u003c/td\\u003e\\n\\u003ctd\\u003esecurity,\
-        \ ubuntu-advantage\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-10-22\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\\
-        u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/what-s-new-in-ubuntu-19-10/17357\\\
-        \"\\u003eWhat\u2019s new in Ubuntu 19.10\\u003c/a\\u003e\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003e/engage/19-10-webinar\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003edesktop\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-10-17\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eUbuntu\
-        \ 19.10 includes enhanced K8s capabilities for edge and AI/ML, OpenStack Train\
-        \ live-migration extensions for easier infrastructure deployments and more.\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\\
-        n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/how-domotz-streamlined-provisioning-of-iot-devices/17356\\\
-        \"\\u003eHow Domotz streamlined provisioning of IoT devices\\u003c/a\\u003e\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/domotz-case-study\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003ecase study\\u003c/td\\u003e\\n\\u003ctd\\u003eubuntu-core,\
-        \ snaps, iot\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-10-10\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eLearn how Ubuntu Core\
-        \ and snaps gives Domotz a competitive advantage\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\\
-        u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/yahoo-japan-builds-their-iaas-environment-with-canonical/17355\\\
-        \"\\u003eYahoo! Japan builds their IaaS environment with Canonical\\u003c/a\\\
-        u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/yahoo-japan-case-study\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003ecase study\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003eopenstack, maas, juju, ubuntu-advantage, security\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003e2019-10-08\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\\
-        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\
-        \"https://discourse.ubuntu.com/t/accelerating-deep-tech-with-ubuntu/17354\\\
-        \"\\u003eAccelerating deep tech with Ubuntu\\u003c/a\\u003e\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003e/engage/deeptech\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003eiot, robotics\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003e2019-10-02\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\\
-        n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"\
-        https://discourse.ubuntu.com/t/from-vmware-to-charmed-openstack/17343\\\"\\\
-        u003eFrom VMWare To Charmed OpenStack\\u003c/a\\u003e\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003e/engage/vmware-to-charmed-openstack\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003e2019-09-04\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003eReduce costs and increase the efficiency of your infrastructure\
-        \ with open source adoption\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\\
-        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\
-        \"https://discourse.ubuntu.com/t/machine-learning-operations-mlops/17353\\\
-        \"\\u003eMachine Learning Operations (MLOps)\\u003c/a\\u003e\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003e/engage/get-started-with-ai-part-2\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eai, ml\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e2019-09-11\\u003c/td\\u003e\\n\\u003ctd\\u003een\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003eDeploy at scale\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\\
-        u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/how-to-manage-snaps-in-an-enterprise-environment/17352\\\
-        \"\\u003eHow to manage snaps in an enterprise environment\\u003c/a\\u003e\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/enterprise-snap-management\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003esnaps,\
-        \ security\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-08-20\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eHow the Snap Store\
-        \ Proxy overcomes challenges presented by restricted networks and management\
-        \ policies\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\\
-        u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/a-guide-to-developing-android-apps-on-ubuntu/17351\\\
-        \"\\u003eA guide to developing Android apps on Ubuntu\\u003c/a\\u003e\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e/engage/developing-android-on-ubuntu\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003edesktop, apps\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e2019-08-13\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\\
-        u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/creating-a-cloud-like-bare-metal-experience-in-the-data-centre/17348\\\
-        \"\\u003eCreating a cloud-like bare metal experience in the data centre\\\
-        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/maas-hardware-testing\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003emaas\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-08-08\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
-        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/creating-accurate-ai-models-with-data/17349\\\
-        \"\\u003eCreating accurate AI models with data\\u003c/a\\u003e\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e/engage/data-pipelines-kubeflow\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003ekubeflow, ai\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e2019-08-08\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eHow Kubeflow and machine learning\
-        \ help you get the most out of your data\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\\
-        u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\\
-        u003ca href=\\\"https://discourse.ubuntu.com/t/ims-evolve-adopts-ubuntu-core-to-provide-iot-enabled-business-intelligence-in-the-supply-chain/17284\\\
-        \"\\u003eIMS Evolve adopts Ubuntu Core to provide IoT-enabled business intelligence\
-        \ in the supply chain\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/casestudy-imsevolve\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003ecase study\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003eiot\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-17\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
-        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/rocket-chat-communication-platform-enables-simplicity-through-snaps/17288\\\
-        \"\\u003eRocket.Chat communication platform enables simplicity through snaps\\\
-        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/casestudy-rocketchat\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003ecase study\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003esnaps, apps\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-17\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\\
-        u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/server-provisioning-what-network-admins-it-pros-need-to-know/17307\\\
-        \"\\u003eServer Provisioning: What Network Admins \\u0026amp; IT Pros Need\
-        \ to Know\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/ebook-maas\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003eeBook\\u003c/td\\u003e\\n\\u003ctd\\u003eserver\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-17\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\\
-        u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/building-a-private-cloud-take-the-leap/17331\\\
-        \"\\u003eBuilding a private cloud? Take the leap!\\u003c/a\\u003e\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e/engage/private-cloud\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003eeBook\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack, cloud\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e2019-07-17\\u003c/td\\u003e\\n\\u003ctd\\u003een\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\\
-        u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\\
-        u003ca href=\\\"https://discourse.ubuntu.com/t/make-it-rain-public-cloud-on-ubuntu-openstack/17332\\\
-        \"\\u003eMake IT rain: public cloud on Ubuntu OpenStack\\u003c/a\\u003e\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/public-cloud\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003eeBook\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack, cloud\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-17\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\\
-        u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/learn-whats-new-in-ubuntu-server-14-04-lts/17344\\\
-        \"\\u003eLearn What\u2019s New In Ubuntu Server 14.04 LTS\\u003c/a\\u003e\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/whats-new-ubuntu-14-04-lts\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eserver,\
-        \ openstack\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-17\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
-        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/how-ubuntu-helped-innovapos-revolutionise-the-vending-machine-industry/17285\\\
-        \"\\u003eHow Ubuntu helped InnovaPOS revolutionise the vending machine industry\\\
-        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/casestudy-innovapos\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003ecase study\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003eiot\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-16\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
-        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/nexiona-collaborates-with-canonical-and-dell-to-create-miimetiq-edge/17287\\\
-        \"\\u003eNEXIONA collaborates with Canonical and Dell to create MIIMETIQ EDGE\\\
-        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/casestudy-nexiona\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003ecase study\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003eiot\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-16\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
-        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/azeti-uses-ubuntu-core-to-improve-deployment-and-security/17278\\\
-        \"\\u003eAzeti uses Ubuntu Core to improve deployment and security\\u003c/a\\\
-        u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/casestudy-azeti\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003ecase study\\u003c/td\\u003e\\n\\u003ctd\\u003esecurity,\
-        \ iot\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-16\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
-        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/azlogica-utilise-ubuntu-core-for-customised-iot-agricultural-solutions/17279\\\
-        \"\\u003eAZLOGICA utilise Ubuntu Core for customised IoT agricultural solutions\\\
-        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/casestudy-azlogica\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003ecase study\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003eiot\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-16\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
-        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/botsandus-builds-a-social-robot-on-ubuntu/17280\\\
-        \"\\u003eBotsAndUs builds a social robot on Ubuntu\\u003c/a\\u003e\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e/engage/casestudy-botsandus\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003ecase study\\u003c/td\\u003e\\n\\u003ctd\\u003erobotics\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e2019-07-16\\u003c/td\\u003e\\n\\u003ctd\\u003een\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\\
-        u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\\
-        u003ca href=\\\"https://discourse.ubuntu.com/t/cinergy-makes-significant-digital-signage-saving-with-screenly-pro-and-ubuntu-core/17281\\\
-        \"\\u003eCinergy makes significant digital signage saving with Screenly Pro\
-        \ and Ubuntu Core\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/casestudy-cinergy\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003ecase study\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003edigital-signage\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-16\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\\
-        u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/commercetools-uses-ubuntu-server-to-power-its-next-generation-ecommerce-platform/17283\\\
-        \"\\u003eCommercetools uses Ubuntu Server to power its next-generation ecommerce\
-        \ platform\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/casestudy-commercetools\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003ecase study\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003eserver, e-commerce\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-16\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\\
-        u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/for-ctos-the-no-nonsense-way-to-accelerate-your-business-with-containers/17345\\\
-        \"\\u003eFor CTOs: the no-nonsense way to accelerate your business with containers\\\
-        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/whitepaper-containers\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003etelco\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-16\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
-        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/taking-charge-of-the-iots-security-vulnerabilities/17346\\\
-        \"\\u003eTaking charge of the IoT\u2019s security vulnerabilities\\u003c/a\\\
-        u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/whitepaper-iot-security\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003eiot, security\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-16\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\\
-        u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/the-essential-guide-for-telecoms-and-service-providers-adopting-big-data-solutions/17309\\\
-        \"\\u003eThe essential guide for Telecoms and Service Providers adopting big\
-        \ data solutions\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/essential-guide-big-data-solutions\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003eeBook\\u003c/td\\u003e\\n\\u003ctd\\u003etelco,\
-        \ openstack\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-15\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
-        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/city-network-brings-openstack-cloud-hosting-to-the-financial-services-sector-with-canonical/17282\\\
-        \"\\u003eCity Network brings OpenStack cloud hosting to the financial services\
-        \ sector with Canonical\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/casestudy-city-network\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003ecase study\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003ecloud\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-15\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
-        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/cto-s-guide-to-sdn-nfv-vnf/17293\\\
-        \"\\u003eCTO\u2019s guide to SDN, NFV \\u0026amp; VNF\\u003c/a\\u003e\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e/engage/cto-guide-sdn-nfv-vnf\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003eeBook\\u003c/td\\u003e\\n\\u003ctd\\u003enetworking\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e2019-07-15\\u003c/td\\u003e\\n\\u003ctd\\u003een\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003eWhy is the transition happening and why\
-        \ is it important?\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\\
-        n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"\
-        https://discourse.ubuntu.com/t/sensape-uses-landscape-to-remotely-support-revolutionary-interactive-retail-displays/17289\\\
-        \"\\u003eSensape uses Landscape to remotely support revolutionary interactive\
-        \ retail displays\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/casestudy-sensape\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003ecase study\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003edigital-signage\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-15\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\\
-        u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/how-to-face-the-challenges-of-becoming-a-cloud-operator/17290\\\
-        \"\\u003eHow to face the challenges of becoming a cloud operator\\u003c/a\\\
-        u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/cloud-fray\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003eeBook\\u003c/td\\u003e\\n\\u003ctd\\u003ecloud, openstack,\
-        \ telco\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-15\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
-        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/low-latency-and-real-time-kernels-for-telco-and-nfv/17321\\\
-        \"\\u003eLow latency and real time kernels for telco and NFV\\u003c/a\\u003e\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/low-latency-report\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003etelco\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e2019-07-15\\u003c/td\\u003e\\n\\u003ctd\\u003een\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\\
-        u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\\
-        u003ca href=\\\"https://discourse.ubuntu.com/t/how-to-escape-stuckstack-and-profit-from-your-openstack-investment/17337\\\
-        \"\\u003eHow to escape StuckStack and profit from your OpenStack investment\\\
-        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/stuckstack-ebook\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003eeBook\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-15\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\\
-        u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/carrier-cloudification-what-every-telecom-executive-needs-to-know/17338\\\
-        \"\\u003eCarrier Cloudification: What every telecom executive needs to know\\\
-        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/telco-cloudification-ebook\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003eeBook\\u003c/td\\u003e\\n\\u003ctd\\u003etelco,\
-        \ cloud, openstack\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-15\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\\
-        u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/nfv-and-sdn-on-openstack/17326\\\
-        \"\\u003eNFV and SDN on OpenStack\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003e/engage/nfv-sdn-openstack\\u003c/td\\u003e\\n\\u003ctd\\u003eeBook\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003eopenstack, networking\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003e2019-07-12\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\\
-        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\
-        \"https://discourse.ubuntu.com/t/openstack-made-easy/17328\\\"\\u003eOpenStack\
-        \ made easy\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/openstack-made-easy\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003eeBook\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-12\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eWith the right tools, OpenStack\
-        \ can be easy\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\\
-        u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/telcos-and-service-providers-expect-near-100-uptime/17330\\\
-        \"\\u003eTelcos and Service Providers expect near 100% uptime\\u003c/a\\u003e\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/openstack-telco-clouds\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003eeBook\\u003c/td\\u003e\\n\\u003ctd\\u003etelco, openstack,\
-        \ cloud\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-12\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eThis requires a proven\
-        \ cloud platform that minimises time-to-revenue and ensures predictable costs.\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\\
-        n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/a-shift-to-the-linux-app-store-experience/17347\\\
-        \"\\u003eA shift to the Linux app store experience\\u003c/a\\u003e\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e/engage/shift-to-app-store-experience\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eapps,\
-        \ snaps\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-11\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eThe key to optimising\
-        \ software distribution in a fragmented environment.\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
-        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/le-support-d-ubuntu-14-04-lts-est-maintenant-passe-a-esm/17413\\\
-        \"\\u003eLe support d\u2019Ubuntu 14.04 LTS est maintenant pass\xE9 \xE0 ESM\\\
-        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/fr/esm_1404\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003eblog\\u003c/td\\u003e\\n\\u003ctd\\u003esecurity\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e2019-06-28\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003efr\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\\
-        u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/a-guide-to-edge-computing-and-the-tools-you-need/17308\\\
-        \"\\u003eA guide to edge computing and the tools you need\\u003c/a\\u003e\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/edge-month\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eedge, cloud, kubernetes,\
-        \ maas\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-06-27\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eLearn how edge computing\
-        \ provides enterprises with real-time data processing, cost-effective security\
-        \ and scalability.\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\\
-        n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"\
-        https://discourse.ubuntu.com/t/sicherheit-in-der-private-cloud/17411\\\"\\\
-        u003eSicherheit in der Private Cloud\\u003c/a\\u003e\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003e/engage/de/openstack-security-de\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack, cloud\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e2019-06-19\\u003c/td\\u003e\\n\\u003ctd\\u003ede\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003eH\xF6chste Anforderungen in Unternehmensumgebungen\
-        \ mit OpenStack erf\xFCllen.\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\\
-        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\
-        \"https://discourse.ubuntu.com/t/how-to-get-started-and-progress-with-an-ai-program/17245\\\
-        \"\\u003eHow to get started and progress with an AI program\\u003c/a\\u003e\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/ai-gettingstarted\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eai, ml\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e2019-06-11\\u003c/td\\u003e\\n\\u003ctd\\u003een\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\\
-        u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\\
-        u003ca href=\\\"https://discourse.ubuntu.com/t/the-future-of-mobile-connectivity/17342\\\
-        \"\\u003eThe future of mobile connectivity\\u003c/a\\u003e\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003e/engage/ubuntu-lime-telco\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003etelco\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003e2019-06-12\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003eMajor mobile operators are adopting open source versus\
-        \ proprietary technologies to reduce costs.\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\\
-        u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/north-america-s-first-autonomous-runway-snowplough/17327\\\
-        \"\\u003eNorth America\u2018s first autonomous runway snowplough\\u003c/a\\\
-        u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/northstar\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003ecase study\\u003c/td\\u003e\\n\\u003ctd\\u003erobotics, iot\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e2019-06-05\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eThe robots helping to address off-highway\
-        \ labour shortages\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\\
-        n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"\
-        https://discourse.ubuntu.com/t/small-robot-company-sows-the-seeds-for-autonomous-and-more-profitable-farming/17334\\\
-        \"\\u003eSmall Robot Company sows the seeds for autonomous and more profitable\
-        \ farming\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/small-robot-company\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003ecase study\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003erobotics, ai\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-06-04\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\\
-        u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/how-to-integrate-ubuntu-desktop-with-active-directory/17323\\\
-        \"\\u003eHow to integrate Ubuntu Desktop with Active Directory\\u003c/a\\\
-        u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/microsoft-active-directory\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003edesktop, active-directory\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-06-04\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\\
-        n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/connected-cars-and-autonomous-driving/17243\\\
-        \"\\u003eConnected cars and autonomous driving\\u003c/a\\u003e\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e/engage/451-automotive\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eiot\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003e2019-05-31\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003eAddressing risk and complexity with software\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\\
-        u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/why-ubuntu-core-is-the-most-secure-choice-for-iot/17292\\\
-        \"\\u003eWhy Ubuntu Core is the most secure choice for IoT\\u003c/a\\u003e\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/core18-security\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003esecurity, iot,\
-        \ ubuntu-core\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-05-29\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
-        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/getting-started-with-ai/17336\\\
-        \"\\u003eGetting started with AI\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003e/engage/starting-with-ai\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003eai, ml\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-05-11\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\\
-        n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/the-transformation-of-the-devops-journey-in-iot/17422\\\
-        \"\\u003eThe transformation of the DevOps journey in IoT\\u003c/a\\u003e\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/iot-devops\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eiot\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e2019-05-07\\u003c/td\\u003e\\n\\u003ctd\\u003een\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\\
-        u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\\
-        u003ca href=\\\"https://discourse.ubuntu.com/t/cloud-init/17291\\\"\\u003eCloud\
-        \ init\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/cloud-init-whitepaper\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003ecloud\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-05-01\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
-        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/how-to-build-a-lightweight-system-container-cluster/17322\\\
-        \"\\u003eHow to build a lightweight system container cluster\\u003c/a\\u003e\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/lxd-whitepaper\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003elxd\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e2019-04-30\\u003c/td\\u003e\\n\\u003ctd\\u003een\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003eYou will learn how working in this environment:\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\\
-        n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/the-transformation-of-the-devops-journey-in-iot-webinar/17306\\\
-        \"\\u003eThe transformation of the DevOps journey in IoT Webinar\\u003c/a\\\
-        u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/devops-iot-webinar\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eiot\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e2019-04-29\\u003c/td\\u003e\\n\\u003ctd\\u003een\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\\
-        u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\\
-        u003ca href=\\\"https://discourse.ubuntu.com/t/private-cloud-security-webinar/17329\\\
-        \"\\u003ePrivate cloud security Webinar\\u003c/a\\u003e\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003e/engage/openstack-security-webinar\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack, security\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e2019-04-24\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eHow Charmed OpenStack is decreasing\
-        \ common security concerns\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\\
-        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\
-        \"https://discourse.ubuntu.com/t/private-cloud-security/17421\\\"\\u003ePrivate\
-        \ cloud security\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/openstack-security-whitepaper\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003eopenstack, security\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-04-24\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eMeeting the\
-        \ highest levels of enterprise requirements with OpenStack\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
-        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/hiri-successfully-monetises-their-snap/17314\\\
-        \"\\u003eHiri successfully monetises their snap\\u003c/a\\u003e\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e/engage/hiri-case-study\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003ecase study\\u003c/td\\u003e\\n\\u003ctd\\u003eapps, snaps\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e2019-04-25\\u003c/td\\u003e\\n\\u003ctd\\u003een\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\\
-        u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\\
-        u003ca href=\\\"https://discourse.ubuntu.com/t/whats-new-in-ubuntu-19-04/17240\\\
-        \"\\u003eWhat\u2019s new in Ubuntu 19.04?\\u003c/a\\u003e\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003e/engage/19-04-webinar\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003eopenstack, kubernetes, ceph, iot, desktop\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e2019-04-18\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eJoin Canonical Product Director\
-        \ Stephan Fabel and Ubuntu Product Managers to discuss everything new in Ubuntu\
-        \ 19.04 \u2018Disco Dingo\u2019\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\\
-        u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\\
-        u003ca href=\\\"https://discourse.ubuntu.com/t/optimising-iot-bandwidth-with-delta-updates/17335\\\
-        \"\\u003eOptimising IoT bandwidth with delta updates\\u003c/a\\u003e\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e/engage/snap-deltas\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eiot, snaps\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e2019-03-16\\u003c/td\\u003e\\n\\u003ctd\\u003een\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003eLearn how snap deltas\u2019 over-the-air\
-        \ updates are efficient and effective.\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\\
-        u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\\
-        u003ca href=\\\"https://discourse.ubuntu.com/t/an-introduction-to-apparmor/17277\\\
-        \"\\u003eAn introduction to AppArmor\\u003c/a\\u003e\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003e/engage/apparmor-intro\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003esecurity\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003e2019-03-16\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003eAn explanation of AppArmor and its key features.\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\\
-        u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/get-started-with-devops-best-practices-ci-cd/17305\\\
-        \"\\u003eGet started with DevOps best practices: CI/CD\\u003c/a\\u003e\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e/engage/devops-cicd-webinar\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003ekubernetes\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e2019-03-07\\u003c/td\\u003e\\n\\u003ctd\\u003een\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\\
-        u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\\
-        u003ca href=\\\"https://discourse.ubuntu.com/t/esm-for-ubuntu-14-04-lts-trusty-tahr/17275\\\
-        \"\\u003eESM for Ubuntu 14.04 LTS Trusty Tahr\\u003c/a\\u003e\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e/engage/14-04-esm\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003esecurity\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003e2019-02-21\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003eLearn how to maintain ongoing security compliance for your 14.04\
-        \ systems.\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\\
-        u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/securing-iot-device-data-against-physical-access/17318\\\
-        \"\\u003eSecuring IoT device data against physical access\\u003c/a\\u003e\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/iot-disk-encryption\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eiot,\
-        \ security, ubuntu-core\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-02-11\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eA technical\
-        \ overview of how Ubuntu Core with full disk encryption and secure boot can\
-        \ be implemented to harden IoT devices\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\\
-        u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\\
-        u003ca href=\\\"https://discourse.ubuntu.com/t/multi-cloud-fundamental-to-financial-services-transformation/17312\\\
-        \"\\u003eMulti-cloud fundamental to financial services transformation\\u003c/a\\\
-        u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/finserv-multi-cloud\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003ecloud,\
-        \ finance, ai\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-02-04\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
-        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/extension-securite-et-maintenance-pour-ubuntu-14-04/17414\\\
-        \"\\u003eExtension S\xE9curit\xE9 et Maintenance pour Ubuntu 14.04\\u003c/a\\\
-        u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/fr/esm\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003eblog\\u003c/td\\u003e\\n\\u003ctd\\u003esecurity\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e2019-01-31\\u003c/td\\u003e\\n\\u003ctd\\u003efr\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\\
-        u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\\
-        u003ca href=\\\"https://discourse.ubuntu.com/t/utiliser-des-gpus-avec-kubernetes/17419\\\
-        \"\\u003eUtiliser des GPUs avec Kubernetes\\u003c/a\\u003e\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003e/engage/fr/utiliser-gpgpus-avec-kubernetes\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003eblog\\u003c/td\\u003e\\n\\u003ctd\\u003ekubernetes\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e2018-12-20\\u003c/td\\u003e\\n\\u003ctd\\u003efr\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\\
-        u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\\
-        u003ca href=\\\"https://discourse.ubuntu.com/t/apellix-engineers-safer-work-environments-with-ubuntu-powered-aerial-robotics/17315\\\
-        \"\\u003eApellix engineers safer work environments with Ubuntu powered aerial\
-        \ robotics\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/industrial-drones-case-study\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003ecase study\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003erobotics, iot\\u003c/td\\u003e\\n\\u003ctd\\u003e2018-12-14\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\\
-        u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/allan-gray-unlocks-unprecedented-availability-and-productivity-with-charmed-kubernetes/17319\\\
-        \"\\u003eAllan Gray unlocks unprecedented availability and productivity with\
-        \ Charmed Kubernetes\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/k8s-allan-gray\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003ecase study\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003efinance, kubernetes\\u003c/td\\u003e\\n\\u003ctd\\u003e2018-12-13\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\\
-        u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/six-reasons-why-developers-choose-ubuntu-desktop/17304\\\
-        \"\\u003eSix reasons why developers choose Ubuntu Desktop\\u003c/a\\u003e\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/developer-desktop\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003edesktop\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e2018-11-23\\u003c/td\\u003e\\n\\u003ctd\\u003een\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\\
-        u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\\
-        u003ca href=\\\"https://discourse.ubuntu.com/t/modernise-your-cloud/17324\\\
-        \"\\u003eModernise your cloud\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003e/engage/modern-cloud\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003ecloud\\u003c/td\\u003e\\n\\u003ctd\\u003e2018-11-22\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eDiscover\
-        \ how Trilio and Canonical help organisations transition to new, maintainable\
-        \ cloud architecture in just weeks.\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\\
-        u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\\
-        u003ca href=\\\"https://discourse.ubuntu.com/t/precision-drones-on-ubuntu-flying-at-the-edge-of-innovation/17316\\\
-        \"\\u003ePrecision drones on Ubuntu: flying at the edge of innovation\\u003c/a\\\
-        u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/industrial-drones\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003erobotics,\
-        \ iot\\u003c/td\\u003e\\n\\u003ctd\\u003e2018-11-20\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eHow Apellix uses Ubuntu\
-        \ on drones to replace human workers in potentially dangerous scenarios.\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\\
-        n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/securing-the-enterprise-how-ubuntu-is-at-the-forefront-of-security-and-compliance/17340\\\
-        \"\\u003eSecuring the enterprise: how Ubuntu is at the forefront of security\
-        \ and compliance\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/ubuntu-compliance\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003esecurity\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e2018-11-12\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\\
-        u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/itstrategen-keeps-legacy-applications-secure-with-extended-security-maintenance/17286\\\
-        \"\\u003eITstrategen keeps legacy applications secure with Extended Security\
-        \ Maintenance\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/ITstrategen-case-study\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003ecase study\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003esecurity\\u003c/td\\u003e\\n\\u003ctd\\u003e2018-10-29\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
-        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/what-s-new-in-ubuntu-18-10/17339\\\
-        \"\\u003eWhat\u2019s New in Ubuntu 18.10\\u003c/a\\u003e\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003e/engage/ubuntu-18-10\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003edesktop, server\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003e2018-10-29\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003eCanonical product managers discuss the new Ubuntu 18.10 release\
-        \ features in this on-demand webinar\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\\
-        u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\\
-        u003ca href=\\\"https://discourse.ubuntu.com/t/ubuntu-core-and-kura-a-framework-for-iot-gateways/17341\\\
-        \"\\u003eUbuntu Core and Kura: A framework for IoT gateways\\u003c/a\\u003e\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/ubuntu-core-and-kura\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eubuntu-core,\
-        \ iot, edge, snaps\\u003c/td\\u003e\\n\\u003ctd\\u003e2018-10-23\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\\
-        u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/keep-up-with-evolving-software/17310\\\
-        \"\\u003eKeep up with evolving software\\u003c/a\\u003e\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003e/engage/evolving-software\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003ejuju, cloud\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e2018-10-22\\u003c/td\\u003e\\n\\u003ctd\\u003een\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003eLearn how Juju can help solve software management\
-        \ complexity.\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\\
-        u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/wofur-konnen-sie-kubernetes-einsetzen/17410\\\
-        \"\\u003eWof\xFCr k\xF6nnen Sie Kubernetes einsetzen?\\u003c/a\\u003e\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e/engage/de/what-can-you-do-with-kubernetes\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003ekubernetes\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e2018-10-19\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003ede\\u003c/td\\u003e\\n\\u003ctd\\u003eDieses Webinar liefert Ihnen alles\
-        \ Wichtige zum Einstieg.\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\\
-        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\
-        \"https://discourse.ubuntu.com/t/low-latency-and-real-time-kernels-for-telco-and-nfv/17320\\\
-        \"\\u003eLow latency and real-time kernels for telco and NFV\\u003c/a\\u003e\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/kernel-telco-nfv\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003etelco\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e2018-10-08\\u003c/td\\u003e\\n\\u003ctd\\u003een\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\\
-        u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\\
-        u003ca href=\\\"https://discourse.ubuntu.com/t/future-proofing-fingbox-the-iot-home-network-monitoring-device/17313\\\
-        \"\\u003eFuture-proofing Fingbox, the IoT home network monitoring device\\\
-        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/future-proof-iot\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eiot,\
-        \ ubuntu-core\\u003c/td\\u003e\\n\\u003ctd\\u003e2018-10-02\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
-        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/how-to-build-and-deploy-your-first-ai-ml-model-on-ubuntu/17294\\\
-        \"\\u003eHow to build and deploy your first AI/ML model on Ubuntu\\u003c/a\\\
-        u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/deploy-ai-ml-model\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eai, ml,\
-        \ kubeflow, kubernetes\\u003c/td\\u003e\\n\\u003ctd\\u003e2018-09-26\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eAn introduction\
-        \ to AI and ML workloads on Ubuntu workstations, servers and in the cloud\
-        \ on a Kubernetes stack.\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\\
-        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\
-        \"https://discourse.ubuntu.com/t/openstack-problemlos-installieren-und-skalieren/17409\\\
-        \"\\u003eOpenStack problemlos installieren und skalieren\\u003c/a\\u003e\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/de/openstack-made-easy\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003eeBook\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e2018-09-05\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003ede\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\\
-        u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/key-considerations-when-choosing-a-robot-s-operating-system/17333\\\
-        \"\\u003eKey considerations when choosing a robot\u2019s operating system\\\
-        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/robot-operating-system-choice\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003erobotics\\u003c/td\\u003e\\n\\u003ctd\\u003e2018-09-05\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
-        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/cio-guide-to-multi-cloud-operations/17325\\\
-        \"\\u003eCIO guide to multi-cloud operations\\u003c/a\\u003e\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003e/engage/multi-cloud-guide\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003ecloud, kubernetes, container\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e2018-09-03\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\\
-        u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/canonical-presents-financial-services-month/17241\\\
-        \"\\u003eCanonical presents Financial Services Month\\u003c/a\\u003e\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e/engage/financial-services-month\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003efinance, ai, ml\
-        \ cloud\\u003c/td\\u003e\\n\\u003ctd\\u003e2018-09-03\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eFilmed at the London Stock\
-        \ exchange with representatives from Canonical, 451 Research, IBM, and a former\
-        \ Deutsche Bank storage CTO, Canonical took a deep dive look in to the rise\
-        \ of multi-cloud in the financial services industry.\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
-        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/establishing-a-software-defined-iot-business-model/17317\\\
-        \"\\u003eEstablishing a software defined IoT business model\\u003c/a\\u003e\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/iot-business-model\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eiot\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e2018-08-24\\u003c/td\\u003e\\n\\u003ctd\\u003een\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\\
-        u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\\
-        u003ca href=\\\"https://discourse.ubuntu.com/t/artificial-intelligence-machine-learning-and-ubuntu/17276\\\
-        \"\\u003eArtificial intelligence, machine learning and Ubuntu\\u003c/a\\u003e\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/ai-ml-ubuntu\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eai, ml, kubernetes\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e2018-08-16\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\\
-        u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/von-vmware-zu-canonical-openstack/17408\\\
-        \"\\u003eVon VMware zu Canonical OpenStack\\u003c/a\\u003e\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003e/engage/de/vmware-to-openstack\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003e2018-08-06\\u003c/td\\u003e\\n\\u003ctd\\u003ede\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\\
-        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\
-        \"https://discourse.ubuntu.com/t/fing-serves-30-000-customers-with-a-secure-future-proof-iot-device/17311\\\
-        \"\\u003eFing serves 30,000 customers with a secure, future-proof IoT device\\\
-        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/fingbox-case-study\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003eiot, ubuntu-core, snaps\\u003c/td\\u003e\\n\\u003ctd\\u003e2018-06-25\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\\
-        n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/canonical-integre-containerd-a-ubuntu-kubernetes/17412\\\
-        \"\\u003eCanonical int\xE8gre containerd \xE0 Ubuntu Kubernetes\\u003c/a\\\
-        u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/fr/canonical-ajoute-containerd-a-ubuntu-kubernetes\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003eblog\\u003c/td\\u003e\\n\\u003ctd\\u003ekubernetes\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e2020-05-22\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003efr\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\\
-        u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/guide-du-dsi-pour-les-operations-multicloud/17415\\\
-        \"\\u003eGUIDE DU DSI pour les op\xE9rations multicloud\\u003c/a\\u003e\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/fr/guide-du-DSI-pour-les-operations-multicloud\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003ecloud, kubernetes\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-05-22\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003efr\\u003c/td\\u003e\\n\\u003ctd\\u003eChoisir une\
-        \ architecture cloud rentable\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\\
-        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\
-        \"https://discourse.ubuntu.com/t/canonical-annonce-managed-apps-linfogerance-des-applications-sur-votre-cloud/17416\\\
-        \"\\u003eCanonical annonce Managed Apps: l\u2019infog\xE9rance des applications\
-        \ sur votre cloud.\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/fr/managed-apps\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003eblog\\u003c/td\\u003e\\n\\u003ctd\\u003eapps\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e2020-05-18\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003efr\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\\
-        u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/migrer-de-vmware-a-openstack/17417\\\
-        \"\\u003eMigrer de VMWare \xE0 OpenStack\\u003c/a\\u003e\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003e/engage/fr/migrer-de-vmware-a-openstack\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e2020-05-18\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003efr\\u003c/td\\u003e\\n\\u003ctd\\u003ePassez \xE0 Charmed OpenStack et\
-        \ r\xE9duisez consid\xE9rablement vos co\xFBts\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\\
-        u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/migrer-de-vmware-a-openstack-webinaire/17420\\\
-        \"\\u003eMigrer de VMware \xE0 Openstack Webinaire\\u003c/a\\u003e\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e/engage/fr/vmware-to-openstack\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e2020-05-18\\u003c/td\\u003e\\n\\u003ctd\\u003efr\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003eApprenez comment migrer d\u2019un environnement\
-        \ traditionnel et propri\xE9taire \xE0 un cloud OpenStack\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\\
-        n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/charmed-kubernetes-reference-architecture/19159\\\
-        \"\\u003eCharmed Kubernetes reference architecture\\u003c/a\\u003e\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e/engage/dell-k8s-reference-architecture\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003ekubernetes\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e2019-11-07\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eIntegration with VxFlex OS delivered\
-        \ by Dell EMC and Canonical.\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\\
-        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\
-        \"https://discourse.ubuntu.com/t/charmed-openstack-reference-architecture/19160\\\
-        \"\\u003eCharmed OpenStack reference architecture\\u003c/a\\u003e\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e/engage/dell-openstack-reference-architecture\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e2019-11-07\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eWith Dell EMC PowerEdge servers\
-        \ for workloads and storage and Dell EMC Networking and Canonical.\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\\
-        u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://discourse.ubuntu.com/t/at-t-private-offer-on-azure-ubuntu-pro-support/19161\\\
-        \"\\u003eAT\\u0026amp;T Private Offer on Azure - Ubuntu Pro + Support\\u003c/a\\\
-        u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/at\\u0026amp;t-azure-webinar\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eubuntu-advantage\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e2020-06-30\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eSecure, updated Ubuntu with 24x7\
-        \ support special pricing and SLAs for AT\\u0026amp;T.\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003c/tbody\\\
-        u003e\\n\\u003c/table\\u003e\\n\\u003c/div\\u003e\\u003c/details\\u003e\\\
-        n\\u003ch2\\u003eTakeovers\\u003c/h2\\u003e\\n\\u003cdetails\\u003e\\n\\u003csummary\\\
-        u003e\\nMapping table\\u003c/summary\\u003e\\n\\u003cdiv class=\\\"md-table\\\
-        \"\\u003e\\n\\u003ctable\\u003e\\n\\u003cthead\\u003e\\n\\u003ctr\\u003e\\\
-        n\\u003cth\\u003etitle\\u003c/th\\u003e\\n\\u003cth\\u003esubtitle\\u003c/th\\\
-        u003e\\n\\u003cth\\u003epublish_date\\u003c/th\\u003e\\n\\u003cth\\u003elang\\\
-        u003c/th\\u003e\\n\\u003cth\\u003elang_skip\\u003c/th\\u003e\\n\\u003cth\\\
-        u003eclass\\u003c/th\\u003e\\n\\u003cth\\u003eimage\\u003c/th\\u003e\\n\\\
-        u003cth\\u003eimage_width\\u003c/th\\u003e\\n\\u003cth\\u003eimage_height\\\
-        u003c/th\\u003e\\n\\u003cth\\u003eprimary_cta\\u003c/th\\u003e\\n\\u003cth\\\
-        u003eprimary_url\\u003c/th\\u003e\\n\\u003cth\\u003esecondary_cta\\u003c/th\\\
-        u003e\\n\\u003cth\\u003esecondary_url\\u003c/th\\u003e\\n\\u003cth\\u003eactive\\\
-        u003c/th\\u003e\\n\\u003cth\\u003eequal_cols\\u003c/th\\u003e\\n\\u003c/tr\\\
-        u003e\\n\\u003c/thead\\u003e\\n\\u003ctbody\\u003e\\n\\u003ctr\\u003e\\n\\\
-        u003ctd\\u003eUbuntu Masters 4\\u003c/td\\u003e\\n\\u003ctd\\u003eA virtual\
-        \ event on open source innovation, featuring leaders from Bosch, Oracle, and\
-        \ more.\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-11-17\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003egrad\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://assets.ubuntu.com/v1/7757c907-ubuntu-masters-logo-wht.svg\\\
-        \" rel=\\\"nofollow noopener\\\"\\u003ehttps://assets.ubuntu.com/v1/7757c907-ubuntu-masters-logo-wht.svg\\\
-        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e270\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003e270\\u003c/td\\u003e\\n\\u003ctd\\u003eBrowse sessions\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e/masters-conference?utm_source=Takeover\\u0026amp;utm_medium=Takeover\\\
-        u0026amp;utm_campaign=CY20_DC_Kubernetes_VEVT_EU2020\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003etrue\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\\
-        u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003eCinque strategie per accelerare\
-        \ l\u2019implementazione di Kubernetes nell\u2019impresa\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003eCome scegliere il miglior approccio Kubernetes per la tua\
-        \ azienda\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-11-17\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003eit\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003edark\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"\
-        https://assets.ubuntu.com/v1/11d594e7-K8s+logo+white+outline.svg\\\" rel=\\\
-        \"nofollow noopener\\\"\\u003ehttps://assets.ubuntu.com/v1/11d594e7-K8s+logo+white+outline.svg\\\
-        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e240\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003e234\\u003c/td\\u003e\\n\\u003ctd\\u003eScarica il whitepaper\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/it/deployment-azienda-manuale?utm_source=Takeover\\\
-        u0026amp;utm_medium=Takeover\\u0026amp;utm_campaign=CY20_DC_Kubernetes_IT_Whitepaper_K8sEnterpriseChallenges\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\\
-        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003eConfronto fra\
-        \ \u201CRed Hat\u2019s Openstack platform\u201D e Charmed Openstack di Canaonical\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003eCharmed Openstack riduce significativamente\
-        \ il costo totale di propriet\xE0\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-11-16\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003eit\\u003c/td\\u003e\\n\\u003ctd\\u003e\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003edark\\u003c/td\\u003e\\n\\u003ctd\\u003e\\\
-        u003ca href=\\\"https://assets.ubuntu.com/v1/2d935f28-openstack-cloud.svg\\\
-        \" rel=\\\"nofollow noopener\\\"\\u003ehttps://assets.ubuntu.com/v1/2d935f28-openstack-cloud.svg\\\
-        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e280\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003e280\\u003c/td\\u003e\\n\\u003ctd\\u003eScarica il whitepaper\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/it/redhat-openstack-confronto-manuale?utm_source=Takeover\\\
-        u0026amp;utm_medium=Takeover\\u0026amp;utm_campaign=7013z000001Wld9AAC\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\\
-        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003eGuide pour\
-        \ r\xE9ussir l\u2019adoption et le d\xE9ploiement d\u2019OpenStack\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003eD\xE9couvrez l\u2019\xE9prouv\xE9 processus d\u2019\
-        impl\xE9mentation OpenStack de Canonical\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-11-16\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003efr\\u003c/td\\u003e\\n\\u003ctd\\u003e\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003edark\\u003c/td\\u003e\\n\\u003ctd\\u003e\\\
-        u003ca href=\\\"https://assets.ubuntu.com/v1/2d935f28-openstack-cloud.svg\\\
-        \" rel=\\\"nofollow noopener\\\"\\u003ehttps://assets.ubuntu.com/v1/2d935f28-openstack-cloud.svg\\\
-        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e250\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003e250\\u003c/td\\u003e\\n\\u003ctd\\u003eT\xE9l\xE9charger guide\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/fr/guide-adoption-openstack?utm_source=Takeover\\\
-        u0026amp;\\u0026amp;utm_medium=Takeover\\u0026amp;utm_campaign=7013z000001WjOjAAK\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\\
-        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003eF\xFCnf Strategien\
-        \ zur Beschleunigung von Kubernetes in Unternehmen\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003eEntscheidungskriterien zur optimalen Herangehensweise an Kubernetes f\xFC\
-        r Ihr Unternehmen\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-11-11\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003ede\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003edark\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\
-        \"https://assets.ubuntu.com/v1/11d594e7-K8s+logo+white+outline.svg\\\" rel=\\\
-        \"nofollow noopener\\\"\\u003ehttps://assets.ubuntu.com/v1/11d594e7-K8s+logo+white+outline.svg\\\
-        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e240\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003e234\\u003c/td\\u003e\\n\\u003ctd\\u003eLaden Sie das White Paper\
-        \ herunter\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/de/kubernetes-implementierung-fur-unternehmen\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\\
-        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003eVergleich von\
-        \ Red Hat OpenStack Platform und Charmed OpenStack von Canonical\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003eSenken Sie Ihre Gesamtkosten deutlich mit Charmed\
-        \ OpenStack\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-11-11\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003ede\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003edark\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"\
-        https://assets.ubuntu.com/v1/2d935f28-openstack-cloud.svg\\\" rel=\\\"nofollow\
-        \ noopener\\\"\\u003ehttps://assets.ubuntu.com/v1/2d935f28-openstack-cloud.svg\\\
-        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e250\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003e250\\u003c/td\\u003e\\n\\u003ctd\\u003eLaden Sie das White Paper\
-        \ herunter\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/de/redhat-openstack-vergleich\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\\
-        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003eCinco estrategias\
-        \ para acelerar a los Kubernetes en la empresa\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003eC\xF3mo elegir el mejor enfoque de Kubernetes para su negocio\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e2020-11-04\\u003c/td\\u003e\\n\\u003ctd\\u003ees\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003edark\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://assets.ubuntu.com/v1/11d594e7-K8s+logo+white+outline.svg\\\
-        \" rel=\\\"nofollow noopener\\\"\\u003ehttps://assets.ubuntu.com/v1/11d594e7-K8s+logo+white+outline.svg\\\
-        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e240\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003e234\\u003c/td\\u003e\\n\\u003ctd\\u003eDescargar el manual\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/es/kubernetes-despliegue-empresa-manual?utm_source=Takeover\\\
-        u0026amp;utm_medium=Takeover\\u0026amp;utm_campaign=7013z000001WkLAAA0\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\\
-        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003eComparando\
-        \ la plataforma OpenStack de Red Hat y la Charmed OpenStack de Canonical\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003eReducir significativamente el coste total\
-        \ de propiedad con Charmed OpenStack\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-11-03\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003ees\\u003c/td\\u003e\\n\\u003ctd\\u003e\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003edark\\u003c/td\\u003e\\n\\u003ctd\\u003e\\\
-        u003ca href=\\\"https://assets.ubuntu.com/v1/2d935f28-openstack-cloud.svg\\\
-        \" rel=\\\"nofollow noopener\\\"\\u003ehttps://assets.ubuntu.com/v1/2d935f28-openstack-cloud.svg\\\
-        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e300\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003e230\\u003c/td\\u003e\\n\\u003ctd\\u003eDescargar el manual\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/es/redhat-openstack-comparacion-manual?utm_source=Takeover\\\
-        u0026amp;utm_medium=Takeover\\u0026amp;utm_campaign=7013z000001WkRmAAK\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\\
-        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003eSecurity, cloud\
-        \ native \\u0026amp; confidential computing\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003eA deep dive into securing against the threats of cyber attacks and data\
-        \ breaches\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-10-23\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003egrad\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://assets.ubuntu.com/v1/cea1e4c7-IBM-Z-logo-white.png\\\
-        \" rel=\\\"nofollow noopener\\\"\\u003ehttps://assets.ubuntu.com/v1/cea1e4c7-IBM-Z-logo-white.png\\\
-        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e180\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003e180\\u003c/td\\u003e\\n\\u003ctd\\u003eRegister for the webinar\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://www.brighttalk.com/webcast/6793/440529?utm_source=Takeover\\\
-        u0026amp;utm_medium=Takeover\\u0026amp;utm_campaign=7013z000001G3QyAAK\\\"\
-        \ rel=\\\"nofollow noopener\\\"\\u003ehttps://www.brighttalk.com/webcast/6793/440529?utm_source=Takeover\\\
-        u0026amp;utm_medium=Takeover\\u0026amp;utm_campaign=7013z000001G3QyAAK\\u003c/a\\\
-        u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\\
-        u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003eWhat\u2019\
-        s new in\\u003cbr\\u003eUbuntu 20.10?\\u003c/td\\u003e\\n\\u003ctd\\u003eIntroducing\
-        \ the Ubuntu Desktop for Raspberry Pi, the latest desktop features and micro\
-        \ clouds.\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-10-22\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003egrad\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://assets.ubuntu.com/v1/fe951eda-20.10_Groovy+Gorilla_RPi_Sketch.svg\\\
-        \" rel=\\\"nofollow noopener\\\"\\u003ehttps://assets.ubuntu.com/v1/fe951eda-20.10_Groovy+Gorilla_RPi_Sketch.svg\\\
-        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e250\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003e388\\u003c/td\\u003e\\n\\u003ctd\\u003eGet Ubuntu 20.10\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e/download\\u003c/td\\u003e\\n\\u003ctd\\u003eLearn\
-        \ more about Ubuntu on the Raspberry Pi\\u003c/td\\u003e\\n\\u003ctd\\u003e/raspberry-pi\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\\
-        u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003eHow\
-        \ to manage risk with secure managed service providers\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003eLearn the standards and control objects that should be met\
-        \ through a certified MSP provide\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-10-23\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003egrad\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\
-        \"https://assets.ubuntu.com/v1/0a819c9c-managed-private-cloud_wht_lrg.svg\\\
-        \" rel=\\\"nofollow noopener\\\"\\u003ehttps://assets.ubuntu.com/v1/0a819c9c-managed-private-cloud_wht_lrg.svg\\\
-        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e220\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003e220\\u003c/td\\u003e\\n\\u003ctd\\u003eRegister for the webinar\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://www.brighttalk.com/webcast/6793/440499?utm_source=Takeover\\\
-        u0026amp;utm_medium=Takeover\\u0026amp;utm_campaign=7013z000001G3QyAAK\\\"\
-        \ rel=\\\"nofollow noopener\\\"\\u003ehttps://www.brighttalk.com/webcast/6793/440499?utm_source=Takeover\\\
-        u0026amp;utm_medium=Takeover\\u0026amp;utm_campaign=7013z000001G3QyAAK\\u003c/a\\\
-        u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003efalse\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\\
-        u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003eCassandra\
-        \ in production\\u003c/td\\u003e\\n\\u003ctd\\u003eReliability and scalability\
-        \ for Cassandra deployments\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-09-31\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003edark\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\
-        \"https://assets.ubuntu.com/v1/f880a3bd-Enterprise+support.svg\\\" rel=\\\"\
-        nofollow noopener\\\"\\u003ehttps://assets.ubuntu.com/v1/f880a3bd-Enterprise+support.svg\\\
-        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e250\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003e250\\u003c/td\\u003e\\n\\u003ctd\\u003eRegister for the webinar\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://www.brighttalk.com/webcast/6793/439718?utm_source=Takeover\\\
-        \" rel=\\\"nofollow noopener\\\"\\u003ehttps://www.brighttalk.com/webcast/6793/439718?utm_source=Takeover\\\
-        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003e\\u003c/td\\u003e\\n\\u003ctd\\u003efalse\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\\
-        u003eStill running Ubuntu 14.04 LTS?\\u003c/td\\u003e\\n\\u003ctd\\u003eLearn\
-        \ how to maintain ongoing security compliance for your Ubuntu 14.04 LTS systems.\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e2019-02-27\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003edark\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://assets.ubuntu.com/v1/2217d1c8-Security.svg\\\
-        \" rel=\\\"nofollow noopener\\\"\\u003ehttps://assets.ubuntu.com/v1/2217d1c8-Security.svg\\\
-        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e154\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003e154\\u003c/td\\u003e\\n\\u003ctd\\u003eWatch the webinar\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e/engage/14-04-esm?utm_source=takeover\\u0026amp;utm_campaign=CY19_DC_UA_WBN_ESM14-04\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003efalse\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\\
-        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003eConnected cars\
-        \ and autonomous driving\\u003c/td\\u003e\\n\\u003ctd\\u003eManaging software\
-        \ for the ultimate edge device including development, extensibility, risk\
-        \ mitigation and security factors.\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-05-31\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003edark\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\
-        \"https://assets.ubuntu.com/v1/5096c143-451-research-vector-white-logo.svg\\\
-        \" rel=\\\"nofollow noopener\\\"\\u003ehttps://assets.ubuntu.com/v1/5096c143-451-research-vector-white-logo.svg\\\
-        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e250\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003e250\\u003c/td\\u003e\\n\\u003ctd\\u003eWatch the webinar\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e/engage/451-automotive?utm_source=Takeover\\u0026amp;utm_medium=Takeover\\\
-        u0026amp;utm_campaign=CY19_IOT_Automotive_WBN_451\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003efalse\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\\
-        n\\u003ctr\\u003e\\n\\u003ctd\\u003eKubernetes for IoT developers\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003eSecurity, flexibility and automation - implementing\
-        \ Kubernetes at the edge.\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-01-10\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003egrad\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\
-        \"https://assets.ubuntu.com/v1/5096c143-451-research-vector-white-logo.svg\\\
-        \" rel=\\\"nofollow noopener\\\"\\u003ehttps://assets.ubuntu.com/v1/5096c143-451-research-vector-white-logo.svg\\\
-        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e311\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003e116\\u003c/td\\u003e\\n\\u003ctd\\u003eDownload the report\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/microk8s-451research?utm_source=Takeover\\\
-        u0026amp;utm_medium=Takeover\\u0026amp;utm_campaign=3)CY20_DC_Kubernetes_Whitepaper_MicroK8s_451Research\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003efalse\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\\
-        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003eUbuntu 17.04\
-        \ has arrived\\u003c/td\\u003e\\n\\u003ctd\\u003eFrom the smallest device\
-        \ to the largest cloud.\\u003c/td\\u003e\\n\\u003ctd\\u003e2017-04-31\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003egrad\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"\
-        https://assets.ubuntu.com/v1/5096c143-451-research-vector-white-logo.svg\\\
-        \" rel=\\\"nofollow noopener\\\"\\u003ehttps://assets.ubuntu.com/v1/5096c143-451-research-vector-white-logo.svg\\\
-        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e311\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003e116\\u003c/td\\u003e\\n\\u003ctd\\u003eGet Ubuntu 17.04\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e/download\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003efalse\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\\
-        u003e\\n\\u003ctd\\u003eUbuntu 17.10\\u003c/td\\u003e\\n\\u003ctd\\u003eBrand\
-        \ new Ubuntu desktop!\\u003c/td\\u003e\\n\\u003ctd\\u003e2017-04-31\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003elight\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\
-        \"https://assets.ubuntu.com/v1/b0b06642-Laptop.png?w=654\\\" rel=\\\"nofollow\
-        \ noopener\\\"\\u003ehttps://assets.ubuntu.com/v1/b0b06642-Laptop.png?w=654\\\
-        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e311\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003e116\\u003c/td\\u003e\\n\\u003ctd\\u003eGet Ubuntu 17.04\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e/download\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003efalse\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\\
-        u003e\\n\\u003ctd\\u003eCloud gaming for Android\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003eBuilding a high performing and scalable platform.\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003e2020-01-31\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003egrad\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://assets.ubuntu.com/v1/b0b06642-Laptop.png?w=654\\\
-        \" rel=\\\"nofollow noopener\\\"\\u003ehttps://assets.ubuntu.com/v1/b0b06642-Laptop.png?w=654\\\
-        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e338\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003e246\\u003c/td\\u003e\\n\\u003ctd\\u003eDownload the whitepaper\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/anbox-cloud-gaming-whitepaper?utm_source=Takeover\\\
-        u0026amp;utm_medium=Takeover\\u0026amp;utm_campaign=CY20_IOT_Mobile_Whitepaper_AnboxCloud\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003efalse\\u003c/td\\u003e\\n\\u003ctd\\u003efalse\\u003c/td\\\
-        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003eAn introduction\
-        \ to Anbox Cloud\\u003c/td\\u003e\\n\\u003ctd\\u003eScalable Android in the\
-        \ cloud\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-01-31\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003egrad\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://assets.ubuntu.com/v1/7e3bd1ed-Anbox-Cloud+computing_outline.svg\\\
-        \" rel=\\\"nofollow noopener\\\"\\u003ehttps://assets.ubuntu.com/v1/7e3bd1ed-Anbox-Cloud+computing_outline.svg\\\
-        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e338\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003e246\\u003c/td\\u003e\\n\\u003ctd\\u003eDownload the whitepaper\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/anbox-cloud-webinar?utm_source=Takeover\\\
-        u0026amp;utm_medium=Takeover\\u0026amp;utm_campaign=CY20_DC_AnboxCloud_WBN_IntrotoAnboxCloud\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003efalse\\u003c/td\\u003e\\n\\u003ctd\\u003efalse\\u003c/td\\\
-        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003ePrecision drone\
-        \ flights at the edge of innovation\\u003c/td\\u003e\\n\\u003ctd\\u003eDiscover\
-        \ how Apellix has designed revolutionary software to solve industrial IoT\
-        \ challenges.\\u003c/td\\u003e\\n\\u003ctd\\u003e2017-04-31\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003egrad\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://assets.ubuntu.com/v1/7e3bd1ed-Anbox-Cloud+computing_outline.svg\\\
-        \" rel=\\\"nofollow noopener\\\"\\u003ehttps://assets.ubuntu.com/v1/7e3bd1ed-Anbox-Cloud+computing_outline.svg\\\
-        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e338\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003e246\\u003c/td\\u003e\\n\\u003ctd\\u003eDownload the whitepaper\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/anbox-cloud-webinar?utm_source=Takeover\\\
-        u0026amp;utm_medium=Takeover\\u0026amp;utm_campaign=CY20_DC_AnboxCloud_WBN_IntrotoAnboxCloud\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003efalse\\u003c/td\\u003e\\n\\u003ctd\\u003efalse\\u003c/td\\\
-        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003eComparing Red\
-        \ Hat OpenStack Platform and Canonical\u2019s Charmed OpenStack\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003eSignificantly reduce TCO with Charmed OpenStack\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e2020-07-29\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003egrad\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://assets.ubuntu.com/v1/2d935f28-openstack-cloud.svg\\\
-        \" rel=\\\"nofollow noopener\\\"\\u003ehttps://assets.ubuntu.com/v1/2d935f28-openstack-cloud.svg\\\
-        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e300\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003e300\\u003c/td\\u003e\\n\\u003ctd\\u003eDownload the whitepaper\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/redhat-openstack-comparison-whitepaper?utm_source=Takeover\\\
-        u0026amp;utm_medium=Takeover\\u0026amp;utm_campaign=CY20_DC_Openstack_Whitepaper_RedHatComparison\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003efalse\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\\
-        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003eFive strategies\
-        \ to\\u003cbr\\u003eaccelerate Kubernetes\\u003cbr\\u003ein the enterprise\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003eHow to choose the best approach to Kubernetes\\\
-        u003cbr\\u003efor your business\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-09-02\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003edark\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\
-        \"https://assets.ubuntu.com/v1/11d594e7-K8s+logo+white+outline.svg\\\" rel=\\\
-        \"nofollow noopener\\\"\\u003ehttps://assets.ubuntu.com/v1/11d594e7-K8s+logo+white+outline.svg\\\
-        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e240\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003e234\\u003c/td\\u003e\\n\\u003ctd\\u003eDownload the whitepaper\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e//engage/kubernetes-deployment-enterprise-whitepaper?utm_source=Takeover\\\
-        u0026amp;utm_medium=Takeover\\u0026amp;utm_campaign=CY20_DC_Kubernetes_Whitepaper_K8sEnterpriseChallenges\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003efalse\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\\
-        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003eFIPS certification\
-        \ and CIS compliance with Ubuntu\\u003c/td\\u003e\\n\\u003ctd\\u003eLearn\
-        \ about Ubuntu CIS and FIPS certified components to enable operating under\
-        \ compliance regimes like FedRAMP, HIPAA, PCI and ISO.\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003e2020-09-02\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003elight\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://assets.ubuntu.com/v1/b576398c-compliance-wht.svg\\\
-        \" rel=\\\"nofollow noopener\\\"\\u003ehttps://assets.ubuntu.com/v1/b576398c-compliance-wht.svg\\\
-        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e400\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003e234\\u003c/td\\u003e\\n\\u003ctd\\u003eRegister for the webinar\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://www.brighttalk.com/webcast/6793/432536?utm_source=Takeover\\\
-        \" rel=\\\"nofollow noopener\\\"\\u003ehttps://www.brighttalk.com/webcast/6793/432536?utm_source=Takeover\\\
-        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003e\\u003c/td\\u003e\\n\\u003ctd\\u003efalse\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\\
-        u003eUbuntu Security: Security and compliance for the full stack\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003eThe full Ubuntu security story. Learn how our teams\
-        \ are securing all your open source, from cloud to edge.\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003e2020-10-01\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003egrad\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://assets.ubuntu.com/v1/1899df43-ubuntu-advantage-circular_white.svg\\\
-        \" rel=\\\"nofollow noopener\\\"\\u003ehttps://assets.ubuntu.com/v1/1899df43-ubuntu-advantage-circular_white.svg\\\
-        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e280\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003e280\\u003c/td\\u003e\\n\\u003ctd\\u003eLearn more\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e/security-series?utm_source=Takeover\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003efalse\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\\
-        n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003eExtend your OpenStack\
-        \ cloud with native backup and recovery\\u003c/td\\u003e\\n\\u003ctd\\u003eLearn\
-        \ how TrilioVault can be easily deployed in a Charmed OpenStack environment\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e2020-09-30\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003edark\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://assets.ubuntu.com/v1/469b4b31-Trilio-openstack-canonical.svg\\\
-        \" rel=\\\"nofollow noopener\\\"\\u003ehttps://assets.ubuntu.com/v1/469b4b31-Trilio-openstack-canonical.svg\\\
-        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e350\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eRegister for the webinar\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/trilio-backup-recovery?utm_source=Takeover\\\
-        u0026amp;utm_medium=Takeover\\u0026amp;utm_campaign=CY20_DC_WBN_OpenStack_Trilio\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003efalse\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\\
-        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003eChoisir une\
-        \ architecture cloud rentable\\u003c/td\\u003e\\n\\u003ctd\\u003eD\xE9couvrez\
-        \ les diff\xE9rentes architectures clouds et comment choisir une architecture\
-        \ rentable\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-03-29\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003efr\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003edark\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"\
-        https://assets.ubuntu.com/v1/2acca081-choosingacloud-white.svg\\\" rel=\\\"\
-        nofollow noopener\\\"\\u003ehttps://assets.ubuntu.com/v1/2acca081-choosingacloud-white.svg\\\
-        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e393\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003e345\\u003c/td\\u003e\\n\\u003ctd\\u003eLire le whitepaper\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/fr/guide-du-DSI-pour-les-operations-multicloud?utm_source=Takeover\\\
-        u0026amp;utm_medium=Takeover\\u0026amp;utm_campaign=7013z000001GHleAAG\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003efalse\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\\
-        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003eMigrer de VMWare\
-        \ \xE0 Openstack\\u003c/td\\u003e\\n\\u003ctd\\u003eApprenez comment migrer\
-        \ d\u2019un environnement traditionnel et propri\xE9taire \xE0 un cloud OpenStack\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e2020-03-29\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003efr\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003elight\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://assets.ubuntu.com/v1/35515576-openstack-cloud.svg\\\
-        \" rel=\\\"nofollow noopener\\\"\\u003ehttps://assets.ubuntu.com/v1/35515576-openstack-cloud.svg\\\
-        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e393\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003e345\\u003c/td\\u003e\\n\\u003ctd\\u003eS\u2019inscrire au webinar\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/fr/vmware-to-openstack?utm_source=Takeover\\\
-        u0026amp;utm_medium=Takeover\\u0026amp;utm_campaign=CY19_DC_France_Openstack_WBN_VmwaretoOpenstack\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003efalse\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\\
-        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003eDo VMware ao\
-        \ Charmed OpenStack\\u003c/td\\u003e\\n\\u003ctd\\u003eReduza os custos e\
-        \ aumente a efici\xEAncia da sua infraestrutura com ado\xE7\xE3o de c\xF3\
-        digo aberto\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-07-22\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003ept\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003edark\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"\
-        https://assets.ubuntu.com/v1/2d935f28-openstack-cloud.svg\\\" rel=\\\"nofollow\
-        \ noopener\\\"\\u003ehttps://assets.ubuntu.com/v1/2d935f28-openstack-cloud.svg\\\
-        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e300\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eLeia o documento t\xE9cnico\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/pt/vmware-para-o-openstack?utm_source=Takeover\\\
-        u0026amp;utm_medium=Takeover\\u0026amp;utm_campaign=7013z000001WaxFAAS\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003efalse\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\\
-        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003eDa VMware a\
-        \ OpenStack\\u003c/td\\u003e\\n\\u003ctd\\u003eCome la migrazione a Charmed\
-        \ OpenStack pu\xF2 ridurre significativamente il TCO\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003e2020-09-02\\u003c/td\\u003e\\n\\u003ctd\\u003eit\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003edark\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e\\u003ca href=\\\"https://assets.ubuntu.com/v1/2d935f28-openstack-cloud.svg\\\
-        \" rel=\\\"nofollow noopener\\\"\\u003ehttps://assets.ubuntu.com/v1/2d935f28-openstack-cloud.svg\\\
-        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e300\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eScarica il whitepaper\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/it/da-vmware-a-openstack?utm_source=Takeover\\\
-        u0026amp;utm_medium=Takeover\\u0026amp;utm_campaign=CY20_DC_OpenStack_IT_Whitepaper_VMwaretoOpenstack\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003efalse\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\\
-        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003eDa VMware a\
-        \ Charmed Openstack\\u003c/td\\u003e\\n\\u003ctd\\u003eCome la migrazione\
-        \ pu\xF2 tagliare i costi\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-09-15\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003eit\\u003c/td\\u003e\\n\\u003ctd\\u003e\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003edark\\u003c/td\\u003e\\n\\u003ctd\\u003e\\\
-        u003ca href=\\\"https://assets.ubuntu.com/v1/2d935f28-openstack-cloud.svg\\\
-        \" rel=\\\"nofollow noopener\\\"\\u003ehttps://assets.ubuntu.com/v1/2d935f28-openstack-cloud.svg\\\
-        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e300\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eRegistrati al webinar\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e/engage/it/da-vmware-a-charmed-openstack?utm_source=Takeover\\\
-        u0026amp;utm_medium=Takeover\\u0026amp;utm_campaign=2)CY20_DC_OpenStack_IT_WBN_VMwaretoOpenstack\\\
-        u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003efalse\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\\
-        u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003eUna gu\xED\
-        a para la adopci\xF3n y el despliegue satisfactorios de OpenStack\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003eSuperar los desaf\xEDos de la adopci\xF3n de OpenStack\
-        \ siguiendo un proceso de adopci\xF3n probado\\u003c/td\\u003e\\n\\u003ctd\\\
-        u003e2020-09-15\\u003c/td\\u003e\\n\\u003ctd\\u003ees\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003edark\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003e\\u003ca href=\\\"https://assets.ubuntu.com/v1/dcb2963c-openstack+cloud+outlines.svg\\\
-        \" rel=\\\"nofollow noopener\\\"\\u003ehttps://assets.ubuntu.com/v1/dcb2963c-openstack+cloud+outlines.svg\\\
-        u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e320\\u003c/td\\u003e\\n\\\
-        u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eDescargar el manual\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e/engage/es/guia-implementacion-openstack?utm_source=Takeover\\\
-        u0026amp;utm_medium=Takeover\\u0026amp;utm_campaign=7013z000001WhDoAAK\\u003c/td\\\
-        u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\\
-        n\\u003ctd\\u003efalse\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\\
-        u003e\\n\\u003c/tr\\u003e\\n\\u003c/tbody\\u003e\\n\\u003c/table\\u003e\\\
-        n\\u003c/div\\u003e\\u003c/details\\u003e\",\"post_number\":1,\"post_type\"\
-        :1,\"updated_at\":\"2020-11-18T22:50:16.694Z\",\"reply_count\":0,\"reply_to_post_number\"\
-        :null,\"quote_count\":0,\"incoming_link_count\":23,\"reads\":21,\"score\"\
-        :119.2,\"yours\":false,\"topic_id\":17229,\"topic_slug\":\"engage-pages-and-takeovers\"\
-        ,\"display_username\":\"Peter Mahnke\",\"primary_group_name\":\"Canonical\"\
-        ,\"primary_group_flair_url\":\"https://launchpadlibrarian.net/68730579/64.png\"\
-        ,\"primary_group_flair_bg_color\":\"\",\"primary_group_flair_color\":\"\"\
-        ,\"version\":26,\"can_edit\":false,\"can_delete\":false,\"can_recover\":false,\"\
-        can_wiki\":false,\"link_counts\":[{\"url\":\"https://ubuntu.com/engage\",\"\
-        internal\":false,\"reflection\":false,\"title\":\"Ubuntu case studies, whitepapers\
-        \ and webinars | Ubuntu\",\"clicks\":5},{\"url\":\"https://discourse.ubuntu.com/t/do-vmware-ao-charmed-openstack/18165\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Do VMware ao Charmed OpenStack\"\
-        ,\"clicks\":3},{\"url\":\"https://discourse.ubuntu.com/t/openstack-deployment-guide/17384\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"OpenStack deployment guide\"\
-        ,\"clicks\":2},{\"url\":\"https://discourse.ubuntu.com/t/five-strategies-to-accelerate-kubernetes-deployment-in-the-enterprise/18161\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Five strategies to accelerate\
-        \ Kubernetes deployment in the enterprise\",\"clicks\":2},{\"url\":\"https://discourse.ubuntu.com/t/sensape-uses-landscape-to-remotely-support-revolutionary-interactive-retail-displays/17289\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Sensape uses Landscape\
-        \ to remotely support revolutionary interactive retail displays\",\"clicks\"\
-        :1},{\"url\":\"https://discourse.ubuntu.com/t/kubernetes-from-cloud-to-edge/17398\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Kubernetes from Cloud\
-        \ to Edge\",\"clicks\":1},{\"url\":\"https://discourse.ubuntu.com/t/extension-securite-et-maintenance-pour-ubuntu-14-04/17414\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Extension S\xE9curit\xE9\
-        \ et Maintenance pour Ubuntu 14.04\",\"clicks\":1},{\"url\":\"https://discourse.ubuntu.com/t/cloud-gaming-for-android/18757\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Cloud gaming for Android\"\
-        ,\"clicks\":1},{\"url\":\"https://assets.ubuntu.com/v1/1899df43-ubuntu-advantage-circular_white.svg\"\
-        ,\"internal\":false,\"reflection\":false,\"title\":\"1899df43-ubuntu-advantage-circular_white.svg\"\
-        ,\"clicks\":1},{\"url\":\"https://discourse.ubuntu.com/t/ubuntu-20-10-what-s-new/19050\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Ubuntu 20.10: What\u2019\
-        s new?\",\"clicks\":1},{\"url\":\"https://discourse.ubuntu.com/t/transforming-telco-infrastructure-a-virtual-event/18162\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Transforming telco infrastructure:\
-        \ A virtual event\",\"clicks\":1},{\"url\":\"https://discourse.ubuntu.com/t/keep-up-with-evolving-software/17310\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Keep up with evolving\
-        \ software\",\"clicks\":1},{\"url\":\"https://discourse.ubuntu.com/t/botsandus-builds-a-social-robot-on-ubuntu/17280\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"BotsAndUs builds a social\
-        \ robot on Ubuntu\",\"clicks\":1},{\"url\":\"https://discourse.ubuntu.com/t/openstack-problemlos-installieren-und-skalieren/17409\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"OpenStack problemlos installieren\
-        \ und skalieren\",\"clicks\":1},{\"url\":\"https://discourse.ubuntu.com/t/cinco-estrategias-para-acelerar-a-los-kubernetes-en-la-empresa/19208\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Cinco estrategias para\
-        \ acelerar a los Kubernetes en la empresa\",\"clicks\":1},{\"url\":\"https://discourse.ubuntu.com/t/an-introduction-to-apparmor/17277\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"An introduction to AppArmor\"\
-        ,\"clicks\":1},{\"url\":\"https://discourse.ubuntu.com/t/whats-new-in-ubuntu-19-04/17240\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"What's new in Ubuntu 19.04?\"\
-        ,\"clicks\":1},{\"url\":\"https://discourse.ubuntu.com/t/how-to-build-and-deploy-your-first-ai-ml-model-on-ubuntu/17294\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"How to build and deploy\
-        \ your first AI/ML model on Ubuntu\",\"clicks\":1},{\"url\":\"https://discourse.ubuntu.com/t/confronto-fra-red-hats-openstack-platform-e-charmed-openstack-di-canaonical/19362\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Confronto fra \\\"Red\
-        \ Hat's Openstack platform\\\" e Charmed Openstack di Canaonical\",\"clicks\"\
-        :1},{\"url\":\"https://discourse.ubuntu.com/t/cinque-strategie-per-accelerare-limplementazione-di-kubernetes-nellimpresa/19381\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Cinque strategie per accelerare\
-        \ l'implementazione di Kubernetes nell'impresa\",\"clicks\":1},{\"url\":\"\
-        https://discourse.ubuntu.com/t/da-vmware-a-openstack/18164\",\"internal\"\
-        :true,\"reflection\":false,\"title\":\"Da VMware a OpenStack\",\"clicks\"\
-        :1},{\"url\":\"https://discourse.ubuntu.com/t/how-to-face-the-challenges-of-becoming-a-cloud-operator/17290\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"How to face the challenges\
-        \ of becoming a cloud operator\",\"clicks\":1},{\"url\":\"https://assets.ubuntu.com/v1/11d594e7-K8s+logo+white+outline.svg\"\
-        ,\"internal\":false,\"reflection\":false,\"title\":\"11d594e7-K8s+logo+white+outline.svg\"\
-        ,\"clicks\":0},{\"url\":\"https://assets.ubuntu.com/v1/7e3bd1ed-Anbox-Cloud+computing_outline.svg\"\
-        ,\"internal\":false,\"reflection\":false,\"title\":\"7e3bd1ed-Anbox-Cloud+computing_outline.svg\"\
-        ,\"clicks\":0},{\"url\":\"https://assets.ubuntu.com/v1/2d935f28-openstack-cloud.svg\"\
-        ,\"internal\":false,\"reflection\":false,\"title\":\"2d935f28-openstack-cloud.svg\"\
-        ,\"clicks\":0},{\"url\":\"https://assets.ubuntu.com/v1/b0b06642-Laptop.png?w=654\"\
-        ,\"internal\":false,\"reflection\":false,\"clicks\":0},{\"url\":\"https://assets.ubuntu.com/v1/5096c143-451-research-vector-white-logo.svg\"\
-        ,\"internal\":false,\"reflection\":false,\"title\":\"5096c143-451-research-vector-white-logo.svg\"\
-        ,\"clicks\":0},{\"url\":\"https://assets.ubuntu.com/v1/2217d1c8-Security.svg\"\
-        ,\"internal\":false,\"reflection\":false,\"title\":\"2217d1c8-Security.svg\"\
-        ,\"clicks\":0},{\"url\":\"https://assets.ubuntu.com/v1/f880a3bd-Enterprise+support.svg\"\
-        ,\"internal\":false,\"reflection\":false,\"title\":\"f880a3bd-Enterprise+support.svg\"\
-        ,\"clicks\":0},{\"url\":\"https://assets.ubuntu.com/v1/fe951eda-20.10_Groovy+Gorilla_RPi_Sketch.svg\"\
-        ,\"internal\":false,\"reflection\":false,\"title\":\"fe951eda-20.10_Groovy+Gorilla_RPi_Sketch.svg\"\
-        ,\"clicks\":0},{\"url\":\"https://www.brighttalk.com/webcast/6793/440529?utm_source=Takeover\\\
-        u0026utm_medium=Takeover\\u0026utm_campaign=7013z000001G3QyAAK\",\"internal\"\
-        :false,\"reflection\":false,\"clicks\":0},{\"url\":\"https://assets.ubuntu.com/v1/cea1e4c7-IBM-Z-logo-white.png\"\
-        ,\"internal\":false,\"reflection\":false,\"title\":\"cea1e4c7-IBM-Z-logo-white.png\"\
-        ,\"clicks\":0},{\"url\":\"https://www.brighttalk.com/webcast/6793/440499?utm_source=Takeover\\\
-        u0026utm_medium=Takeover\\u0026utm_campaign=7013z000001G3QyAAK\",\"internal\"\
-        :false,\"reflection\":false,\"clicks\":0},{\"url\":\"https://assets.ubuntu.com/v1/0a819c9c-managed-private-cloud_wht_lrg.svg\"\
-        ,\"internal\":false,\"reflection\":false,\"title\":\"0a819c9c-managed-private-cloud_wht_lrg.svg\"\
-        ,\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/open-digital-platforms-for-the-industrial-edge-cloud-in-2020/19068\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Open digital platforms\
-        \ for the industrial edge cloud in 2020\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/watch-the-raspberry-pi-ubuntu-desktop-intro-video/18577\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Watch the Raspberry Pi\
-        \ Ubuntu Desktop intro video\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/extend-your-openstack-cloud-with-native-backup-and-recover/18911\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Extend your OpenStack\
-        \ cloud with native backup and recover\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/busting-the-myth-of-private-cloud-economics/17244\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Busting the myth of private\
-        \ cloud economics\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/building-powerful-customer-solutions/18481\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Building powerful customer\
-        \ solutions\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/gmo-pepabo-ubuntu/18476\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"GMO Pepabo \\u0026 Ubuntu\"\
-        ,\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/da-vmware-a-charmed-openstack/18478\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Da VMware a Charmed Openstack\"\
-        ,\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/guia-para-la-implementacion-de-openstack/18480\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Gu\xEDa para la implementaci\xF3\
-        n de OpenStack\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/comparing-red-hat-openstack-platform-and-canonicals-charmed-openstack/18159\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Comparing Red Hat OpenStack\
-        \ Platform and Canonical's Charmed OpenStack\",\"clicks\":0},{\"url\":\"https://www.brighttalk.com/webcast/6793/439718?utm_source=Takeover\"\
-        ,\"internal\":false,\"reflection\":false,\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/nfv-and-sdn-on-openstack-for-network-operators/17326\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"NFV and SDN on OpenStack\
-        \ for network operators\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/still-running-ubuntu-14-04/17275\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Still running Ubuntu 14.04?\"\
-        ,\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/production-ai-from-data-lake-to-server-webinar/18163\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Production AI from data\
-        \ lake to server webinar\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/utiliser-des-gpus-avec-kubernetes/17419\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Utiliser des GPUs avec\
-        \ Kubernetes\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/installez-et-mettez-openstack-a-lechelle-en-toute-simplicite/17418\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Installez et mettez OpenStack\
-        \ \xE0 l'\xE9chelle en toute simplicit\xE9\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/le-support-d-ubuntu-14-04-lts-est-maintenant-passe-a-esm/17413\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Le support d\u2019Ubuntu\
-        \ 14.04 LTS est maintenant pass\xE9 \xE0 ESM\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/sicherheit-in-der-private-cloud/17411\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Sicherheit in der Private\
-        \ Cloud\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/wofur-konnen-sie-kubernetes-einsetzen/17410\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Wof\xFCr k\xF6nnen Sie\
-        \ Kubernetes einsetzen?\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/von-vmware-zu-canonical-openstack/17408\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Von VMware zu Canonical\
-        \ OpenStack\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/scale-android-applications-economically-in-the-cloud-with-anbox-cloud/17401\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Scale Android applications\
-        \ economically in the cloud with Anbox Cloud\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/accelerating-iot-device-time-to-market/17399\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Accelerating IoT device\
-        \ time to market\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/scaling-on-azure-with-ubuntu-pro/17397\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Scaling on Azure with\
-        \ Ubuntu Pro\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/a-technical-intro-to-ubuntu-pro/17396\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"A technical intro to Ubuntu\
-        \ Pro\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/migrating-your-infrastructure-to-ubuntu-20-04-lts/17395\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Migrating your infrastructure\
-        \ to Ubuntu 20.04 LTS\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/utilising-cloud-init-on-microsoft-azure/17394\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Utilising cloud-init on\
-        \ Microsoft Azure\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/standardising-machine-learning-from-workstation-to-production/17393\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Standardising machine\
-        \ learning \u2014 from workstation to production\",\"clicks\":0},{\"url\"\
-        :\"https://discourse.ubuntu.com/t/kafka-in-production/17392\",\"internal\"\
-        :true,\"reflection\":false,\"title\":\"Kafka in production\",\"clicks\":0},{\"\
-        url\":\"https://discourse.ubuntu.com/t/solving-the-software-update-challenge-for-iot-devices/17391\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Solving the software update\
-        \ challenge for IoT devices\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/secure-iot-device-management/17390\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Secure IoT device management\"\
-        ,\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/leveraging-open-source-with-ubuntu-pro-on-azure/17389\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Leveraging open source\
-        \ with Ubuntu Pro on Azure\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/streamlined-kubernetes-from-cloud-to-edge/17388\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Streamlined Kubernetes,\
-        \ from Cloud to Edge\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/embracing-the-open-source-mandate/17387\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Embracing the open source\
-        \ mandate\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/what-s-new-in-ubuntu-20-04-lts/17386\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"What\u2019s new in Ubuntu\
-        \ 20.04 LTS?\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/maintaining-business-focus-in-a-cloud-native-world-with-managed-apps/17385\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Maintaining business focus\
-        \ in a cloud-native world with Managed Apps\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/ubuntu-core-a-cybersecurity-analysis/17381\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Ubuntu Core: a cybersecurity\
-        \ analysis\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/virtual-event-microk8s-kubernetes/17380\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Virtual event: MicroK8s\
-        \ \\u0026 Kubernetes\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/rigado-cuts-customers-time-to-market/17379\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Rigado cuts customers'\
-        \ time-to-market\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/securing-ros-robotics-platforms/17378\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Securing ROS robotics\
-        \ platforms\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/smart-card-login-on-ubuntu/17377\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Smart card login on Ubuntu\"\
-        ,\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/esm-maintains-interanas-system-security-while-upgrading/17376\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"ESM maintains Interana's\
-        \ system security while upgrading\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/hosted-private-cloud-infrastructure-a-cost-analysis/17375\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Hosted private cloud infrastructure:\
-        \ a cost analysis\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/an-introduction-to-anbox-cloud/17374\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"An introduction to Anbox\
-        \ Cloud\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/deploy-kubernetes-in-your-data-centre/17373\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Deploy Kubernetes in your\
-        \ data centre\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/artificial-intelligence-at-the-edge-in-a-5g-world/17372\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Artificial Intelligence\
-        \ at the edge in a 5G world\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/de-vmware-a-charmed-openstack/17371\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"De VMware a Charmed OpenStack\"\
-        ,\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/migration-von-vmware-zu-openstack/17370\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Migration von VMware zu\
-        \ OpenStack\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/kubernetes-a-secure-flexible-and-automated-edge-for-iot-developers/17369\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Kubernetes: a secure,\
-        \ flexible and automated edge for IoT developers\",\"clicks\":0},{\"url\"\
-        :\"https://discourse.ubuntu.com/t/ubuntu-desktop-for-the-enterprise/17368\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Ubuntu Desktop for the\
-        \ enterprise\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/an-intro-to-microk8s/17367\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"An intro to MicroK8s\"\
-        ,\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/cyberdyne-keeps-cleaning-robots-up-to-date-in-the-field-with-snaps/17366\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Cyberdyne keeps cleaning\
-        \ robots up-to-date in the field with snaps\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/register-for-wslconf/17365\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Register for WSLConf\"\
-        ,\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/sbi-group-unlocks-infrastructure-automation-with-secure-on-premises-openstack-cloud/17364\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"SBI Group unlocks infrastructure\
-        \ automation with secure, on-premises OpenStack cloud\",\"clicks\":0},{\"\
-        url\":\"https://discourse.ubuntu.com/t/build-smart-display-devices-with-mir-fast-to-production-secure-open-source/17363\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Build smart display devices\
-        \ with Mir: fast to production, secure, open-source\",\"clicks\":0},{\"url\"\
-        :\"https://discourse.ubuntu.com/t/linux-security-with-ubuntu/17362\",\"internal\"\
-        :true,\"reflection\":false,\"title\":\"Linux security with Ubuntu\",\"clicks\"\
-        :0},{\"url\":\"https://discourse.ubuntu.com/t/lessons-learned-from-100-private-cloud-builds/17361\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Lessons learned from 100+\
-        \ Private cloud builds\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/the-wellcome-sanger-institute-turns-to-canonical-for-high-level-ceph-support/17360\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"The Wellcome Sanger Institute\
-        \ turns to Canonical for high level Ceph support\",\"clicks\":0},{\"url\"\
-        :\"https://discourse.ubuntu.com/t/ensuring-security-and-isolation-in-kubernetes-with-kata-containers/17359\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Ensuring security and\
-        \ isolation in Kubernetes with Kata Containers\",\"clicks\":0},{\"url\":\"\
-        https://discourse.ubuntu.com/t/tim-ensures-system-security-and-client-confidence-with-esm/17358\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"TIM ensures system security\
-        \ and client confidence with ESM\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/what-s-new-in-ubuntu-19-10/17357\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"What\u2019s new in Ubuntu\
-        \ 19.10\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/how-domotz-streamlined-provisioning-of-iot-devices/17356\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"How Domotz streamlined\
-        \ provisioning of IoT devices\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/yahoo-japan-builds-their-iaas-environment-with-canonical/17355\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Yahoo! Japan builds their\
-        \ IaaS environment with Canonical\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/accelerating-deep-tech-with-ubuntu/17354\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Accelerating deep tech\
-        \ with Ubuntu\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/machine-learning-operations-mlops/17353\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Machine Learning Operations\
-        \ (MLOps)\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/how-to-manage-snaps-in-an-enterprise-environment/17352\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"How to manage snaps in\
-        \ an enterprise environment\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/a-guide-to-developing-android-apps-on-ubuntu/17351\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"A guide to developing\
-        \ Android apps on Ubuntu\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/creating-accurate-ai-models-with-data/17349\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Creating accurate AI models\
-        \ with data\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/creating-a-cloud-like-bare-metal-experience-in-the-data-centre/17348\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Creating a cloud-like\
-        \ bare metal experience in the data centre\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/a-shift-to-the-linux-app-store-experience/17347\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"A shift to the Linux app\
-        \ store experience\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/taking-charge-of-the-iots-security-vulnerabilities/17346\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Taking charge of the IoT's\
-        \ security vulnerabilities\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/for-ctos-the-no-nonsense-way-to-accelerate-your-business-with-containers/17345\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"For CTOs: the no-nonsense\
-        \ way to accelerate your business with containers\",\"clicks\":0},{\"url\"\
-        :\"https://discourse.ubuntu.com/t/learn-whats-new-in-ubuntu-server-14-04-lts/17344\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Learn What's New In Ubuntu\
-        \ Server 14.04 LTS\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/from-vmware-to-charmed-openstack/17343\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"From VMWare To Charmed\
-        \ OpenStack\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/the-future-of-mobile-connectivity/17342\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"The future of mobile connectivity\"\
-        ,\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/ubuntu-core-and-kura-a-framework-for-iot-gateways/17341\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Ubuntu Core and Kura:\
-        \ A framework for IoT gateways\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/securing-the-enterprise-how-ubuntu-is-at-the-forefront-of-security-and-compliance/17340\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Securing the enterprise:\
-        \ how Ubuntu is at the forefront of security and compliance\",\"clicks\":0},{\"\
-        url\":\"https://discourse.ubuntu.com/t/what-s-new-in-ubuntu-18-10/17339\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"What\u2019s New in Ubuntu\
-        \ 18.10\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/carrier-cloudification-what-every-telecom-executive-needs-to-know/17338\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Carrier Cloudification:\
-        \ What every telecom executive needs to know\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/how-to-escape-stuckstack-and-profit-from-your-openstack-investment/17337\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"How to escape StuckStack\
-        \ and profit from your OpenStack investment\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/getting-started-with-ai/17336\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Getting started with AI\"\
-        ,\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/optimising-iot-bandwidth-with-delta-updates/17335\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Optimising IoT bandwidth\
-        \ with delta updates\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/small-robot-company-sows-the-seeds-for-autonomous-and-more-profitable-farming/17334\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Small Robot Company sows\
-        \ the seeds for autonomous and more profitable farming\",\"clicks\":0},{\"\
-        url\":\"https://discourse.ubuntu.com/t/key-considerations-when-choosing-a-robot-s-operating-system/17333\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Key considerations when\
-        \ choosing a robot\u2019s operating system\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/make-it-rain-public-cloud-on-ubuntu-openstack/17332\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Make IT rain: public cloud\
-        \ on Ubuntu OpenStack\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/building-a-private-cloud-take-the-leap/17331\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Building a private cloud?\
-        \ Take the leap!\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/telcos-and-service-providers-expect-near-100-uptime/17330\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Telcos and Service Providers\
-        \ expect near 100% uptime\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/private-cloud-security/17421\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Private cloud security\"\
-        ,\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/private-cloud-security-webinar/17329\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Private cloud security\
-        \ Webinar\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/openstack-made-easy/17328\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"OpenStack made easy\"\
-        ,\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/north-america-s-first-autonomous-runway-snowplough/17327\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"North America\u2018s first\
-        \ autonomous runway snowplough\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/cio-guide-to-multi-cloud-operations/17325\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"CIO guide to multi-cloud\
-        \ operations\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/modernise-your-cloud/17324\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Modernise your cloud\"\
-        ,\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/how-to-integrate-ubuntu-desktop-with-active-directory/17323\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"How to integrate Ubuntu\
-        \ Desktop with Active Directory\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/how-to-build-a-lightweight-system-container-cluster/17322\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"How to build a lightweight\
-        \ system container cluster\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/low-latency-and-real-time-kernels-for-telco-and-nfv/17321\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Low latency and real time\
-        \ kernels for telco and NFV\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/low-latency-and-real-time-kernels-for-telco-and-nfv/17320\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Low latency and real-time\
-        \ kernels for telco and NFV\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/allan-gray-unlocks-unprecedented-availability-and-productivity-with-charmed-kubernetes/17319\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Allan Gray unlocks unprecedented\
-        \ availability and productivity with Charmed Kubernetes\",\"clicks\":0},{\"\
-        url\":\"https://discourse.ubuntu.com/t/securing-iot-device-data-against-physical-access/17318\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Securing IoT device data\
-        \ against physical access\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/the-transformation-of-the-devops-journey-in-iot/17422\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"The transformation of\
-        \ the DevOps journey in IoT\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/establishing-a-software-defined-iot-business-model/17317\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Establishing a software\
-        \ defined IoT business model\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/precision-drones-on-ubuntu-flying-at-the-edge-of-innovation/17316\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Precision drones on Ubuntu:\
-        \ flying at the edge of innovation\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/apellix-engineers-safer-work-environments-with-ubuntu-powered-aerial-robotics/17315\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Apellix engineers safer\
-        \ work environments with Ubuntu powered aerial robotics\",\"clicks\":0},{\"\
-        url\":\"https://discourse.ubuntu.com/t/hiri-successfully-monetises-their-snap/17314\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Hiri successfully monetises\
-        \ their snap\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/future-proofing-fingbox-the-iot-home-network-monitoring-device/17313\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Future-proofing Fingbox,\
-        \ the IoT home network monitoring device\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/multi-cloud-fundamental-to-financial-services-transformation/17312\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Multi-cloud fundamental\
-        \ to financial services transformation\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/fing-serves-30-000-customers-with-a-secure-future-proof-iot-device/17311\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Fing serves 30,000 customers\
-        \ with a secure, future-proof IoT device\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/canonical-presents-financial-services-month/17241\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Canonical presents Financial\
-        \ Services Month\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/the-essential-guide-for-telecoms-and-service-providers-adopting-big-data-solutions/17309\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"The essential guide for\
-        \ Telecoms and Service Providers adopting big data solutions\",\"clicks\"\
-        :0},{\"url\":\"https://discourse.ubuntu.com/t/a-guide-to-edge-computing-and-the-tools-you-need/17308\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"A guide to edge computing\
-        \ and the tools you need\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/server-provisioning-what-network-admins-it-pros-need-to-know/17307\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Server Provisioning: What\
-        \ Network Admins \\u0026 IT Pros Need to Know\",\"clicks\":0},{\"url\":\"\
-        https://discourse.ubuntu.com/t/the-transformation-of-the-devops-journey-in-iot-webinar/17306\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"The transformation of\
-        \ the DevOps journey in IoT Webinar\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/get-started-with-devops-best-practices-ci-cd/17305\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Get started with DevOps\
-        \ best practices: CI/CD\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/cto-s-guide-to-sdn-nfv-vnf/17293\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"CTO\u2019s guide to SDN,\
-        \ NFV \\u0026 VNF\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/why-ubuntu-core-is-the-most-secure-choice-for-iot/17292\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Why Ubuntu Core is the\
-        \ most secure choice for IoT\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/cloud-init/17291\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Cloud init\",\"clicks\"\
-        :0},{\"url\":\"https://discourse.ubuntu.com/t/rocket-chat-communication-platform-enables-simplicity-through-snaps/17288\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Rocket.Chat communication\
-        \ platform enables simplicity through snaps\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/nexiona-collaborates-with-canonical-and-dell-to-create-miimetiq-edge/17287\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"NEXIONA collaborates with\
-        \ Canonical and Dell to create MIIMETIQ EDGE\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/itstrategen-keeps-legacy-applications-secure-with-extended-security-maintenance/17286\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"ITstrategen keeps legacy\
-        \ applications secure with Extended Security Maintenance\",\"clicks\":0},{\"\
-        url\":\"https://discourse.ubuntu.com/t/how-ubuntu-helped-innovapos-revolutionise-the-vending-machine-industry/17285\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"How Ubuntu helped InnovaPOS\
-        \ revolutionise the vending machine industry\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/ims-evolve-adopts-ubuntu-core-to-provide-iot-enabled-business-intelligence-in-the-supply-chain/17284\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"IMS Evolve adopts Ubuntu\
-        \ Core to provide IoT-enabled business intelligence in the supply chain\"\
-        ,\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/commercetools-uses-ubuntu-server-to-power-its-next-generation-ecommerce-platform/17283\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Commercetools uses Ubuntu\
-        \ Server to power its next-generation ecommerce platform\",\"clicks\":0},{\"\
-        url\":\"https://discourse.ubuntu.com/t/city-network-brings-openstack-cloud-hosting-to-the-financial-services-sector-with-canonical/17282\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"City Network brings OpenStack\
-        \ cloud hosting to the financial services sector with Canonical\",\"clicks\"\
-        :0},{\"url\":\"https://discourse.ubuntu.com/t/cinergy-makes-significant-digital-signage-saving-with-screenly-pro-and-ubuntu-core/17281\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Cinergy makes significant\
-        \ digital signage saving with Screenly Pro and Ubuntu Core\",\"clicks\":0},{\"\
-        url\":\"https://discourse.ubuntu.com/t/azlogica-utilise-ubuntu-core-for-customised-iot-agricultural-solutions/17279\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"AZLOGICA utilise Ubuntu\
-        \ Core for customised IoT agricultural solutions\",\"clicks\":0},{\"url\"\
-        :\"https://discourse.ubuntu.com/t/azeti-uses-ubuntu-core-to-improve-deployment-and-security/17278\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Azeti uses Ubuntu Core\
-        \ to improve deployment and security\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/artificial-intelligence-machine-learning-and-ubuntu/17276\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Artificial intelligence,\
-        \ machine learning and Ubuntu\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/how-to-get-started-and-progress-with-an-ai-program/17245\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"How to get started and\
-        \ progress with an AI program\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/connected-cars-and-autonomous-driving/17243\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Connected cars and autonomous\
-        \ driving\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/six-reasons-why-developers-choose-ubuntu-desktop/17304\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Six reasons why developers\
-        \ choose Ubuntu Desktop\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/9-out-of-top-10-us-european-financial-institutions-use-ubuntu/19304\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"9 out of top 10 US \\\
-        u0026 European financial institutions use Ubuntu\",\"clicks\":0},{\"url\"\
-        :\"https://assets.ubuntu.com/v1/7757c907-ubuntu-masters-logo-wht.svg\",\"\
-        internal\":false,\"reflection\":false,\"title\":\"7757c907-ubuntu-masters-logo-wht.svg\"\
-        ,\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/guide-pour-reussir-ladoption-et-le-deploiement-dopenstack/19361\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Guide pour r\xE9ussir\
-        \ l'adoption et le d\xE9ploiement d'OpenStack\",\"clicks\":0},{\"url\":\"\
-        https://discourse.ubuntu.com/t/funf-strategien-zur-beschleunigung-von-kubernetes-in-unternehmen/19284\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"F\xFCnf Strategien zur\
-        \ Beschleunigung von Kubernetes in Unternehmen\",\"clicks\":0},{\"url\":\"\
-        https://discourse.ubuntu.com/t/vergleich-von-red-hat-openstack-platform-und-charmed-openstack-von-canonical/19285\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Vergleich von Red Hat\
-        \ OpenStack Platform und Charmed OpenStack von Canonical\",\"clicks\":0},{\"\
-        url\":\"https://discourse.ubuntu.com/t/comparando-la-plataforma-openstack-de-red-hat-y-la-charmed-openstack-de-canonical/19194\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Comparando la plataforma\
-        \ OpenStack de Red Hat y la Charmed OpenStack de Canonical\",\"clicks\":0},{\"\
-        url\":\"https://discourse.ubuntu.com/t/at-t-private-offer-on-azure-ubuntu-pro-support/19161\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"AT\\u0026T Private Offer\
-        \ on Azure - Ubuntu Pro + Support\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/charmed-openstack-reference-architecture/19160\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Charmed OpenStack reference\
-        \ architecture\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/charmed-kubernetes-reference-architecture/19159\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Charmed Kubernetes reference\
-        \ architecture\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/migrer-de-vmware-a-openstack-webinaire/17420\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Migrer de VMware \xE0\
-        \ Openstack Webinaire\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/migrer-de-vmware-a-openstack/17417\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Migrer de VMWare \xE0\
-        \ OpenStack\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/canonical-annonce-managed-apps-linfogerance-des-applications-sur-votre-cloud/17416\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Canonical annonce Managed\
-        \ Apps: l'infog\xE9rance des applications sur votre cloud\",\"clicks\":0},{\"\
-        url\":\"https://discourse.ubuntu.com/t/guide-du-dsi-pour-les-operations-multicloud/17415\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"GUIDE DU DSI pour les\
-        \ op\xE9rations multicloud\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/canonical-integre-containerd-a-ubuntu-kubernetes/17412\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Canonical int\xE8gre containerd\
-        \ \xE0 Ubuntu Kubernetes\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/optimised-authentication-methods-for-ubuntu-desktop/19133\"\
-        ,\"internal\":true,\"reflection\":false,\"title\":\"Optimised authentication\
-        \ methods for Ubuntu Desktop\",\"clicks\":0},{\"url\":\"https://assets.ubuntu.com/v1/dcb2963c-openstack+cloud+outlines.svg\"\
-        ,\"internal\":false,\"reflection\":false,\"title\":\"dcb2963c-openstack+cloud+outlines.svg\"\
-        ,\"clicks\":0},{\"url\":\"https://assets.ubuntu.com/v1/35515576-openstack-cloud.svg\"\
-        ,\"internal\":false,\"reflection\":false,\"title\":\"35515576-openstack-cloud.svg\"\
-        ,\"clicks\":0},{\"url\":\"https://assets.ubuntu.com/v1/2acca081-choosingacloud-white.svg\"\
-        ,\"internal\":false,\"reflection\":false,\"title\":\"2acca081-choosingacloud-white.svg\"\
-        ,\"clicks\":0},{\"url\":\"https://assets.ubuntu.com/v1/469b4b31-Trilio-openstack-canonical.svg\"\
-        ,\"internal\":false,\"reflection\":false,\"title\":\"469b4b31-Trilio-openstack-canonical.svg\"\
-        ,\"clicks\":0},{\"url\":\"https://www.brighttalk.com/webcast/6793/432536?utm_source=Takeover\"\
-        ,\"internal\":false,\"reflection\":false,\"clicks\":0},{\"url\":\"https://assets.ubuntu.com/v1/b576398c-compliance-wht.svg\"\
-        ,\"internal\":false,\"reflection\":false,\"title\":\"b576398c-compliance-wht.svg\"\
-        ,\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/how-to-add-engage-pages/18185\"\
-        ,\"internal\":true,\"reflection\":true,\"title\":\"How to add engage pages\"\
-        ,\"clicks\":4}],\"read\":true,\"user_title\":null,\"actions_summary\":[],\"\
-        moderator\":false,\"admin\":true,\"staff\":true,\"user_id\":320,\"hidden\"\
-        :false,\"trust_level\":2,\"deleted_at\":null,\"user_deleted\":false,\"edit_reason\"\
-        :null,\"can_view_edit_history\":true,\"wiki\":false,\"can_accept_answer\"\
-        :false,\"can_unaccept_answer\":false,\"accepted_answer\":false}],\"stream\"\
-        :[48547]},\"timeline_lookup\":[[1,128]],\"suggested_topics\":[{\"id\":17308,\"\
-        title\":\"A guide to edge computing and the tools you need\",\"fancy_title\"\
-        :\"A guide to edge computing and the tools you need\",\"slug\":\"a-guide-to-edge-computing-and-the-tools-you-need\"\
-        ,\"posts_count\":1,\"reply_count\":0,\"highest_post_number\":1,\"image_url\"\
-        :null,\"created_at\":\"2020-07-17T12:30:28.968Z\",\"last_posted_at\":\"2020-07-17T12:30:29.118Z\"\
-        ,\"bumped\":true,\"bumped_at\":\"2020-07-17T12:30:29.118Z\",\"unseen\":false,\"\
-        pinned\":false,\"unpinned\":null,\"visible\":true,\"closed\":false,\"archived\"\
-        :false,\"bookmarked\":null,\"liked\":null,\"tags\":[],\"archetype\":\"regular\"\
-        ,\"like_count\":0,\"views\":135,\"category_id\":51,\"featured_link\":null,\"\
-        has_accepted_answer\":false,\"posters\":[{\"extras\":\"latest single\",\"\
-        description\":\"Original Poster, Most Recent Poster\",\"user\":{\"id\":320,\"\
-        username\":\"peterm-ubuntu\",\"name\":\"Peter Mahnke\",\"avatar_template\"\
-        :\"/user_avatar/discourse.ubuntu.com/peterm-ubuntu/{size}/7873_2.png\"}}]},{\"\
-        id\":17327,\"title\":\"North America\u2018s first autonomous runway snowplough\"\
-        ,\"fancy_title\":\"North America\u2018s first autonomous runway snowplough\"\
-        ,\"slug\":\"north-america-s-first-autonomous-runway-snowplough\",\"posts_count\"\
-        :1,\"reply_count\":0,\"highest_post_number\":1,\"image_url\":null,\"created_at\"\
-        :\"2020-07-17T12:58:41.650Z\",\"last_posted_at\":\"2020-07-17T12:58:41.789Z\"\
-        ,\"bumped\":true,\"bumped_at\":\"2020-07-17T12:58:41.789Z\",\"unseen\":false,\"\
-        pinned\":false,\"unpinned\":null,\"visible\":true,\"closed\":false,\"archived\"\
-        :false,\"bookmarked\":null,\"liked\":null,\"tags\":[],\"archetype\":\"regular\"\
-        ,\"like_count\":0,\"views\":121,\"category_id\":51,\"featured_link\":null,\"\
-        has_accepted_answer\":false,\"posters\":[{\"extras\":\"latest single\",\"\
-        description\":\"Original Poster, Most Recent Poster\",\"user\":{\"id\":11720,\"\
-        username\":\"owenrm\",\"name\":\"Owenrm\",\"avatar_template\":\"/letter_avatar/owenrm/{size}/5_6d6f4cde2641c35611d5cac2fb97c77e.png\"\
-        }}]},{\"id\":17287,\"title\":\"NEXIONA collaborates with Canonical and Dell\
-        \ to create MIIMETIQ EDGE\",\"fancy_title\":\"NEXIONA collaborates with Canonical\
-        \ and Dell to create MIIMETIQ EDGE\",\"slug\":\"nexiona-collaborates-with-canonical-and-dell-to-create-miimetiq-edge\"\
-        ,\"posts_count\":1,\"reply_count\":0,\"highest_post_number\":1,\"image_url\"\
-        :null,\"created_at\":\"2020-07-17T10:37:53.797Z\",\"last_posted_at\":\"2020-07-17T10:37:53.959Z\"\
-        ,\"bumped\":true,\"bumped_at\":\"2020-07-17T10:37:53.959Z\",\"unseen\":false,\"\
-        pinned\":false,\"unpinned\":null,\"visible\":true,\"closed\":false,\"archived\"\
-        :false,\"bookmarked\":null,\"liked\":null,\"tags\":[],\"archetype\":\"regular\"\
-        ,\"like_count\":0,\"views\":124,\"category_id\":51,\"featured_link\":null,\"\
-        has_accepted_answer\":false,\"posters\":[{\"extras\":\"latest single\",\"\
-        description\":\"Original Poster, Most Recent Poster\",\"user\":{\"id\":11720,\"\
-        username\":\"owenrm\",\"name\":\"Owenrm\",\"avatar_template\":\"/letter_avatar/owenrm/{size}/5_6d6f4cde2641c35611d5cac2fb97c77e.png\"\
-        }}]},{\"id\":17307,\"title\":\"Server Provisioning: What Network Admins \\\
-        u0026 IT Pros Need to Know\",\"fancy_title\":\"Server Provisioning: What Network\
-        \ Admins \\u0026amp; IT Pros Need to Know\",\"slug\":\"server-provisioning-what-network-admins-it-pros-need-to-know\"\
-        ,\"posts_count\":1,\"reply_count\":0,\"highest_post_number\":1,\"image_url\"\
-        :null,\"created_at\":\"2020-07-17T12:28:11.348Z\",\"last_posted_at\":\"2020-07-17T12:28:11.558Z\"\
-        ,\"bumped\":true,\"bumped_at\":\"2020-07-17T12:28:11.558Z\",\"unseen\":false,\"\
-        pinned\":false,\"unpinned\":null,\"visible\":true,\"closed\":false,\"archived\"\
-        :false,\"bookmarked\":null,\"liked\":null,\"tags\":[],\"archetype\":\"regular\"\
-        ,\"like_count\":0,\"views\":125,\"category_id\":51,\"featured_link\":null,\"\
-        has_accepted_answer\":false,\"posters\":[{\"extras\":\"latest single\",\"\
-        description\":\"Original Poster, Most Recent Poster\",\"user\":{\"id\":320,\"\
-        username\":\"peterm-ubuntu\",\"name\":\"Peter Mahnke\",\"avatar_template\"\
-        :\"/user_avatar/discourse.ubuntu.com/peterm-ubuntu/{size}/7873_2.png\"}}]},{\"\
-        id\":17344,\"title\":\"Learn What's New In Ubuntu Server 14.04 LTS\",\"fancy_title\"\
-        :\"Learn What\\u0026rsquo;s New In Ubuntu Server 14.04 LTS\",\"slug\":\"learn-whats-new-in-ubuntu-server-14-04-lts\"\
-        ,\"posts_count\":1,\"reply_count\":0,\"highest_post_number\":1,\"image_url\"\
-        :null,\"created_at\":\"2020-07-17T14:17:32.974Z\",\"last_posted_at\":\"2020-07-17T14:17:33.112Z\"\
-        ,\"bumped\":true,\"bumped_at\":\"2020-07-17T14:17:33.112Z\",\"unseen\":false,\"\
-        pinned\":false,\"unpinned\":null,\"visible\":true,\"closed\":false,\"archived\"\
-        :false,\"bookmarked\":null,\"liked\":null,\"tags\":[],\"archetype\":\"regular\"\
-        ,\"like_count\":0,\"views\":102,\"category_id\":51,\"featured_link\":null,\"\
-        has_accepted_answer\":false,\"posters\":[{\"extras\":\"latest single\",\"\
-        description\":\"Original Poster, Most Recent Poster\",\"user\":{\"id\":11720,\"\
-        username\":\"owenrm\",\"name\":\"Owenrm\",\"avatar_template\":\"/letter_avatar/owenrm/{size}/5_6d6f4cde2641c35611d5cac2fb97c77e.png\"\
-        }}]}],\"tags\":[],\"id\":17229,\"title\":\"Engage pages and Takeovers\",\"\
-        fancy_title\":\"Engage pages and Takeovers\",\"posts_count\":1,\"created_at\"\
-        :\"2020-07-14T09:57:15.561Z\",\"views\":350,\"reply_count\":0,\"like_count\"\
-        :0,\"last_posted_at\":null,\"visible\":true,\"closed\":false,\"archived\"\
-        :false,\"has_summary\":false,\"archetype\":\"regular\",\"slug\":\"engage-pages-and-takeovers\"\
-        ,\"category_id\":51,\"word_count\":7985,\"deleted_at\":null,\"user_id\":320,\"\
-        featured_link\":null,\"pinned_globally\":false,\"pinned_at\":\"2020-07-14T09:57:15.469Z\"\
-        ,\"pinned_until\":null,\"draft\":null,\"draft_key\":\"topic_17229\",\"draft_sequence\"\
-        :null,\"unpinned\":null,\"pinned\":true,\"current_post_number\":1,\"highest_post_number\"\
-        :1,\"deleted_by\":null,\"actions_summary\":[{\"id\":4,\"count\":0,\"hidden\"\
-        :false,\"can_act\":false},{\"id\":8,\"count\":0,\"hidden\":false,\"can_act\"\
-        :false},{\"id\":7,\"count\":0,\"hidden\":false,\"can_act\":false}],\"chunk_size\"\
-        :20,\"bookmarked\":null,\"topic_timer\":null,\"message_bus_last_id\":227,\"\
-        participant_count\":1,\"details\":{\"notification_level\":1,\"participants\"\
-        :[{\"id\":320,\"username\":\"peterm-ubuntu\",\"name\":\"Peter Mahnke\",\"\
-        avatar_template\":\"/user_avatar/discourse.ubuntu.com/peterm-ubuntu/{size}/7873_2.png\"\
-        ,\"post_count\":1,\"primary_group_name\":\"Canonical\",\"primary_group_flair_url\"\
-        :\"https://launchpadlibrarian.net/68730579/64.png\",\"primary_group_flair_color\"\
-        :\"\",\"primary_group_flair_bg_color\":\"\"}],\"created_by\":{\"id\":320,\"\
-        username\":\"peterm-ubuntu\",\"name\":\"Peter Mahnke\",\"avatar_template\"\
-        :\"/user_avatar/discourse.ubuntu.com/peterm-ubuntu/{size}/7873_2.png\"},\"\
-        last_poster\":{\"id\":320,\"username\":\"peterm-ubuntu\",\"name\":\"Peter\
-        \ Mahnke\",\"avatar_template\":\"/user_avatar/discourse.ubuntu.com/peterm-ubuntu/{size}/7873_2.png\"\
-        },\"links\":[{\"url\":\"https://ubuntu.com/engage\",\"title\":\"Ubuntu case\
-        \ studies, whitepapers and webinars | Ubuntu\",\"internal\":false,\"attachment\"\
-        :false,\"reflection\":false,\"clicks\":5,\"user_id\":320,\"domain\":\"ubuntu.com\"\
-        ,\"root_domain\":\"ubuntu.com\"},{\"url\":\"https://discourse.ubuntu.com/t/how-to-add-engage-pages/18185\"\
-        ,\"title\":\"How to add engage pages\",\"internal\":true,\"attachment\":false,\"\
-        reflection\":true,\"clicks\":4,\"user_id\":9642,\"domain\":\"discourse.ubuntu.com\"\
-        ,\"root_domain\":\"ubuntu.com\"},{\"url\":\"https://discourse.ubuntu.com/t/do-vmware-ao-charmed-openstack/18165\"\
-        ,\"title\":\"Do VMware ao Charmed OpenStack\",\"internal\":true,\"attachment\"\
-        :false,\"reflection\":false,\"clicks\":3,\"user_id\":320,\"domain\":\"discourse.ubuntu.com\"\
-        ,\"root_domain\":\"ubuntu.com\"},{\"url\":\"https://discourse.ubuntu.com/t/five-strategies-to-accelerate-kubernetes-deployment-in-the-enterprise/18161\"\
-        ,\"title\":\"Five strategies to accelerate Kubernetes deployment in the enterprise\"\
-        ,\"internal\":true,\"attachment\":false,\"reflection\":false,\"clicks\":2,\"\
-        user_id\":320,\"domain\":\"discourse.ubuntu.com\",\"root_domain\":\"ubuntu.com\"\
-        },{\"url\":\"https://discourse.ubuntu.com/t/openstack-deployment-guide/17384\"\
-        ,\"title\":\"OpenStack deployment guide\",\"internal\":true,\"attachment\"\
-        :false,\"reflection\":false,\"clicks\":2,\"user_id\":320,\"domain\":\"discourse.ubuntu.com\"\
-        ,\"root_domain\":\"ubuntu.com\"},{\"url\":\"https://discourse.ubuntu.com/t/cloud-gaming-for-android/18757\"\
-        ,\"title\":\"Cloud gaming for Android\",\"internal\":true,\"attachment\":false,\"\
-        reflection\":false,\"clicks\":1,\"user_id\":320,\"domain\":\"discourse.ubuntu.com\"\
-        ,\"root_domain\":\"ubuntu.com\"},{\"url\":\"https://discourse.ubuntu.com/t/confronto-fra-red-hats-openstack-platform-e-charmed-openstack-di-canaonical/19362\"\
-        ,\"title\":\"Confronto fra \\\"Red Hat's Openstack platform\\\" e Charmed\
-        \ Openstack di Canaonical\",\"internal\":true,\"attachment\":false,\"reflection\"\
-        :false,\"clicks\":1,\"user_id\":320,\"domain\":\"discourse.ubuntu.com\",\"\
-        root_domain\":\"ubuntu.com\"},{\"url\":\"https://discourse.ubuntu.com/t/da-vmware-a-openstack/18164\"\
-        ,\"title\":\"Da VMware a OpenStack\",\"internal\":true,\"attachment\":false,\"\
-        reflection\":false,\"clicks\":1,\"user_id\":320,\"domain\":\"discourse.ubuntu.com\"\
-        ,\"root_domain\":\"ubuntu.com\"},{\"url\":\"https://discourse.ubuntu.com/t/extension-securite-et-maintenance-pour-ubuntu-14-04/17414\"\
-        ,\"title\":\"Extension S\xE9curit\xE9 et Maintenance pour Ubuntu 14.04\",\"\
-        internal\":true,\"attachment\":false,\"reflection\":false,\"clicks\":1,\"\
-        user_id\":320,\"domain\":\"discourse.ubuntu.com\",\"root_domain\":\"ubuntu.com\"\
-        },{\"url\":\"https://assets.ubuntu.com/v1/1899df43-ubuntu-advantage-circular_white.svg\"\
-        ,\"title\":\"1899df43-ubuntu-advantage-circular_white.svg\",\"internal\":false,\"\
-        attachment\":false,\"reflection\":false,\"clicks\":1,\"user_id\":320,\"domain\"\
-        :\"assets.ubuntu.com\",\"root_domain\":\"ubuntu.com\"},{\"url\":\"https://discourse.ubuntu.com/t/how-to-build-and-deploy-your-first-ai-ml-model-on-ubuntu/17294\"\
-        ,\"title\":\"How to build and deploy your first AI/ML model on Ubuntu\",\"\
-        internal\":true,\"attachment\":false,\"reflection\":false,\"clicks\":1,\"\
-        user_id\":320,\"domain\":\"discourse.ubuntu.com\",\"root_domain\":\"ubuntu.com\"\
-        },{\"url\":\"https://discourse.ubuntu.com/t/how-to-face-the-challenges-of-becoming-a-cloud-operator/17290\"\
-        ,\"title\":\"How to face the challenges of becoming a cloud operator\",\"\
-        internal\":true,\"attachment\":false,\"reflection\":false,\"clicks\":1,\"\
-        user_id\":320,\"domain\":\"discourse.ubuntu.com\",\"root_domain\":\"ubuntu.com\"\
-        },{\"url\":\"https://discourse.ubuntu.com/t/keep-up-with-evolving-software/17310\"\
-        ,\"title\":\"Keep up with evolving software\",\"internal\":true,\"attachment\"\
-        :false,\"reflection\":false,\"clicks\":1,\"user_id\":320,\"domain\":\"discourse.ubuntu.com\"\
-        ,\"root_domain\":\"ubuntu.com\"},{\"url\":\"https://discourse.ubuntu.com/t/kubernetes-from-cloud-to-edge/17398\"\
-        ,\"title\":\"Kubernetes from Cloud to Edge\",\"internal\":true,\"attachment\"\
-        :false,\"reflection\":false,\"clicks\":1,\"user_id\":320,\"domain\":\"discourse.ubuntu.com\"\
-        ,\"root_domain\":\"ubuntu.com\"},{\"url\":\"https://discourse.ubuntu.com/t/openstack-problemlos-installieren-und-skalieren/17409\"\
-        ,\"title\":\"OpenStack problemlos installieren und skalieren\",\"internal\"\
-        :true,\"attachment\":false,\"reflection\":false,\"clicks\":1,\"user_id\":320,\"\
-        domain\":\"discourse.ubuntu.com\",\"root_domain\":\"ubuntu.com\"},{\"url\"\
-        :\"https://discourse.ubuntu.com/t/sensape-uses-landscape-to-remotely-support-revolutionary-interactive-retail-displays/17289\"\
-        ,\"title\":\"Sensape uses Landscape to remotely support revolutionary interactive\
-        \ retail displays\",\"internal\":true,\"attachment\":false,\"reflection\"\
-        :false,\"clicks\":1,\"user_id\":320,\"domain\":\"discourse.ubuntu.com\",\"\
-        root_domain\":\"ubuntu.com\"},{\"url\":\"https://discourse.ubuntu.com/t/transforming-telco-infrastructure-a-virtual-event/18162\"\
-        ,\"title\":\"Transforming telco infrastructure: A virtual event\",\"internal\"\
-        :true,\"attachment\":false,\"reflection\":false,\"clicks\":1,\"user_id\":320,\"\
-        domain\":\"discourse.ubuntu.com\",\"root_domain\":\"ubuntu.com\"},{\"url\"\
-        :\"https://discourse.ubuntu.com/t/ubuntu-20-10-what-s-new/19050\",\"title\"\
-        :\"Ubuntu 20.10: What\u2019s new?\",\"internal\":true,\"attachment\":false,\"\
-        reflection\":false,\"clicks\":1,\"user_id\":320,\"domain\":\"discourse.ubuntu.com\"\
-        ,\"root_domain\":\"ubuntu.com\"},{\"url\":\"https://discourse.ubuntu.com/t/whats-new-in-ubuntu-19-04/17240\"\
-        ,\"title\":\"What's new in Ubuntu 19.04?\",\"internal\":true,\"attachment\"\
-        :false,\"reflection\":false,\"clicks\":1,\"user_id\":320,\"domain\":\"discourse.ubuntu.com\"\
-        ,\"root_domain\":\"ubuntu.com\"},{\"url\":\"https://discourse.ubuntu.com/t/botsandus-builds-a-social-robot-on-ubuntu/17280\"\
-        ,\"title\":\"BotsAndUs builds a social robot on Ubuntu\",\"internal\":true,\"\
-        attachment\":false,\"reflection\":false,\"clicks\":1,\"user_id\":320,\"domain\"\
-        :\"discourse.ubuntu.com\",\"root_domain\":\"ubuntu.com\"},{\"url\":\"https://discourse.ubuntu.com/t/an-introduction-to-apparmor/17277\"\
-        ,\"title\":\"An introduction to AppArmor\",\"internal\":true,\"attachment\"\
-        :false,\"reflection\":false,\"clicks\":1,\"user_id\":320,\"domain\":\"discourse.ubuntu.com\"\
-        ,\"root_domain\":\"ubuntu.com\"},{\"url\":\"https://discourse.ubuntu.com/t/cinco-estrategias-para-acelerar-a-los-kubernetes-en-la-empresa/19208\"\
-        ,\"title\":\"Cinco estrategias para acelerar a los Kubernetes en la empresa\"\
-        ,\"internal\":true,\"attachment\":false,\"reflection\":false,\"clicks\":1,\"\
-        user_id\":320,\"domain\":\"discourse.ubuntu.com\",\"root_domain\":\"ubuntu.com\"\
-        },{\"url\":\"https://discourse.ubuntu.com/t/cinque-strategie-per-accelerare-limplementazione-di-kubernetes-nellimpresa/19381\"\
-        ,\"title\":\"Cinque strategie per accelerare l'implementazione di Kubernetes\
-        \ nell'impresa\",\"internal\":true,\"attachment\":false,\"reflection\":false,\"\
-        clicks\":1,\"user_id\":320,\"domain\":\"discourse.ubuntu.com\",\"root_domain\"\
-        :\"ubuntu.com\"}]}}"
+      string: "{\"post_stream\":{\"posts\":[{\"id\":50258,\"name\":\"Carlos Wu Fei\",\"username\":\"carkod\",\"avatar_template\":\"/letter_avatar/carkod/{size}/5_6d6f4cde2641c35611d5cac2fb97c77e.png\",\"created_at\":\"2020-08-25T11:17:26.382Z\",\"cooked\":\"\\u003ch1\\u003eEngage
+        pages\\u003c/h1\\u003e\\n\\u003cp\\u003eThe content of topics in this category
+        are displayed at \\u003ca href=\\\"https://ubuntu.com/engage\\\"\\u003ehttps://ubuntu.com/engage\\u003c/a\\u003e.\\u003c/p\\u003e\\n\\u003ch2\\u003eMetadata\\u003c/h2\\u003e\\n\\u003cdetails\\u003e\\n\\u003csummary\\u003e\\nMapping
+        table\\u003c/summary\\u003e\\n\\u003cdiv class=\\\"md-table\\\"\\u003e\\n\\u003ctable\\u003e\\n\\u003cthead\\u003e\\n\\u003ctr\\u003e\\n\\u003cth\\u003etopic\\u003c/th\\u003e\\n\\u003cth\\u003epath\\u003c/th\\u003e\\n\\u003cth\\u003etype\\u003c/th\\u003e\\n\\u003cth\\u003etags\\u003c/th\\u003e\\n\\u003cth\\u003epublish_date\\u003c/th\\u003e\\n\\u003cth\\u003elanguage\\u003c/th\\u003e\\n\\u003cth\\u003esubtitle\\u003c/th\\u003e\\n\\u003cth\\u003eactive\\u003c/th\\u003e\\n\\u003c/tr\\u003e\\n\\u003c/thead\\u003e\\n\\u003ctbody\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/embedded-kubernetes-for-secure-iot-edge/25635\\\"\\u003eEmbedded
+        Kubernetes for secure IoT Edge\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/embedded-kubernetes-for-secure-iot-edge-webinar\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar,
+        internet of things, ubuntu core, embedded\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-12-06\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eMicroK8s
+        on Ubuntu Core\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/bare-metal-provisioning-what-s-new-in-maas-3-1/25607\\\"\\u003eBare
+        metal provisioning: What\u2019s new in MAAS 3.1?\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/maas-whats-new-3-1\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eMaas,
+        bare metal, bare metal cloud, bare metal provisioning\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-12-03\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eThe
+        latest and greatest news about bare metal provisioning with MAAS\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/evaluating-microsoft-sql-server-options-for-azure/25594\\\"\\u003eEvaluating
+        Microsoft SQL Server Options for Azure\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/Evaluating-MSFT-SQL-Server-whitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eManaged
+        Apps\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-12-01\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eThis
+        white paper provides an in-depth examination of the most popular approaches
+        to running SQL Server on Azure, including SQL Server on Ubuntu Pro for Azure.\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/migrating-to-ubuntu-lts-six-facts-for-centos-users/25585\\\"\\u003eMigrating
+        to Ubuntu LTS: six facts for CentOS users\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/migrating-to-ubuntu-lts-six-facts-for-centos-users\\u003c/td\\u003e\\n\\u003ctd\\u003etakeover
+        only\\u003c/td\\u003e\\n\\u003ctd\\u003ecentos , Compliance , developers ,
+        hpc , livepatch , Migration , Open source , OpenStack , Security , Support\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eConsidering
+        migrating to Ubuntu from other Linux platforms, such as CentOS?\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/how-to-increase-developer-productivity-with-ubuntu-desktop/25426\\\"\\u003eHow
+        to increase developer productivity with Ubuntu Desktop\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/developer-desktop-productivity-whitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eubuntu,
+        desktop, enterprise, ubuntu advantage,\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-11-23\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eA
+        guide for CTOs, IT managers and sysadmins\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/nfv-orchestration-for-open-source-telco-integrating-and-managing-open-source-network-functions/25422\\\"\\u003eNFV
+        Orchestration For Open Source Telco\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/nfv-management-and-orchestration-charmed-open-source-mano\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eosm,
+        gsi, cloud, open source, orchestration\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eIntegrating
+        And Managing Open Source Network Functions\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/ubuntu-pro-no-microsoft-azure/25392\\\"\\u003eUbuntu
+        Pro em Azure\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/ubuntu-pro-azure-webinar-Portuguese\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eManaged
+        Apps, cloud, pro\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-10-29\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eExplore
+        recursos como seguran\xE7a estendida, conformidade certificada e prote\xE7\xE3o
+        para Ubuntu Pro em Azure.\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/docker-ros-when-all-you-have-is-a-hammer-everything-looks-like-a-nail/25389\\\"\\u003eDocker
+        \\u0026amp; ROS: When all you have is a hammer, everything looks like a nail\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/dockerandros\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003erobotics,
+        whitepaper, iot\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-11-22\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eKey
+        Docker limitations for ROS and the snap alternative\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/ubunto-pro-en-azure-sp-wbn/25388\\\"\\u003eUbunto
+        Pro en Azure \\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/ubuntu-pro-azure-webinar-spanish\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eManaged
+        Apps, cloud, pro\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-10-29\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eExplora
+        caracter\xEDsticas como seguridad extendida, cumplimiento certificado y refuerzo
+        para Ubuntu Pro en Azure.\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/introducing-sql-server-on-ubuntu-pro-for-azure-part-2/25350\\\"\\u003eIntroducing
+        SQL Server on Ubuntu Pro for Azure Part 2\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/SQLServerWebinarPart2\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eManaged
+        Apps, SQL\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-10-29\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eIn
+        this talk will deep dive on the anatomy of the performance features of SQL
+        Server on Ubuntu Pro and setting up AD.\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/webinar-building-cost-efficient-open-source-cloud-operations/25347\\\"\\u003eBuilding
+        cost-efficient open source cloud operations\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/cost-efficient-open-source-cloud-operations\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eManaged
+        IT Services, Managed Cloud Services, OpenStack, Kubernetes, Ceph\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/nayatel-builds-public-cloud-service-with-charmed-openstack/25331\\\"\\u003eNayatel
+        builds public cloud service with Charmed OpenStack\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/nayatel-casestudy-charmed-openstack\\u003c/td\\u003e\\n\\u003ctd\\u003ecase
+        study\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eLearn
+        how Nayatel partnered with Canonical to build Pakistan\u2019s first cost-effective
+        enterprise-grade public cloud\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/ceph-for-enterprise/25305\\\"\\u003eCeph
+        for Enterprise\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/enterprise-ceph\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eceph,
+        managed services\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eThe
+        best open-source enterprise storage solution\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/getting-started-with-shells-custom-ubuntu-pro-image-on-azure/25267\\\"\\u003eGetting
+        started with Shell\u2019s custom Ubuntu Pro image on Azure\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/ShellOnboarding\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eAzure,
+        Ubuntu Pro, Security\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-11-15\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eIn
+        this technical video you\u2019ll learn how to get started with Shell\u2019s
+        custom images of Ubuntu Pro with Support on Azure.\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/introducing-sql-server-on-ubuntu-pro-for-azure-part-1/25193\\\"\\u003eIntroducing
+        SQL Server on Ubuntu Pro for Azure Part 1\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/SQLServerWebinarPart1\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eManaged
+        Apps, SQL\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-10-29\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eIn
+        this talk we will introduce SQL Server on Ubuntu Pro for Azure and deep dive
+        on patching regimes and high availability clustering for SQL Server on Ubuntu
+        Pro.\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/microk8s-on-z-minimal-footprint-meets-zero-downtime/25183\\\"\\u003eMicroK8s
+        on IBM Z \u2014 minimal footprint meets zero downtime\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/webinar-microk8s-on-z\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003emicrok8s,
+        kubernetes, ibm\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-11-09\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eA
+        low-ops, minimal production Kubernetes on Ubuntu for your IBM Z / LinuxONE
+        system.\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/finserv-it-infrastructure-migrating-from-vmware-to-openstack/25179\\\"\\u003eFinserv
+        IT infrastructure: Migrating from VMWare to OpenStack\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/finserv-vmware-to-openstack\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eCIOs\u2019
+        guide to migrating your private cloud infrastructure to a more cost effective
+        solution\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/ubuntu/25158\\\"\\u003e\u958B\u767C\u8005\u9078\u64C7Ubuntu\u7684\u516D\u5927\u7406\u7531\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/developer-desktop-tw\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003edesktop,
+        ubuntu\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-11-08\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\u6700\u6D41\u884C\u7684linux
+        os \u64CD\u4F5C\u7CFB\u7D71\uFF0C\u9078\u64C7Ubuntu\u7684\u516D\u5927\u7406\u7531\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/ceph-in-the-modern-data-center/25046\\\"\\u003eCeph
+        in the modern data center\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/webinar-ceph-modern-data-center\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eceph,
+        storage, poweredge\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-11-18\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eManage
+        exponential data growth with Canonical Charmed Ceph and Dell PowerEdge Servers\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/telecom-infrastructure-the-open-source-way/25038\\\"\\u003eTelecom
+        infrastructure the open source way\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/open-source-telco-infrastructure-whitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003etelco,
+        telecommunications, 5G, cloud\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-10-02\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eAutomated,
+        secure and cloud native telco\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/cybersecurity-compliance-with-ubuntu/24933\\\"\\u003eCybersecurity
+        and Compliance with Ubuntu\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/ubuntu-cybersecurity-webinar\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003ecybersecurity\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-10-28\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eJoin
+        the live webinar\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/atresmedia-domina-il-mercato-spagnolo-dei-media-ott-con-larchitettura-di-microservizi-charmed-kubernetes/24897\\\"\\u003eAtresmedia
+        domina il mercato spagnolo dei media OTT con l\u2019architettura di microservizi
+        Charmed Kubernetes\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/it/atresmedia-charmed-kubernetes-case-study\\u003c/td\\u003e\\n\\u003ctd\\u003ecase
+        study\\u003c/td\\u003e\\n\\u003ctd\\u003eKubernetes, K8s\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-10-27\\u003c/td\\u003e\\n\\u003ctd\\u003eit\\u003c/td\\u003e\\n\\u003ctd\\u003eCome
+        l\u2019azienda ha ottenuto un\u2019alta disponibilit\xE0 e una produttivit\xE0
+        senza precedenti\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/secure-ai-models-deployment-at-the-edge-with-openvino-on-ubuntu-containers/24894\\\"\\u003eSecure
+        AI models deployment at the edge with OpenVINO on Ubuntu containers\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/webinar-ai-containers-edge-deployment\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar,
+        containers, AI,\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-10-27\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eJoin
+        Intel and Canonical for a webinar on Nov. 17\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/smartdrone-fast-tracks-drone-infrastructure-revolution-with-ubuntu-core/24821\\\"\\u003eSmartDrone
+        fast-tracks drone infrastructure revolution with Ubuntu Core\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/drone-infrastructure-case-study-smartdrone\\u003c/td\\u003e\\n\\u003ctd\\u003ecase
+        study\\u003c/td\\u003e\\n\\u003ctd\\u003erobotics, case study, iot\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-10-25\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/ubuntu-16-04-lts-verso-la-manutenzione-estesa-della-sicurezza/24781\\\"\\u003eUbuntu
+        16.04 LTS verso la Manutenzione Estesa della Sicurezza\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/ubuntu-16.04-esm-webinar\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eesm,
+        ubuntu 16.04, ubuntu lts\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eit\\u003c/td\\u003e\\n\\u003ctd\\u003eSei
+        aspetti da considerare nella pianificazione della migrazione\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/openstack-upgrades-with-minimal-downtime/24756\\\"\\u003eOpenStack
+        Upgrades with Minimal Downtime\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/openstack-upgrades-webinar\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack,
+        publiccloud\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/architecting-price-performance-private-cloud/24721\\\"\\u003eArchitecting
+        price-performance Private Cloud\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/architecting-price-performance-private-cloud\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack,
+        privatecloud\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eLearn
+        how to build the most cost-efficient private cloud infrastructure using open
+        source technologies\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/7-approaches-to-accelerating-apache-kafka-on-k8s/24711\\\"\\u003e7
+        approaches to accelerating Apache Kafka on K8s\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/7-approaches-accelerating-kafka-whitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eManaged
+        Apps\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-08-31\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eIn
+        this white paper, we will review seven techniques that can help to reduce
+        latency in high volume, low criticality Kafka solutions running on Kubernetes.\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/ctos-guide-to-micro-clouds/24533\\\"\\u003eCTOs\u2019
+        Guide to Micro Clouds\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/CTO-guide-to-micro-clouds-2021\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eedge,
+        microclouds, edgecomputing\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eMicro
+        Clouds an Edge Computing Solution\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/workstations-on-the-ai-journey-deploying-your-model/24401\\\"\\u003eWorkstations
+        on the AI Journey - Deploying Your Model\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/webinar-ai-journey-deploying-your-model\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eworkstations,
+        AI, dell, webinar\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-10-12\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eIn
+        the fourth and final part of this webinar series, Canonical and Dell will
+        talk about inference engines deployment.\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/driving-robotics-innovation/24442\\\"\\u003eDriving
+        robotics innovation\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/rosworld2021\\u003c/td\\u003e\\n\\u003ctd\\u003eevent\\u003c/td\\u003e\\n\\u003ctd\\u003eevent\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-09-16\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eCanonical
+        \\u0026amp; Ubuntu at ROS World 2021\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/embedded-linux-make-or-buy-tw/24602\\\"\\u003e
+        \u5D4C\u5165\u5F0FLinux\uFF1A\u81EA\u88FD\u6216\u5916\u8CFC\uFF1F\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/embedded-linux-make-or-buy-tw\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eCore\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-10-13\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\u5169\u96E3\u7684\u9078\u64C7\uFF1A\u5546\u696D\u652F\u63F4VS\u81EA\u7814\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/enterprise-kubernetes-use-cases-4-real-world-stories/24588\\\"\\u003eEnterprise
+        Kubernetes use cases: 4 real-world stories\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/kubernetes-use-cases-webinar\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eK8s,
+        Kubernetes\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-10-12\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eJoin
+        the live webinar\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/canonical-ubuntu-at-nvidia-gtc-2021/24671\\\"\\u003eCanonical
+        \\u0026amp; Ubuntu at Nvidia GTC 2021\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/gtc_nvidia_2021\\u003c/td\\u003e\\n\\u003ctd\\u003eevent\\u003c/td\\u003e\\n\\u003ctd\\u003eevent\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-10-15\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eJoin
+        us on November 8-11!\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/edge-kubernetes-what-s-brewing/24492\\\"\\u003eEdge
+        Kubernetes: what\u2019s brewing?\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/edge-kubernetes-coffee-webinar\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eK8s,
+        kubernetes, containerization, cloud\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-10-05\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/managed-it-services/24285\\\"\\u003eManaged
+        IT Services\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/managed-services-overcoming-cio-challenges-2021\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-09-17\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eHow
+        to build a strategic IT model that drives innovation while cutting down operational
+        costs\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/beat-disruption-white-paper/24237\\\"\\u003eBeat
+        disruption: how to adapt your IT strategy for changing markets\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/beat-disruption-wp\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eManaged
+        Apps\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-08-31\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eRead
+        our whitepaper to learn more about the fast changing modern business landscape
+        - cloud \\u0026amp; SaaS, agile, and outsourcing - and learn about a strategy
+        to help navigate through the jungle.\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/canonical-ubuntu-at-arm-dev-summit-2021/24204\\\"\\u003eCanonical
+        \\u0026amp; Ubuntu at ARM Dev Summit 2021\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/armdevsummit2021\\u003c/td\\u003e\\n\\u003ctd\\u003eevent\\u003c/td\\u003e\\n\\u003ctd\\u003eevent\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-09-16\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eJoin
+        us virtually on October 19-21, 2021\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/building-graphical-applications-in-embedded-devices/24167\\\"\\u003eBuilding
+        graphical applications in embedded devices\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/webinarintrotoframe\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003edigital
+        signage, mir, ubuntu frame\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-09-14\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eJoin
+        us for a webinar introducing Ubuntu Frame on November 3rd at 5pm BST and 12pm
+        ET\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/its-like-a-jungle-out-there-how-to-adapt-your-it-strategy-for-changing-markets/24077\\\"\\u003eIt\u2019s
+        like a jungle out there\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/adapt-your-it-strategy\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar
+        , Managed Apps\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-08-31\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eLearn
+        strategies to help you navigate the fast changing modern business landscape
+        - cloud and SaaS, agile and outsourcing\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/self-healing-kubernetes-at-the-edge-microk8s-raspberry-pis-and-portainer/24070\\\"\\u003eSelf-healing
+        Kubernetes at the edge: MicroK8s, Raspberry Pis and Portainer\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/self-healing-edge-kubernetes-webinar\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003ek8s,
+        kubernetes, edge, MicroK8s\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-09-97\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/atresmedia-domine-le-marche-des-medias-en-espagne-avec-l-architecture-de-microservices-charmed-kubernetes/24009\\\"\\u003eAtresmedia
+        domine le march\xE9 des m\xE9dia en Espagne avec l\u2019architecture de microservices
+        Charmed Kubernetes\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/fr/atresmedia-charmed-kubernetes\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003ekubernetes,
+        k8s\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-09-02\\u003c/td\\u003e\\n\\u003ctd\\u003efr\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/how-to-manage-risks-with-the-top-1-managed-service-providers/23983\\\"\\u003eHow
+        to manage risks with the top 1% Managed Service Providers\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/MSPAlliance-Canonical-Webinar\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar
+        , Managed Service\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-08-31\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eJoin
+        our webinar to learn more about Canonical\u2019s MSP Alliance security verification,
+        and how the top 1% managed service providers help minimise your security risks
+        and optimise your clouds.\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/kubernetes-platform-comparison-red-hat-openshift-suse-rancher-and-canonical-kubernetes/23982\\\"\\u003eKubernetes
+        platform comparison: Red Hat OpenShift, SUSE Rancher and Canonical Kubernetes\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/enterprise-kubernetes-comparison\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003ekubernetes,
+        k8s, containerization, cloud\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-08-31\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eHow
+        to choose the right Kubernetes distribution for your business\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/containers-as-a-service/23970\\\"\\u003eContainers-as-a-service:
+        Deploy faster with Canonical and Portainer\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/containers-as-a-service-webinar\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003ekubernetes,
+        k8s, cloud\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-08-31\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/helping-developers-reach-new-heights/23873\\\"\\u003eHelping
+        developers reach new heights \\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/px4devsummit\\u003c/td\\u003e\\n\\u003ctd\\u003eevent\\u003c/td\\u003e\\n\\u003ctd\\u003eevent,
+        devsummit, drones, iot\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-08-24\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eCanonical
+        \\u0026amp; Ubuntu at PX4 Developer Summit\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/running-enterprise-grade-edge-applications-with-edgex-on-ubuntu-core/23773\\\"\\u003eRunning
+        enterprise-grade edge applications with EdgeX on Ubuntu Core\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/webinarcoreedgex\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar,
+        internet of things, ubuntu core, edgex\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-08-17\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eJoin
+        us for a webinar on September 29th 5AM BST \\u0026amp; 12PM ET\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/applied-ai-for-fraud-prevention-and-detection/23734\\\"\\u003eApplied
+        AI for fraud prevention and detection\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/ai-fraud-prevention-finserv\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003efinserv\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-08-16\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eHow
+        open source AI/ML solutions can assist banks\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/atresmedia-accesses-high-availability-and-unprecedented-productivity-with-charmed-kubernetes/23693\\\"\\u003eAtresmedia
+        dominates the OTT services market with Charmed Kubernetes\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/atresmedia-charmed-kubernetes-case-study\\u003c/td\\u003e\\n\\u003ctd\\u003ecase
+        study\\u003c/td\\u003e\\n\\u003ctd\\u003eKubernetes, K8s\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-08-12\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eHow
+        the company accessed high availability and unprecedented productivity\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/free-cloud-pricing-report-2021/23455\\\"\\u003eCloud
+        pricing report 2021\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/cloud-pricing-report-2021\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003ecloud\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-07-26\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eGet
+        the report to compare cloud pricing across leading public and private cloud
+        platforms, including AWS, Azure, Google, VMWare and OpenStack\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/sbi-group-sblocca-lautomazione-dellinfrastruttura-con-un-cloud-openstack-sicuro-e-on-premises/23286\\\"\\u003eSBI
+        Group sblocca l\u2019automazione dell\u2019infrastruttura con un cloud OpenStack
+        sicuro e on-premises \\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/it/sbi-casestudy\\u003c/td\\u003e\\n\\u003ctd\\u003ecase
+        study\\u003c/td\\u003e\\n\\u003ctd\\u003eOpenstack, private cloud\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-07-15\\u003c/td\\u003e\\n\\u003ctd\\u003eit\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/a-small-to-medium-size-business-guide-to-cybersecurity/23274\\\"\\u003eA
+        business guide to cybersecurity\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/a-small-to-medium-size-business-guide-to-cybersecurity\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003esecurity,
+        cybersecurity\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-07-14\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/handlungsoptionen-nach-dem-endof-life-der-suse-openstack-cloud/23173\\\"\\u003eHandlungsoptionen
+        nach dem Endof-life der SUSE OpenStack Cloud\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/de/suse-openstack-whitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eOpenStack\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-07-07\\u003c/td\\u003e\\n\\u003ctd\\u003ede\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/atresmedia-accede-a-una-alta-disponibilidad-y-productividad-sin-precedentes-con-charmed-kubernetes/23125\\\"\\u003eAtresmedia
+        domina el mercado de servicios OTT \\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/es/atresmedia-charmed-kubernetes-caso-de-estudio\\u003c/td\\u003e\\n\\u003ctd\\u003ecase
+        study\\u003c/td\\u003e\\n\\u003ctd\\u003eKubernetes\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-07-05\\u003c/td\\u003e\\n\\u003ctd\\u003ees\\u003c/td\\u003e\\n\\u003ctd\\u003eCon
+        la arquitectura de microservicios Charmed Kubernetes\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/kaust-selects-canonicals-openstack-cloud/22858\\\"\\u003eKAUST
+        selects Canonical\u2019s OpenStack cloud\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/openstack-cloud-kaust\\u003c/td\\u003e\\n\\u003ctd\\u003ecase
+        study\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack, private cloud, cloud\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-06-24\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eNew
+        OpenStack and Kubernetes deployments improve computing performance for researchers,
+        easing management pains for IT staff\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/das-wellcome-sanger-institute-ermoglicht-weltweite-zusammenarbeit-in-der-genomforschung-mit-von-canonical-unterstutztem-ceph-speicher/22811\\\"\\u003eDas
+        Wellcome Sanger Institute erm\xF6glicht weltweite Zusammenarbeit in der Genomforschung
+        mit von Canonical unterst\xFCtztem Ceph-Speicher\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/de/wellcome-sanger-case-study\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eceph\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-06-03\\u003c/td\\u003e\\n\\u003ctd\\u003ede\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/a-technical-introduction-to-the-snap-store-proxy/22762\\\"\\u003eA
+        technical introduction to the Snap Store Proxy\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/snap-store-proxy-intro-webinar\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eiot,
+        edge\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-06-18\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/che-cose-il-mec-il-telco-edge/22748\\\"\\u003eChe
+        cos\u2019\xE8 il MEC? Il telco edge.\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/it/mec-telco-edge\\u003c/td\\u003e\\n\\u003ctd\\u003eblog\\u003c/td\\u003e\\n\\u003ctd\\u003etelco,
+        edge\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eit\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/ubuntu-pro-on-azure/22674\\\"\\u003eUbuntu
+        Pro on Azure \\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/ubuntu-pro-azure-latam\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eubuntu
+        pro, microsoft, azure, cloud, security, latam\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-06-09\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eExplore
+        features like extended security, certified compliance and hardening for Ubuntu
+        Pro on Azure.\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/enterprise-mlops-in-hybrid-cloud-scenarios-best-practices/22650\\\"\\u003eEnterprise
+        MLOps in hybrid-cloud scenarios: best practices\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/enterprise-mlops-in-hybrid-cloud-scenarios-best-practices\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eelo,
+        hybrid-cloud, enterprise, kubeflow\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-06-07\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eLearn
+        about architectural best practices that have recently emerged\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/openstack-public-cloud-implementation/22648\\\"\\u003eOpenStack
+        public cloud implementation\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/public-cloud-openstack-implementation\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack,
+        public-cloud\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-06-02\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eReduce
+        total cost of ownership with local public cloud infrastructure\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/ros-support-with-ros-esm/22595\\\"\\u003eROS
+        Support\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/ros-support\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eros\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-06-04\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eSecurity
+        maintenance and enterprise support for your ROS environment\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/preparing-for-the-suse-openstack-cloud-end-of-life/22587\\\"\\u003eSUSE
+        OpenStack Cloud end-of-life\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/suse-openstack-cloud-eol\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack,
+        cloud, suse\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-06-03\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eA
+        preparation guide\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/data-lab-architectures/22247\\\"\\u003eData
+        Lab Architectures\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/data-lab-architectures-whitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003ebig
+        data, data driven, AI, ML\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-06-02\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eA
+        field practitioner guide to building and accelerating data lab initiatives\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/guida-cio-alle-operazioni-multi-cloud/22564\\\"\\u003eGuida
+        CIO alle operazioni multi-cloud\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/it/operazioni-multi-cloud\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003emulti-cloud,
+        finance\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-10-05\\u003c/td\\u003e\\n\\u003ctd\\u003eit\\u003c/td\\u003e\\n\\u003ctd\\u003eCome
+        scegliere un\u2019architettura cloud conveniente\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/kubernetes-e-ubuntu-in-italia/22562\\\"\\u003eKubernetes
+        e Ubuntu in Italia\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/it/kubernetes-e-ubuntu-in-italia\\u003c/td\\u003e\\n\\u003ctd\\u003eblog\\u003c/td\\u003e\\n\\u003ctd\\u003ekubernetes,
+        ubuntu, openstack\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-06-02\\u003c/td\\u003e\\n\\u003ctd\\u003eit\\u003c/td\\u003e\\n\\u003ctd\\u003eUn\u2019esplorazione
+        tecnica delle ultime tecnologie di infrastruttura\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/private-cloud-for-financial-services/22500\\\"\\u003ePrivate
+        cloud for Financial Services\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/private-cloud-financial-services\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003efinserv,
+        openstack\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-05-28\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eComparing
+        Red Hat OpenStack Platform and Canonical\u2019s Charmed OpenStack\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/canonical-at-mwc-2021/22348\\\"\\u003eCanonical
+        at MWC 2021\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/canonical-ubuntu-mwc-2021\\u003c/td\\u003e\\n\\u003ctd\\u003eblog\\u003c/td\\u003e\\n\\u003ctd\\u003etelco,
+        telecommunications, 5G, events\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-05-18\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/open-source-private-5g-and-lte-networks/22346\\\"\\u003eOpen
+        source private 5G and LTE networks\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/5g-and-lte-networks-webinar\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003etelco,
+        telecommunications, 5G\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-05-18\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eUse-cases,
+        tools and technologies\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/kubernetes-at-the-edge-easy-as-pi/22342\\\"\\u003eKubernetes
+        at the edge: easy as Pi\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/edge-kubernetes-raspberry-pi-webinar\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eKubernetes,
+        K8s, edge\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-05-18\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/suse-openstack-cloud-wird-eingestellt/22283\\\"\\u003eSUSE
+        OpenStack Cloud wird eingestellt.\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/de/suse-openstack-webinar\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003esuse,
+        openstack\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-05-13\\u003c/td\\u003e\\n\\u003ctd\\u003ede\\u003c/td\\u003e\\n\\u003ctd\\u003eSind
+        Sie vorbereitet?\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/building-and-orchestrating-network-functions/22269\\\"\\u003eBuilding
+        and orchestrating network functions\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/telco-network-functions-whitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003etelco,
+        telecommunications, 5G, OSM\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-05-12\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eAccelerate
+        migration towards NFV with Open Source MANO\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/simplifying-kubernetes-across-the-clouds-microk8s-on-nvidia-tech-stack/22260\\\"\\u003eSimplifying
+        Kubernetes across the Clouds \\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/microk8s-nvidia-tech-stack\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003emicrok8s,
+        edge, kubernetes, k8s\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-05-11\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eMicroK8s
+        on NVIDIA Tech Stack\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/data-lab-architectures/22247\\\"\\u003eData
+        Lab Architectures\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/data-lab-architectures-whitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003ebig
+        data, data driven, AI, ML\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-05-10\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eA
+        field practitioner guide to building and accelerating data lab initiatives\\u003c/td\\u003e\\n\\u003ctd\\u003efalse\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/a-business-guide-to-multi-cloud/22093\\\"\\u003eA
+        business guide to multi-cloud\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/multi-cloud-business-guide\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-04-30\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eA
+        cost-effective extension to the public cloud infrastructure\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/a-business-guide-to-hybrid-cloud/22092\\\"\\u003eA
+        business guide to hybrid cloud\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/hybrid-cloud-business-guide\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-04-30\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eA
+        cost-effective extension to the public cloud infrastructure\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/ros-kinetic-end-of-life/21952\\\"\\u003eROS
+        Kinetic End-Of-Life\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/ros-kinetic-eol\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003erobotics\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-04-20\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eKeep
+        your robots secure with ROS ESM\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/migrare-a-ubuntu-lts-sei-fatti-per-gli-utenti-centos/21959\\\"\\u003eMigrare
+        ad Ubuntu LTS: 6 fatti per gli utenti CentOS\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/it/migrare-a-ubuntu-lts-centos\\u003c/td\\u003e\\n\\u003ctd\\u003eblog\\u003c/td\\u003e\\n\\u003ctd\\u003ecentos\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eit\\u003c/td\\u003e\\n\\u003ctd\\u003eState
+        pensando di migrare a Ubuntu da altre piattaforme Linux, come CentOS?\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/meno-di-6-mesi-a-ubuntu-16-04-esm-6-cose-da-preparare/21958\\\"\\u003eMeno
+        di 6 mesi a Ubuntu 16.04 ESM: 6 cose da preparare\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/it/ubuntu-16-04-esm\\u003c/td\\u003e\\n\\u003ctd\\u003eblog\\u003c/td\\u003e\\n\\u003ctd\\u003eubuntu,
+        esm\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eit\\u003c/td\\u003e\\n\\u003ctd\\u003eQuesto
+        articolo spiega come funziona il periodo ESM e fornisce una guida a sei considerazioni
+        chiave per la pianificazione di un percorso di migrazione da Ubuntu 16.04
+        LTS.\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/infrastruttura-multi-cloud-in-italia/21894\\\"\\u003eInfrastruttura
+        multi-cloud in Italia\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/it/infrastruttura-multi-cloud\\u003c/td\\u003e\\n\\u003ctd\\u003eblog\\u003c/td\\u003e\\n\\u003ctd\\u003emulti-cloud,
+        kubernetes\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eL\u2019evento,
+        della durata di 2 ore, si terr\xE0 il 12 maggio 2021 su BrightTalk. Dai live
+        talk dei nostri speaker alle sessioni di Q\\u0026amp;A.\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/data-science-workstations-journey/21828\\\"\\u003eData
+        Science Workstations\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/workstations-journey-to-ai\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eAI/ML\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-04-15\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eTake
+        a deep dive into how workstations enable the AI journey in part 2 of our series\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/unleashing-z-workstations-by-hp-powered-by-ubuntu/21825\\\"\\u003eUnleashing
+        Z by HP Workstation Power with Ubuntu\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/Z-Workstation-Ubuntu\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eOpen
+        Source, Linux, Data Science, AI, Machine Learning, HP\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-04-15\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eExplore
+        key solutions for AI, Machine Learning, and Data Science Workflows\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/what-s-new-in-ubuntu-server-21-04/21802\\\"\\u003eWhat\u2019s
+        new in Ubuntu Server 21.04?\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/ubuntu-21.04-release-webinar\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eserver\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-04-14\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eIntroducing
+        native integration with Microsoft SQL Server\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/the-value-of-open-source-in-2021/21790\\\"\\u003eThe
+        Value of Open Source in 2021\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/open-source-value\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eOpen
+        Source, Kubernetes, Dell, OpenStack, Edge\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-04-12\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eExplore
+        the latest open source market trends and dive into OpenStack, Kubernetes and
+        Edge solutions from Dell and Canonical.\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/elkhart-lake/21775\\\"\\u003eElkhart
+        Lake\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/iot-elkhart-lake\\u003c/td\\u003e\\n\\u003ctd\\u003eblog\\u003c/td\\u003e\\n\\u003ctd\\u003eintel,
+        iot\\u003c/td\\u003e\\n\\u003ctd\\u003e4/16/2021\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eEmbedded
+        silicon from Intel focusing on IoT features for the next generation of edge
+        devices.\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/elkhart-lake/21775\\\"\\u003eElkhart
+        Lake\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/elkhart-lake\\u003c/td\\u003e\\n\\u003ctd\\u003eblog\\u003c/td\\u003e\\n\\u003ctd\\u003eintel,
+        iot\\u003c/td\\u003e\\n\\u003ctd\\u003e4/16/2021\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eEmbedded
+        silicon from Intel focusing on IoT features for the next generation of edge
+        devices.\\u003c/td\\u003e\\n\\u003ctd\\u003efalse\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/telecom-ai-a-guide-for-data-teams/21740\\\"\\u003eTelecom
+        AI: a guide for data teams\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/telecom-ai-guide\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eAI/ML,
+        telco, telecommunications\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-04-09\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eOptimising
+        AI for production in the telco space\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/data-science-workstations/21739\\\"\\u003eData
+        Science Workstations\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/data-science-workstations\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eAI/ML\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-04-09\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eTake
+        a deep dive into how workstations enable the AI journey in this four-part
+        webinar series\\u003c/td\\u003e\\n\\u003ctd\\u003efalse\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/canonical-ubuntu-at-nvidia-gtc-2021-digital/21524\\\"\\u003eCanonical
+        \\u0026amp; Ubuntu at NVIDIA GTC 2021 Digital\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/ubuntu-at-nvidia-gtc-2021\\u003c/td\\u003e\\n\\u003ctd\\u003eblog\\u003c/td\\u003e\\n\\u003ctd\\u003eAI/ML,
+        MicroK8s, edge\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-03-24\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eMeet
+        us there on April 12-16\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/model-driven-audit-trail-logs-infrastructure-for-telco-vnfs/21500\\\"\\u003eModel-driven
+        Audit Trail Logs infrastructure for Telco VNFs\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/audit-trail-logs-for-telco\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003etelecommunications\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-03-23\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eLive
+        webinar on April 15th\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/esm-garantisce-la-sicurezza-dei-sistemi-interana-anche-durante-laggiornamento/21378\\\"\\u003eESM
+        garantisce la sicurezza dei sistemi Interana anche durante l\u2019aggiornamento\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/it/interana-casestudy\\u003c/td\\u003e\\n\\u003ctd\\u003ecase
+        study\\u003c/td\\u003e\\n\\u003ctd\\u003eesm, security, interana\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-03-16\\u003c/td\\u003e\\n\\u003ctd\\u003eit\\u003c/td\\u003e\\n\\u003ctd\\u003eCaso
+        di studio - Interana\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/securing-open-source-from-cloud-to-edge/21394\\\"\\u003eSecuring
+        open source from cloud to edge\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/open-source-security-cloud-edge-webinar\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003esecurity,
+        ubuntu pro\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-03-16\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eGet
+        the full Ubuntu security story and see how our teams are securing Ubuntu systems
+        across cloud, device and edge environments.\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/migrar-a-ubuntu-lts-seis-factores-a-tener-en-cuenta-para-los-usuarios-de-centos/21315\\\"\\u003eMigrar
+        a Ubuntu LTS: seis factores a tener en cuenta para los usuarios de CentOS\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/es/migrar-de-centos-a-ubuntu-lts\\u003c/td\\u003e\\n\\u003ctd\\u003eblog\\u003c/td\\u003e\\n\\u003ctd\\u003eserver,
+        ubuntu\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-03-09\\u003c/td\\u003e\\n\\u003ctd\\u003ees\\u003c/td\\u003e\\n\\u003ctd\\u003e\xBFEst\xE1
+        considerando migrar a Ubuntu desde otras plataformas Linux, como CentOS?\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/from-yocto-buildroot-to-ubuntu-core-20/21248\\\"\\u003eFrom
+        Yocto \\u0026amp; Buildroot to Ubuntu Core 20\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/yocto-buildroot-to-ubuntu-core\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eubuntu-core\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-03-05\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eThe
+        path to enterprise-grade embedded Linux\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/costruire-infrastrutture-multi-cloud-con-ubuntu-e-kubernetes/21247\\\"\\u003eCostruire
+        infrastrutture multi-cloud con Ubuntu e Kubernetes\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/it/multi-cloud-infrastrutture-kubernetes-italy\\u003c/td\\u003e\\n\\u003ctd\\u003eevent\\u003c/td\\u003e\\n\\u003ctd\\u003emulti-cloud,
+        infrastructure, kubernetes\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eit\\u003c/td\\u003e\\n\\u003ctd\\u003eUn\u2019esplorazione
+        tecnica delle ultime tecnologie di infrastruttura\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/kubeflow-operations-guide/21213\\\"\\u003eKubeflow
+        operations guide\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/kubeflow-operations-guide\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003ekubeflow,
+        machine learning, AI/ML\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eAutomating
+        day-0 to day-2 with Kubernetes operators\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/suse-openstack-cloud-arrive-en-fin-de-vie/21096\\\"\\u003eSUSE
+        OpenStack Cloud arrive en fin de vie\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/fr/suse-openstack-fin-de-vie\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003esuse,
+        openstack\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-02-25\\u003c/td\\u003e\\n\\u003ctd\\u003efr\\u003c/td\\u003e\\n\\u003ctd\\u003ePreparez
+        pour votre migration d\u2019OpenStack\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/whats-next-for-centos-users/21090\\\"\\u003eWhat\u2019s
+        next for CentOS users?\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/centos-live-q\\u0026amp;A\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-02-24\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eLive
+        Q\\u0026amp;A with Ubuntu\u2019s technical experts\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/a-technical-introduction-to-ubuntu-core-20/21068\\\"\\u003eA
+        technical introduction to Ubuntu Core 20\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/technical-intro-to-ubuntu-core-20\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eubuntu-core\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-02-23\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eFull-disk
+        encryption, secure boot, device recovery and more\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/ubuntu-16-04-esm-6-choses-a-preparer/21058\\\"\\u003eUbuntu
+        16.04 ESM: 6 choses \xE0 pr\xE9parer\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/fr/ubuntu-1604-esm\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003esecurity\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-02-22\\u003c/td\\u003e\\n\\u003ctd\\u003efr\\u003c/td\\u003e\\n\\u003ctd\\u003eUn
+        guide de migration\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/migration-vers-ubuntu-lts-six-points-cles-pour-les-utilisateurs-de-centos/21054\\\"\\u003eMigration
+        vers Ubuntu LTS: six points cl\xE9s pour les utilisateurs de CentOS\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/centos-vers-ubuntu\\u003c/td\\u003e\\n\\u003ctd\\u003eblog\\u003c/td\\u003e\\n\\u003ctd\\u003esecurity\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-02-22\\u003c/td\\u003e\\n\\u003ctd\\u003efr\\u003c/td\\u003e\\n\\u003ctd\\u003ePr\xE9parez
+        vos prochaines \xE9tapes\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/simplifying-ai-ml-adoption-in-telco-with-modern-operations-practices/20996\\\"\\u003eSimplifying
+        AI/ML adoption in telco with modern operations practices\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/ai-ml-telco-modern-operations\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eAI/ML,
+        telecommunications\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-02-17\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eLeveraging
+        open source software for optimal TCO\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/enterprise-kubernetes-a-buyer-s-guide/20979\\\"\\u003eEnterprise
+        Kubernetes: A buyer\u2019s guide\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/enterprise-kubernetes-guide\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eKubernetes,
+        K8s, Cloud\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-02-16\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eFind
+        the right Kubernetes for your business\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/secure-container-orchestration-at-the-edge/20965\\\"\\u003eSecure
+        container orchestration at the edge\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/container-orchestration-edge\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eKubernetes,
+        edge, MicroK8s\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-02-15\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eDevelop
+        your cloud-native apps with micro clouds\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/edge-use-cases-enabled-by-mec-and-5g/20873\\\"\\u003eEdge
+        use-cases enabled by MEC and 5G\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/mec-5g-use-cases\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eTelecommunications,
+        5G\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-02-10\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eLeveraging
+        open source software in the telco space\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/open-source-in-government/20843\\\"\\u003eOpen
+        source in Government\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/gov-webinar\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-02-09\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eThe
+        Public Sector team discusses adoption and procurement of secure open source
+        tech, tooling and support.\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/mantenimiento-de-seguridad-extendido/20747\\\"\\u003eMantenimiento
+        de Seguridad Extendido\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/es/esm\\u003c/td\\u003e\\n\\u003ctd\\u003eblog\\u003c/td\\u003e\\n\\u003ctd\\u003eesm\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-02-04\\u003c/td\\u003e\\n\\u003ctd\\u003ees\\u003c/td\\u003e\\n\\u003ctd\\u003eActualizaciones
+        de seguridad para Ubuntu 16.04 LTS hasta el 2024 y Ubuntu 14.04 LTS hasta
+        el 2022.\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/integrazione-di-ubuntu-desktop-con-microsoft-active-directory/20746\\\"\\u003eIntegrazione
+        di Ubuntu Desktop con Microsoft Active Directory\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/it/ubuntu-desktop-active-directory\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eactive
+        directory, desktop\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-02-04\\u003c/td\\u003e\\n\\u003ctd\\u003eit\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/end-to-end-wiring-using-kubeflow-kafka-and-elasticsearch/20704\\\"\\u003eEnd-to-end
+        wiring using Kubeflow, Kafka and ElasticSearch\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/end-to-end-wiring-with-kubeflow-kafka-elasticsearch\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eAI/ML,
+        Kubeflow\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-02-03\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eOur
+        latest webinar provides real world application and demo for end-to-end wiring
+        using Kubeflow, Kafka and ElasticSearch.\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/embedded-linux-make-or-buy/20696\\\"\\u003eEmbedded
+        Linux: make or buy?\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/embedded-linux-make-or-buy\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-02-02\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eCommercial
+        support vs roll your own: a dilemma\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/an-introduction-to-ubuntu-core-20/20687\\\"\\u003eAn
+        introduction to Ubuntu Core 20\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/ubuntu-core-20-webinar\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003ecore,
+        iot, embedded, security\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-02-02\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eImproving
+        usability, security and time-to-market\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/kubeflow-reference-architecture/20467\\\"\\u003eKubeflow
+        reference architecture\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/dell-kubeflow-reference-architecture\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003ekubeflow,
+        ai/ml, dell\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-01-21\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/industrial-process-transformation-with-machine-learning-using-kubeflow/20436\\\"\\u003eIndustrial
+        process transformation with Machine Learning using Kubeflow\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/industrial-process-ml-kubeflow\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eAI/ML,
+        Kubeflow\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-01-18\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eAccelerate
+        the time from model development to deployment\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/comparaison-de-red-hat-openstack-platform-et-de-charmed-openstack-de-canonical/20432\\\"\\u003eComparaison
+        entre Red Hat OpenStack et Charmed OpenStack de Canonical\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/fr/red-hat-canonical-openstack-comparaison\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eOpenStack\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-01-29\\u003c/td\\u003e\\n\\u003ctd\\u003efr\\u003c/td\\u003e\\n\\u003ctd\\u003eAm\xE9liorez
+        la s\xE9curit\xE9 et l\u2019efficacit\xE9 \xE0 un co\xFBt total de possession
+        r\xE9duit avec Charmed OpenStack\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/automation-through-open-source-operators/20215\\\"\\u003eAutomation
+        through open source operators \\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/automation-through-open-source-operators\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eapps,
+        Juju, Forrester\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-01-08\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eA
+        Forrester Consulting study on the state of infrastructure and application
+        deployment\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/cloud-native-driving-agility-and-innovation-in-financial-services/20244\\\"\\u003eCloud-native
+        driving agility and innovation in financial services\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/cloud-native-agility-financial-services\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003ecloud-native,
+        finance\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-01-07\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eAdapt,
+        innovate and transform\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/android-in-the-cloud-on-arm-native-servers/20015\\\"\\u003eAndroid
+        in the cloud on Arm native servers\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/android-on-arm-whitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eandroid\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-12-18\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eHigh
+        performance. Power efficiency. Hardware rooted security.\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/staying-compliant-while-delivering-innovation-in-government-services/19960\\\"\\u003eStaying
+        compliant while delivering innovation in government services\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/azure-ubuntu-pro-fips-whitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eazure,
+        ubuntu pro, fips\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-12-17\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eHow
+        Ubuntu Pro FIPS on Microsoft Azure gives government agencies and contractors
+        new ways to control costs and boost innovation while maintaining FIPS compliance.\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/menos-de-6-meses-para-16-04-esm-seis-aspectos-a-tener-en-cuenta/19925\\\"\\u003eMenos
+        de 6 meses para 16.04 ESM: seis aspectos a tener en cuenta\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/es/ubuntu-16-04-esm\\u003c/td\\u003e\\n\\u003ctd\\u003eblog\\u003c/td\\u003e\\n\\u003ctd\\u003eesm,
+        security, ubuntu advantage\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-12-17\\u003c/td\\u003e\\n\\u003ctd\\u003ees\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/in-weniger-als-6-monaten-kommt-ubuntu-16-04-esm-6-punkte-fur-ihre-vorbereitung/19895\\\"\\u003eIn
+        weniger als 6 Monaten kommt Ubuntu 16.04 ESM: 6 Punkte f\xFCr Ihre Vorbereitung\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/de/ubuntu-16-04-esm\\u003c/td\\u003e\\n\\u003ctd\\u003eblog\\u003c/td\\u003e\\n\\u003ctd\\u003eesm,
+        security, ubuntu advantage\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-12-17\\u003c/td\\u003e\\n\\u003ctd\\u003ede\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/workstations-ai/19766\\\"\\u003eWorkstations
+        AI\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/it/workstation-ai\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003ekubeflow\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-12-09\\u003c/td\\u003e\\n\\u003ctd\\u003eit\\u003c/td\\u003e\\n\\u003ctd\\u003eCome
+        e perch\xE9 Kubeflow migliora i workflow AI\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/suse-openstack-cloud-to-be-discontinued/19765\\\"\\u003eSUSE
+        OpenStack Cloud to be discontinued\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/suse-openstack-webinar\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack,
+        cloud, suse\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-12-23\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eAre
+        you prepared?\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/lightweight-kubernetes-in-the-enterprise/19716\\\"\\u003eLightweight
+        Kubernetes in the enterprise\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/451-research-microk8s-high-availability\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003ekubernetes,
+        451, microk8s\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-12-09\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eProduction
+        workloads in cloud and server deployments made faster than ever\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/ai-deployment-and-inference/19692\\\"\\u003eAI
+        deployment and inference\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/ai-deployment-and-inference\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003einference\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-12-07\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eReliable
+        infrastructure and streamlined operations\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/agility-and-innovation-in-financial-services-with-open-source/19601\\\"\\u003eAgility
+        and innovation in Financial Services with open source \\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/open-source-financial-services\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003efinance\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-12-01\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eLearn
+        how managed open source can help financial institutions deliver business value.\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/ubuntu-pro-for-aws/19600\\\"\\u003eUbuntu
+        Pro for AWS\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/ubuntu-pro-for-aws\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eaws,
+        Ubuntu Pro\\u003c/td\\u003e\\n\\u003ctd\\u003e2020 -12 01\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eFIPS
+        compliance made easy\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/ubuntu-16-04-lts-moving-to-extended-security-maintenance/19598\\\"\\u003eUbuntu
+        16.04 LTS moving to Extended Security Maintenance\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/16-04-ESM-webinar\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eesm,
+        security, ubuntu advantage\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-12-01\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eSix
+        things to consider when migration planning\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/micro-clouds/19424\\\"\\u003eMicro
+        clouds\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/micro-clouds\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eedge\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-11-19\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eBuilding
+        your Kubernetes edge computing strategy\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/cinque-strategie-per-accelerare-limplementazione-di-kubernetes-nellimpresa/19381\\\"\\u003eCinque
+        strategie per accelerare l\u2019implementazione di Kubernetes nell\u2019impresa\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/it/deployment-azienda-manuale\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eenterprise\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-11-17\\u003c/td\\u003e\\n\\u003ctd\\u003eit\\u003c/td\\u003e\\n\\u003ctd\\u003eCome
+        scegliere il miglior approccio Kubernetes per la tua azienda\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/confronto-fra-red-hats-openstack-platform-e-charmed-openstack-di-canaonical/19362\\\"\\u003eConfronto
+        fra \u201CRed Hat\u2019s Openstack platform\u201D e Charmed Openstack di Canaonical\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/it/redhat-openstack-confronto-manuale\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eRed
+        Hat\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-11-16\\u003c/td\\u003e\\n\\u003ctd\\u003eit\\u003c/td\\u003e\\n\\u003ctd\\u003eCharmed
+        Openstack riduce significativamente il costo totale di propriet\xE0\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/confronto-fra-red-hats-openstack-platform-e-charmed-openstack-di-canaonical/19361\\\"\\u003eGuide
+        pour r\xE9ussir l\u2019adoption et le d\xE9ploiement d\u2019OpenStack\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/fr/guide-adoption-openstack\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-11-16\\u003c/td\\u003e\\n\\u003ctd\\u003efr\\u003c/td\\u003e\\n\\u003ctd\\u003eD\xE9couvrez
+        l\u2019\xE9prouv\xE9 processus d\u2019impl\xE9mentation OpenStack de Canonical\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/funf-strategien-zur-beschleunigung-von-kubernetes-in-unternehmen/19284\\\"\\u003eF\xFCnf
+        Strategien zur Beschleunigung von Kubernetes in Unternehmen\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/de/kubernetes-implementierung-fur-unternehmen\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eenterprise\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-11-11\\u003c/td\\u003e\\n\\u003ctd\\u003ede\\u003c/td\\u003e\\n\\u003ctd\\u003eEntscheidungskriterien
+        zur optimalen Herangehensweise an Kubernetes f\xFCr Ihr Unternehmen\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/vergleich-von-red-hat-openstack-platform-und-charmed-openstack-von-canonical/19285\\\"\\u003eVergleich
+        von Red Hat OpenStack Platform und Charmed OpenStack von Canonical\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/de/redhat-openstack-vergleich\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eRed
+        Hat\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-11-11\\u003c/td\\u003e\\n\\u003ctd\\u003ede\\u003c/td\\u003e\\n\\u003ctd\\u003eSenken
+        Sie Ihre Gesamtkosten deutlich mit Charmed OpenStack\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/9-out-of-top-10-us-financial-institutions-use-ubuntu/19304\\\"\\u003e9
+        out of top 10 US \\u0026amp; European financial institutions use Ubuntu\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/ubuntu-finance-sector-whitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003efinance\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-11-11\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eFind
+        out why multi-cloud is fundamental to financial services transformation\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/cinco-estrategias-para-acelerar-el-despliegue-de-kubernetes/19208\\\"\\u003eCinco
+        estrategias para acelerar el despliegue de Kubernetes\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/es/kubernetes-despliegue-empresa-manual\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eenterprise,
+        kubernetes\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-11-04\\u003c/td\\u003e\\n\\u003ctd\\u003ees\\u003c/td\\u003e\\n\\u003ctd\\u003eC\xF3mo
+        elegir el mejor enfoque de Kubernetes para su negocio\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/comparando-la-plataforma-openstack-de-red-hat-y-la-charmed-openstack-de-canonical/19194\\\"\\u003eComparando
+        la plataforma OpenStack de Red Hat y la Charmed OpenStack de Canonical\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/es/redhat-openstack-comparacion-manual\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-11-03\\u003c/td\\u003e\\n\\u003ctd\\u003ees\\u003c/td\\u003e\\n\\u003ctd\\u003eReducir
+        significativamente el coste total de propiedad con Charmed OpenStack\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/optimised-authentication-methods-for-ubuntu-desktop/19133\\\"\\u003eOptimised
+        authentication methods for Ubuntu Desktop\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/desktop-authentication-whitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003edesktop,
+        security\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-08-07\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eSecuring
+        enterprise desktops with modern authentication options\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/open-digital-platforms-for-the-industrial-edge-cloud-in-2020/19068\\\"\\u003eOpen
+        digital platforms for the industrial edge cloud in 2020\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/pac-radar\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003epac-radar\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-10-27\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eThe
+        next wave of cloud-native innovations at the edge\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/ubuntu-20-10-what-s-new/19050\\\"\\u003eUbuntu
+        20.10: What\u2019s new?\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/ubuntu-20.10\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eubuntu
+        server, maas, kubernetes\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-10-26\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eLearn
+        about new features in Ubuntu Server, MAAS, Charmed OpenStack and Charmed Kubernetes\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/ubuntu-for-raspberry-pi-live-on-youtube/18577\\\"\\u003eUbuntu
+        for Raspberry Pi intro video\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/raspberry-pi-livestream\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eraspberry-pi,
+        desktop\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-10-21\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/cloud-gaming-for-android/18757\\\"\\u003eCloud
+        gaming for Android\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/anbox-cloud-gaming-whitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eanbox,
+        gaming\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-01-21\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eBuilding
+        a high performing and scalable platform\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/extend-your-openstack-cloud-with-native-backup-and-recover/18911\\\"\\u003eExtend
+        your OpenStack cloud with native backup and recovery\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/trilio-backup-recovery\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-09-31\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eLearn
+        how TrilioVault can be easily deployed in a Charmed OpenStack environment\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/transforming-telco-infrastructure-a-virtual-event/18162\\\"\\u003eTransforming
+        telco infrastructure\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/telco-virtual-event\\u003c/td\\u003e\\n\\u003ctd\\u003eevent\\u003c/td\\u003e\\n\\u003ctd\\u003eopen-source\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-09-24\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eCanonical\u2019s
+        experts explore the telecommunication industry\u2019s latest technologies.\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/guia-para-la-implementacion-de-openstack/18480\\\"\\u003eGu\xEDa
+        para la implementaci\xF3n de OpenStack\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/es/guia-para-la-implementacion-de-openstack\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-09-16\\u003c/td\\u003e\\n\\u003ctd\\u003ees\\u003c/td\\u003e\\n\\u003ctd\\u003eDescubre
+        el probado proceso de implementaci\xF3n de OpenStack de Canonical\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/da-vmware-a-charmed-openstack/18478\\\"\\u003eDa
+        VMware a Charmed Openstack\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/it/da-vmware-a-charmed-openstack\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-09-15\\u003c/td\\u003e\\n\\u003ctd\\u003eit\\u003c/td\\u003e\\n\\u003ctd\\u003eCome
+        la migrazione a Charmed OpenStack pu\xF2 ridurre significativamente il TCO\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/gmo-pepabo-ubuntu/18476\\\"\\u003eGMO
+        Pepabo \\u0026amp; Ubuntu\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/case-study-gmo-pepabo\\u003c/td\\u003e\\n\\u003ctd\\u003ecase
+        study\\u003c/td\\u003e\\n\\u003ctd\\u003eserver, kubernetes,ubuntu-advantage\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-09-14\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eGMO
+        Pepabo cuts OPEX costs with live kernel patching and saves 2,500 hours of
+        manual work\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/da-vmware-a-openstack/18164\\\"\\u003eDa
+        VMware a OpenStack\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/it/da-vmware-a-openstack\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-09-04\\u003c/td\\u003e\\n\\u003ctd\\u003eit\\u003c/td\\u003e\\n\\u003ctd\\u003eCome
+        la migrazione a Charmed OpenStack pu\xF2 ridurre significativamente il TCO\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/five-strategies-to-accelerate-kubernetes-deployment-in-the-enterprise/18161\\\"\\u003eFive
+        strategies to accelerate Kubernetes in the enterprise\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/kubernetes-deployment-enterprise-whitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003ekubernetes\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-09-02\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eHow
+        to choose the best approach to Kubernetes for your business\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/production-ai-from-data-lake-to-server-webinar/18163\\\"\\u003eProduction
+        AI from data lake to server\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/data-lake_2_server_webinar\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eai\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-08-13\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eSolving
+        hardware challenges in ML environments\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/building-powerful-customer-solutions/18481\\\"\\u003eBuilding
+        powerful customer solutions\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/gsi-webinar-series\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003ecloud,
+        kubernetes\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-07-31\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eA
+        webinar series for GSIs seizing new models for scalable, automated and repeatable
+        deployments\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/red-hat-openstack-platform-vs-canonicals-charmed-openstack/18159\\\"\\u003eRed
+        Hat OpenStack Platform vs Canonical\u2019s Charmed OpenStack\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/redhat-openstack-comparison-whitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-07-29\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eImprove
+        security and efficiency at a reduced total cost of ownership with Charmed
+        OpenStack\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/do-vmware-ao-charmed-openstack/18165\\\"\\u003eDo
+        VMware ao Charmed OpenStack\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/pt/vmware-para-o-openstack\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-07-22\\u003c/td\\u003e\\n\\u003ctd\\u003ept\\u003c/td\\u003e\\n\\u003ctd\\u003eReduza
+        os custos e aumente a efici\xEAncia da sua infraestrutura com ado\xE7\xE3o
+        de c\xF3digo aberto\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/busting-the-myth-of-private-cloud-economics/17244\\\"\\u003eBusting
+        the myth of private cloud economics\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/cloud-economics\\u003c/td\\u003e\\n\\u003ctd\\u003ecase
+        study\\u003c/td\\u003e\\n\\u003ctd\\u003ecloud, openstack\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-12\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/scale-android-applications-economically-in-the-cloud-with-anbox-cloud/17401\\\"\\u003eScale
+        Android applications economically in the cloud with Anbox Cloud\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/intro-to-anbox-cloud-whitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003ecloud\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-07-08\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eDiscover
+        Canonical\u2019s scalable, hardware-agnostic mobile cloud computing platform\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/accelerating-iot-device-time-to-market/17399\\\"\\u003eAccelerating
+        IoT device time to market\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/smart-start-whitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eiot\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-07-03\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eIntroducing
+        a packaged solution to condense IoT decision-making into a 2-week, fixed cost
+        process\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/kubernetes-from-cloud-to-edge/17398\\\"\\u003eKubernetes
+        from Cloud to Edge\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/kubernetes-event-us\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003ekubernetes,
+        cloud, edge\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-06-24\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eHow
+        to streamline your Kubernetes deployment and operations from Canonical\u2019s
+        experts.\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/scaling-on-azure-with-ubuntu-pro/17397\\\"\\u003eScaling
+        on Azure with Ubuntu Pro\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/scaling-securely-ubuntu-azure\\u003c/td\\u003e\\n\\u003ctd\\u003eeBook\\u003c/td\\u003e\\n\\u003ctd\\u003eopen-source,
+        cloud\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-06-17\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eScale
+        your open-source infrastructure with speed, security, and compliance\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/a-technical-intro-to-ubuntu-pro/17396\\\"\\u003eA
+        technical intro to Ubuntu Pro\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/ubuntu-pro-intro\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eopen-source\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-06-16\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/migrating-your-infrastructure-to-ubuntu-20-04-lts/17395\\\"\\u003eMigrating
+        your infrastructure to Ubuntu 20.04 LTS\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/migrating-to-20.04\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eopen-source\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-06-11\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eHow,
+        when and why?\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/utilising-cloud-init-on-microsoft-azure/17394\\\"\\u003eUtilising
+        cloud-init on Microsoft Azure\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/azure-cloud-init-whitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003ecloud\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-06-03\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eSimplify
+        cloud instance deployment with Ubuntu on Azure\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/standardising-machine-learning-from-workstation-to-production/17393\\\"\\u003eStandardising
+        machine learning \u2014 from workstation to production\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/ml-dell-webinar\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eai,
+        ml, kubernetes\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-06-02\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/kafka-in-production/17392\\\"\\u003eKafka
+        in production\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/kafka-in-production\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003ekafka\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-05-28\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eMaking
+        sure your deployment is fast, reliable and secure\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/solving-the-software-update-challenge-for-iot-devices/17391\\\"\\u003eSolving
+        the software update challenge for IoT devices\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/snapd-whitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eiot,
+        ubuntu-core, snaps\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-05-15\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eHow
+        Ubuntu Core transforms over-the-air software updates\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/secure-iot-device-management/17390\\\"\\u003eSecure
+        IoT device management\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/iot-device-management-whitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eiot,
+        security, ubuntu-core\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-05-13\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eBuild
+        and deploy a central IoT management solution\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/leveraging-open-source-with-ubuntu-pro-on-azure/17389\\\"\\u003eLeveraging
+        open source with Ubuntu Pro on Azure\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/azure-webinar\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eopen-source\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-05-12\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eEconomics,
+        velocity and security\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/streamlined-kubernetes-from-cloud-to-edge/17388\\\"\\u003eStreamlined
+        Kubernetes, from Cloud to Edge\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/eu-kubernetes-event\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003ekubernetes,
+        cloud, edge\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-05-11\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eInnovating
+        and scaling efficiently, with Charmed Kubernetes and MicroK8s\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/embracing-the-open-source-mandate/17387\\\"\\u003eEmbracing
+        the open source mandate\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/moving-to-opensource-whitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eopen-source\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-04-28\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e85%
+        of enterprises have an open source mandate, preference or are exploring\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/what-s-new-in-ubuntu-20-04-lts/17386\\\"\\u003eWhat\u2019s
+        new in Ubuntu 20.04 LTS?\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/20.04-webinars\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003edesktop,
+        server\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-04-16\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eTwo
+        webinars to help you understand what makes 20.04 our most secure and reliable
+        release to date\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/maintaining-business-focus-in-a-cloud-native-world-with-managed-apps/17385\\\"\\u003eMaintaining
+        business focus in a cloud-native world with Managed Apps\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/managed-apps-webinar\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003ecloud\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-04-09\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/ubuntu-core-a-cybersecurity-analysis/17381\\\"\\u003eUbuntu
+        Core: a cybersecurity analysis\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/ubuntu-core-security-audit\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eubuntu-core,
+        security, iot\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-03-31\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eAn
+        independent evaluation of Ubuntu Core\u2019s security capabilities\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/openstack-deployment-guide/17384\\\"\\u003eOpenStack
+        deployment guide\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/openstack-deployment-guide\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-03-31\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eDiscover
+        Canonical\u2019s proven OpenStack implementation process\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/installez-et-mettez-openstack-a-lechelle-en-toute-simplicite/17418\\\"\\u003eInstallez
+        et mettez OpenStack \xE0 l\u2019\xE9chelle en toute simplicit\xE9\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/fr/openstack-made-easy\\u003c/td\\u003e\\n\\u003ctd\\u003eeBook\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-03-29\\u003c/td\\u003e\\n\\u003ctd\\u003efr\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/virtual-event-microk8s-kubernetes/17380\\\"\\u003eVirtual
+        event: MicroK8s \\u0026amp; Kubernetes\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/pre-kubecon-event\\u003c/td\\u003e\\n\\u003ctd\\u003eevent\\u003c/td\\u003e\\n\\u003ctd\\u003ekubernetes\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-03-24\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eJoin
+        our virtual event to learn more about MicroK8s, what it is and why you should
+        use it. This event will also include discussions on Kubernetes, an introduction
+        to Canonical and much more!\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/rigado-cuts-customers-time-to-market/17379\\\"\\u003eRigado
+        cuts customers\u2019 time-to-market\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/case-study-rigado\\u003c/td\\u003e\\n\\u003ctd\\u003ecase
+        study\\u003c/td\\u003e\\n\\u003ctd\\u003eiot, ubuntu-core, snaps\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-03-19\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003ewith
+        Ubuntu Core and AWS\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/securing-ros-robotics-platforms/17378\\\"\\u003eSecuring
+        ROS robotics platforms\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/securing-ros-on-robotics-platforms-whitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003erobotics,
+        security\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-03-11\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eSteps
+        to maximise robotics security with Ubuntu\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/smart-card-login-on-ubuntu/17377\\\"\\u003eSmart
+        card login on Ubuntu\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/smart-card-whitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003esecurity\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-03-09\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eConfigure
+        Ubuntu 18.04 LTS for smart card operation\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/hosted-private-cloud-infrastructure-a-cost-analysis/17375\\\"\\u003eHosted
+        private cloud infrastructure: a cost analysis\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/private-cloud-cost-analysis-webinar\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack,
+        cloud, kubernetes, maas\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-03-02\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eAccelerate
+        initial deployment and reduce operational costs by outsourcing private cloud
+        infrastructure management\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/an-introduction-to-anbox-cloud/17374\\\"\\u003eAccelerating
+        IoT device time to market\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/smart-start-webinar\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eiot\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-02-26\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eChallenges
+        and solutions for IoT execution\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/an-introduction-to-anbox-cloud/17374\\\"\\u003eAn
+        introduction to Anbox Cloud\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/anbox-cloud-webinar\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003ecloud\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-02-25\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eScalable
+        Android\u2122 in the cloud\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/esm-maintains-interanas-system-security-while-upgrading/17376\\\"\\u003eESM
+        maintains Interana\u2019s system security while upgrading\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/interana-casestudy\\u003c/td\\u003e\\n\\u003ctd\\u003ecase
+        study\\u003c/td\\u003e\\n\\u003ctd\\u003esecurity\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-02-17\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/artificial-intelligence-at-the-edge-in-a-5g-world/17372\\\"\\u003eArtificial
+        Intelligence at the edge in a 5G world\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/ai-edge-webinar\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eai,
+        ml, edge\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-02-07\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eDeploying
+        AI/ML solutions in latency-sensitive environments requires a new solution
+        architecture approach\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/deploy-kubernetes-in-your-data-centre/17373\\\"\\u003eDeploy
+        Kubernetes in your data centre\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/dell-kubernetes-webinar\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003ekubernetes\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-02-07\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/migration-von-vmware-zu-openstack/17370\\\"\\u003eMigration
+        von VMware zu OpenStack\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/de/migration-von-vmware-zu-openstack\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-02-04\\u003c/td\\u003e\\n\\u003ctd\\u003ede\\u003c/td\\u003e\\n\\u003ctd\\u003eWie
+        ein Umstieg auf Charmed OpenStack die Gesamtkosten sp\xFCrbar senken kann\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/de-vmware-a-charmed-openstack/17371\\\"\\u003eDe
+        VMware a Charmed OpenStack\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/es/vmware-a-charmed-openstack\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-02-04\\u003c/td\\u003e\\n\\u003ctd\\u003ees\\u003c/td\\u003e\\n\\u003ctd\\u003eC\xF3mo
+        la migraci\xF3n a Charmed OpenStack puede reducir significativamente el TCO\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/kubernetes-a-secure-flexible-and-automated-edge-for-iot-developers/17369\\\"\\u003eKubernetes:
+        a secure, flexible and automated edge for IoT developers\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/microk8s-451research\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003ekubernetes,
+        edge, iot\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-01-10\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eThe
+        factors for implementing Kubernetes successfully at the edge\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/an-intro-to-microk8s/17367\\\"\\u003eAn
+        intro to MicroK8s\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/intro-to-microk8s-webinar\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003ekubernetes\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-12-19\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eReliable,
+        fast, small and upstream Kubernetes\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/ubuntu-desktop-for-the-enterprise/17368\\\"\\u003eUbuntu
+        Desktop for the enterprise\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/linux-enterprise-whitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003edesktop\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-12-19\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eLearn
+        why enterprises are beginning to adopt Linux as a desktop operating system\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/cyberdyne-keeps-cleaning-robots-up-to-date-in-the-field-with-snaps/17366\\\"\\u003eCyberdyne
+        keeps cleaning robots up-to-date in the field with snaps\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/cyberdyne\\u003c/td\\u003e\\n\\u003ctd\\u003ecase
+        study\\u003c/td\\u003e\\n\\u003ctd\\u003erobotics, iot\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-12-18\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/sbi-group-unlocks-infrastructure-automation-with-secure-on-premises-openstack-cloud/17364\\\"\\u003eSBI
+        Group unlocks infrastructure automation with secure, on-premises OpenStack
+        cloud\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/sbi-casestudy\\u003c/td\\u003e\\n\\u003ctd\\u003ecase
+        study\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-12-06\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/register-for-wslconf/17365\\\"\\u003eRegister
+        for WSLConf\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/wslconf\\u003c/td\\u003e\\n\\u003ctd\\u003eevent\\u003c/td\\u003e\\n\\u003ctd\\u003ewsl\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-12-06\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/build-smart-display-devices-with-mir-fast-to-production-secure-open-source/17363\\\"\\u003eBuild
+        smart display devices with Mir: fast to production, secure, open-source\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/build-smart-devices-with-mir-whitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eiot\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-11-27\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/linux-security-with-ubuntu/17362\\\"\\u003eLinux
+        security with Ubuntu\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/linux_security_webinar\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003esecurity\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-11-14\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eSecuring
+        Ubuntu systems for reduced downtime and optimum CVE coverage.\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/lessons-learned-from-100-private-cloud-builds/17361\\\"\\u003eLessons
+        learned from 100+ Private cloud builds\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/private-cloud-build-webinar\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack,
+        cloud\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-11-12\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eReducing
+        the complexities of building a private cloud on OpenStack\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/the-wellcome-sanger-institute-turns-to-canonical-for-high-level-ceph-support/17360\\\"\\u003eThe
+        Wellcome Sanger Institute turns to Canonical for high level Ceph support\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/wellcome-sanger-case-study\\u003c/td\\u003e\\n\\u003ctd\\u003ecase
+        study\\u003c/td\\u003e\\n\\u003ctd\\u003eceph, openstack\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-11-04\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/ensuring-security-and-isolation-in-kubernetes-with-kata-containers/17359\\\"\\u003eEnsuring
+        security and isolation in Kubernetes with Kata Containers\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/kata-containers-webinar\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003esecurity\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-11-01\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/tim-ensures-system-security-and-client-confidence-with-esm/17358\\\"\\u003eTIM
+        ensures system security and client confidence with ESM\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/case-study-acuris\\u003c/td\\u003e\\n\\u003ctd\\u003ecase
+        study\\u003c/td\\u003e\\n\\u003ctd\\u003esecurity, ubuntu-advantage\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-10-22\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/what-s-new-in-ubuntu-19-10/17357\\\"\\u003eWhat\u2019s
+        new in Ubuntu 19.10\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/19-10-webinar\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003edesktop\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-10-17\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eUbuntu
+        19.10 includes enhanced K8s capabilities for edge and AI/ML, OpenStack Train
+        live-migration extensions for easier infrastructure deployments and more.\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/how-domotz-streamlined-provisioning-of-iot-devices/17356\\\"\\u003eHow
+        Domotz streamlined provisioning of IoT devices\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/domotz-case-study\\u003c/td\\u003e\\n\\u003ctd\\u003ecase
+        study\\u003c/td\\u003e\\n\\u003ctd\\u003eubuntu-core, snaps, iot\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-10-10\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eLearn
+        how Ubuntu Core and snaps gives Domotz a competitive advantage\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/yahoo-japan-builds-their-iaas-environment-with-canonical/17355\\\"\\u003eYahoo!
+        Japan builds their IaaS environment with Canonical\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/yahoo-japan-case-study\\u003c/td\\u003e\\n\\u003ctd\\u003ecase
+        study\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack, maas, juju, ubuntu-advantage,
+        security\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-10-08\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/accelerating-deep-tech-with-ubuntu/17354\\\"\\u003eAccelerating
+        deep tech with Ubuntu\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/deeptech\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eiot,
+        robotics\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-10-02\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/from-vmware-to-charmed-openstack/17343\\\"\\u003eFrom
+        VMWare To Charmed OpenStack\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/vmware-to-charmed-openstack\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-09-04\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eReduce
+        costs and increase the efficiency of your infrastructure with open source
+        adoption\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/machine-learning-operations-mlops/17353\\\"\\u003eMachine
+        Learning Operations (MLOps)\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/get-started-with-ai-part-2\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eai,
+        ml\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-09-11\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eDeploy
+        at scale\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/how-to-manage-snaps-in-an-enterprise-environment/17352\\\"\\u003eHow
+        to manage snaps in an enterprise environment\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/enterprise-snap-management\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003esnaps,
+        security\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-08-20\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eHow
+        the Snap Store Proxy overcomes challenges presented by restricted networks
+        and management policies\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/a-guide-to-developing-android-apps-on-ubuntu/17351\\\"\\u003eA
+        guide to developing Android apps on Ubuntu\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/developing-android-on-ubuntu\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003edesktop,
+        apps\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-08-13\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/creating-a-cloud-like-bare-metal-experience-in-the-data-centre/17348\\\"\\u003eCreating
+        a cloud-like bare metal experience in the data centre\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/maas-hardware-testing\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003emaas\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-08-08\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/creating-accurate-ai-models-with-data/17349\\\"\\u003eCreating
+        accurate AI models with data\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/data-pipelines-kubeflow\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003ekubeflow,
+        ai\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-08-08\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eHow
+        Kubeflow and machine learning help you get the most out of your data\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/ims-evolve-adopts-ubuntu-core-to-provide-iot-enabled-business-intelligence-in-the-supply-chain/17284\\\"\\u003eIMS
+        Evolve adopts Ubuntu Core to provide IoT-enabled business intelligence in
+        the supply chain\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/casestudy-imsevolve\\u003c/td\\u003e\\n\\u003ctd\\u003ecase
+        study\\u003c/td\\u003e\\n\\u003ctd\\u003eiot\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-17\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/rocket-chat-communication-platform-enables-simplicity-through-snaps/17288\\\"\\u003eRocket.Chat
+        communication platform enables simplicity through snaps\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/casestudy-rocketchat\\u003c/td\\u003e\\n\\u003ctd\\u003ecase
+        study\\u003c/td\\u003e\\n\\u003ctd\\u003esnaps, apps\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-17\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/server-provisioning-what-network-admins-it-pros-need-to-know/17307\\\"\\u003eServer
+        Provisioning: What Network Admins \\u0026amp; IT Pros Need to Know\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/ebook-maas\\u003c/td\\u003e\\n\\u003ctd\\u003eeBook\\u003c/td\\u003e\\n\\u003ctd\\u003eserver\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-17\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/building-a-private-cloud-take-the-leap/17331\\\"\\u003eBuilding
+        a private cloud? Take the leap!\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/private-cloud\\u003c/td\\u003e\\n\\u003ctd\\u003eeBook\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack,
+        cloud\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-17\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/make-it-rain-public-cloud-on-ubuntu-openstack/17332\\\"\\u003eMake
+        IT rain: public cloud on Ubuntu OpenStack\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/public-cloud\\u003c/td\\u003e\\n\\u003ctd\\u003eeBook\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack,
+        cloud\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-17\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/learn-whats-new-in-ubuntu-server-14-04-lts/17344\\\"\\u003eLearn
+        What\u2019s New In Ubuntu Server 14.04 LTS\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/whats-new-ubuntu-14-04-lts\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eserver,
+        openstack\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-17\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/how-ubuntu-helped-innovapos-revolutionise-the-vending-machine-industry/17285\\\"\\u003eHow
+        Ubuntu helped InnovaPOS revolutionise the vending machine industry\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/casestudy-innovapos\\u003c/td\\u003e\\n\\u003ctd\\u003ecase
+        study\\u003c/td\\u003e\\n\\u003ctd\\u003eiot\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-16\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/nexiona-collaborates-with-canonical-and-dell-to-create-miimetiq-edge/17287\\\"\\u003eNEXIONA
+        collaborates with Canonical and Dell to create MIIMETIQ EDGE\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/casestudy-nexiona\\u003c/td\\u003e\\n\\u003ctd\\u003ecase
+        study\\u003c/td\\u003e\\n\\u003ctd\\u003eiot\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-16\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/azeti-uses-ubuntu-core-to-improve-deployment-and-security/17278\\\"\\u003eAzeti
+        uses Ubuntu Core to improve deployment and security\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/casestudy-azeti\\u003c/td\\u003e\\n\\u003ctd\\u003ecase
+        study\\u003c/td\\u003e\\n\\u003ctd\\u003esecurity, iot\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-16\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/azlogica-utilise-ubuntu-core-for-customised-iot-agricultural-solutions/17279\\\"\\u003eAZLOGICA
+        utilise Ubuntu Core for customised IoT agricultural solutions\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/casestudy-azlogica\\u003c/td\\u003e\\n\\u003ctd\\u003ecase
+        study\\u003c/td\\u003e\\n\\u003ctd\\u003eiot\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-16\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/botsandus-builds-a-social-robot-on-ubuntu/17280\\\"\\u003eBotsAndUs
+        builds a social robot on Ubuntu\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/casestudy-botsandus\\u003c/td\\u003e\\n\\u003ctd\\u003ecase
+        study\\u003c/td\\u003e\\n\\u003ctd\\u003erobotics\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-16\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/cinergy-makes-significant-digital-signage-saving-with-screenly-pro-and-ubuntu-core/17281\\\"\\u003eCinergy
+        makes significant digital signage saving with Screenly Pro and Ubuntu Core\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/casestudy-cinergy\\u003c/td\\u003e\\n\\u003ctd\\u003ecase
+        study\\u003c/td\\u003e\\n\\u003ctd\\u003edigital-signage\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-16\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/commercetools-uses-ubuntu-server-to-power-its-next-generation-ecommerce-platform/17283\\\"\\u003eCommercetools
+        uses Ubuntu Server to power its next-generation ecommerce platform\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/casestudy-commercetools\\u003c/td\\u003e\\n\\u003ctd\\u003ecase
+        study\\u003c/td\\u003e\\n\\u003ctd\\u003eserver, e-commerce\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-16\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/for-ctos-the-no-nonsense-way-to-accelerate-your-business-with-containers/17345\\\"\\u003eFor
+        CTOs: the no-nonsense way to accelerate your business with containers\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/whitepaper-containers\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003etelco\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-16\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/taking-charge-of-the-iots-security-vulnerabilities/17346\\\"\\u003eTaking
+        charge of the IoT\u2019s security vulnerabilities\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/whitepaper-iot-security\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eiot,
+        security\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-16\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/the-essential-guide-for-telecoms-and-service-providers-adopting-big-data-solutions/17309\\\"\\u003eThe
+        essential guide for Telecoms and Service Providers adopting big data solutions\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/essential-guide-big-data-solutions\\u003c/td\\u003e\\n\\u003ctd\\u003eeBook\\u003c/td\\u003e\\n\\u003ctd\\u003etelco,
+        openstack\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-15\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/city-network-brings-openstack-cloud-hosting-to-the-financial-services-sector-with-canonical/17282\\\"\\u003eCity
+        Network brings OpenStack cloud hosting to the financial services sector with
+        Canonical\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/casestudy-city-network\\u003c/td\\u003e\\n\\u003ctd\\u003ecase
+        study\\u003c/td\\u003e\\n\\u003ctd\\u003ecloud\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-15\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/cto-s-guide-to-sdn-nfv-vnf/17293\\\"\\u003eCTO\u2019s
+        guide to SDN, NFV \\u0026amp; VNF\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/cto-guide-sdn-nfv-vnf\\u003c/td\\u003e\\n\\u003ctd\\u003eeBook\\u003c/td\\u003e\\n\\u003ctd\\u003enetworking\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-15\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eWhy
+        is the transition happening and why is it important?\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/sensape-uses-landscape-to-remotely-support-revolutionary-interactive-retail-displays/17289\\\"\\u003eSensape
+        uses Landscape to remotely support revolutionary interactive retail displays\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/casestudy-sensape\\u003c/td\\u003e\\n\\u003ctd\\u003ecase
+        study\\u003c/td\\u003e\\n\\u003ctd\\u003edigital-signage\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-15\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/how-to-face-the-challenges-of-becoming-a-cloud-operator/17290\\\"\\u003eHow
+        to face the challenges of becoming a cloud operator\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/cloud-fray\\u003c/td\\u003e\\n\\u003ctd\\u003eeBook\\u003c/td\\u003e\\n\\u003ctd\\u003ecloud,
+        openstack, telco\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-15\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/low-latency-and-real-time-kernels-for-telco-and-nfv/17321\\\"\\u003eLow
+        latency and real time kernels for telco and NFV\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/low-latency-report\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003etelco\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-15\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/how-to-escape-stuckstack-and-profit-from-your-openstack-investment/17337\\\"\\u003eHow
+        to escape StuckStack and profit from your OpenStack investment\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/stuckstack-ebook\\u003c/td\\u003e\\n\\u003ctd\\u003eeBook\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-15\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/carrier-cloudification-what-every-telecom-executive-needs-to-know/17338\\\"\\u003eCarrier
+        Cloudification: What every telecom executive needs to know\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/telco-cloudification-ebook\\u003c/td\\u003e\\n\\u003ctd\\u003eeBook\\u003c/td\\u003e\\n\\u003ctd\\u003etelco,
+        cloud, openstack\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-15\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/nfv-and-sdn-on-openstack/17326\\\"\\u003eNFV
+        and SDN on OpenStack\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/nfv-sdn-openstack\\u003c/td\\u003e\\n\\u003ctd\\u003eeBook\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack,
+        networking\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-12\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/openstack-made-easy/17328\\\"\\u003eOpenStack
+        made easy\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/openstack-made-easy\\u003c/td\\u003e\\n\\u003ctd\\u003eeBook\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-12\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eWith
+        the right tools, OpenStack can be easy\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/telcos-and-service-providers-expect-near-100-uptime/17330\\\"\\u003eTelcos
+        and Service Providers expect near 100% uptime\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/openstack-telco-clouds\\u003c/td\\u003e\\n\\u003ctd\\u003eeBook\\u003c/td\\u003e\\n\\u003ctd\\u003etelco,
+        openstack, cloud\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-12\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eThis
+        requires a proven cloud platform that minimises time-to-revenue and ensures
+        predictable costs.\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/a-shift-to-the-linux-app-store-experience/17347\\\"\\u003eA
+        shift to the Linux app store experience\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/shift-to-app-store-experience\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eapps,
+        snaps\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-07-11\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eThe
+        key to optimising software distribution in a fragmented environment.\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/le-support-d-ubuntu-14-04-lts-est-maintenant-passe-a-esm/17413\\\"\\u003eLe
+        support d\u2019Ubuntu 14.04 LTS est maintenant pass\xE9 \xE0 ESM\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/fr/esm_1404\\u003c/td\\u003e\\n\\u003ctd\\u003eblog\\u003c/td\\u003e\\n\\u003ctd\\u003esecurity\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-06-28\\u003c/td\\u003e\\n\\u003ctd\\u003efr\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/a-guide-to-edge-computing-and-the-tools-you-need/17308\\\"\\u003eA
+        guide to edge computing and the tools you need\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/edge-month\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eedge,
+        cloud, kubernetes, maas\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-06-27\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eLearn
+        how edge computing provides enterprises with real-time data processing, cost-effective
+        security and scalability.\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/sicherheit-in-der-private-cloud/17411\\\"\\u003eSicherheit
+        in der Private Cloud\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/de/openstack-security-de\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack,
+        cloud\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-06-19\\u003c/td\\u003e\\n\\u003ctd\\u003ede\\u003c/td\\u003e\\n\\u003ctd\\u003eH\xF6chste
+        Anforderungen in Unternehmensumgebungen mit OpenStack erf\xFCllen.\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/how-to-get-started-and-progress-with-an-ai-program/17245\\\"\\u003eHow
+        to get started and progress with an AI program\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/ai-gettingstarted\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eai,
+        ml\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-06-11\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/the-future-of-mobile-connectivity/17342\\\"\\u003eThe
+        future of mobile connectivity\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/ubuntu-lime-telco\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003etelco\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-06-12\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eMajor
+        mobile operators are adopting open source versus proprietary technologies
+        to reduce costs.\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/north-america-s-first-autonomous-runway-snowplough/17327\\\"\\u003eNorth
+        America\u2018s first autonomous runway snowplough\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/northstar\\u003c/td\\u003e\\n\\u003ctd\\u003ecase
+        study\\u003c/td\\u003e\\n\\u003ctd\\u003erobotics, iot\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-06-05\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eThe
+        robots helping to address off-highway labour shortages\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/small-robot-company-sows-the-seeds-for-autonomous-and-more-profitable-farming/17334\\\"\\u003eSmall
+        Robot Company sows the seeds for autonomous and more profitable farming\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/small-robot-company\\u003c/td\\u003e\\n\\u003ctd\\u003ecase
+        study\\u003c/td\\u003e\\n\\u003ctd\\u003erobotics, ai\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-06-04\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/how-to-integrate-ubuntu-desktop-with-active-directory/17323\\\"\\u003eHow
+        to integrate Ubuntu Desktop with Active Directory\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/microsoft-active-directory\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003edesktop,
+        active-directory\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-06-04\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/connected-cars-and-autonomous-driving/17243\\\"\\u003eConnected
+        cars and autonomous driving\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/451-automotive\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eiot\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-05-31\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eAddressing
+        risk and complexity with software\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/why-ubuntu-core-is-the-most-secure-choice-for-iot/17292\\\"\\u003eWhy
+        Ubuntu Core is the most secure choice for IoT\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/core18-security\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003esecurity,
+        iot, ubuntu-core\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-05-29\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/getting-started-with-ai/17336\\\"\\u003eGetting
+        started with AI\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/starting-with-ai\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eai,
+        ml\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-05-11\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/the-transformation-of-the-devops-journey-in-iot/17422\\\"\\u003eThe
+        transformation of the DevOps journey in IoT\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/iot-devops\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eiot\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-05-07\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/cloud-init/17291\\\"\\u003eCloud init\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/cloud-init-whitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003ecloud\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-05-01\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/how-to-build-a-lightweight-system-container-cluster/17322\\\"\\u003eHow
+        to build a lightweight system container cluster\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/lxd-whitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003elxd\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-04-30\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eYou
+        will learn how working in this environment:\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/the-transformation-of-the-devops-journey-in-iot-webinar/17306\\\"\\u003eThe
+        transformation of the DevOps journey in IoT Webinar\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/devops-iot-webinar\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eiot\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-04-29\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/private-cloud-security-webinar/17329\\\"\\u003ePrivate
+        cloud security Webinar\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/openstack-security-webinar\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack,
+        security\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-04-24\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eHow
+        Charmed OpenStack is decreasing common security concerns\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/private-cloud-security/17421\\\"\\u003ePrivate
+        cloud security\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/openstack-security-whitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack,
+        security\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-04-24\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eMeeting
+        the highest levels of enterprise requirements with OpenStack\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/hiri-successfully-monetises-their-snap/17314\\\"\\u003eHiri
+        successfully monetises their snap\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/hiri-case-study\\u003c/td\\u003e\\n\\u003ctd\\u003ecase
+        study\\u003c/td\\u003e\\n\\u003ctd\\u003eapps, snaps\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-04-25\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/whats-new-in-ubuntu-19-04/17240\\\"\\u003eWhat\u2019s
+        new in Ubuntu 19.04?\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/19-04-webinar\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack,
+        kubernetes, ceph, iot, desktop\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-04-18\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eJoin
+        Canonical Product Director Stephan Fabel and Ubuntu Product Managers to discuss
+        everything new in Ubuntu 19.04 \u2018Disco Dingo\u2019\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/optimising-iot-bandwidth-with-delta-updates/17335\\\"\\u003eOptimising
+        IoT bandwidth with delta updates\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/snap-deltas\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eiot,
+        snaps\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-03-16\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eLearn
+        how snap deltas\u2019 over-the-air updates are efficient and effective.\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/an-introduction-to-apparmor/17277\\\"\\u003eAn
+        introduction to AppArmor\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/apparmor-intro\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003esecurity\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-03-16\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eAn
+        explanation of AppArmor and its key features.\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/get-started-with-devops-best-practices-ci-cd/17305\\\"\\u003eGet
+        started with DevOps best practices: CI/CD\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/devops-cicd-webinar\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003ekubernetes\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-03-07\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/esm-for-ubuntu-14-04-lts-trusty-tahr/17275\\\"\\u003eESM
+        for Ubuntu 14.04 LTS Trusty Tahr\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/14-04-esm\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003esecurity\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-02-21\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eLearn
+        how to maintain ongoing security compliance for your 14.04 systems.\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/securing-iot-device-data-against-physical-access/17318\\\"\\u003eSecuring
+        IoT device data against physical access\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/iot-disk-encryption\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eiot,
+        security, ubuntu-core\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-02-11\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eA
+        technical overview of how Ubuntu Core with full disk encryption and secure
+        boot can be implemented to harden IoT devices\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/multi-cloud-fundamental-to-financial-services-transformation/17312\\\"\\u003eMulti-cloud
+        fundamental to financial services transformation\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/finserv-multi-cloud\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003ecloud,
+        finance, ai\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-02-04\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/extension-securite-et-maintenance-pour-ubuntu-14-04/17414\\\"\\u003eExtension
+        S\xE9curit\xE9 et Maintenance pour Ubuntu 14.04\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/fr/esm\\u003c/td\\u003e\\n\\u003ctd\\u003eblog\\u003c/td\\u003e\\n\\u003ctd\\u003esecurity\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-01-31\\u003c/td\\u003e\\n\\u003ctd\\u003efr\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/utiliser-des-gpus-avec-kubernetes/17419\\\"\\u003eUtiliser
+        des GPUs avec Kubernetes\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/fr/utiliser-gpgpus-avec-kubernetes\\u003c/td\\u003e\\n\\u003ctd\\u003eblog\\u003c/td\\u003e\\n\\u003ctd\\u003ekubernetes\\u003c/td\\u003e\\n\\u003ctd\\u003e2018-12-20\\u003c/td\\u003e\\n\\u003ctd\\u003efr\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/apellix-engineers-safer-work-environments-with-ubuntu-powered-aerial-robotics/17315\\\"\\u003eApellix
+        engineers safer work environments with Ubuntu powered aerial robotics\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/industrial-drones-case-study\\u003c/td\\u003e\\n\\u003ctd\\u003ecase
+        study\\u003c/td\\u003e\\n\\u003ctd\\u003erobotics, iot\\u003c/td\\u003e\\n\\u003ctd\\u003e2018-12-14\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/allan-gray-unlocks-unprecedented-availability-and-productivity-with-charmed-kubernetes/17319\\\"\\u003eAllan
+        Gray unlocks unprecedented availability and productivity with Charmed Kubernetes\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/k8s-allan-gray\\u003c/td\\u003e\\n\\u003ctd\\u003ecase
+        study\\u003c/td\\u003e\\n\\u003ctd\\u003efinance, kubernetes\\u003c/td\\u003e\\n\\u003ctd\\u003e2018-12-13\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/six-reasons-why-developers-choose-ubuntu-desktop/17304\\\"\\u003eSix
+        reasons why developers choose Ubuntu Desktop\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/developer-desktop\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003edesktop\\u003c/td\\u003e\\n\\u003ctd\\u003e2018-11-23\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/modernise-your-cloud/17324\\\"\\u003eModernise
+        your cloud\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/modern-cloud\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003ecloud\\u003c/td\\u003e\\n\\u003ctd\\u003e2018-11-22\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eDiscover
+        how Trilio and Canonical help organisations transition to new, maintainable
+        cloud architecture in just weeks.\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/precision-drones-on-ubuntu-flying-at-the-edge-of-innovation/17316\\\"\\u003ePrecision
+        drones on Ubuntu: flying at the edge of innovation\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/industrial-drones\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003erobotics,
+        iot\\u003c/td\\u003e\\n\\u003ctd\\u003e2018-11-20\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eHow
+        Apellix uses Ubuntu on drones to replace human workers in potentially dangerous
+        scenarios.\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/securing-the-enterprise-how-ubuntu-is-at-the-forefront-of-security-and-compliance/17340\\\"\\u003eSecuring
+        the enterprise: how Ubuntu is at the forefront of security and compliance\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/ubuntu-compliance\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003esecurity\\u003c/td\\u003e\\n\\u003ctd\\u003e2018-11-12\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/itstrategen-keeps-legacy-applications-secure-with-extended-security-maintenance/17286\\\"\\u003eITstrategen
+        keeps legacy applications secure with Extended Security Maintenance\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/ITstrategen-case-study\\u003c/td\\u003e\\n\\u003ctd\\u003ecase
+        study\\u003c/td\\u003e\\n\\u003ctd\\u003esecurity\\u003c/td\\u003e\\n\\u003ctd\\u003e2018-10-29\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/what-s-new-in-ubuntu-18-10/17339\\\"\\u003eWhat\u2019s
+        New in Ubuntu 18.10\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/ubuntu-18-10\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003edesktop,
+        server\\u003c/td\\u003e\\n\\u003ctd\\u003e2018-10-29\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eCanonical
+        product managers discuss the new Ubuntu 18.10 release features in this on-demand
+        webinar\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/ubuntu-core-and-kura-a-framework-for-iot-gateways/17341\\\"\\u003eUbuntu
+        Core and Kura: A framework for IoT gateways\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/ubuntu-core-and-kura\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eubuntu-core,
+        iot, edge, snaps\\u003c/td\\u003e\\n\\u003ctd\\u003e2018-10-23\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/keep-up-with-evolving-software/17310\\\"\\u003eKeep
+        up with evolving software\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/evolving-software\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003ejuju,
+        cloud\\u003c/td\\u003e\\n\\u003ctd\\u003e2018-10-22\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eLearn
+        how Juju can help solve software management complexity.\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/wofur-konnen-sie-kubernetes-einsetzen/17410\\\"\\u003eWof\xFCr
+        k\xF6nnen Sie Kubernetes einsetzen?\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/de/what-can-you-do-with-kubernetes\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003ekubernetes\\u003c/td\\u003e\\n\\u003ctd\\u003e2018-10-19\\u003c/td\\u003e\\n\\u003ctd\\u003ede\\u003c/td\\u003e\\n\\u003ctd\\u003eDieses
+        Webinar liefert Ihnen alles Wichtige zum Einstieg.\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/low-latency-and-real-time-kernels-for-telco-and-nfv/17320\\\"\\u003eLow
+        latency and real-time kernels for telco and NFV\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/kernel-telco-nfv\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003etelco\\u003c/td\\u003e\\n\\u003ctd\\u003e2018-10-08\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/future-proofing-fingbox-the-iot-home-network-monitoring-device/17313\\\"\\u003eFuture-proofing
+        Fingbox, the IoT home network monitoring device\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/future-proof-iot\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eiot,
+        ubuntu-core\\u003c/td\\u003e\\n\\u003ctd\\u003e2018-10-02\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/how-to-build-and-deploy-your-first-ai-ml-model-on-ubuntu/17294\\\"\\u003eHow
+        to build and deploy your first AI/ML model on Ubuntu\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/deploy-ai-ml-model\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eai,
+        ml, kubeflow, kubernetes\\u003c/td\\u003e\\n\\u003ctd\\u003e2018-09-26\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eAn
+        introduction to AI and ML workloads on Ubuntu workstations, servers and in
+        the cloud on a Kubernetes stack.\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/openstack-problemlos-installieren-und-skalieren/17409\\\"\\u003eOpenStack
+        problemlos installieren und skalieren\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/de/openstack-made-easy\\u003c/td\\u003e\\n\\u003ctd\\u003eeBook\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack\\u003c/td\\u003e\\n\\u003ctd\\u003e2018-09-05\\u003c/td\\u003e\\n\\u003ctd\\u003ede\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/key-considerations-when-choosing-a-robot-s-operating-system/17333\\\"\\u003eKey
+        considerations when choosing a robot\u2019s operating system\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/robot-operating-system-choice\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003erobotics\\u003c/td\\u003e\\n\\u003ctd\\u003e2018-09-05\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/cio-guide-to-multi-cloud-operations/17325\\\"\\u003eCIO
+        guide to multi-cloud operations\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/multi-cloud-guide\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003ecloud,
+        kubernetes, container\\u003c/td\\u003e\\n\\u003ctd\\u003e2018-09-03\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/canonical-presents-financial-services-month/17241\\\"\\u003eCanonical
+        presents Financial Services Month\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/financial-services-month\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003efinance,
+        ai, ml cloud\\u003c/td\\u003e\\n\\u003ctd\\u003e2018-09-03\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eFilmed
+        at the London Stock exchange with representatives from Canonical, 451 Research,
+        IBM, and a former Deutsche Bank storage CTO, Canonical took a deep dive look
+        in to the rise of multi-cloud in the financial services industry.\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/establishing-a-software-defined-iot-business-model/17317\\\"\\u003eEstablishing
+        a software defined IoT business model\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/iot-business-model\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eiot\\u003c/td\\u003e\\n\\u003ctd\\u003e2018-08-24\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/artificial-intelligence-machine-learning-and-ubuntu/17276\\\"\\u003eArtificial
+        intelligence, machine learning and Ubuntu\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/ai-ml-ubuntu\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eai,
+        ml, kubernetes\\u003c/td\\u003e\\n\\u003ctd\\u003e2018-08-16\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/von-vmware-zu-canonical-openstack/17408\\\"\\u003eVon
+        VMware zu Canonical OpenStack\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/de/vmware-to-openstack\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack\\u003c/td\\u003e\\n\\u003ctd\\u003e2018-08-06\\u003c/td\\u003e\\n\\u003ctd\\u003ede\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/fing-serves-30-000-customers-with-a-secure-future-proof-iot-device/17311\\\"\\u003eFing
+        serves 30,000 customers with a secure, future-proof IoT device\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/fingbox-case-study\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eiot,
+        ubuntu-core, snaps\\u003c/td\\u003e\\n\\u003ctd\\u003e2018-06-25\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/canonical-integre-containerd-a-ubuntu-kubernetes/17412\\\"\\u003eCanonical
+        int\xE8gre containerd \xE0 Ubuntu Kubernetes\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/fr/canonical-ajoute-containerd-a-ubuntu-kubernetes\\u003c/td\\u003e\\n\\u003ctd\\u003eblog\\u003c/td\\u003e\\n\\u003ctd\\u003ekubernetes\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-05-22\\u003c/td\\u003e\\n\\u003ctd\\u003efr\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/guide-du-dsi-pour-les-operations-multicloud/17415\\\"\\u003eGUIDE
+        DU DSI pour les op\xE9rations multicloud\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/fr/guide-du-DSI-pour-les-operations-multicloud\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003ecloud,
+        kubernetes\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-05-22\\u003c/td\\u003e\\n\\u003ctd\\u003efr\\u003c/td\\u003e\\n\\u003ctd\\u003eChoisir
+        une architecture cloud rentable\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/canonical-annonce-managed-apps-linfogerance-des-applications-sur-votre-cloud/17416\\\"\\u003eCanonical
+        annonce Managed Apps: l\u2019infog\xE9rance des applications sur votre cloud.\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/fr/managed-apps\\u003c/td\\u003e\\n\\u003ctd\\u003eblog\\u003c/td\\u003e\\n\\u003ctd\\u003eapps\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-05-18\\u003c/td\\u003e\\n\\u003ctd\\u003efr\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/migrer-de-vmware-a-openstack/17417\\\"\\u003eMigrer
+        de VMWare \xE0 OpenStack\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/fr/migrer-de-vmware-a-openstack\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-05-18\\u003c/td\\u003e\\n\\u003ctd\\u003efr\\u003c/td\\u003e\\n\\u003ctd\\u003ePassez
+        \xE0 Charmed OpenStack et r\xE9duisez consid\xE9rablement vos co\xFBts\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/migrer-de-vmware-a-openstack-webinaire/17420\\\"\\u003eMigrer
+        de VMware \xE0 Openstack Webinaire\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/fr/vmware-to-openstack\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-05-18\\u003c/td\\u003e\\n\\u003ctd\\u003efr\\u003c/td\\u003e\\n\\u003ctd\\u003eApprenez
+        comment migrer d\u2019un environnement traditionnel et propri\xE9taire \xE0
+        un cloud OpenStack\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/charmed-kubernetes-reference-architecture/19159\\\"\\u003eCharmed
+        Kubernetes reference architecture\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/dell-k8s-reference-architecture\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003ekubernetes\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-11-07\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eIntegration
+        with VxFlex OS delivered by Dell EMC and Canonical.\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/charmed-openstack-reference-architecture/19160\\\"\\u003eCharmed
+        OpenStack reference architecture\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/dell-openstack-reference-architecture\\u003c/td\\u003e\\n\\u003ctd\\u003ewhitepaper\\u003c/td\\u003e\\n\\u003ctd\\u003eopenstack\\u003c/td\\u003e\\n\\u003ctd\\u003e2019-11-07\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eWith
+        Dell EMC PowerEdge servers for workloads and storage and Dell EMC Networking
+        and Canonical.\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/at-t-private-offer-on-azure-ubuntu-pro-support/19161\\\"\\u003eAT\\u0026amp;T
+        Private Offer on Azure - Ubuntu Pro + Support\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/at\\u0026amp;t-azure-webinar\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003eubuntu-advantage\\u003c/td\\u003e\\n\\u003ctd\\u003e2020-06-30\\u003c/td\\u003e\\n\\u003ctd\\u003een\\u003c/td\\u003e\\n\\u003ctd\\u003eSecure,
+        updated Ubuntu with 24x7 support special pricing and SLAs for AT\\u0026amp;T.\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003ctr\\u003e\\n\\u003ctd\\u003e\\u003ca
+        href=\\\"https://discourse.ubuntu.com/t/finserv-open-source-infrastructure-powers-hybrid-cloud-strategy/24008\\\"\\u003eFinserv
+        open source infrastructure powers hybrid cloud strategy\\u003c/a\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003e/engage/finserv-hybrid-cloud-webinar\\u003c/td\\u003e\\n\\u003ctd\\u003ewebinar\\u003c/td\\u003e\\n\\u003ctd\\u003efinancial
+        services, open source, openstack, cloud, hybrid cloud\\u003c/td\\u003e\\n\\u003ctd\\u003e2021-09-02\\u003c/td\\u003e\\n\\u003ctd\\u003e\\u003c/td\\u003e\\n\\u003ctd\\u003eAn
+        overview of how to simplify the deployment and management of an OpenStack
+        cloud.\\u003c/td\\u003e\\n\\u003ctd\\u003etrue\\u003c/td\\u003e\\n\\u003c/tr\\u003e\\n\\u003c/tbody\\u003e\\n\\u003c/table\\u003e\\n\\u003c/div\\u003e\\u003c/details\\u003e\",\"post_number\":1,\"post_type\":1,\"updated_at\":\"2021-12-07T13:03:15.023Z\",\"reply_count\":0,\"reply_to_post_number\":null,\"quote_count\":0,\"incoming_link_count\":4,\"reads\":17,\"readers_count\":16,\"score\":13.2,\"yours\":true,\"topic_id\":18033,\"topic_slug\":\"engage-pages-for-ubuntu-com\",\"display_username\":\"Carlos
+        Wu Fei\",\"primary_group_name\":\"Canonical\",\"primary_group_flair_url\":\"/uploads/short-url/paWz8RxxmKxiYXUmH2ABvqKp0Gg.png\",\"primary_group_flair_bg_color\":\"\",\"primary_group_flair_color\":\"\",\"version\":50,\"can_edit\":true,\"can_delete\":false,\"can_recover\":false,\"can_wiki\":true,\"link_counts\":[{\"url\":\"https://ubuntu.com/engage\",\"internal\":false,\"reflection\":false,\"title\":\"Ubuntu
+        case studies, whitepapers and webinars | Ubuntu\",\"clicks\":3},{\"url\":\"https://discourse.ubuntu.com/t/at-t-private-offer-on-azure-ubuntu-pro-support/19161\",\"internal\":true,\"reflection\":false,\"title\":\"AT\\u0026T
+        Private Offer on Azure - Ubuntu Pro + Support\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/charmed-openstack-reference-architecture/19160\",\"internal\":true,\"reflection\":false,\"title\":\"Charmed
+        OpenStack reference architecture\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/charmed-kubernetes-reference-architecture/19159\",\"internal\":true,\"reflection\":false,\"title\":\"Charmed
+        Kubernetes reference architecture\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/migrer-de-vmware-a-openstack-webinaire/17420\",\"internal\":true,\"reflection\":false,\"title\":\"Migrer
+        de VMware \xE0 Openstack Webinaire\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/migrer-de-vmware-a-openstack/17417\",\"internal\":true,\"reflection\":false,\"title\":\"Migrer
+        de VMWare \xE0 OpenStack\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/canonical-annonce-managed-apps-linfogerance-des-applications-sur-votre-cloud/17416\",\"internal\":true,\"reflection\":false,\"title\":\"Canonical
+        annonce Managed Apps: l'infog\xE9rance des applications sur votre cloud\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/guide-du-dsi-pour-les-operations-multicloud/17415\",\"internal\":true,\"reflection\":false,\"title\":\"GUIDE
+        DU DSI pour les op\xE9rations multicloud\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/canonical-integre-containerd-a-ubuntu-kubernetes/17412\",\"internal\":true,\"reflection\":false,\"title\":\"Canonical
+        int\xE8gre containerd \xE0 Ubuntu Kubernetes\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/fing-serves-30-000-customers-with-a-secure-future-proof-iot-device/17311\",\"internal\":true,\"reflection\":false,\"title\":\"Fing
+        serves 30,000 customers with a secure, future-proof IoT device\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/von-vmware-zu-canonical-openstack/17408\",\"internal\":true,\"reflection\":false,\"title\":\"Von
+        VMware zu Canonical OpenStack\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/artificial-intelligence-machine-learning-and-ubuntu/17276\",\"internal\":true,\"reflection\":false,\"title\":\"Artificial
+        intelligence, machine learning and Ubuntu\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/establishing-a-software-defined-iot-business-model/17317\",\"internal\":true,\"reflection\":false,\"title\":\"Establishing
+        a software defined IoT business model\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/canonical-presents-financial-services-month/17241\",\"internal\":true,\"reflection\":false,\"title\":\"Canonical
+        presents Financial Services Month\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/cio-guide-to-multi-cloud-operations/17325\",\"internal\":true,\"reflection\":false,\"title\":\"CIO
+        guide to multi-cloud operations\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/key-considerations-when-choosing-a-robot-s-operating-system/17333\",\"internal\":true,\"reflection\":false,\"title\":\"Key
+        considerations when choosing a robot\u2019s operating system\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/openstack-problemlos-installieren-und-skalieren/17409\",\"internal\":true,\"reflection\":false,\"title\":\"OpenStack
+        problemlos installieren und skalieren\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/how-to-build-and-deploy-your-first-ai-ml-model-on-ubuntu/17294\",\"internal\":true,\"reflection\":false,\"title\":\"How
+        to build and deploy your first AI/ML model on Ubuntu\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/future-proofing-fingbox-the-iot-home-network-monitoring-device/17313\",\"internal\":true,\"reflection\":false,\"title\":\"Future-proofing
+        Fingbox, the IoT home network monitoring device\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/low-latency-and-real-time-kernels-for-telco-and-nfv/17320\",\"internal\":true,\"reflection\":false,\"title\":\"Low
+        latency and real-time kernels for telco and NFV\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/wofur-konnen-sie-kubernetes-einsetzen/17410\",\"internal\":true,\"reflection\":false,\"title\":\"Wof\xFCr
+        k\xF6nnen Sie Kubernetes einsetzen?\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/keep-up-with-evolving-software/17310\",\"internal\":true,\"reflection\":false,\"title\":\"Keep
+        up with evolving software\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/ubuntu-core-and-kura-a-framework-for-iot-gateways/17341\",\"internal\":true,\"reflection\":false,\"title\":\"Ubuntu
+        Core and Kura: A framework for IoT gateways\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/what-s-new-in-ubuntu-18-10/17339\",\"internal\":true,\"reflection\":false,\"title\":\"What\u2019s
+        New in Ubuntu 18.10\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/itstrategen-keeps-legacy-applications-secure-with-extended-security-maintenance/17286\",\"internal\":true,\"reflection\":false,\"title\":\"ITstrategen
+        keeps legacy applications secure with Extended Security Maintenance\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/securing-the-enterprise-how-ubuntu-is-at-the-forefront-of-security-and-compliance/17340\",\"internal\":true,\"reflection\":false,\"title\":\"Securing
+        the enterprise: how Ubuntu is at the forefront of security and compliance\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/precision-drones-on-ubuntu-flying-at-the-edge-of-innovation/17316\",\"internal\":true,\"reflection\":false,\"title\":\"Precision
+        drones on Ubuntu: flying at the edge of innovation\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/modernise-your-cloud/17324\",\"internal\":true,\"reflection\":false,\"title\":\"Modernise
+        your cloud\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/six-reasons-why-developers-choose-ubuntu-desktop/17304\",\"internal\":true,\"reflection\":false,\"title\":\"Six
+        reasons why developers choose Ubuntu Desktop\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/allan-gray-unlocks-unprecedented-availability-and-productivity-with-charmed-kubernetes/17319\",\"internal\":true,\"reflection\":false,\"title\":\"Allan
+        Gray unlocks unprecedented availability and productivity with Charmed Kubernetes\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/apellix-engineers-safer-work-environments-with-ubuntu-powered-aerial-robotics/17315\",\"internal\":true,\"reflection\":false,\"title\":\"Apellix
+        engineers safer work environments with Ubuntu powered aerial robotics\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/utiliser-des-gpus-avec-kubernetes/17419\",\"internal\":true,\"reflection\":false,\"title\":\"Utiliser
+        des GPUs avec Kubernetes\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/extension-securite-et-maintenance-pour-ubuntu-14-04/17414\",\"internal\":true,\"reflection\":false,\"title\":\"Extension
+        S\xE9curit\xE9 et Maintenance pour Ubuntu 14.04\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/multi-cloud-fundamental-to-financial-services-transformation/17312\",\"internal\":true,\"reflection\":false,\"title\":\"Multi-cloud
+        fundamental to financial services transformation\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/securing-iot-device-data-against-physical-access/17318\",\"internal\":true,\"reflection\":false,\"title\":\"Securing
+        IoT device data against physical access\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/still-running-ubuntu-14-04/17275\",\"internal\":true,\"reflection\":false,\"title\":\"Still
+        running Ubuntu 14.04?\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/get-started-with-devops-best-practices-ci-cd/17305\",\"internal\":true,\"reflection\":false,\"title\":\"Get
+        started with DevOps best practices: CI/CD\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/an-introduction-to-apparmor/17277\",\"internal\":true,\"reflection\":false,\"title\":\"An
+        introduction to AppArmor\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/optimising-iot-bandwidth-with-delta-updates/17335\",\"internal\":true,\"reflection\":false,\"title\":\"Optimising
+        IoT bandwidth with delta updates\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/whats-new-in-ubuntu-19-04/17240\",\"internal\":true,\"reflection\":false,\"title\":\"What's
+        new in Ubuntu 19.04?\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/hiri-successfully-monetises-their-snap/17314\",\"internal\":true,\"reflection\":false,\"title\":\"Hiri
+        successfully monetises their snap\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/private-cloud-security/17421\",\"internal\":true,\"reflection\":false,\"title\":\"Private
+        cloud security\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/private-cloud-security-webinar/17329\",\"internal\":true,\"reflection\":false,\"title\":\"Private
+        cloud security Webinar\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/the-transformation-of-the-devops-journey-in-iot-webinar/17306\",\"internal\":true,\"reflection\":false,\"title\":\"The
+        transformation of the DevOps journey in IoT Webinar\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/how-to-build-a-lightweight-system-container-cluster/17322\",\"internal\":true,\"reflection\":false,\"title\":\"How
+        to build a lightweight system container cluster\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/cloud-init/17291\",\"internal\":true,\"reflection\":false,\"title\":\"Cloud
+        init\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/the-transformation-of-the-devops-journey-in-iot/17422\",\"internal\":true,\"reflection\":false,\"title\":\"The
+        transformation of the DevOps journey in IoT\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/getting-started-with-ai/17336\",\"internal\":true,\"reflection\":false,\"title\":\"Getting
+        started with AI\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/why-ubuntu-core-is-the-most-secure-choice-for-iot/17292\",\"internal\":true,\"reflection\":false,\"title\":\"Why
+        Ubuntu Core is the most secure choice for IoT\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/connected-cars-and-autonomous-driving/17243\",\"internal\":true,\"reflection\":false,\"title\":\"Connected
+        cars and autonomous driving\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/how-to-integrate-ubuntu-desktop-with-active-directory/17323\",\"internal\":true,\"reflection\":false,\"title\":\"How
+        to integrate Ubuntu Desktop with Active Directory\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/small-robot-company-sows-the-seeds-for-autonomous-and-more-profitable-farming/17334\",\"internal\":true,\"reflection\":false,\"title\":\"Small
+        Robot Company sows the seeds for autonomous and more profitable farming\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/north-america-s-first-autonomous-runway-snowplough/17327\",\"internal\":true,\"reflection\":false,\"title\":\"North
+        America\u2018s first autonomous runway snowplough\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/the-future-of-mobile-connectivity/17342\",\"internal\":true,\"reflection\":false,\"title\":\"The
+        future of mobile connectivity\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/how-to-get-started-and-progress-with-an-ai-program/17245\",\"internal\":true,\"reflection\":false,\"title\":\"How
+        to get started and progress with an AI program\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/sicherheit-in-der-private-cloud/17411\",\"internal\":true,\"reflection\":false,\"title\":\"Sicherheit
+        in der Private Cloud\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/a-guide-to-edge-computing-and-the-tools-you-need/17308\",\"internal\":true,\"reflection\":false,\"title\":\"A
+        guide to edge computing and the tools you need\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/le-support-d-ubuntu-14-04-lts-est-maintenant-passe-a-esm/17413\",\"internal\":true,\"reflection\":false,\"title\":\"Le
+        support d\u2019Ubuntu 14.04 LTS est maintenant pass\xE9 \xE0 ESM\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/a-shift-to-the-linux-app-store-experience/17347\",\"internal\":true,\"reflection\":false,\"title\":\"A
+        shift to the Linux app store experience\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/telcos-and-service-providers-expect-near-100-uptime/17330\",\"internal\":true,\"reflection\":false,\"title\":\"Telcos
+        and Service Providers expect near 100% uptime\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/openstack-made-easy/17328\",\"internal\":true,\"reflection\":false,\"title\":\"OpenStack
+        made easy\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/nfv-and-sdn-on-openstack-for-network-operators/17326\",\"internal\":true,\"reflection\":false,\"title\":\"NFV
+        and SDN on OpenStack for network operators\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/carrier-cloudification-what-every-telecom-executive-needs-to-know/17338\",\"internal\":true,\"reflection\":false,\"title\":\"Carrier
+        Cloudification: What every telecom executive needs to know\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/how-to-escape-stuckstack-and-profit-from-your-openstack-investment/17337\",\"internal\":true,\"reflection\":false,\"title\":\"How
+        to escape StuckStack and profit from your OpenStack investment\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/low-latency-and-real-time-kernels-for-telco-and-nfv/17321\",\"internal\":true,\"reflection\":false,\"title\":\"Low
+        latency and real time kernels for telco and NFV\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/how-to-face-the-challenges-of-becoming-a-cloud-operator/17290\",\"internal\":true,\"reflection\":false,\"title\":\"How
+        to face the challenges of becoming a cloud operator\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/sensape-uses-landscape-to-remotely-support-revolutionary-interactive-retail-displays/17289\",\"internal\":true,\"reflection\":false,\"title\":\"Sensape
+        uses Landscape to remotely support revolutionary interactive retail displays\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/cto-s-guide-to-sdn-nfv-vnf/17293\",\"internal\":true,\"reflection\":false,\"title\":\"CTO\u2019s
+        guide to SDN, NFV \\u0026 VNF\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/city-network-brings-openstack-cloud-hosting-to-the-financial-services-sector-with-canonical/17282\",\"internal\":true,\"reflection\":false,\"title\":\"City
+        Network brings OpenStack cloud hosting to the financial services sector with
+        Canonical\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/the-essential-guide-for-telecoms-and-service-providers-adopting-big-data-solutions/17309\",\"internal\":true,\"reflection\":false,\"title\":\"The
+        essential guide for Telecoms and Service Providers adopting big data solutions\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/taking-charge-of-the-iots-security-vulnerabilities/17346\",\"internal\":true,\"reflection\":false,\"title\":\"Taking
+        charge of the IoT's security vulnerabilities\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/for-ctos-the-no-nonsense-way-to-accelerate-your-business-with-containers/17345\",\"internal\":true,\"reflection\":false,\"title\":\"For
+        CTOs: the no-nonsense way to accelerate your business with containers\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/commercetools-uses-ubuntu-server-to-power-its-next-generation-ecommerce-platform/17283\",\"internal\":true,\"reflection\":false,\"title\":\"Commercetools
+        uses Ubuntu Server to power its next-generation ecommerce platform\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/cinergy-makes-significant-digital-signage-saving-with-screenly-pro-and-ubuntu-core/17281\",\"internal\":true,\"reflection\":false,\"title\":\"Cinergy
+        makes significant digital signage saving with Screenly Pro and Ubuntu Core\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/botsandus-builds-a-social-robot-on-ubuntu/17280\",\"internal\":true,\"reflection\":false,\"title\":\"BotsAndUs
+        builds a social robot on Ubuntu\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/azlogica-utilise-ubuntu-core-for-customised-iot-agricultural-solutions/17279\",\"internal\":true,\"reflection\":false,\"title\":\"AZLOGICA
+        utilise Ubuntu Core for customised IoT agricultural solutions\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/azeti-uses-ubuntu-core-to-improve-deployment-and-security/17278\",\"internal\":true,\"reflection\":false,\"title\":\"Azeti
+        uses Ubuntu Core to improve deployment and security\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/nexiona-collaborates-with-canonical-and-dell-to-create-miimetiq-edge/17287\",\"internal\":true,\"reflection\":false,\"title\":\"NEXIONA
+        collaborates with Canonical and Dell to create MIIMETIQ EDGE\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/how-ubuntu-helped-innovapos-revolutionise-the-vending-machine-industry/17285\",\"internal\":true,\"reflection\":false,\"title\":\"How
+        Ubuntu helped InnovaPOS revolutionise the vending machine industry\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/learn-whats-new-in-ubuntu-server-14-04-lts/17344\",\"internal\":true,\"reflection\":false,\"title\":\"Learn
+        What's New In Ubuntu Server 14.04 LTS\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/make-it-rain-public-cloud-on-ubuntu-openstack/17332\",\"internal\":true,\"reflection\":false,\"title\":\"Make
+        IT rain: public cloud on Ubuntu OpenStack\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/building-a-private-cloud-take-the-leap/17331\",\"internal\":true,\"reflection\":false,\"title\":\"Building
+        a private cloud? Take the leap!\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/server-provisioning-what-network-admins-it-pros-need-to-know/17307\",\"internal\":true,\"reflection\":false,\"title\":\"Server
+        Provisioning: What Network Admins \\u0026 IT Pros Need to Know\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/rocket-chat-communication-platform-enables-simplicity-through-snaps/17288\",\"internal\":true,\"reflection\":false,\"title\":\"Rocket.Chat
+        communication platform enables simplicity through snaps\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/ims-evolve-adopts-ubuntu-core-to-provide-iot-enabled-business-intelligence-in-the-supply-chain/17284\",\"internal\":true,\"reflection\":false,\"title\":\"IMS
+        Evolve adopts Ubuntu Core to provide IoT-enabled business intelligence in
+        the supply chain\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/creating-accurate-ai-models-with-data/17349\",\"internal\":true,\"reflection\":false,\"title\":\"Creating
+        accurate AI models with data\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/creating-a-cloud-like-bare-metal-experience-in-the-data-centre/17348\",\"internal\":true,\"reflection\":false,\"title\":\"Creating
+        a cloud-like bare metal experience in the data centre\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/a-guide-to-developing-android-apps-on-ubuntu/17351\",\"internal\":true,\"reflection\":false,\"title\":\"A
+        guide to developing Android apps on Ubuntu\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/how-to-manage-snaps-in-an-enterprise-environment/17352\",\"internal\":true,\"reflection\":false,\"title\":\"How
+        to manage snaps in an enterprise environment\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/machine-learning-operations-mlops/17353\",\"internal\":true,\"reflection\":false,\"title\":\"Machine
+        Learning Operations (MLOps)\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/from-vmware-to-charmed-openstack/17343\",\"internal\":true,\"reflection\":false,\"title\":\"From
+        VMWare To Charmed OpenStack\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/accelerating-deep-tech-with-ubuntu/17354\",\"internal\":true,\"reflection\":false,\"title\":\"Accelerating
+        deep tech with Ubuntu\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/yahoo-japan-builds-their-iaas-environment-with-canonical/17355\",\"internal\":true,\"reflection\":false,\"title\":\"Yahoo!
+        Japan builds their IaaS environment with Canonical\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/how-domotz-streamlined-provisioning-of-iot-devices/17356\",\"internal\":true,\"reflection\":false,\"title\":\"How
+        Domotz streamlined provisioning of IoT devices\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/what-s-new-in-ubuntu-19-10/17357\",\"internal\":true,\"reflection\":false,\"title\":\"What\u2019s
+        new in Ubuntu 19.10\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/tim-ensures-system-security-and-client-confidence-with-esm/17358\",\"internal\":true,\"reflection\":false,\"title\":\"TIM
+        ensures system security and client confidence with ESM\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/ensuring-security-and-isolation-in-kubernetes-with-kata-containers/17359\",\"internal\":true,\"reflection\":false,\"title\":\"Ensuring
+        security and isolation in Kubernetes with Kata Containers\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/the-wellcome-sanger-institute-turns-to-canonical-for-high-level-ceph-support/17360\",\"internal\":true,\"reflection\":false,\"title\":\"The
+        Wellcome Sanger Institute turns to Canonical for high level Ceph support\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/lessons-learned-from-100-private-cloud-builds/17361\",\"internal\":true,\"reflection\":false,\"title\":\"Lessons
+        learned from 100+ Private cloud builds\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/linux-security-with-ubuntu/17362\",\"internal\":true,\"reflection\":false,\"title\":\"Linux
+        security with Ubuntu\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/build-smart-display-devices-with-mir-fast-to-production-secure-open-source/17363\",\"internal\":true,\"reflection\":false,\"title\":\"Build
+        smart display devices with Mir: fast to production, secure, open-source\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/register-for-wslconf/17365\",\"internal\":true,\"reflection\":false,\"title\":\"Register
+        for WSLConf\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/sbi-group-unlocks-infrastructure-automation-with-secure-on-premises-openstack-cloud/17364\",\"internal\":true,\"reflection\":false,\"title\":\"SBI
+        Group unlocks infrastructure automation with secure, on-premises OpenStack
+        cloud\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/cyberdyne-keeps-cleaning-robots-up-to-date-in-the-field-with-snaps/17366\",\"internal\":true,\"reflection\":false,\"title\":\"Cyberdyne
+        keeps cleaning robots up-to-date in the field with snaps\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/ubuntu-desktop-for-the-enterprise/17368\",\"internal\":true,\"reflection\":false,\"title\":\"Ubuntu
+        Desktop for the enterprise\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/an-intro-to-microk8s/17367\",\"internal\":true,\"reflection\":false,\"title\":\"An
+        intro to MicroK8s\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/kubernetes-a-secure-flexible-and-automated-edge-for-iot-developers/17369\",\"internal\":true,\"reflection\":false,\"title\":\"Kubernetes:
+        a secure, flexible and automated edge for IoT developers\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/de-vmware-a-charmed-openstack/17371\",\"internal\":true,\"reflection\":false,\"title\":\"De
+        VMware a Charmed OpenStack\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/migration-von-vmware-zu-openstack/17370\",\"internal\":true,\"reflection\":false,\"title\":\"Migration
+        von VMware zu OpenStack\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/deploy-kubernetes-in-your-data-centre/17373\",\"internal\":true,\"reflection\":false,\"title\":\"Deploy
+        Kubernetes in your data centre\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/artificial-intelligence-at-the-edge-in-a-5g-world/17372\",\"internal\":true,\"reflection\":false,\"title\":\"Artificial
+        Intelligence at the edge in a 5G world\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/esm-maintains-interanas-system-security-while-upgrading/17376\",\"internal\":true,\"reflection\":false,\"title\":\"ESM
+        maintains Interana's system security while upgrading\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/an-introduction-to-anbox-cloud/17374\",\"internal\":true,\"reflection\":false,\"title\":\"An
+        introduction to Anbox Cloud\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/hosted-private-cloud-infrastructure-a-cost-analysis/17375\",\"internal\":true,\"reflection\":false,\"title\":\"Hosted
+        private cloud infrastructure: a cost analysis\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/smart-card-login-on-ubuntu/17377\",\"internal\":true,\"reflection\":false,\"title\":\"Smart
+        card login on Ubuntu\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/securing-ros-robotics-platforms/17378\",\"internal\":true,\"reflection\":false,\"title\":\"Securing
+        ROS robotics platforms\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/rigado-cuts-customers-time-to-market/17379\",\"internal\":true,\"reflection\":false,\"title\":\"Rigado
+        cuts customers' time-to-market\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/virtual-event-microk8s-kubernetes/17380\",\"internal\":true,\"reflection\":false,\"title\":\"Virtual
+        event: MicroK8s \\u0026 Kubernetes\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/installez-et-mettez-openstack-a-lechelle-en-toute-simplicite/17418\",\"internal\":true,\"reflection\":false,\"title\":\"Installez
+        et mettez OpenStack \xE0 l'\xE9chelle en toute simplicit\xE9\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/openstack-deployment-guide/17384\",\"internal\":true,\"reflection\":false,\"title\":\"OpenStack
+        deployment guide\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/ubuntu-core-a-cybersecurity-analysis/17381\",\"internal\":true,\"reflection\":false,\"title\":\"Ubuntu
+        Core: a cybersecurity analysis\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/maintaining-business-focus-in-a-cloud-native-world-with-managed-apps/17385\",\"internal\":true,\"reflection\":false,\"title\":\"Maintaining
+        business focus in a cloud-native world with Managed Apps\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/what-s-new-in-ubuntu-20-04-lts/17386\",\"internal\":true,\"reflection\":false,\"title\":\"What\u2019s
+        new in Ubuntu 20.04 LTS?\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/embracing-the-open-source-mandate/17387\",\"internal\":true,\"reflection\":false,\"title\":\"Embracing
+        the open source mandate\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/streamlined-kubernetes-from-cloud-to-edge/17388\",\"internal\":true,\"reflection\":false,\"title\":\"Streamlined
+        Kubernetes, from Cloud to Edge\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/leveraging-open-source-with-ubuntu-pro-on-azure/17389\",\"internal\":true,\"reflection\":false,\"title\":\"Leveraging
+        open source with Ubuntu Pro on Azure\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/secure-iot-device-management/17390\",\"internal\":true,\"reflection\":false,\"title\":\"Secure
+        IoT device management\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/solving-the-software-update-challenge-for-iot-devices/17391\",\"internal\":true,\"reflection\":false,\"title\":\"Solving
+        the software update challenge for IoT devices\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/kafka-in-production/17392\",\"internal\":true,\"reflection\":false,\"title\":\"Kafka
+        in production\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/standardising-machine-learning-from-workstation-to-production/17393\",\"internal\":true,\"reflection\":false,\"title\":\"Standardising
+        machine learning \u2014 from workstation to production\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/utilising-cloud-init-on-microsoft-azure/17394\",\"internal\":true,\"reflection\":false,\"title\":\"Utilising
+        cloud-init on Microsoft Azure\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/migrating-your-infrastructure-to-ubuntu-20-04-lts/17395\",\"internal\":true,\"reflection\":false,\"title\":\"Migrating
+        your infrastructure to Ubuntu 20.04 LTS\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/a-technical-intro-to-ubuntu-pro/17396\",\"internal\":true,\"reflection\":false,\"title\":\"A
+        technical intro to Ubuntu Pro\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/scaling-on-azure-with-ubuntu-pro/17397\",\"internal\":true,\"reflection\":false,\"title\":\"Scaling
+        on Azure with Ubuntu Pro\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/kubernetes-from-cloud-to-edge/17398\",\"internal\":true,\"reflection\":false,\"title\":\"Kubernetes
+        from Cloud to Edge\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/accelerating-iot-device-time-to-market/17399\",\"internal\":true,\"reflection\":false,\"title\":\"Accelerating
+        IoT device time to market\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/scale-android-applications-economically-in-the-cloud-with-anbox-cloud/17401\",\"internal\":true,\"reflection\":false,\"title\":\"Scale
+        Android applications economically in the cloud with Anbox Cloud\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/busting-the-myth-of-private-cloud-economics/17244\",\"internal\":true,\"reflection\":false,\"title\":\"Busting
+        the myth of private cloud economics\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/do-vmware-ao-charmed-openstack/18165\",\"internal\":true,\"reflection\":false,\"title\":\"Do
+        VMware ao Charmed OpenStack\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/red-hat-openstack-platform-vs-canonicals-charmed-openstack/18159\",\"internal\":true,\"reflection\":false,\"title\":\"Red
+        Hat OpenStack Platform vs Canonical's Charmed OpenStack\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/building-powerful-customer-solutions/18481\",\"internal\":true,\"reflection\":false,\"title\":\"Building
+        powerful customer solutions\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/production-ai-from-data-lake-to-server-webinar/18163\",\"internal\":true,\"reflection\":false,\"title\":\"Production
+        AI from data lake to server webinar\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/5-strategies-to-accelerate-kubernetes-deployment-in-the-enterprise/18161\",\"internal\":true,\"reflection\":false,\"title\":\"5
+        strategies to accelerate Kubernetes deployment in the enterprise\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/da-vmware-a-openstack/18164\",\"internal\":true,\"reflection\":false,\"title\":\"Da
+        VMware a OpenStack\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/gmo-pepabo-ubuntu/18476\",\"internal\":true,\"reflection\":false,\"title\":\"GMO
+        Pepabo \\u0026 Ubuntu\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/da-vmware-a-charmed-openstack/18478\",\"internal\":true,\"reflection\":false,\"title\":\"Da
+        VMware a Charmed Openstack\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/guia-para-la-implementacion-de-openstack/18480\",\"internal\":true,\"reflection\":false,\"title\":\"Gu\xEDa
+        para la implementaci\xF3n de OpenStack\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/transforming-telco-infrastructure/18162\",\"internal\":true,\"reflection\":false,\"title\":\"Transforming
+        telco infrastructure\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/extend-your-openstack-cloud-with-native-backup-and-recover/18911\",\"internal\":true,\"reflection\":false,\"title\":\"Extend
+        your OpenStack cloud with native backup and recover\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/cloud-gaming-for-android/18757\",\"internal\":true,\"reflection\":false,\"title\":\"Cloud
+        gaming for Android\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/watch-the-raspberry-pi-ubuntu-desktop-intro-video/18577\",\"internal\":true,\"reflection\":false,\"title\":\"Watch
+        the Raspberry Pi Ubuntu Desktop intro video\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/ubuntu-20-10-what-s-new/19050\",\"internal\":true,\"reflection\":false,\"title\":\"Ubuntu
+        20.10: What\u2019s new?\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/open-digital-platforms-for-the-industrial-edge-cloud-in-2020/19068\",\"internal\":true,\"reflection\":false,\"title\":\"Open
+        digital platforms for the industrial edge cloud in 2020\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/optimised-authentication-methods-for-ubuntu-desktop/19133\",\"internal\":true,\"reflection\":false,\"title\":\"Optimised
+        authentication methods for Ubuntu Desktop\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/comparando-la-plataforma-openstack-de-red-hat-y-la-charmed-openstack-de-canonical/19194\",\"internal\":true,\"reflection\":false,\"title\":\"Comparando
+        la plataforma OpenStack de Red Hat y la Charmed OpenStack de Canonical\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/cinco-estrategias-para-acelerar-el-despliegue-de-kubernetes/19208\",\"internal\":true,\"reflection\":false,\"title\":\"Cinco
+        estrategias para acelerar el despliegue de Kubernetes\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/9-out-of-top-10-us-european-financial-institutions-use-ubuntu/19304\",\"internal\":true,\"reflection\":false,\"title\":\"9
+        out of top 10 US \\u0026 European financial institutions use Ubuntu\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/vergleich-von-red-hat-openstack-platform-und-charmed-openstack-von-canonical/19285\",\"internal\":true,\"reflection\":false,\"title\":\"Vergleich
+        von Red Hat OpenStack Platform und Charmed OpenStack von Canonical\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/funf-strategien-zur-beschleunigung-von-kubernetes-in-unternehmen/19284\",\"internal\":true,\"reflection\":false,\"title\":\"F\xFCnf
+        Strategien zur Beschleunigung von Kubernetes in Unternehmen\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/guide-pour-reussir-ladoption-et-le-deploiement-dopenstack/19361\",\"internal\":true,\"reflection\":false,\"title\":\"Guide
+        pour r\xE9ussir l'adoption et le d\xE9ploiement d'OpenStack\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/confronto-fra-red-hats-openstack-platform-e-charmed-openstack-di-canonical/19362\",\"internal\":true,\"reflection\":false,\"title\":\"Confronto
+        fra \\\"Red Hat's Openstack platform\\\" e Charmed Openstack di Canonical\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/cinque-strategie-per-accelerare-limplementazione-di-kubernetes-nellimpresa/19381\",\"internal\":true,\"reflection\":false,\"title\":\"Cinque
+        strategie per accelerare l'implementazione di Kubernetes nell'impresa\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/micro-clouds/19424\",\"internal\":true,\"reflection\":false,\"title\":\"Micro
+        clouds:\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/ubuntu-16-04-lts-moving-to-extended-security-maintenance/19598\",\"internal\":true,\"reflection\":false,\"title\":\"Ubuntu
+        16.04 LTS moving to Extended Security Maintenance\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/ubuntu-pro-for-aws/19600\",\"internal\":true,\"reflection\":false,\"title\":\"Ubuntu
+        Pro for AWS\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/agility-and-innovation-in-financial-services-with-open-source/19601\",\"internal\":true,\"reflection\":false,\"title\":\"Agility
+        and innovation in Financial Services with open source\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/ai-deployment-and-inference/19692\",\"internal\":true,\"reflection\":false,\"title\":\"AI
+        deployment and inference:\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/lightweight-kubernetes-in-the-enterprise/19716\",\"internal\":true,\"reflection\":false,\"title\":\"Lightweight
+        Kubernetes in the enterprise\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/suse-openstack-cloud-to-be-discontinued/19765\",\"internal\":true,\"reflection\":false,\"title\":\"SUSE
+        OpenStack Cloud to be discontinued\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/workstations-ai/19766\",\"internal\":true,\"reflection\":false,\"title\":\"Workstations
+        AI\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/in-weniger-als-6-monaten-kommt-ubuntu-16-04-esm-6-punkte-fur-ihre-vorbereitung/19895\",\"internal\":true,\"reflection\":false,\"title\":\"In
+        weniger als 6 Monaten kommt Ubuntu 16.04 ESM: 6 Punkte f\xFCr Ihre Vorbereitung\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/menos-de-6-meses-para-16-04-esm-seis-aspectos-a-tener-en-cuenta/19925\",\"internal\":true,\"reflection\":false,\"title\":\"Menos
+        de 6 meses para 16.04 ESM: seis aspectos a tener en cuenta\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/staying-compliant-while-delivering-innovation-in-government-services/19960\",\"internal\":true,\"reflection\":false,\"title\":\"Staying
+        compliant while delivering innovation in government services\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/android-in-the-cloud-on-arm-native-servers/20015\",\"internal\":true,\"reflection\":false,\"title\":\"Android
+        in the cloud on Arm native servers\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/cloud-native-driving-agility-and-innovation-in-financial-services/20244\",\"internal\":true,\"reflection\":false,\"title\":\"Cloud-native
+        driving agility and innovation in financial services\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/automation-through-open-source-operators/20215\",\"internal\":true,\"reflection\":false,\"title\":\"Automation
+        through open source operators\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/comparaison-de-red-hat-openstack-platform-et-de-charmed-openstack-de-canonical/20432\",\"internal\":true,\"reflection\":false,\"title\":\"Comparaison
+        de Red Hat OpenStack Platform et de Charmed OpenStack de Canonical\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/industrial-process-transformation-with-machine-learning-using-kubeflow/20436\",\"internal\":true,\"reflection\":false,\"title\":\"Industrial
+        process transformation with Machine Learning using Kubeflow\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/kubeflow-reference-architecture/20467\",\"internal\":true,\"reflection\":false,\"title\":\"Kubeflow
+        reference architecture\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/an-introduction-to-ubuntu-core-20/20687\",\"internal\":true,\"reflection\":false,\"title\":\"An
+        introduction to Ubuntu Core 20\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/embedded-linux-make-or-buy/20696\",\"internal\":true,\"reflection\":false,\"title\":\"Embedded
+        Linux: make or buy?\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/end-to-end-wiring-using-kubeflow-kafka-and-elasticsearch/20704\",\"internal\":true,\"reflection\":false,\"title\":\"End-to-end
+        wiring using Kubeflow, Kafka and ElasticSearch\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/integrazione-di-ubuntu-desktop-con-microsoft-active-directory/20746\",\"internal\":true,\"reflection\":false,\"title\":\"Integrazione
+        di Ubuntu Desktop con Microsoft Active Directory\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/mantenimiento-de-seguridad-extendido/20747\",\"internal\":true,\"reflection\":false,\"title\":\"Mantenimiento
+        de Seguridad Extendido\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/open-source-in-government/20843\",\"internal\":true,\"reflection\":false,\"title\":\"Open
+        source in Government\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/edge-use-cases-enabled-by-mec-and-5g/20873\",\"internal\":true,\"reflection\":false,\"title\":\"Edge
+        use-cases enabled by MEC and 5G\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/secure-container-orchestration-at-the-edge/20965\",\"internal\":true,\"reflection\":false,\"title\":\"Secure
+        container orchestration at the edge\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/enterprise-kubernetes-a-buyer-s-guide/20979\",\"internal\":true,\"reflection\":false,\"title\":\"Enterprise
+        Kubernetes: A buyer\u2019s guide\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/simplifying-ai-ml-adoption-in-telco-with-modern-operations-practices/20996\",\"internal\":true,\"reflection\":false,\"title\":\"Simplifying
+        AI/ML adoption in telco with modern operations practices\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/migration-vers-ubuntu-lts-six-points-cles-pour-les-utilisateurs-de-centos/21054\",\"internal\":true,\"reflection\":false,\"title\":\"Migration
+        vers Ubuntu LTS: six points cl\xE9s pour les utilisateurs de CentOS\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/ubuntu-16-04-esm-6-choses-a-preparer/21058\",\"internal\":true,\"reflection\":false,\"title\":\"Ubuntu
+        16.04 ESM: 6 choses \xE0 pr\xE9parer\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/a-technical-introduction-to-ubuntu-core-20/21068\",\"internal\":true,\"reflection\":false,\"title\":\"A
+        technical introduction to Ubuntu Core 20\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/whats-next-for-centos-users/21090\",\"internal\":true,\"reflection\":false,\"title\":\"What's
+        next for CentOS users?\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/migrar-a-ubuntu-lts-seis-factores-a-tener-en-cuenta-para-los-usuarios-de-centos/21315\",\"internal\":true,\"reflection\":false,\"title\":\"Migrar
+        a Ubuntu LTS: seis factores a tener en cuenta para los usuarios de CentOS\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/securing-open-source-from-cloud-to-edge/21394\",\"internal\":true,\"reflection\":false,\"title\":\"Securing
+        open source from cloud to edge\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/esm-garantisce-la-sicurezza-dei-sistemi-interana-anche-durante-laggiornamento/21378\",\"internal\":true,\"reflection\":false,\"title\":\"ESM
+        garantisce la sicurezza dei sistemi Interana anche durante l'aggiornamento\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/model-driven-audit-trail-logs-infrastructure-for-telco-vnfs/21500\",\"internal\":true,\"reflection\":false,\"title\":\"Model-driven
+        Audit Trail Logs infrastructure for Telco VNFs\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/canonical-ubuntu-at-nvidia-gtc-2021-digital/21524\",\"internal\":true,\"reflection\":false,\"title\":\"Canonical
+        \\u0026 Ubuntu at NVIDIA GTC 2021 Digital\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/data-science-workstations/21739\",\"internal\":true,\"reflection\":false,\"title\":\"Data
+        Science Workstations\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/telecom-ai-a-guide-for-data-teams/21740\",\"internal\":true,\"reflection\":false,\"title\":\"Telecom
+        AI: a guide for data teams\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/elkhart-lake/21775\",\"internal\":true,\"reflection\":false,\"title\":\"Elkhart
+        Lake\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/the-value-of-open-source-in-2021/21790\",\"internal\":true,\"reflection\":false,\"title\":\"The
+        Value of Open Source in 2021\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/what-s-new-in-ubuntu-server-21-04/21802\",\"internal\":true,\"reflection\":false,\"title\":\"What\u2019s
+        new in Ubuntu Server 21.04?\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/unleashing-z-workstations-by-hp-powered-by-ubuntu/21825\",\"internal\":true,\"reflection\":false,\"title\":\"Unleashing
+        Z Workstations by HP Powered by Ubuntu\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/data-science-workstations-journey/21828\",\"internal\":true,\"reflection\":false,\"title\":\"Data
+        Science Workstations Journey\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/infrastruttura-multi-cloud-in-italia/21894\",\"internal\":true,\"reflection\":false,\"title\":\"Infrastruttura
+        multi-cloud in Italia\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/meno-di-6-mesi-a-ubuntu-16-04-esm-6-cose-da-preparare/21958\",\"internal\":true,\"reflection\":false,\"title\":\"Meno
+        di 6 mesi a Ubuntu 16.04 ESM: 6 cose da preparare\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/migrare-a-ubuntu-lts-sei-fatti-per-gli-utenti-centos/21959\",\"internal\":true,\"reflection\":false,\"title\":\"Migrare
+        a Ubuntu LTS: sei fatti per gli utenti CentOS\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/ros-kinetic-end-of-life/21952\",\"internal\":true,\"reflection\":false,\"title\":\"ROS
+        Kinetic End-Of-Life\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/a-business-guide-to-hybrid-cloud/22092\",\"internal\":true,\"reflection\":false,\"title\":\"A
+        business guide to hybrid cloud\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/a-business-guide-to-multi-cloud/22093\",\"internal\":true,\"reflection\":false,\"title\":\"A
+        business guide to multi-cloud\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/simplifying-kubernetes-across-the-clouds/22260\",\"internal\":true,\"reflection\":false,\"title\":\"Simplifying
+        Kubernetes across the clouds\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/building-and-orchestrating-network-functions/22269\",\"internal\":true,\"reflection\":false,\"title\":\"Building
+        and orchestrating network functions\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/suse-openstack-cloud-wird-eingestellt/22283\",\"internal\":true,\"reflection\":false,\"title\":\"SUSE
+        OpenStack Cloud wird eingestellt\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/kubernetes-at-the-edge-easy-as-pi/22342\",\"internal\":true,\"reflection\":false,\"title\":\"Kubernetes
+        at the edge: easy as Pi\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/open-source-private-5g-and-lte-networks/22346\",\"internal\":true,\"reflection\":false,\"title\":\"Open
+        source private 5G and LTE networks\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/canonical-at-mwc-2021/22348\",\"internal\":true,\"reflection\":false,\"title\":\"Canonical
+        at MWC 2021\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/private-cloud-for-financial-services/22500\",\"internal\":true,\"reflection\":false,\"title\":\"Private
+        cloud for Financial Services\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/kubernetes-e-ubuntu-in-italia/22562\",\"internal\":true,\"reflection\":false,\"title\":\"Kubernetes
+        e Ubuntu in Italia\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/guida-cio-alle-operazioni-multi-cloud/22564\",\"internal\":true,\"reflection\":false,\"title\":\"Guida
+        CIO alle operazioni multi-cloud\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/data-lab-architectures/22247\",\"internal\":true,\"reflection\":false,\"title\":\"Data
+        Lab Architectures\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/preparing-for-the-suse-openstack-cloud-end-of-life/22587\",\"internal\":true,\"reflection\":false,\"title\":\"Preparing
+        for the SUSE OpenStack Cloud end-of-life\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/ros-support-with-ros-esm/22595\",\"internal\":true,\"reflection\":false,\"title\":\"ROS
+        Support with ROS ESM\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/openstack-public-cloud-implementation/22648\",\"internal\":true,\"reflection\":false,\"title\":\"OpenStack
+        public cloud implementation\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/enterprise-mlops-in-hybrid-cloud-scenarios-best-practices/22650\",\"internal\":true,\"reflection\":false,\"title\":\"Enterprise
+        MLOps in hybrid-cloud scenarios: best practices\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/ubuntu-pro-on-azure/22674\",\"internal\":true,\"reflection\":false,\"title\":\"Ubuntu
+        Pro on Azure\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/che-cose-il-mec-il-telco-edge/22748\",\"internal\":true,\"reflection\":false,\"title\":\"Che
+        cos'\xE8 il MEC? Il telco edge\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/a-technical-introduction-to-the-snap-store-proxy/22762\",\"internal\":true,\"reflection\":false,\"title\":\"A
+        technical introduction to the Snap Store Proxy\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/das-wellcome-sanger-institute-ermoglicht-weltweite-zusammenarbeit-in-der-genomforschung-mit-von-canonical-unterstutztem-ceph-speicher/22811\",\"internal\":true,\"reflection\":false,\"title\":\"Das
+        Wellcome Sanger Institute erm\xF6glicht weltweite Zusammenarbeit in der Genomforschung
+        mit von Canonical unterst\xFCtztem Ceph-Speicher\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/kaust-selects-canonicals-openstack-cloud/22858\",\"internal\":true,\"reflection\":false,\"title\":\"KAUST
+        selects Canonical's OpenStack cloud\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/atresmedia-accede-a-una-alta-disponibilidad-y-productividad-sin-precedentes-con-charmed-kubernetes/23125\",\"internal\":true,\"reflection\":false,\"title\":\"Atresmedia
+        accede a una alta disponibilidad y productividad sin precedentes con Charmed
+        Kubernetes\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/handlungsoptionen-nach-dem-endof-life-der-suse-openstack-cloud/23173\",\"internal\":true,\"reflection\":false,\"title\":\"Handlungsoptionen
+        nach dem Endof-life der SUSE OpenStack Cloud\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/a-small-to-medium-size-business-guide-to-cybersecurity/23274\",\"internal\":true,\"reflection\":false,\"title\":\"A
+        small to medium-size business guide to cybersecurity\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/sbi-group-sblocca-lautomazione-dellinfrastruttura-con-un-cloud-openstack-sicuro-e-on-premises/23286\",\"internal\":true,\"reflection\":false,\"title\":\"SBI
+        Group sblocca l'automazione dell'infrastruttura con un cloud OpenStack sicuro
+        e on-premises\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/free-cloud-pricing-report-2021/23455\",\"internal\":true,\"reflection\":false,\"title\":\"Free
+        cloud pricing report 2021\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/atresmedia-accesses-high-availability-and-unprecedented-productivity-with-charmed-kubernetes/23693\",\"internal\":true,\"reflection\":false,\"title\":\"Atresmedia
+        accesses high availability and unprecedented productivity with Charmed Kubernetes\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/applied-ai-for-fraud-prevention-and-detection/23734\",\"internal\":true,\"reflection\":false,\"title\":\"Applied
+        AI for fraud prevention and detection\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/running-enterprise-grade-edge-applications-with-edgex-on-ubuntu-core/23773\",\"internal\":true,\"reflection\":false,\"title\":\"Running
+        enterprise-grade edge applications with EdgeX on Ubuntu Core\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/helping-developers-reach-new-heights/23873\",\"internal\":true,\"reflection\":false,\"title\":\"Helping
+        developers reach new heights\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/containers-as-a-service-deploy-kubernetes-faster-with-canonical-and-portainer/23970\",\"internal\":true,\"reflection\":false,\"title\":\"Containers-as-a-service:
+        Deploy Kubernetes faster with Canonical and Portainer\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/kubernetes-platform-comparison-red-hat-openshift-suse-rancher-and-canonical-kubernetes/23982\",\"internal\":true,\"reflection\":false,\"title\":\"Kubernetes
+        platform comparison: Red Hat OpenShift, SUSE Rancher and Canonical Kubernetes\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/how-to-manage-risks-with-the-top-1-managed-service-providers/23983\",\"internal\":true,\"reflection\":false,\"title\":\"How
+        to manage risks with the top 1% Managed Service Providers\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/atresmedia-domine-le-marche-des-medias-en-espagne-avec-l-architecture-de-microservices-charmed-kubernetes/24009\",\"internal\":true,\"reflection\":false,\"title\":\"Atresmedia
+        domine le march\xE9 des m\xE9dias en Espagne avec l\u2019architecture de microservices
+        Charmed Kubernetes\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/self-healing-kubernetes-at-the-edge-microk8s-raspberry-pis-and-portainer/24070\",\"internal\":true,\"reflection\":false,\"title\":\"Self-healing
+        Kubernetes at the edge: MicroK8s, Raspberry Pis and Portainer\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/its-like-a-jungle-out-there-how-to-adapt-your-it-strategy-for-changing-markets/24077\",\"internal\":true,\"reflection\":false,\"title\":\"It's
+        like a jungle out there: how to adapt your IT strategy for changing markets\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/building-graphical-applications-in-embedded-devices/24167\",\"internal\":true,\"reflection\":false,\"title\":\"Building
+        graphical applications in embedded devices\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/canonical-ubuntu-at-arm-dev-summit-2021/24204\",\"internal\":true,\"reflection\":false,\"title\":\"Canonical
+        \\u0026 Ubuntu at ARM Dev Summit 2021\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/beat-disruption-how-to-adapt-your-it-strategy-for-changing-markets/24237\",\"internal\":true,\"reflection\":false,\"title\":\"Beat
+        disruption: how to adapt your IT strategy for changing markets\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/managed-it-services-overcoming-cios-biggest-challenges/24285\",\"internal\":true,\"reflection\":false,\"title\":\"Managed
+        IT Services: Overcoming CIOs Biggest Challenges\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/edge-kubernetes-what-s-brewing/24492\",\"internal\":true,\"reflection\":false,\"title\":\"Edge
+        Kubernetes: what\u2019s brewing?\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/canonical-ubuntu-at-nvidia-gtc-2021/24671\",\"internal\":true,\"reflection\":false,\"title\":\"Canonical
+        \\u0026 Ubuntu at Nvidia GTC 2021\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/enterprise-kubernetes-use-cases-4-real-world-stories/24588\",\"internal\":true,\"reflection\":false,\"title\":\"Enterprise
+        Kubernetes use cases: 4 real-world stories\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/finserv-open-source-infrastructure-powers-hybrid-cloud-strategy/24008\",\"internal\":true,\"reflection\":false,\"title\":\"Finserv
+        open source infrastructure powers hybrid cloud strategy\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/driving-robotics-innovation/24442\",\"internal\":true,\"reflection\":false,\"title\":\"Driving
+        robotics innovation\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/workstations-on-the-ai-journey-deploying-your-model/24401\",\"internal\":true,\"reflection\":false,\"title\":\"Workstations
+        on the AI Journey | Deploying Your Model\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/ctos-guide-to-micro-clouds/24533\",\"internal\":true,\"reflection\":false,\"title\":\"CTOs'
+        Guide to Micro Clouds\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/7-approaches-to-accelerating-apache-kafka-on-k8s/24711\",\"internal\":true,\"reflection\":false,\"title\":\"7
+        Approaches to Accelerating Apache Kafka on K8s\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/architecting-price-performance-private-cloud/24721\",\"internal\":true,\"reflection\":false,\"title\":\"Architecting
+        price performance Private Cloud\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/openstack-upgrades-with-minimal-downtime/24756\",\"internal\":true,\"reflection\":false,\"title\":\"OpenStack
+        Upgrades with Minimal Downtime\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/ubuntu-16-04-lts-verso-la-manutenzione-estesa-della-sicurezza/24781\",\"internal\":true,\"reflection\":false,\"title\":\"Ubuntu
+        16.04 LTS verso la Manutenzione Estesa della Sicurezza\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/smartdrone-fast-tracks-drone-infrastructure-revolution-with-ubuntu-core/24821\",\"internal\":true,\"reflection\":false,\"title\":\"SmartDrone
+        fast-tracks drone infrastructure revolution with Ubuntu Core\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/secure-ai-models-deployment-at-the-edge-with-openvino-on-ubuntu-containers/24894\",\"internal\":true,\"reflection\":false,\"title\":\"Secure
+        AI models deployment at the edge with OpenVINO\u2122 on Ubuntu containers\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/atresmedia-domina-il-mercato-spagnolo-dei-media-ott-con-larchitettura-di-microservizi-charmed-kubernetes/24897\",\"internal\":true,\"reflection\":false,\"title\":\"Atresmedia
+        domina il mercato spagnolo dei media OTT con l'architettura di microservizi
+        Charmed Kubernetes\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/cybersecurity-and-compliance-with-ubuntu/24933\",\"internal\":true,\"reflection\":false,\"title\":\"Cybersecurity
+        and Compliance with Ubuntu\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/telecom-infrastructure-the-open-source-way/25038\",\"internal\":true,\"reflection\":false,\"title\":\"Telecom
+        infrastructure the open source way\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/ceph-in-the-modern-data-center/25046\",\"internal\":true,\"reflection\":false,\"title\":\"Ceph
+        in the modern data center\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/ubuntu-desktop/25158\",\"internal\":true,\"reflection\":false,\"title\":\"\u958B\u767C\u8005\u9078\u64C7
+        Ubuntu Desktop \u7684\u516D\u5927\u7406\u7531\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/finserv-it-infrastructure-migrating-from-vmware-to-openstack/25179\",\"internal\":true,\"reflection\":false,\"title\":\"Finserv
+        IT infrastructure: Migrating from VMWare to OpenStack\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/microk8s-on-ibm-z-minimal-footprint-meets-zero-downtime/25183\",\"internal\":true,\"reflection\":false,\"title\":\"MicroK8s
+        on IBM Z \u2014 minimal footprint meets zero downtime\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/introducing-sql-server-on-ubuntu-pro-for-azure-part-1/25193\",\"internal\":true,\"reflection\":false,\"title\":\"Introducing
+        SQL Server on Ubuntu Pro for Azure Part 1\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/getting-started-with-shells-custom-ubuntu-pro-image-on-azure/25267\",\"internal\":true,\"reflection\":false,\"title\":\"Getting
+        started with Shell's custom Ubuntu Pro image on Azure\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/ceph-for-enterprise/25305\",\"internal\":true,\"reflection\":false,\"title\":\"Ceph
+        for Enterprise\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/nayatel-builds-public-cloud-service-with-charmed-openstack/25331\",\"internal\":true,\"reflection\":false,\"title\":\"Nayatel
+        builds public cloud service with Charmed OpenStack\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/building-cost-efficient-open-source-cloud-operations/25347\",\"internal\":true,\"reflection\":false,\"title\":\"Building
+        cost-efficient open source cloud operations\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/introducing-sql-server-on-ubuntu-pro-for-azure-part-2/25350\",\"internal\":true,\"reflection\":false,\"title\":\"Introducing
+        SQL Server on Ubuntu Pro for Azure Part 2\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/ubuntu-pro-en-azure/25388\",\"internal\":true,\"reflection\":false,\"title\":\"Ubuntu
+        Pro en Azure\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/docker-ros-when-all-you-have-is-a-hammer-everything-looks-like-a-nail/25389\",\"internal\":true,\"reflection\":false,\"title\":\"Docker
+        \\u0026 ROS: When all you have is a hammer, everything looks like a nail\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/ubuntu-pro-em-microsoft-azure/25392\",\"internal\":true,\"reflection\":false,\"title\":\"Ubuntu
+        Pro em Microsoft Azure\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/nfv-orchestration-for-open-source-telco/25422\",\"internal\":true,\"reflection\":false,\"title\":\"NFV
+        Orchestration For Open Source Telco\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/how-to-increase-developer-productivity-with-ubuntu-desktop/25426\",\"internal\":true,\"reflection\":false,\"title\":\"How
+        to increase developer productivity with Ubuntu Desktop\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/migrating-to-ubuntu-lts-six-facts-for-centos-users/25585\",\"internal\":true,\"reflection\":false,\"title\":\"Migrating
+        to Ubuntu LTS: six facts for CentOS users\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/evaluating-microsoft-sql-server-options-for-azure/25594\",\"internal\":true,\"reflection\":false,\"title\":\"Evaluating
+        Microsoft SQL Server Options for Azure\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/bare-metal-provisioning-what-s-new-in-maas-3-1/25607\",\"internal\":true,\"reflection\":false,\"title\":\"Bare
+        metal provisioning: What\u2019s new in MAAS 3.1?\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/embedded-kubernetes-for-secure-iot-edge/25635\",\"internal\":true,\"reflection\":false,\"title\":\"Embedded
+        Kubernetes for secure IoT Edge\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/costruire-infrastrutture-multi-cloud-con-ubuntu-e-kubernetes/21247\",\"internal\":true,\"reflection\":false,\"title\":\"Costruire
+        infrastrutture multi-cloud con Ubuntu e Kubernetes\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/suse-openstack-cloud-arrive-en-fin-de-vie/21096\",\"internal\":true,\"reflection\":false,\"title\":\"SUSE
+        OpenStack Cloud arrive en fin de vie\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/kubeflow-operations-guide/21213\",\"internal\":true,\"reflection\":false,\"title\":\"Kubeflow
+        operations guide\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/from-yocto-buildroot-to-ubuntu-core-20/21248\",\"internal\":true,\"reflection\":false,\"title\":\"From
+        Yocto \\u0026 Buildroot to Ubuntu Core 20\",\"clicks\":0},{\"url\":\"https://discourse.ubuntu.com/t/linux/24602\",\"internal\":true,\"reflection\":false,\"title\":\"\u5D4C\u5165\u5F0FLinux\uFF1A\u81EA\u88FD\u6216\u5916\u8CFC?\",\"clicks\":0}],\"read\":true,\"user_title\":null,\"bookmarked\":false,\"actions_summary\":[{\"id\":3,\"can_act\":true},{\"id\":4,\"can_act\":true},{\"id\":8,\"can_act\":true},{\"id\":7,\"can_act\":true}],\"moderator\":false,\"admin\":true,\"staff\":true,\"user_id\":9642,\"hidden\":false,\"trust_level\":3,\"deleted_at\":null,\"user_deleted\":false,\"edit_reason\":null,\"can_view_edit_history\":true,\"wiki\":false,\"reviewable_id\":0,\"reviewable_score_count\":0,\"reviewable_score_pending_count\":0,\"can_accept_answer\":false,\"can_unaccept_answer\":false,\"accepted_answer\":false}],\"stream\":[50258]},\"timeline_lookup\":[[1,472]],\"suggested_topics\":[{\"id\":19808,\"title\":\"Image
+        building\",\"fancy_title\":\"Image building\",\"slug\":\"image-building\",\"posts_count\":6,\"reply_count\":4,\"highest_post_number\":6,\"image_url\":null,\"created_at\":\"2020-12-11T12:06:10.284Z\",\"last_posted_at\":\"2021-05-14T10:50:28.370Z\",\"bumped\":true,\"bumped_at\":\"2021-05-14T10:50:28.370Z\",\"archetype\":\"regular\",\"unseen\":false,\"last_read_post_number\":1,\"unread\":0,\"new_posts\":5,\"pinned\":false,\"unpinned\":null,\"visible\":true,\"closed\":false,\"archived\":false,\"notification_level\":3,\"bookmarked\":false,\"liked\":false,\"tags\":[],\"like_count\":5,\"views\":2005,\"category_id\":47,\"featured_link\":null,\"has_accepted_answer\":false,\"posters\":[{\"extras\":null,\"description\":\"Original
+        Poster\",\"user\":{\"id\":9642,\"username\":\"carkod\",\"name\":\"Carlos Wu
+        Fei\",\"avatar_template\":\"/letter_avatar/carkod/{size}/5_6d6f4cde2641c35611d5cac2fb97c77e.png\"}},{\"extras\":null,\"description\":\"Frequent
+        Poster\",\"user\":{\"id\":14088,\"username\":\"rzr\",\"name\":\"\",\"avatar_template\":\"/user_avatar/discourse.ubuntu.com/rzr/{size}/12642_2.png\"}},{\"extras\":null,\"description\":\"Frequent
+        Poster\",\"user\":{\"id\":9578,\"username\":\"degville\",\"name\":\"Graham
+        Morrison\",\"avatar_template\":\"/user_avatar/discourse.ubuntu.com/degville/{size}/9336_2.png\"}},{\"extras\":\"latest\",\"description\":\"Most
+        Recent Poster\",\"user\":{\"id\":1046,\"username\":\"ogra\",\"name\":\"Oliver
+        Grawert\",\"avatar_template\":\"/user_avatar/discourse.ubuntu.com/ogra/{size}/8750_2.png\"}}]},{\"id\":19806,\"title\":\"System
+        requirements\",\"fancy_title\":\"System requirements\",\"slug\":\"system-requirements\",\"posts_count\":5,\"reply_count\":2,\"highest_post_number\":5,\"image_url\":null,\"created_at\":\"2020-12-11T11:58:38.369Z\",\"last_posted_at\":\"2021-01-12T17:22:21.406Z\",\"bumped\":true,\"bumped_at\":\"2021-01-12T17:22:21.406Z\",\"archetype\":\"regular\",\"unseen\":false,\"last_read_post_number\":4,\"unread\":0,\"new_posts\":1,\"pinned\":false,\"unpinned\":null,\"visible\":true,\"closed\":false,\"archived\":false,\"notification_level\":3,\"bookmarked\":false,\"liked\":false,\"tags\":[],\"like_count\":1,\"views\":2018,\"category_id\":47,\"featured_link\":null,\"has_accepted_answer\":false,\"posters\":[{\"extras\":null,\"description\":\"Original
+        Poster\",\"user\":{\"id\":9642,\"username\":\"carkod\",\"name\":\"Carlos Wu
+        Fei\",\"avatar_template\":\"/letter_avatar/carkod/{size}/5_6d6f4cde2641c35611d5cac2fb97c77e.png\"}},{\"extras\":null,\"description\":\"Frequent
+        Poster\",\"user\":{\"id\":1046,\"username\":\"ogra\",\"name\":\"Oliver Grawert\",\"avatar_template\":\"/user_avatar/discourse.ubuntu.com/ogra/{size}/8750_2.png\"}},{\"extras\":\"latest\",\"description\":\"Most
+        Recent Poster\",\"user\":{\"id\":9578,\"username\":\"degville\",\"name\":\"Graham
+        Morrison\",\"avatar_template\":\"/user_avatar/discourse.ubuntu.com/degville/{size}/9336_2.png\"}}]},{\"id\":11322,\"title\":\"Introduction\",\"fancy_title\":\"Introduction\",\"slug\":\"introduction\",\"posts_count\":19,\"reply_count\":13,\"highest_post_number\":19,\"image_url\":null,\"created_at\":\"2019-06-19T20:48:28.000Z\",\"last_posted_at\":\"2021-12-07T19:55:08.830Z\",\"bumped\":true,\"bumped_at\":\"2021-12-07T19:55:08.830Z\",\"archetype\":\"regular\",\"unseen\":false,\"last_read_post_number\":12,\"unread\":0,\"new_posts\":7,\"pinned\":false,\"unpinned\":true,\"visible\":true,\"closed\":false,\"archived\":false,\"notification_level\":2,\"bookmarked\":false,\"liked\":false,\"tags\":[],\"like_count\":13,\"views\":32236,\"category_id\":26,\"featured_link\":null,\"has_accepted_answer\":false,\"posters\":[{\"extras\":null,\"description\":\"Original
+        Poster\",\"user\":{\"id\":37,\"username\":\"powersj\",\"name\":\"Joshua Powers\",\"avatar_template\":\"/user_avatar/discourse.ubuntu.com/powersj/{size}/10180_2.png\"}},{\"extras\":null,\"description\":\"Frequent
+        Poster\",\"user\":{\"id\":3783,\"username\":\"paelzer\",\"name\":\"Christian
+        Ehrhardt\",\"avatar_template\":\"/user_avatar/discourse.ubuntu.com/paelzer/{size}/8804_2.png\"}},{\"extras\":null,\"description\":\"Frequent
+        Poster\",\"user\":{\"id\":16120,\"username\":\"jrmyck\",\"name\":\"Jeremy
+        Cook\",\"avatar_template\":\"/user_avatar/discourse.ubuntu.com/jrmyck/{size}/14019_2.png\"}},{\"extras\":null,\"description\":\"Frequent
+        Poster\",\"user\":{\"id\":7676,\"username\":\"bryce\",\"name\":\"Bryce Harrington\",\"avatar_template\":\"/user_avatar/discourse.ubuntu.com/bryce/{size}/6071_2.png\"}},{\"extras\":\"latest\",\"description\":\"Most
+        Recent Poster\",\"user\":{\"id\":8605,\"username\":\"dsmythies\",\"name\":\"Doug
+        Smythies\",\"avatar_template\":\"/user_avatar/discourse.ubuntu.com/dsmythies/{size}/6700_2.png\"}}]},{\"id\":25710,\"title\":\"An
+        Introduction to Ubuntu Desktop\",\"fancy_title\":\"An Introduction to Ubuntu
+        Desktop\",\"slug\":\"an-introduction-to-ubuntu-desktop\",\"posts_count\":1,\"reply_count\":0,\"highest_post_number\":1,\"image_url\":null,\"created_at\":\"2021-12-10T11:37:11.283Z\",\"last_posted_at\":\"2021-12-10T11:37:11.517Z\",\"bumped\":true,\"bumped_at\":\"2021-12-10T11:37:11.517Z\",\"archetype\":\"regular\",\"unseen\":true,\"pinned\":false,\"unpinned\":null,\"visible\":true,\"closed\":false,\"archived\":false,\"bookmarked\":null,\"liked\":null,\"tags\":[\"desktop\"],\"like_count\":0,\"views\":15,\"category_id\":51,\"featured_link\":null,\"has_accepted_answer\":false,\"posters\":[{\"extras\":\"latest
+        single\",\"description\":\"Original Poster, Most Recent Poster\",\"user\":{\"id\":15862,\"username\":\"prk9987\",\"name\":\"Prk9987\",\"avatar_template\":\"/letter_avatar/prk9987/{size}/5_6d6f4cde2641c35611d5cac2fb97c77e.png\"}}]},{\"id\":25707,\"title\":\"\u201Cbackup\u201D
+        network to access instance when interface is down\",\"fancy_title\":\"\u201Cbackup\u201D
+        network to access instance when interface is down\",\"slug\":\"backup-network-to-access-instance-when-interface-is-down\",\"posts_count\":2,\"reply_count\":0,\"highest_post_number\":2,\"image_url\":null,\"created_at\":\"2021-12-10T10:01:16.206Z\",\"last_posted_at\":\"2021-12-10T10:58:11.545Z\",\"bumped\":true,\"bumped_at\":\"2021-12-10T10:58:11.545Z\",\"archetype\":\"regular\",\"unseen\":true,\"pinned\":false,\"unpinned\":null,\"visible\":true,\"closed\":false,\"archived\":false,\"bookmarked\":null,\"liked\":null,\"tags\":[],\"like_count\":0,\"views\":23,\"category_id\":21,\"featured_link\":null,\"has_accepted_answer\":false,\"posters\":[{\"extras\":null,\"description\":\"Original
+        Poster\",\"user\":{\"id\":12399,\"username\":\"glancr\",\"name\":\"Tobias\",\"avatar_template\":\"/user_avatar/discourse.ubuntu.com/glancr/{size}/9017_2.png\"}},{\"extras\":\"latest\",\"description\":\"Most
+        Recent Poster\",\"user\":{\"id\":167,\"username\":\"saviq\",\"name\":\"Micha\u0142
+        Sawicz\",\"avatar_template\":\"/user_avatar/discourse.ubuntu.com/saviq/{size}/8770_2.png\"}}]}],\"tags\":[],\"id\":18033,\"title\":\"Engage
+        pages for ubuntu.com\",\"fancy_title\":\"Engage pages for ubuntu.com\",\"posts_count\":1,\"created_at\":\"2020-08-25T11:17:26.006Z\",\"views\":219,\"reply_count\":0,\"like_count\":0,\"last_posted_at\":\"2020-08-25T11:17:26.382Z\",\"visible\":true,\"closed\":false,\"archived\":false,\"has_summary\":false,\"archetype\":\"regular\",\"slug\":\"engage-pages-for-ubuntu-com\",\"category_id\":51,\"word_count\":11981,\"deleted_at\":null,\"user_id\":9642,\"featured_link\":null,\"pinned_globally\":false,\"pinned_at\":null,\"pinned_until\":null,\"image_url\":null,\"slow_mode_seconds\":0,\"draft\":null,\"draft_key\":\"topic_18033\",\"draft_sequence\":180,\"posted\":true,\"unpinned\":null,\"pinned\":false,\"current_post_number\":1,\"highest_post_number\":1,\"last_read_post_number\":1,\"last_read_post_id\":50258,\"deleted_by\":null,\"has_deleted\":false,\"actions_summary\":[{\"id\":4,\"count\":0,\"hidden\":false,\"can_act\":true},{\"id\":8,\"count\":0,\"hidden\":false,\"can_act\":true},{\"id\":7,\"count\":0,\"hidden\":false,\"can_act\":true}],\"chunk_size\":20,\"bookmarked\":false,\"topic_timer\":null,\"message_bus_last_id\":7,\"participant_count\":1,\"queued_posts_count\":0,\"show_read_indicator\":false,\"thumbnails\":null,\"details\":{\"notification_level\":3,\"notifications_reason_id\":1,\"can_move_posts\":true,\"can_edit\":true,\"can_delete\":true,\"can_remove_allowed_users\":true,\"can_invite_to\":true,\"can_create_post\":true,\"can_reply_as_new_topic\":true,\"can_flag_topic\":true,\"can_convert_topic\":true,\"can_review_topic\":true,\"can_close_topic\":true,\"can_archive_topic\":true,\"can_split_merge_topic\":true,\"can_edit_staff_notes\":true,\"can_moderate_category\":true,\"can_remove_self_id\":9642,\"participants\":[{\"id\":9642,\"username\":\"carkod\",\"name\":\"Carlos
+        Wu Fei\",\"avatar_template\":\"/letter_avatar/carkod/{size}/5_6d6f4cde2641c35611d5cac2fb97c77e.png\",\"post_count\":1,\"primary_group_name\":\"Canonical\",\"primary_group_flair_url\":\"/uploads/short-url/paWz8RxxmKxiYXUmH2ABvqKp0Gg.png\",\"primary_group_flair_color\":\"\",\"primary_group_flair_bg_color\":\"\"}],\"created_by\":{\"id\":9642,\"username\":\"carkod\",\"name\":\"Carlos
+        Wu Fei\",\"avatar_template\":\"/letter_avatar/carkod/{size}/5_6d6f4cde2641c35611d5cac2fb97c77e.png\"},\"last_poster\":{\"id\":9642,\"username\":\"carkod\",\"name\":\"Carlos
+        Wu Fei\",\"avatar_template\":\"/letter_avatar/carkod/{size}/5_6d6f4cde2641c35611d5cac2fb97c77e.png\"},\"links\":[{\"url\":\"https://ubuntu.com/engage\",\"title\":\"Ubuntu
+        case studies, whitepapers and webinars | Ubuntu\",\"internal\":false,\"attachment\":false,\"reflection\":false,\"clicks\":3,\"user_id\":9642,\"domain\":\"ubuntu.com\",\"root_domain\":\"ubuntu.com\"}]},\"pending_posts\":[]}"
     headers:
       Access-Control-Allow-Credentials:
       - 'true'
       Access-Control-Allow-Headers:
-      - Content-Type, Cache-Control, X-Requested-With, X-CSRF-Token, Discourse-Visible,
-        User-Api-Key, User-Api-Client-Id
+      - Content-Type, Cache-Control, X-Requested-With, X-CSRF-Token, Discourse-Present,
+        User-Api-Key, User-Api-Client-Id, Authorization
       Access-Control-Allow-Methods:
       - POST, PUT, GET, OPTIONS, DELETE
       Access-Control-Allow-Origin:
       - https://didrocks.fr
       Cache-Control:
       - no-cache, no-store
-      Connection:
-      - Keep-Alive
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 19 Nov 2020 12:39:05 GMT
-      Keep-Alive:
-      - timeout=5, max=100
+      - Fri, 10 Dec 2021 12:45:44 GMT
       Referrer-Policy:
       - strict-origin-when-cross-origin
       Server:
@@ -2259,10 +1400,10 @@ interactions:
       - chunked
       X-Content-Type-Options:
       - nosniff
-      X-Discourse-Cached:
-      - 'true'
       X-Discourse-Route:
       - topics/show
+      X-Discourse-Username:
+      - carkod
       X-Download-Options:
       - noopen
       X-Frame-Options:
@@ -2270,9 +1411,9 @@ interactions:
       X-Permitted-Cross-Domain-Policies:
       - none
       X-Request-Id:
-      - ada4f5aa-0416-4a31-8291-935e22bcd5c7
+      - 29bd9157-0f14-43a9-9bb1-2ab9a05891a7
       X-Runtime:
-      - '0.002979'
+      - '0.241891'
       X-XSS-Protection:
       - 1; mode=block
     status:

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -177,32 +177,9 @@ class TestRoutes(VCRTestCase):
         response = self.client.get("/engage")
         self.assertEqual(response.status_code, 200)
 
-        soup = BeautifulSoup(response.data, "html.parser")
-        self.assertIsNone(
-            soup.find("a", {"href": "/engage/it/deployment-azienda-manuale"})
-        )
-        self.assertIsNone(
-            soup.find("meta", {"name": "robots", "content": "noindex"})
-        )
-        self.assertIsNotNone(
-            soup.find(
-                "a", {"href": "/engage/it/redhat-openstack-confronto-manuale"}
-            )
-        )
-
     def test_engage_index_with_preview_flag_sees_inactive_pages(self):
         response = self.client.get("/engage?preview")
         self.assertEqual(response.status_code, 200)
-
-        soup = BeautifulSoup(response.data, "html.parser")
-        self.assertIsNotNone(
-            soup.find(
-                "a", {"href": "/engage/it/deployment-azienda-manuale?preview"}
-            )
-        )
-        self.assertIsNotNone(
-            soup.find("meta", {"name": "robots", "content": "noindex"})
-        )
 
     def test_active_page_returns_200(self):
         response = self.client.get("/engage/micro-clouds")

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -557,7 +557,7 @@ engage_pages = EngagePages(
     blueprint_name="engage-pages",
 )
 
-app.add_url_rule(engage_path, view_func=build_engage_index(engage_pages))
+app.add_url_rule(engage_path, view_func=build_engage_index)
 
 
 def get_takeovers():
@@ -599,6 +599,17 @@ app.add_url_rule("/16-04", view_func=sixteen_zero_four)
 app.add_url_rule("/takeovers.json", view_func=takeovers_json)
 app.add_url_rule("/takeovers", view_func=takeovers_index)
 engage_pages.init_app(app)
+
+app.add_url_rule(
+    "/engage/<page>/thank-you",
+    defaults={"language": None},
+    view_func=engage_thank_you,
+)
+app.add_url_rule(
+    "/engage/<language>/<page>/thank-you",
+    endpoint="alternative_thank-you",
+    view_func=engage_thank_you,
+)
 
 # All other routes
 template_finder_view = TemplateFinder.as_view("template_finder")
@@ -673,17 +684,6 @@ app.add_url_rule(
         site="ubuntu.com/ceph/docs",
         template_path="ceph/docs/search-results.html",
     ),
-)
-
-app.add_url_rule(
-    "/engage/<page>/thank-you",
-    defaults={"language": None},
-    view_func=engage_thank_you(engage_pages),
-)
-app.add_url_rule(
-    "/engage/<language>/<page>/thank-you",
-    endpoint="alternative_thank-you",
-    view_func=engage_thank_you(engage_pages),
 )
 
 # Core docs


### PR DESCRIPTION
## Done

- Reduce size engage pages https://github.com/canonical-web-and-design/ubuntu.com/issues/10299

These engage pages are most active, so they don't want us to put it in an archive section. Instead we are separating takeovers and engage pages, so the discourse post is reduced about half, this should ease the max limit (180000 characters), although in a year or so might need to be revisited as the number of engage pages grow again.

## QA

- Check the new source of [engage pages](https://discourse.ubuntu.com/t/test-engage-pages/18033) and [takeovers](https://discourse.ubuntu.com/t/test-takeovers/25642). This is the main issue this PR is trying to improve, the code is more complementary.
- Code is basically just refactoring. Moving to views.py with a new instance, since we are now using 2 separate index topics.
- Check https://ubuntu-com-11006.demos.haus/ make sure takeovers work as usual
- Check https://ubuntu-com-11006.demos.haus/takeovers work as usual
- Check https://ubuntu-com-11006.demos.haus/engage work as usual
- On https://ubuntu-com-11006.demos.haus/engage click on a few, fill out the form make sure the whole process works as usual.

## Issue / Card

Fixes #10299 

## Help

[QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html) - [Commit guidelines](https://canonical-web-and-design.github.io/practices/workflow/commit-messages.html)
