### PR TITLE
Added Screenly section

### DIFF
--- a/templates/core/stories.html
+++ b/templates/core/stories.html
@@ -215,7 +215,31 @@
   <div class="row">
     <h2>Ubuntu Core in digital signage</h2>
   </div>
-  <div class="row u-equal-height">
+  <div class="row">
+    <div class="col-8">
+      <h4>Screenly innovates IoT fleet management for secure digital signage</h4>
+      <p>Originally having relied on home-grown infrastructure to deliver over-the-air (OTA) patches to devices in the field, Screenly needed a better way to manage its fast scaling and distributed IoT fleet. After a comprehensive market evaluation, Ubuntu Core stood out as the ideal fit.</p>
+      <p>
+        <a href="/engage/secure-digital-signage-screenly">Screenly innovates IoT fleet management for secure digital signage&nbsp;&rsaquo;</a>
+      </p>
+    </div>
+    <div class="col-4 u-vertically-center u-align--center u-hide--small">
+      {{ 
+        image (
+        url="https://assets.ubuntu.com/v1/3eb6002c-screenly+box-logo-horizontal+purple+%281%29.png",
+        alt="Screenly logo",
+        width="262",
+        height="126",
+        hi_def=True,
+        loading="lazy"
+        ) | safe
+      }}
+    </div>
+  </div>
+</section>
+
+<section class="p-strip">
+  <div class="row">
     <div class="col-8">
       <h4>Cinergy makes significant digital signage saving with Screenly Pro and Ubuntu Core</h4>
       <p>Cinema entertainment centres (CECs) are an all in one venue incorporating cinemas, restaurants, bowling and other activities such as escape rooms and are a growing market. Find out why they turned to Screenly Pro and Ubuntu Core to help with their content management needs in such a marketing driven business.</p>
@@ -239,6 +263,10 @@
     </div>
   </div>
 </section>
+
+<div class="u-fixed-width">
+  <hr class="p-separator" />
+</div>
 
 <section class="p-strip u-sv3">
   <div class="row">

--- a/templates/core/stories.html
+++ b/templates/core/stories.html
@@ -224,7 +224,7 @@
       </p>
     </div>
     <div class="col-4 u-align--center u-hide--small">
-      {{ 
+      {{
         image (
         url="https://assets.ubuntu.com/v1/3eb6002c-screenly+box-logo-horizontal+purple+%281%29.png",
         alt="",
@@ -262,13 +262,11 @@
         }}
     </div>
   </div>
-</section>
 
-<div class="u-fixed-width">
-  <hr class="p-separator" />
-</div>
+  <div class="u-fixed-width">
+    <hr class="p-separator" />
+  </div>
 
-<section class="p-strip u-sv3">
   <div class="row">
     <h2>Ubuntu Core in consumer applications</h2>
   </div>
@@ -315,7 +313,7 @@
         }}
     </div>
   </div>
-  <div class="row">
+  <div class="row u-sv3">
     <p>
       <a href="/engage/domotz-case-study">How Domotz streamlined provisioning of IoT devices&nbsp;&rsaquo;</a>
     </p>

--- a/templates/core/stories.html
+++ b/templates/core/stories.html
@@ -217,7 +217,7 @@
   </div>
   <div class="row">
     <div class="col-8">
-      <h4>Screenly innovates IoT fleet management for secure digital signage</h4>
+      <h3 class="p-heading--4">Screenly innovates IoT fleet management for secure digital signage</h3>
       <p>Originally having relied on home-grown infrastructure to deliver over-the-air (OTA) patches to devices in the field, Screenly needed a better way to manage its fast scaling and distributed IoT fleet. After a comprehensive market evaluation, Ubuntu Core stood out as the ideal fit.</p>
       <p>
         <a href="/engage/secure-digital-signage-screenly">Screenly innovates IoT fleet management for secure digital signage&nbsp;&rsaquo;</a>

--- a/templates/core/stories.html
+++ b/templates/core/stories.html
@@ -227,7 +227,7 @@
       {{ 
         image (
         url="https://assets.ubuntu.com/v1/3eb6002c-screenly+box-logo-horizontal+purple+%281%29.png",
-        alt="Screenly logo",
+        alt="",
         width="262",
         height="126",
         hi_def=True,

--- a/templates/core/stories.html
+++ b/templates/core/stories.html
@@ -223,7 +223,7 @@
         <a href="/engage/secure-digital-signage-screenly">Screenly innovates IoT fleet management for secure digital signage&nbsp;&rsaquo;</a>
       </p>
     </div>
-    <div class="col-4 u-vertically-center u-align--center u-hide--small">
+    <div class="col-4 u-align--center u-hide--small">
       {{ 
         image (
         url="https://assets.ubuntu.com/v1/3eb6002c-screenly+box-logo-horizontal+purple+%281%29.png",


### PR DESCRIPTION
## Done

- Updated page as per [copy doc](https://docs.google.com/document/d/1mXnYnpaCJznDLtYn9Q74aVeEI3iFxVOMzF0pdL7wdu0/edit)

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: https://ubuntu-com-11058.demos.haus/core/stories
    - Be sure to test on mobile, tablet and desktop screen sizes
- Check against copy doc and see that all changes are there
- Test link and see that it works as expected

## Issue / Card

Fixes https://github.com/canonical-web-and-design/web-squad/issues/4724

## Screenshots 
<img width="1001" alt="Screenshot 2021-12-15 at 14 01 26" src="https://user-images.githubusercontent.com/17607612/146248658-72968178-8876-4f45-930a-5b66c69b62c3.png">


