### PR TITLE
Copy update on /download/xilinx

### DIFF
--- a/templates/download/xilinx/index.html
+++ b/templates/download/xilinx/index.html
@@ -37,16 +37,16 @@ familiar developer experience and an accelerated path to production.{% endblock 
     <div class="p-tabs">
       <div class="p-tabs__list js-tabbed-content" role="tablist" aria-label="Install xilinx">
         <div class="p-tabs__item">
-          <button class="p-tabs__link" role="tab" aria-selected="true" aria-controls="zynq-ultrascale-tab" id="zynq-ultrascale">Xilinx Zynq UltraScale+ MPSoC
-            Development Boards</button>
+          <button class="p-tabs__link" role="tab" aria-selected="true" aria-controls="kira-kv260-vision-ai-tab" id="kira-kv260-vision-ai">Xilinx
+            Kria KV260 Vision AI Starter Kit</button>
         </div>
         <div class="p-tabs__item">
-          <button class="p-tabs__link" role="tab" aria-selected="false" aria-controls="kira-kv260-vision-ai-tab" id="kira-kv260-vision-ai" tabindex="-1">Xilinx
-            Kria KV260 Vision AI Starter Kit</button>
+          <button class="p-tabs__link" role="tab" aria-selected="false" aria-controls="zynq-ultrascale-tab" id="zynq-ultrascale" tabindex="-1">Xilinx Zynq UltraScale+ MPSoC
+            Development Boards</button>
         </div>
       </div>
 
-      <div tabindex="0" role="tabpanel" id="zynq-ultrascale-tab" aria-labelledby="zynq-ultrascale">
+      <div tabindex="0" role="tabpanel" id="zynq-ultrascale-tab" aria-labelledby="zynq-ultrascale" hidden="true">
         <div class="row u-vertically-center u-no-padding">
           <div class="col-6">
             <h2>Download Ubuntu Desktop</h2>
@@ -128,7 +128,7 @@ familiar developer experience and an accelerated path to production.{% endblock 
         </div>
       </div>
 
-      <div tabindex="0" role="tabpanel" id="kira-kv260-vision-ai-tab" aria-labelledby="kira-kv260-vision-ai" hidden="true">
+      <div tabindex="0" role="tabpanel" id="kira-kv260-vision-ai-tab" aria-labelledby="kira-kv260-vision-ai">
         <div class="row u-vertically-center u-no-padding">
           <div class="col-6">
             <h2>Download Ubuntu Desktop</h2>
@@ -158,9 +158,7 @@ familiar developer experience and an accelerated path to production.{% endblock 
 
         <div class="u-fixed-width">
           <h4>First time installing Ubuntu on Xilinx?</h4>
-          <p>Please see the <a class="p-link--external"
-               href="https://xilinx-wiki.atlassian.net/wiki/spaces/A/pages/2037317633/Getting+Started+with+Certified+Ubuntu+20.04+LTS+for+Xilinx+Devices?utm_source=canonical&utm_medium=referral&utm_campaign=ubuntu&utm_content=download&utm_term=desktop_image">Xilinx
-              Getting Started Guide</a> for more information.</p>
+          <p>Please see the <a href="https://xlnx.com/3DxEglK" class="p-link--external">Kria KV260 Getting Started Guide</a> for more information.</p>
           <p><strong>Xilinx Ubuntu Software Development Kit</strong></p>
           <p>Ubuntu Developers targeting Kria KV260 platform may also want to download the following files:</p>
         </div>


### PR DESCRIPTION
## Done

- Copy update on `/download/xilinx`
- Switch the two tabs position 

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/download/xilinx
-  Be sure to test on mobile, tablet and desktop screen sizes
- Please check page against [copy doc](https://docs.google.com/document/d/1DZxf-ZbJtyS69XQBslJry3Ien1FSHYLB2Qt78iRkhOs/edit#) and resolve comments

## Issue / Card

Fixes [#4675](https://github.com/canonical-web-and-design/web-squad/issues/4675)

## Screenshots
Before:
![image](https://user-images.githubusercontent.com/57550290/145192579-83fd16a7-5324-46f8-be97-cf05cd74b460.png)

After : 
![image](https://user-images.githubusercontent.com/57550290/145192431-780897da-a01b-44d2-bffe-1e10769c2515.png)


## Help

[QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html) - [Commit guidelines](https://canonical-web-and-design.github.io/practices/workflow/commit-messages.html)
