### PR TITLE
Build /iot-management page

### DIFF
--- a/navigation.yaml
+++ b/navigation.yaml
@@ -1227,7 +1227,7 @@ iot:
     - title: Smart city
       path: /internet-of-things/smart-city
     - title: IoT Management
-      path: /internet-of-things/iot-management
+      path: /internet-of-things/management
 
     - title: Thank you
       path: /internet-of-things/newsletter-thank-you

--- a/navigation.yaml
+++ b/navigation.yaml
@@ -1226,7 +1226,7 @@ iot:
       path: /internet-of-things/networking
     - title: Smart city
       path: /internet-of-things/smart-city
-    - title: IoT Management
+    - title: Management
       path: /internet-of-things/management
 
     - title: Thank you

--- a/navigation.yaml
+++ b/navigation.yaml
@@ -1226,6 +1226,8 @@ iot:
       path: /internet-of-things/networking
     - title: Smart city
       path: /internet-of-things/smart-city
+    - title: IoT Management
+      path: /internet-of-things/iot-management
 
     - title: Thank you
       path: /internet-of-things/newsletter-thank-you

--- a/templates/internet-of-things/contact-us.html
+++ b/templates/internet-of-things/contact-us.html
@@ -18,7 +18,7 @@
   {% elif product == 'gateways' %}
 
 {% with h1="Contact us about gateways",
-  intro_text="If you would like to know more about Ubuntu for edge gateways please fill in your details below and a member of our team will get in touch.",
+  intro_text="If you would like to know more about Ubuntu for edge gateways, please fill in your details below and a member of our team will get in touch.",
   formid="1663",
   lpId="3143",
   returnURL="/internet-of-things/thank-you?product=gateways" %}
@@ -28,7 +28,7 @@
   {% elif product == 'robotics' %}
 
 {% with h1="Contact us about robotics",
-  intro_text="If you would like to know more about Ubuntu for Robotics please fill in your details below and a member of our team will get in touch.",
+  intro_text="If you would like to know more about Ubuntu for Robotics, please fill in your details below and a member of our team will get in touch.",
   formid="1650",
   lpId="2838",
   returnURL="/internet-of-things/thank-you?product=robotics" %}
@@ -62,6 +62,16 @@
   formid="3484",
   lpId="",
   returnURL="/internet-of-things/thank-you?product=networking" %}
+  {% include "shared/_client-contact-us-form.html" %}
+{% endwith %}
+
+    {% elif product == 'iot-management' %}
+
+{% with h1="Contact us about IoT device management",
+  intro_text="If you would like to learn more about our enterprise device management features, please fill in the form below and a member of our team will be in touch.",
+  formid="2639",
+  lpId="5811",
+  returnURL="/internet-of-things/thank-you?product=iot-management" %}
   {% include "shared/_client-contact-us-form.html" %}
 {% endwith %}
 

--- a/templates/internet-of-things/contact-us.html
+++ b/templates/internet-of-things/contact-us.html
@@ -65,13 +65,13 @@
   {% include "shared/_client-contact-us-form.html" %}
 {% endwith %}
 
-    {% elif product == 'iot-management' %}
+    {% elif product == 'management' %}
 
 {% with h1="Contact us about IoT device management",
   intro_text="If you would like to learn more about our enterprise device management features, please fill in the form below and a member of our team will be in touch.",
-  formid="2639",
-  lpId="5811",
-  returnURL="/internet-of-things/thank-you?product=iot-management" %}
+  formid="4296",
+  lpId="",
+  returnURL="/internet-of-things/thank-you?product=management" %}
   {% include "shared/_client-contact-us-form.html" %}
 {% endwith %}
 

