### PR TITLE
Add marketing opt-in and Marketo form for CUBE purchases

### DIFF
--- a/static/js/src/cube/components/CubeBuyButton/CubeBuyButton.tsx
+++ b/static/js/src/cube/components/CubeBuyButton/CubeBuyButton.tsx
@@ -130,10 +130,8 @@ const CubeBuyButton = ({
     if (pendingPurchase?.status === "done") {
       const request = new XMLHttpRequest();
       const formData = new FormData();
-      formData.append("munchkinId", "066-EOV-335");
       formData.append("formid", "3756");
-      formData.append("formVid", "3756");
-      formData.append("Email", userInfo?.customerInfo?.email);
+      formData.append("email", userInfo?.customerInfo?.email);
       formData.append("Consent_to_Processing__c", "yes");
       formData.append("GCLID__c", sessionData?.gclid || "");
       formData.append("utm_campaign", sessionData?.utm_campaign || "");
@@ -145,10 +143,7 @@ const CubeBuyButton = ({
         isMarketingOptInChecked ? "yes" : "no"
       );
 
-      request.open(
-        "POST",
-        "https://app-sjg.marketo.com/index.php/leadCapture/save2"
-      );
+      request.open("POST", "/marketo/submit");
       request.send(formData);
 
       request.onreadystatechange = () => {

--- a/static/js/src/cube/components/CubePurchaseModal/CubePurchaseModal.tsx
+++ b/static/js/src/cube/components/CubePurchaseModal/CubePurchaseModal.tsx
@@ -34,6 +34,9 @@ const CubePurchaseModal = ({
     </>
   );
 
+  const marketingLabel =
+    "I agree to receive information about Canonical's products and services";
+
   const summary = () => <Summary productListingId={productListingId} />;
 
   const buyButton = ({ ...props }: BuyButtonProps) => (
@@ -52,6 +55,7 @@ const CubePurchaseModal = ({
         modalTitle="Complete purchase"
         marketplace="canonical-cube"
         termsLabel={termsLabel}
+        marketingLabel={marketingLabel}
         isFreeTrialApplicable={false}
         product={productName}
         quantity={quantity}


### PR DESCRIPTION
## Done

- Add marketing opt-in terms to the purchase modal
- Submit the Marketo form on purchase

## QA

- Run the server with `dotrun`
- Go to http://localhost:8001/cube/microcerts?test_backend=true
- Click the "Buy now" button and enter payment info to get to step 2 of the purchase modal
  - Verify that the marketing opt-in checkbox appears and is functional
  - Complete the purchase
  - Verify in Marketo that the settings have been updated (Morgan can check for you)

## Issue / Card

Fixes https://github.com/canonical-web-and-design/commercial-squad/issues/426

## Screenshots

![cube-marketing-opt-in](https://user-images.githubusercontent.com/995051/145210579-b2fa291c-39b1-4e13-9714-debfd15addf2.png)