### PR TITLE
Second step of the modal is reached even if setting customer info fails

### DIFF
--- a/static/js/src/PurchaseModal/PurchaseModal.tsx
+++ b/static/js/src/PurchaseModal/PurchaseModal.tsx
@@ -15,6 +15,7 @@ import {
 import StepOne from "./components/ModalSteps/StepOne";
 import StepTwo from "./components/ModalSteps/StepTwo";
 import { BuyButtonProps } from "./utils/utils";
+
 type Props = {
   accountId?: string;
   termsLabel: React.ReactNode;
@@ -97,6 +98,11 @@ const PurchaseModal = ({
                   <a href="/login">sign in</a> to your account first.
                 </>
               );
+            } else if (error.message === "tax_id_invalid") {
+              actions.setErrors({
+                VATNumber:
+                  "That VAT number is invalid. Check the number and try again.",
+              });
             } else {
               const knownErrorMessage = getErrorMessage({
                 message: "",

--- a/static/js/src/PurchaseModal/hooks/registerPaymentMethod.tsx
+++ b/static/js/src/PurchaseModal/hooks/registerPaymentMethod.tsx
@@ -58,7 +58,11 @@ const registerPaymentMethod = () => {
     if (error) {
       throw new Error(error.code);
     }
-    let accountRes = { accountID: window.accountId, code: null, message: "" };
+    let accountRes = {
+      accountID: window.accountId || window.tempAccountId,
+      code: null,
+      message: "",
+    };
 
     if (!accountRes.accountID) {
       accountRes = await ensurePurchaseAccount({
@@ -91,6 +95,7 @@ const registerPaymentMethod = () => {
     });
 
     if (customerInfoRes.errors) {
+      window.tempAccountId = accountRes.accountID;
       const errors = JSON.parse(customerInfoRes.errors);
       throw new Error(errors.decline_code ?? errors.code);
     }

--- a/static/js/src/PurchaseModal/hooks/registerPaymentMethod.tsx
+++ b/static/js/src/PurchaseModal/hooks/registerPaymentMethod.tsx
@@ -92,10 +92,7 @@ const registerPaymentMethod = () => {
 
     if (customerInfoRes.errors) {
       const errors = JSON.parse(customerInfoRes.errors);
-      //We ignore VAT errors but throw the others
-      if (errors.code !== "tax_id_invalid") {
-        throw new Error(errors.decline_code ?? errors.code);
-      }
+      throw new Error(errors.decline_code ?? errors.code);
     }
 
     return {

--- a/static/js/src/advantage/subscribe/react/app.tsx
+++ b/static/js/src/advantage/subscribe/react/app.tsx
@@ -14,6 +14,7 @@ declare global {
     isGuest?: boolean;
     isLoggedIn?: boolean;
     accountId?: string;
+    tempAccountId?: string;
     previousPurchaseIds?: string[];
     handleTogglePurchaseModal?: () => void;
   }


### PR DESCRIPTION
## Done

- Remove the explicit instruction to ignore VAT validation. :thinking: 

I can't remember why this was done. I tried most journeys, they still work as expected.

## QA

- go to https://ubuntu-com-11040.demos.haus/advantage/subscribe?test_backend=true as a guest or with a brand new SSO account
- select a product
- Fill in the details
- Select a country where VAT is applicable (eg. UK)
- input `GB123` as the VAT number
- Click next
- it should fail with an error telling you to fix the VAT number


## Issue / Card Fixes canonical-web-and-design/commercial-squad#355


## Screenshots

![image](https://user-images.githubusercontent.com/11927929/145968947-3b336d00-d945-4605-900b-4d10af0be888.png)

