### PR TITLE
Add VAT option for South Africa

### DIFF
--- a/static/js/src/PurchaseModal/hooks/registerPaymentMethod.tsx
+++ b/static/js/src/PurchaseModal/hooks/registerPaymentMethod.tsx
@@ -85,7 +85,7 @@ const registerPaymentMethod = () => {
       address: addressObject,
       name: name,
       taxID: {
-        type: "eu_vat",
+        type: country === "ZA" ? "za_vat" : "eu_vat",
         value: VATNumber,
       },
     });

--- a/static/js/src/PurchaseModal/hooks/usePostCustomerInfoForPurchasePreview.tsx
+++ b/static/js/src/PurchaseModal/hooks/usePostCustomerInfoForPurchasePreview.tsx
@@ -29,7 +29,7 @@ const usePostCustomerInfoForPurchasePreview = () => {
         name,
         addressObject,
         {
-          type: "eu_vat",
+          type: country === "ZA" ? "za_vat" : "eu_vat",
           value: VATNumber,
         }
       );

--- a/static/js/src/advantage/countries-and-states.js
+++ b/static/js/src/advantage/countries-and-states.js
@@ -28,6 +28,7 @@ export const vatCountries = [
   "ES",
   "SE",
   "GB",
+  "ZA",
 ];
 
 export const countries = [


### PR DESCRIPTION
:warning: Don't merge until @alnvdl says it's good to go (should be on Wednesday) :warning: 

## Done

- Added `ZA` to the list of VAT countries
- Check if the country is ZA to set the type as `za_vat` instead of `eu_vat`

## QA

- Go to https://ubuntu-com-11038.demos.haus/advantage/subscribe?test_backend=true
- select a product and click buy
- select "South Africa" as your country
- fill in the VAT code with `4220122222`
- see that if can get the preview and make a purchase correctly

## Issue / Card

Fixes canonical-web-and-design/commercial-squad#443
