### PR TITLE
use hardware details per certified entry

### DIFF
--- a/templates/certified/model-details.html
+++ b/templates/certified/model-details.html
@@ -117,7 +117,7 @@
               <h4>Hardware</h4>
               <table aria-label="Hardware" class="u-no-margin--bottom">
                 <tbody>
-                {% for hardware_subtitle, values in release_details["components"].items() %}
+                {% for hardware_subtitle, values in release["components"].items() %}
                   <tr>
                     <th colspan="2" class="u-text--muted">{{ hardware_subtitle }}</th>
                     <td colspan="8">{% for value in values %} 

--- a/webapp/certified/views.py
+++ b/webapp/certified/views.py
@@ -145,12 +145,11 @@ def certified_model_details(canonical_id):
             "level": model_release["level"],
             "notes": model_release["notes"],
             "version": ubuntu_version,
+            "components": {},
         }
 
         if release_info["level"] == "Enabled":
             has_enabled_releases = True
-
-        release_details["releases"].append(release_info)
 
         for device_category, devices in model_release.items():
             if (
@@ -160,11 +159,11 @@ def certified_model_details(canonical_id):
             ):
                 device_category = device_category.capitalize()
 
-                release_details["components"][device_category] = []
+                release_info["components"][device_category] = []
 
-                if device_category in release_details["components"]:
+                if device_category in release_info["components"]:
                     for device in devices:
-                        release_details["components"][device_category].append(
+                        release_info["components"][device_category].append(
                             {
                                 "name": (
                                     f"{device['make']} {device['name']}"
@@ -174,6 +173,7 @@ def certified_model_details(canonical_id):
                                 "identifier": device["identifier"],
                             }
                         )
+        release_details["releases"].append(release_info)
 
     # default to category, which contains the least specific form_factor
     form_factor = model_release and model_release.get(


### PR DESCRIPTION
Display hardware details specific to each certificate rather than displaying one set of hardware details for all.

note: it's the Friday before winter break, so you may want to wait on merging this on the off chance it breaks anything before everyone goes on break.


## Done

This updates the view so that it collects hardware info per certificate rather than grabbing the most recent certificate's hardware details to display everywhere.

## QA

- View https://ubuntu-com-11076.demos.haus/certified/201809-26501
- verify that the first certificate shows _Intel(R) Xeon(R) Platinum 8276 CPU @ 2.20GHz_ as the processor.

## Issue / Card

Fixes #11074