--- a/templates/internet-of-things/iot-management.html
+++ b/templates/internet-of-things/iot-management.html
@@ -1,0 +1,273 @@
+{% extends "internet-of-things/base_things.html" %}
+
+{% block title %}IoT Management - Manage Ubuntu Core devices{% endblock %}
+
+{% block meta_copydoc %}https://docs.google.com/document/d/1C-1ywVzBHkc4I3f-G7Rpy-epaXdbPisbolHUC1Jb7cE/edit#{% endblock meta_copydoc %}
+
+{% block meta_description %}Manage your Ubuntu Core powered IoT edge devices in a secure and reliable way. We provide solutions covering the whole project lifecycle from prototyping to deploying and maintaining your entire fleet.{% endblock %}
+
+{% block outer_content %}
+{% block content %}
+
+<section class="p-strip--suru-topped is-dark">
+  <div class="row u-vertically-center">
+    <div class="col-7">
+      <h1>IoT Device Management</h1>
+      <p>Simplify and automate the management of your Internet of Things (IoT) devices. Leverage the power of Ubuntu Core and your IoT app store to deliver long lasting projects. We provide the technology and infrastructure to securely manage and maintain your fleet.</p>
+      <p>Whether you need to manage a globally distributed deployment or devices in a strictly controlled environment, we have a solution for you.</p>
+      <p>
+        <a href="/internet-of-things/contact-us?product=iot-management" class="p-button--positive">Get in touch</a>
+      </p>
+    </div>
+    <div class="col-5 u-align--center u-vertically-center u-hide--small">
+      {{ image (
+        url="https://assets.ubuntu.com/v1/46f1b890-IoT_field_updates_from_Cloud.svg",
+        alt="",
+        width="328",
+        height="200",
+        hi_def=True,
+        loading="auto"
+        ) | safe
+        }}
+    </div>
+  </div>
+</section>
+<section class="p-strip--light is-deep">
+  <div class="row">
+    <div class="col-8">
+      <h2>Securely manage your IoT fleet</h2>
+    </div>
+  </div>
+  <div class="row u-equal-height">
+    <ul class="p-matrix p-matrix--two-col u-clearfix">
+      <li class="p-matrix__item">
+        <div class="p-matrix__content">
+          <h3>Onboard new devices</h3>
+          <div class="p-matrix__desc">
+            <p>Securely authenticate and add new devices to your managed IoT fleet. Connect them to your private app store with built in cryptographic protection. Control the access to your edge data and interfaces for all of your devices.</p>
+          </div>
+        </div>
+      </li>
+      <li class="p-matrix__item">
+        <div class="p-matrix__content">
+          <h3>Reliable over-the-air (OTA) updates</h3>
+          <div class="p-matrix__desc">
+            <p>Benefit from over-the-air updates that are transactional, allowing devices to roll back to a stable state if a failure occurs. Deliver application and operating system updates as deltas, minimising bandwidth consumption and associated costs.</p>
+          </div>
+        </div>
+      </li>
+      <li class="p-matrix__item">
+        <div class="p-matrix__content">
+          <h3>Organise your fleet</h3>
+          <div class="p-matrix__desc">
+            <p>Use device groups to control application workloads by hardware and device function. Curate software bundles for different scenarios. Roll out updates on your terms.</p>
+          </div>
+        </div>
+      </li>
+      <li class="p-matrix__item">
+        <div class="p-matrix__content">
+          <h3>Integrate with cloud solutions</h3>
+          <div class="p-matrix__desc">
+            <p>Deploy and manage your workloads from a public or private cloud of your choice. Reduce the complexity of your stack and optimise your IoT pipeline.</p>
+          </div>
+        </div>
+      </li>
+    </ul>
+  </div>
+</section>
+<section class="p-strip--suru">
+  <div class="row">
+    <h2 class="u-sv1">Learn more about enterprise device management </h2>
+  </div>
+  <div class="row p-divider is-dark">
+    <div class="col-4 p-divider__block">
+      <div class="p-heading-icon">
+        <div class="p-heading-icon__header">
+          {{ 
+            image (
+            url="https://assets.ubuntu.com/v1/4ab8ff35-Whitepaper+-+white.svg",
+            alt="",
+            width="32",
+            height="28",
+            hi_def=True,
+            loading="lazy",
+            attrs={"class": "p-heading-icon__img p-heading-icon__img--small"},
+            ) | safe
+          }}
+          <h3 class="p-heading-icon__title p-heading--4">Whitepaper</h3>
+        </div>
+      </div>
+      <p><a class="p-link--inverted"href="/iot-device-management-whitepaper?_ga=2.90790234.1537229770.1638375570-1154790289.1626446765">Secure IoT device management&nbsp;&rsaquo;</a></p>
+    </div>
+    <div class="col-4 p-divider__block">
+      <div class="p-heading-icon">
+        <div class="p-heading-icon__header"> 
+          {{ 
+            image (
+            url="https://assets.ubuntu.com/v1/816ae23b-Webinar+-+white.svg",
+            alt="",
+            width="32",
+            height="28",
+            hi_def=True,
+            loading="lazy",
+            attrs={"class": "p-heading-icon__img p-heading-icon__img--small"},
+            ) | safe
+          }}
+          <h3 class="p-heading-icon__title p-heading--4">Webinar</h3>
+        </div>
+      </div>
+      <p><a class="p-link--inverted" href="/engage/snap-store-proxy-intro-webinar">A technical introduction to the Snap Store Prox&nbsp;&rsaquo;</a></p>
+    </div>
+    <div class="col-4 p-divider__block">
+      <div class="p-heading-icon">
+        <div class="p-heading-icon__header">
+          {{ 
+            image (
+            url="https://assets.ubuntu.com/v1/4ab8ff35-Whitepaper+-+white.svg",
+            alt="",
+            width="32",
+            height="28",
+            hi_def=True,
+            loading="lazy",
+            attrs={"class": "p-heading-icon__img p-heading-icon__img--small"},
+            ) | safe
+          }}
+          <h3 class="p-heading-icon__title p-heading--4">Whitepaper</h3>
+        </div>
+      </div>
+      <p><a href="/engage/enterprise-snap-management" class="p-link--inverted">Enterprise snap management&nbsp;&rsaquo;</a></p>
+    </div>
+  </div>
+</section>
+<section class="p-strip">
+  <div class="row">
+    <div class="col-8">
+      <h2>Ubuntu Core</h2>
+      <p>Ubuntu Core is an all-snap version of Ubuntu engineered for IoT and mission critical applications. It is optimised for security and reliable updates. With a significantly reduced attack surface, Ubuntu Core is tamper resistant and hardened against corruption. It is easy to deploy and manage, allowing you to run your workloads consistently across a wide range of hardware.</p>
+      <p><a href="/core/docs/getting-started" class="p-button--positive">Get started</a></p>
+      <p><a href="/core">Find out more&nbsp;&rsaquo;</a></p>
+    </div>
+    <div class="col-4 u-align--center u-vertically-center u-hide--small">
+      {{ image (
+        url="https://assets.ubuntu.com/v1/07e4894f-core_black-orange_st_hex.svg",
+        alt="",
+        width="564",
+        height="400",
+        hi_def=True,
+        loading="lazy"
+        ) | safe
+      }}
+    </div>
+  </div>
+</section>
+<section class="p-strip--light">
+  <div class="row">
+    <div class="col-8">
+      <h2>IoT App Store</h2>
+      <p>The IoT app store is a dedicated, private, and customisable platform for your applications. It’s enterprise-ready and primed for efficient software distribution. It lets you utilise a huge range of our existing apps or build your own. Having a managed app store gives you role-based access controls, application versioning, OTA updates, controlled software rollouts, and much more.</p>
+      <p><a href="https://snapcraft.io/docs/getting-started" class="p-button--positive">Get started</a></p>
+      <p><a href="/internet-of-things/appstore">Find out more&nbsp;&rsaquo;</a></p>
+    </div>
+    <div class="col-4 u-align--center u-vertically-center u-hide--small">
+      {{ image (
+        url="https://assets.ubuntu.com/v1/bd695c08-app+store.svg",
+        alt="",
+        width="200",
+        height="200",
+        hi_def=True,
+        loading="lazy"
+        ) | safe
+      }}
+    </div>
+  </div>
+</section>
+<section class="p-strip--suru">
+  <div class="row">
+    <h2 class="u-sv1">Learn about our IoT portfolio</h2>
+  </div>
+  <div class="row p-divider is-dark">
+    <div class="col-4 p-divider__block">
+      <div class="p-heading-icon">
+        <div class="p-heading-icon__header">
+          {{ 
+            image (
+            url="https://assets.ubuntu.com/v1/4ab8ff35-Whitepaper+-+white.svg",
+            alt="",
+            width="32",
+            height="28",
+            hi_def=True,
+            loading="lazy",
+            attrs={"class": "p-heading-icon__img p-heading-icon__img--small"},
+            ) | safe
+          }}
+          <h3 class="p-heading-icon__title p-heading--4">Whitepaper</h3>
+        </div>
+      </div>
+      <p><a class="p-link--inverted p-link--external"href="/engage/smart-start-whitepaper">Accelerating IoT device time to market&nbsp;&rsaquo;</a></p>
+    </div>
+    <div class="col-4 p-divider__block">
+      <div class="p-heading-icon">
+        <div class="p-heading-icon__header"> 
+          {{ 
+            image (
+            url="https://assets.ubuntu.com/v1/816ae23b-Webinar+-+white.svg",
+            alt="",
+            width="32",
+            height="28",
+            hi_def=True,
+            loading="lazy",
+            attrs={"class": "p-heading-icon__img p-heading-icon__img--small"},
+            ) | safe
+          }}
+          <h3 class="p-heading-icon__title p-heading--4">Webinar</h3>
+        </div>
+      </div>
+      <p><a class="p-link--inverted" href="/engage/ubuntu-core-20-webinar">An introduction to Ubuntu Core 20&nbsp;&rsaquo;</a></p>
+    </div>
+    <div class="col-4 p-divider__block">
+      <div class="p-heading-icon">
+        <div class="p-heading-icon__header">
+          {{ 
+            image (
+            url="https://assets.ubuntu.com/v1/4ab8ff35-Whitepaper+-+white.svg",
+            alt="",
+            width="32",
+            height="28",
+            hi_def=True,
+            loading="lazy",
+            attrs={"class": "p-heading-icon__img p-heading-icon__img--small"},
+            ) | safe
+          }}
+          <h3 class="p-heading-icon__title p-heading--4">Whitepaper</h3>
+        </div>
+      </div>
+      <p><a href="/engage/snapd-whitepaper" class="p-link--inverted">Solving the software update challenge for IoT device&nbsp;&rsaquo;</a></p>
+    </div>
+  </div>
+</section>
+
+<section class="p-strip">
+  <div class="row u-equal-height">
+    <div class="col-4 u-align--left u-hide--small">
+      {{
+        image(
+          url="https://assets.ubuntu.com/v1/c4b290c8-Contact+us.svg",
+          alt="",
+          width="280",
+          height="280",
+          hi_def=True,
+        ) | safe
+      }}
+    </div>
+    <div class="col-8 u-vertically-center">
+      <div>
+        <h2>Let’s work together</h2>
+        <p>We work closely with our customers to solve complex problems together. Our talented engineers are experts in IoT and are well-qualified to provide guidance to both smaller businesses and larger enterprises. Share your story with us and let’s work together.</p>
+        <p><a href="/internet-of-things/contact-us?product=iot-management" class="p-button--positive">Get in touch</a></p>
+      </div>
+    </div>
+  </div>
+</section>
+
+{% endblock content %}
+{% endblock outer_content %}

