### PR TITLE
Add buy offer endpoint

### DIFF
--- a/webapp/advantage/schemas.py
+++ b/webapp/advantage/schemas.py
@@ -60,6 +60,14 @@ cancel_advantage_subscriptions = {
     ),
 }
 
+post_offer_schema = {
+    "account_id": String(),
+    "offer_id": String(),
+    "marketplace": String(
+        validate=validate.OneOf(["canonical-ua", "canonical-cube", "blender"])
+    ),
+}
+
 post_anonymised_customer_info = {
     "account_id": String(required=True),
     "name": String(required=True),

--- a/webapp/advantage/views.py
+++ b/webapp/advantage/views.py
@@ -474,7 +474,7 @@ def cancel_advantage_subscriptions(**kwargs):
 
 @advantage_decorator(permission="user", response="json")
 @use_kwargs(post_offer_schema, location="json")
-def post_offer(preview, **kwargs):
+def post_offer(**kwargs):
     account_id = kwargs.get("account_id")
     offer_id = kwargs.get("offer_id")
     marketplace = kwargs.get("marketplace", "canonical-ua")

--- a/webapp/advantage/views.py
+++ b/webapp/advantage/views.py
@@ -41,6 +41,7 @@ from webapp.advantage.schemas import (
     delete_account_user_role,
     put_contract_entitlements,
     post_auto_renewal_settings,
+    post_offer_schema,
 )
 
 
@@ -469,6 +470,22 @@ def cancel_advantage_subscriptions(**kwargs):
         )
 
     return flask.jsonify(purchase), 200
+
+
+@advantage_decorator(permission="user", response="json")
+@use_kwargs(post_offer_schema, location="json")
+def post_offer(preview, **kwargs):
+    account_id = kwargs.get("account_id")
+    offer_id = kwargs.get("offer_id")
+    marketplace = kwargs.get("marketplace", "canonical-ua")
+
+    g.api.purchase_from_marketplace(
+        marketplace=marketplace,
+        purchase_request={
+            "accountID": account_id,
+            "offerID": offer_id,
+        },
+    )
 
 
 @advantage_decorator(permission="user", response="json")

--- a/webapp/advantage/views.py
+++ b/webapp/advantage/views.py
@@ -479,7 +479,7 @@ def post_offer(**kwargs):
     offer_id = kwargs.get("offer_id")
     marketplace = kwargs.get("marketplace", "canonical-ua")
 
-    g.api.purchase_from_marketplace(
+    return g.api.purchase_from_marketplace(
         marketplace=marketplace,
         purchase_request={
             "accountID": account_id,

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -105,6 +105,7 @@ from webapp.advantage.views import (
     blender_thanks_view,
     blender_shop_view,
     support,
+    post_offer,
 )
 
 from webapp.login import login_handler, logout, user_info, empty_session
@@ -353,6 +354,7 @@ app.add_url_rule(
     methods=["POST"],
     defaults={"preview": True},
 )
+app.add_url_rule("/advantage/offer", view_func=post_offer, methods=["POST"])
 app.add_url_rule(
     "/advantage/customer-info", view_func=post_customer_info, methods=["POST"]
 )


### PR DESCRIPTION
## Done

- Create offer endpoint

## QA

- Tricky to QA without front-end. I use Postman with the cookie capture feature, but CURL works too:
```
curl --location --request POST 'https://ubuntu-com-11023.demos.haus/advantage/offer?test_backend=true' \
--header 'Content-Type: application/json' \
--header 'Cookie: <browser-cookie>' \
--data-raw '{
    "marketplace": "canonical-ua",
    "offer_id": "asd",
    "account_id": "asd"
}'
```
- It should return 200.

## Issue / Card

Fixes #https://github.com/canonical-web-and-design/commercial-squad/issues/432