### PR TITLE
Generate dynamic list of topics for dropdown

### DIFF
--- a/templates/tutorials/index.html
+++ b/templates/tutorials/index.html
@@ -33,15 +33,15 @@
         <label for="tutorials-topic">Topic:</label>
         <select name="tutorials-topic" id="tutorials-topic" class="u-no-margin--bottom">
           <option value="">Any</option>
-          <option value="cloud">Cloud</option>
-          <option value="community">Community</option>
-          <option value="containers">Containers</option>
-          <option value="desktop">Desktop</option>
-          <option value="development">Development</option>
-          <option value="iot">IoT</option>
-          <option value="packaging">Packaging</option>
-          <option value="server">Server</option>
-          <option value="ua">Ubuntu Advantage</option>
+          {% for item in topics_list %}
+            {% if item == "ua" %}
+              <option value="{{ item }}">Ubuntu Advantage</option>
+            {% elif item == "iot" %}
+              <option value="{{ item }}">IoT</option>
+            {% else %}
+              <option value="{{ item }}">{{item | capitalize}}</option>
+            {% endif %}
+          {% endfor %}
         </select>
       </div>
     </div>

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -310,6 +310,7 @@ def build_tutorials_index(session, tutorials_docs):
 
         tutorials_docs.parser.parse()
         tutorials_docs.parser.parse_topic(tutorials_docs.parser.index_topic)
+
         if not topic:
             tutorials = tutorials_docs.parser.tutorials
         else:
@@ -318,6 +319,14 @@ def build_tutorials_index(session, tutorials_docs):
                 for doc in tutorials_docs.parser.tutorials
                 if topic in doc["categories"]
             ]
+
+        # Create list of topics
+        topics_list = set()
+        for item in tutorials_docs.parser.tutorials:
+            if "categories" in item and item["categories"] not in topics_list:
+                topics_list = topics_list | set(
+                    item["categories"].replace(" ", "").lower().split(",")
+                )
 
         if query:
             temp_metadata = []
@@ -351,6 +360,7 @@ def build_tutorials_index(session, tutorials_docs):
             tutorials=tutorials,
             page=page,
             topic=topic,
+            topics_list=sorted(list(topics_list)),
             sort=sort,
             query=query,
             posts_per_page=posts_per_page,


### PR DESCRIPTION
## Done

In the issue, the topic "development" isn't returning any results, because the authors writing those tutorials haven't used this topic and the list showing in the dropdown is a static list (authors may add or remove topics and the front-end doesn't know)
Therefore, to definately solve this issue, I compiled the list of topics directly from all the tutorials, so we will always have an up to date list.

## QA

- Check https://ubuntu-com-11024.demos.haus/tutorials
- Open the topics dropdown to find a new up to date generated list of topics (you can compare with current https://ubuntu.com/tutorials)
- You can check that every single topic contains at least one tutorial

## Issue / Card

Fixes https://github.com/canonical-web-and-design/ubuntu.com/issues/6841

## Screenshots

<img width="1440" alt="Screenshot 2021-12-09 at 15 59 46" src="https://user-images.githubusercontent.com/14939793/145431152-d3110672-e44c-4ae5-99a5-712688dbe022.png">


## Help

[QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html) - [Commit guidelines](https://canonical-web-and-design.github.io/practices/workflow/commit-messages.html)
