### PR TITLE
Remove blender logo from footer

### DIFF
--- a/templates/advantage/subscribe/blender/index.html
+++ b/templates/advantage/subscribe/blender/index.html
@@ -65,7 +65,6 @@
       <div class="col-4">
         <p class="u-no-padding--top">
           <span data-prop="user-count">1</span> &times;
-          <img src="https://assets.ubuntu.com/v1/786ed546-blender.svg" width="30" height="24" style="position: relative; top: 3px;">
           <span data-prop="selected-package">Blender Support Standard</span>
         </p>
       </div>


### PR DESCRIPTION
## Done

- Removed the blender logo from the wizard's footer

## QA

- go to /advantage/subscribe/blender?test_backend=true
- select a product
- check that the blender logo is gone from the summary footer
- 
## Issue / Card

Fixes https://github.com/canonical-web-and-design/commercial-squad/issues/440

## Screenshots

![image](https://user-images.githubusercontent.com/11927929/145965160-97371a8d-dc6d-4ff0-82ec-c021fe712592.png)


