### PR TITLE
Update links on /security

### DIFF
--- a/templates/security/index.html
+++ b/templates/security/index.html
@@ -80,7 +80,7 @@
   <div class="row u-equal-height">
     <div class="col-4 p-card u-align--center">
       <p>
-        <a href="/security/notices">
+        <a>
           {{ image (
             url="https://assets.ubuntu.com/v1/5edefef9-Datasheet.svg",
             alt="",
@@ -93,11 +93,11 @@
         </a>
       </p>
 
-      <h3 class="p-heading--four u-no-margin--bottom"><a href="/security/notices"  onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Security notices', 'eventLabel' : 'Security notices - find out more' : undefined });">Datasheet</a></h3>
+      <h3 class="p-heading--four u-no-margin--bottom"><a href="https://assets.ubuntu.com/v1/3ac9bf64-B.Cybersecurity.with.Ubuntu_11.10.21.2.pdf">Datasheet</a></h3>
     </div>
     <div class="col-4 p-card u-align--center">
       <p>
-        <a href="/blog/tag/security">
+        <a>
           {{
             image(
               url="https://assets.ubuntu.com/v1/fd84bbdc-Document-open.svg",
@@ -111,11 +111,11 @@
         </a>
       </p>
 
-      <h3 class="p-heading--four u-no-margin--bottom"><a href="/blog/tag/security" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Security news', 'eventLabel' : 'Security news - find out more' : undefined });">Security notices</a></h3>
+      <h3 class="p-heading--four u-no-margin--bottom"><a href="/security/notices"  onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Security notices', 'eventLabel' : 'Security notices - find out more' : undefined });">Security notices</a></h3>
     </div>
     <div class="col-4 p-card u-align--center">
       <p>
-        <a href="https://wiki.ubuntu.com/Security/Features">
+        <a>
           {{
             image(
               url="https://assets.ubuntu.com/v1/fd84bbdc-Document-open.svg",


### PR DESCRIPTION
## Done

- Update links on `/security`

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/security
- Be sure to test on mobile, tablet and desktop screen sizes
- Please compare against this [copy doc](https://docs.google.com/document/d/1yEocR1WXQvN_B1L1yBYrG_0D7ikS6QhcOz27sYs-teI/edit) and check the links are correct.


