### PR TITLE
Remove mention of Rackspace from /download/cloud

### DIFF
--- a/templates/download/cloud/index.html
+++ b/templates/download/cloud/index.html
@@ -9,7 +9,7 @@
   <div class="row u-equal-height">
     <div class="col-8">
       <h1>Optimised Ubuntu on&nbsp;public&nbsp;clouds</h1>
-      <p>Ubuntu builds optimised and certified server images for partners like Amazon AWS, Microsoft Azure, Google Cloud Platform, IBM Cloud, Rackspace and Oracle. In addition, Canonical offers Ubuntu Advantage, enterprise-grade commercial support, on these images.</p>
+      <p>Ubuntu builds optimised and certified server images for partners like Amazon AWS, Microsoft Azure, Google Cloud Platform, IBM Cloud and Oracle. In addition, Canonical offers Ubuntu Advantage, enterprise-grade commercial support, on these images.</p>
     </div>
     <div class="col-4 u-align--center u-vertically-center u-hide--small">
       {{
@@ -131,28 +131,6 @@
       </div>
       <ul class="p-list">
         <li class="p-list__item u-no-margin--top"><a href="https://www.ibm.com/cloud/" class="p-link--external">Get started on IBM Cloud</a></li>
-      </ul>
-    </div>
-    <div class="p-card col-4">
-      <div class="p-card__content">
-        <h4>
-          <a class="u-align--center u-vertically-center" style="min-height:10rem;display: flex;" href="https://www.rackspace.com/managed-hosting">
-            {{
-              image(
-                  url="https://assets.ubuntu.com/v1/ff936628-rackspace.svg",
-                  alt="Rackspace",
-                  width="192",
-                  height="56",
-                  hi_def=True,
-                  loading="lazy",
-                  attrs={"style": "align-self: center;max-height: 10rem; max-width:12rem;"},
-                ) | safe
-            }}
-          </a>
-        </h4>
-      </div>
-      <ul class="p-list">
-        <li class="p-list__item u-no-margin--top"><a href="https://www.rackspace.com/managed-hosting" class="p-link--external">Get started on Rackspace</a></li>
       </ul>
     </div>
     <div class="p-card col-4">


### PR DESCRIPTION
## Done

- Updated /download/cloud according to most recent comments in the [copy doc](https://docs.google.com/document/d/1kp7QQXst1EbCjZjzWZP3YZwfmG0EIXLfQoRUVaMEZng/edit#)

## QA

- View the demo in your web browser at: http://0.0.0.0:8001/
- See that it matches the copy doc

## Issue / Card

Fixes https://github.com/canonical-web-and-design/web-squad/issues/4681
