### PR TITLE
Fix typo on iot/management page

### DIFF
--- a/templates/internet-of-things/management.html
+++ b/templates/internet-of-things/management.html
@@ -116,7 +116,7 @@
           <h3 class="p-heading-icon__title p-heading--4">Webinar</h3>
         </div>
       </div>
-      <p><a class="p-link--inverted" href="/engage/snap-store-proxy-intro-webinar">A technical introduction to the Snap Store Prox&nbsp;&rsaquo;</a></p>
+      <p><a class="p-link--inverted" href="/engage/snap-store-proxy-intro-webinar">A technical introduction to the Snap Store Proxy&nbsp;&rsaquo;</a></p>
     </div>
     <div class="col-4 p-divider__block">
       <div class="p-heading-icon">


### PR DESCRIPTION
## Done
Add "y" to "A technical introduction to the Snap Store Prox" webinar link.

## QA
- Check the code is good

## Issue / Card
Fixes https://github.com/canonical-web-and-design/ubuntu.com/issues/11069
