### PR TITLE
Add cheat sheet CTA to openstack tutorials

### DIFF
--- a/templates/openstack/tutorials.html
+++ b/templates/openstack/tutorials.html
@@ -209,7 +209,7 @@
   </div>
 
   <div class="u-fixed-width u-align--center">
-    <a href="#" class="p-button--positive">Get Openstack cheat sheet</a>
+    <a href="https://assets.ubuntu.com/v1/8d3130a1-OpenStack.cheat.sheet.1.pdf" class="p-button--positive">Get Openstack cheat sheet</a>
   </div>
 </section>
 

--- a/templates/openstack/tutorials.html
+++ b/templates/openstack/tutorials.html
@@ -207,11 +207,15 @@
       </div>
     </div>                                          
   </div>
+
+  <div class="u-fixed-width u-align--center">
+    <a href="#" class="p-button--positive">Get Openstack cheat sheet</a>
+  </div>
 </section>
 
 <section class="p-strip is-deep is-bordered">
   <div class="u-fixed-width">
-    <h2>Learn more</h2>
+    <h2>Additional resources</h2>
     <div class="p-divider row">
       <div class="col-4 p-divider__block">
         <div class="p-heading-icon--muted">


### PR DESCRIPTION
## Done

**BLOCKED:** waiting on a link to the cheat sheet to be provided here: https://github.com/canonical-web-and-design/brand-squad/issues/610
- Updated the openstack tutorials list with a CTA link to a cheat sheet, per the [copy doc](https://docs.google.com/document/d/1_4EJlX-fbcQBVC9Ojhjdbls6kbmITGvHKi5IEqw-HAA/edit#)

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the demo in your web browser at: https://ubuntu-com-11017.demos.haus/openstack/tutorials
    - Be sure to test on mobile, tablet and desktop screen sizes
- See that it matches the copy doc

## Issue / Card

Fixes [#4663](https://github.com/canonical-web-and-design/web-squad/issues/4663)