--- a/templates/internet-of-things/management.html
+++ b/templates/internet-of-things/management.html
@@ -97,7 +97,7 @@
           <h3 class="p-heading-icon__title p-heading--4">Whitepaper</h3>
         </div>
       </div>
-      <p><a class="p-link--inverted"href="/iot-device-management-whitepaper?_ga=2.90790234.1537229770.1638375570-1154790289.1626446765">Secure IoT device management&nbsp;&rsaquo;</a></p>
+      <p><a class="p-link--inverted"href="/engage/iot-device-management-whitepaper?_ga=2.90790234.1537229770.1638375570-1154790289.1626446765">Secure IoT device management&nbsp;&rsaquo;</a></p>
     </div>
     <div class="col-4 p-divider__block">
       <div class="p-heading-icon">
@@ -203,7 +203,7 @@
           <h3 class="p-heading-icon__title p-heading--4">Whitepaper</h3>
         </div>
       </div>
-      <p><a class="p-link--inverted p-link--external"href="/engage/smart-start-whitepaper">Accelerating IoT device time to market&nbsp;&rsaquo;</a></p>
+      <p><a class="p-link--inverted" href="/engage/smart-start-whitepaper">Accelerating IoT device time to market&nbsp;&rsaquo;</a></p>
     </div>
     <div class="col-4 p-divider__block">
       <div class="p-heading-icon">

