### PR TITLE
UA Shop: Add label to subscriptions that are not editable

### DIFF
--- a/static/js/src/advantage/react/components/Subscriptions/SubscriptionDetails/SubscriptionDetails.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/SubscriptionDetails/SubscriptionDetails.tsx
@@ -136,7 +136,14 @@ export const SubscriptionDetails = forwardRef<HTMLDivElement, Props>(
                   >
                     Edit subscription&hellip;
                   </Button>
-                ) : null}
+                ) : (
+                  <h5 className="u-no-padding--top p-subscriptions__details-small-title">
+                    <span style={{ fontWeight: 300 }} className="u-text--muted">
+                      {" "}
+                      This subscription cannot be edited online.
+                    </span>
+                  </h5>
+                )}
               </>
             )}
           </div>


### PR DESCRIPTION
## Done
Show a label saying a subscription is not editable when they are not.

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/advantage?test_backend=true
- Check a subscription that was purchased on offer and make sure it displays `This subscription cannot be edited online.`