### PR TITLE
If actionable is null make it false

### DIFF
--- a/webapp/advantage/ua_contracts/helpers.py
+++ b/webapp/advantage/ua_contracts/helpers.py
@@ -265,7 +265,7 @@ def get_user_subscription_statuses(
         return statuses
 
     if type == "legacy":
-        statuses["is_renewal_actionable"] = renewal.actionable
+        statuses["is_renewal_actionable"] = renewal.actionable or False
 
         if renewal.actionable and renewal.status == "pending":
             start = parse(renewal.start_date)


### PR DESCRIPTION
## Done

- If `renewal.actionable` is `null`, then the value of the `statuses.renewal_is_actionable` is `null`. It should default to `False` instead. 

## QA

- Login with your account that has view as permissions: https://ubuntu-com-11036.demos.haus/advantage?test_backend=true
- View as https://ubuntu-com-11036.demos.haus/advantage?test_backend=true&email=albert.kolozsvari%2Btester16@canonical.com you should see the renewal button
- View as https://ubuntu-com-11036.demos.haus/advantage?test_backend=true&email=albert.kolozsvari%2Btester19@canonical.com you will not see the renewal button

## Issue / Card

Fixes #https://github.com/canonical-web-and-design/commercial-squad/issues/442