--- a/templates/internet-of-things/management.html
+++ b/templates/internet-of-things/management.html
@@ -16,7 +16,7 @@
       <p>Simplify and automate the management of your Internet of Things (IoT) devices. Leverage the power of Ubuntu Core and your IoT app store to deliver long lasting projects. We provide the technology and infrastructure to securely manage and maintain your fleet.</p>
       <p>Whether you need to manage a globally distributed deployment or devices in a strictly controlled environment, we have a solution for you.</p>
       <p>
-        <a href="/internet-of-things/contact-us?product=iot-management" class="p-button--positive">Get in touch</a>
+        <a href="/internet-of-things/contact-us?product=management" class="p-button--positive">Get in touch</a>
       </p>
     </div>
     <div class="col-5 u-align--center u-vertically-center u-hide--small">
@@ -263,7 +263,7 @@
       <div>
         <h2>Let’s work together</h2>
         <p>We work closely with our customers to solve complex problems together. Our talented engineers are experts in IoT and are well-qualified to provide guidance to both smaller businesses and larger enterprises. Share your story with us and let’s work together.</p>
-        <p><a href="/internet-of-things/contact-us?product=iot-management" class="p-button--positive">Get in touch</a></p>
+        <p><a href="/internet-of-things/contact-us?product=management" class="p-button--positive">Get in touch</a></p>
       </div>
     </div>
   </div>

