### PR TITLE
Support for engage pages in Russian language

### DIFF
--- a/templates/engage/shared/_ru_engage_form.html
+++ b/templates/engage/shared/_ru_engage_form.html
@@ -1,0 +1,77 @@
+<!-- MARKETO FORM -->
+<form action="/marketo/submit" method="post" id="mktoForm_{{ id }}" onSubmit='if (typeof fbq === "function"){fbq("trackCustom", "Download"); }'>
+    <fieldset class="u-no-padding--top" style="border-bottom-width: 1px;">
+        <ul class="p-list">
+        <li class="p-list__item">
+            <label for="firstName">First name:</label>
+            <input required id="firstName" name="firstName" maxlength="255" type="text">
+        </li>
+        <li>
+            <label for="lastName">Last name:</label>
+            <input required id="lastName" name="lastName" maxlength="255" type="text">
+        </li>
+        <li>
+            <label for="email">Work email:</label>
+            <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$">
+        </li>
+        <li>
+            <label for="company">Company name:</label>
+            <input required id="company" name="company" maxlength="255" type="text">
+        </li>
+        <li>
+            <label for="jobTitle">Job title:</label>
+            <input required id="jobTitle" name="title" maxlength="255" type="text">
+        </li>
+        <li>
+            <label for="phone">Mobile/cell phone number:</label>
+            <input required id="phone" name="phone" maxlength="255" type="tel">
+        </li>
+        <li>
+            <input name="utm_campaign" aria-label="utm_campaign" value="{{utm_campaign}}"
+            type="hidden">
+        </li>
+        <li>
+            <input name="utm_medium" aria-label="utm_medium" value="{{utm_medium}}" type="hidden">
+        </li>
+        <li>
+            <input name="utm_source" aria-label="utm_source" value="{{utm_source}}" type="hidden">
+        </li>
+        <li>
+            <input name="canonicalUpdatesOptIn" aria-label="canonicalUpdatesOptIn" id="canonicalUpdatesOptIn" value="yes"
+            type="checkbox">
+                <label for="canonicalUpdatesOptIn">I agree to receive information about Canonical's products and services.</label>
+        </li>
+        <li>
+            <p>In submitting this form, I confirm that I have read and agree to <a href="/legal/data-privacy/contact">Canonical's Privacy Notice</a> and <a href="/legal/data-privacy">Privacy Policy</a>.
+            <input name="RichText" aria-label="RichText" type="hidden">
+            </p>
+        </li>
+        {# These are honey pot fields to catch bots #}
+        <li class="u-off-screen">
+            <label class="website" for="website">Website:</label>
+            <input name="website" type="text" class="website" autocomplete="off" value="" id="website" tabindex="-1" />
+        </li>
+        <li class="u-off-screen">
+            <label class="name" for="name">Name:</label>
+            <input name="name" type="text" class="name" autocomplete="off" value="" id="name" tabindex="-1" />
+        </li>
+        {# End of honey pots #}
+        <li>
+            <input name="Consent_to_Processing__c" aria-label="Consent" value="Yes" type="hidden">
+        </li>
+        <li>
+            <button type="submit" class="u-no-margin--bottom" >{% if cta %}{{ cta }}{% else %}Download the whitepaper{% endif %}</button>
+            <input name="formid" aria-label="formid" value="{{ id }}" type="hidden">
+            <input type="hidden" name="returnURL" aria-label="returnURL" value="{{ returnURL }}" />
+            <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" id="utm_campaign" value="" />
+            <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" id="utm_medium" value="" />
+            <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" id="utm_source" value="" />
+            <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content" id="utm_content" value="" />
+            <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" id="utm_term" value="" />
+            <input type="hidden" aria-hidden="true" aria-label="hidden field" name="GCLID__c" id="GCLID__c" value="" />
+            <input type="hidden" aria-hidden="true" aria-label="hidden field" name="Facebook_Click_ID__c" id="Facebook_Click_ID__c" value="" />
+        </li>
+        </ul>
+    </fieldset>
+</form>
+<!-- /MARKETO FORM -->

--- a/templates/engage/shared/_ru_thank-you.html
+++ b/templates/engage/shared/_ru_thank-you.html
@@ -1,0 +1,75 @@
+{% extends "engage/base_engage.html" %}
+
+{% block title %}Download {{ resource_name }} {% endblock %}
+
+{% block head_extra%}<meta name="robots" content="noindex" />{% endblock %}
+
+{% block content %}
+<style>
+  .global-nav .global-nav__header-logo-anchor {
+    padding-left: 0 !important;
+  }
+</style>
+<section class="p-strip p-engage-banner--grad">
+  <div class="u-fixed-width navigation-logo-engage">
+    <a href="/">
+      {{
+        image(
+            url="https://assets.ubuntu.com/v1/f263d9c4-logo-ubuntu-white.svg",
+            alt="Ubuntu",
+            width="143",
+            height="32",
+            hi_def=True,
+            loading="auto",
+        ) | safe
+      }}
+    </a>
+  </div>
+  <div class="row">
+    <div class="col-8">
+      <h1>
+        Thank you
+      </h1>
+    </div>
+  </div>
+</section>
+
+<section class="p-strip">
+  <div class="row">
+    <div class="col-8">
+      {% if 'pages.ubuntu.com' or 'assets.ubuntu.com' in resource_url %}
+      <p>
+        The {{ resource_name }} is now ready to download.
+      </p>
+      <p>
+        <a class="p-button--positive" href="{{ resource_url }}">Download</a>
+      </p>
+      {% else %}
+        <p>
+          Sorry, we do not recognise this download request.  Please let us know by <a class="p-link--external" href="https://github.com/canonical-websites/www.ubuntu.com/issues/new?body=Bad+resource+download+link+from {{ request.url | urlencode }}">filing and issue on GitHub</a>. And let us know what you excepted to download.
+        </p>
+      {% endif %}
+    </div>
+  </div>
+</section>
+
+{% if related | length > 0 %}
+<section class="p-strip--light">
+  <div class="row">
+    <div class="col-8">
+      <h2 class="p-heading--three">You may also be interested in &hellip;</h2>
+    </div>
+  </div>
+  <div class="row p-divider">
+    {% for page in related[0:3] %}
+    <div class="col-4 p-divider__block">
+      <!-- THREE ADDITIONAL CTAs -->
+      <h4>{{page["topic_name"]}}</h4>
+      <p>{{page["subtitle"]}}</p>
+      <p><a href="{{page['path']}}">See more&nbsp;&rsaquo;</a></p>
+    </div>
+    {% endfor %}
+  </div>
+</section>
+{% endif %}
+{% endblock content %}


### PR DESCRIPTION
## Done

Add form and thank you page for engage pages in Russian

## QA

- Check /engage and click on the Engage page in Russian language
- Boom it should work now, with form and thank you in English language (until we can get the translation)
- Make sure the form works, and you can reach the thank you page and download the whitepaper


## Help

[QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html) - [Commit guidelines](https://canonical-web-and-design.github.io/practices/workflow/commit-messages.html)
