### PR TITLE
Add endpoint to surface users purchase account linked offers

### DIFF
--- a/tests/advantage/fixtures/offers.json
+++ b/tests/advantage/fixtures/offers.json
@@ -1,0 +1,15 @@
+[{
+    "id": "1",
+    "items": [
+    {
+        "productListingID": "listing_id_1",
+        "value": 2
+    },
+    {
+        "productListingID": "listing_id_2",
+        "value": 5
+    }
+    ],
+    "lastModified": "0001-01-01T00:00:00Z",
+    "marketplace": "canonical-ua"
+}]

--- a/webapp/advantage/ua_contracts/api.py
+++ b/webapp/advantage/ua_contracts/api.py
@@ -109,6 +109,15 @@ class UAContractsAPI:
 
         return contract
 
+    def get_account_offers(self, account_id: str):
+        response = self._request(
+            method="get",
+            path=f"v1/accounts/{account_id}/offers",
+            error_rules=["default", "no-found", "user-role"],
+        )
+
+        return response.json()
+
     def get_account_users(self, account_id: str):
         response = self._request(
             method="get",

--- a/webapp/advantage/ua_contracts/parsers.py
+++ b/webapp/advantage/ua_contracts/parsers.py
@@ -1,13 +1,13 @@
 from typing import List, Dict
 
 from webapp.advantage.ua_contracts.primitives import (
-    Entitlement,
+    Account,
     Contract,
     ContractItem,
+    Entitlement,
+    Renewal,
     Subscription,
     SubscriptionItem,
-    Account,
-    Renewal,
     User,
 )
 from webapp.advantage.models import Listing, Product

--- a/webapp/advantage/views.py
+++ b/webapp/advantage/views.py
@@ -770,6 +770,22 @@ def accept_renewal(renewal_id):
     return g.api.accept_renewal(renewal_id)
 
 
+@advantage_decorator(permission="user", response="json")
+def get_account_offers():
+    try:
+        account = g.api.get_purchase_account("canonical-ua")
+    except UAContractsUserHasNoAccount:
+        return flask.jsonify({"error": "User has no purchase account"}), 400
+    except AccessForbiddenError:
+        return (
+            flask.jsonify({"error": "User has no permission to purchase"}),
+            403,
+        )
+
+    offers = g.api.get_account_offers(account["id"])
+    return flask.jsonify(offers)
+
+
 @advantage_decorator(permission="user", response="html")
 def account_view():
     email = flask.session["openid"]["email"]

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -93,6 +93,7 @@ from webapp.advantage.views import (
     account_view,
     invoices_view,
     download_invoice,
+    get_account_offers,
     get_user_subscriptions,
     get_last_purchase_ids,
     get_contract_token,
@@ -410,6 +411,12 @@ app.add_url_rule(
 app.add_url_rule(
     "/advantage/subscribe/blender/thank-you",
     view_func=blender_thanks_view,
+)
+
+app.add_url_rule(
+    "/advantage/offers.json",
+    view_func=get_account_offers,
+    methods=["GET"],
 )
 
 app.add_url_rule("/account", view_func=account_view)


### PR DESCRIPTION
## Done

Add endpoint to surface users purchase account linked offers

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- Create an offer using the contracts API
- Go to http://0.0.0.0:8001/advatage/offers and check the offer