--- a/templates/internet-of-things/thank-you.html
+++ b/templates/internet-of-things/thank-you.html
@@ -19,6 +19,9 @@
 {% elif product == 'networking' %}
   {% with thanks_context="your interest in Ubuntu for your networking project", thanks_message="A member of our team will follow up with you shortly." %}{% include "shared/_thank_you.html" %}{% endwith %}
 
+{% elif product == 'management' %}
+  {% with thanks_context="your interest in IoT device management!", thanks_message="A member of our team will follow up with you shortly." %}{% include "shared/_thank_you.html" %}{% endwith %} 
+
 {% else %}
   {% with thanks_context="your interest in Ubuntu for the Internet of Things", thanks_message="A member of our team will follow up with you shortly. In the meantime, explore <a href='/appliance'>Ubuntu Appliances</a>, where vendors and the open source community collaborate to deliver great software, securely, to a wide range of devices and cloud." %}{% include "shared/_thank_you.html" %}{% endwith %}
 {% endif %}


### PR DESCRIPTION
## Done

- Build `/internet-of-things/iot-management` page
- Add `IoT Management` on secondary navigation
- Update contact form

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Be sure to test on mobile, tablet and desktop screen sizes
- Please check page against [copy doc](https://docs.google.com/document/d/1C-1ywVzBHkc4I3f-G7Rpy-epaXdbPisbolHUC1Jb7cE/edit#) 
- Please refer to this [brief](https://docs.google.com/document/d/1ENKan1AIRTkzdARyYYE6U9lW1jhw5sRVY76GKrRRa2Y/edit) and [doc](https://docs.google.com/document/d/1Se-fD5hhb7EaR75jd_1D-JkADmg6aLjUs7_bScATvwE/edit#) for contact form 
## Issue / Card

Fixes [#4671](https://github.com/canonical-web-and-design/web-squad/issues/4671) & [#4673](https://github.com/canonical-web-and-design/web-squad/issues/4673)

## Screenshots

<img width="1440" alt="IoT Management - Manage Ubuntu Core devices | Ubuntu (2021-12-09 11-56-43)" src="https://user-images.githubusercontent.com/57550290/145392358-6ab2667b-d786-4e81-ad25-11cd17e509e8.png">



## Help

[QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html) - [Commit guidelines](https://canonical-web-and-design.github.io/practices/workflow/commit-messages.html)
