### PR TITLE
Replace `leadCapture/save2` with the marketo endpoint

### DIFF
--- a/static/js/src/advantage/react/components/Subscriptions/RenewalModal/RenewButton/RenewButton.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/RenewalModal/RenewButton/RenewButton.tsx
@@ -135,10 +135,8 @@ const BuyButton = ({
     if (pendingRenewal?.status === "done") {
       const request = new XMLHttpRequest();
       const formData = new FormData();
-      formData.append("munchkinId", "066-EOV-335");
       formData.append("formid", "3756");
-      formData.append("formVid", "3756");
-      formData.append("Email", userInfo?.customerInfo?.email);
+      formData.append("email", userInfo?.customerInfo?.email ?? "");
       formData.append("Consent_to_Processing__c", "yes");
       formData.append("GCLID__c", sessionData?.gclid || "");
       formData.append("utm_campaign", sessionData?.utm_campaign || "");
@@ -150,10 +148,7 @@ const BuyButton = ({
         isMarketingOptInChecked ? "yes" : "no"
       );
 
-      request.open(
-        "POST",
-        "https://app-sjg.marketo.com/index.php/leadCapture/save2"
-      );
+      request.open("POST", "/marketo/submit");
       request.send(formData);
 
       request.onreadystatechange = () => {

--- a/static/js/src/advantage/subscribe/blender/BuyButton.tsx
+++ b/static/js/src/advantage/subscribe/blender/BuyButton.tsx
@@ -142,10 +142,8 @@ const BuyButton = ({
 
       const request = new XMLHttpRequest();
       const formData = new FormData();
-      formData.append("munchkinId", "066-EOV-335");
       formData.append("formid", "3756");
-      formData.append("formVid", "3756");
-      formData.append("Email", userInfo?.customerInfo?.email);
+      formData.append("email", userInfo?.customerInfo?.email ?? "");
       formData.append("Consent_to_Processing__c", "yes");
       formData.append("GCLID__c", sessionData?.gclid || "");
       formData.append("utm_campaign", sessionData?.utm_campaign || "");
@@ -157,10 +155,7 @@ const BuyButton = ({
         isMarketingOptInChecked ? "yes" : "no"
       );
 
-      request.open(
-        "POST",
-        "https://app-sjg.marketo.com/index.php/leadCapture/save2"
-      );
+      request.open("POST", "/marketo/submit");
       request.send(formData);
 
       request.onreadystatechange = () => {

--- a/static/js/src/advantage/subscribe/react/components/BuyButton/BuyButton.tsx
+++ b/static/js/src/advantage/subscribe/react/components/BuyButton/BuyButton.tsx
@@ -201,10 +201,8 @@ const BuyButton = ({
 
       const request = new XMLHttpRequest();
       const formData = new FormData();
-      formData.append("munchkinId", "066-EOV-335");
       formData.append("formid", "3756");
-      formData.append("formVid", "3756");
-      formData.append("Email", userInfo?.customerInfo?.email);
+      formData.append("email", userInfo?.customerInfo?.email ?? "");
       formData.append("Consent_to_Processing__c", "yes");
       formData.append("GCLID__c", sessionData?.gclid || "");
       formData.append("utm_campaign", sessionData?.utm_campaign || "");
@@ -216,10 +214,7 @@ const BuyButton = ({
         isMarketingOptInChecked ? "yes" : "no"
       );
 
-      request.open(
-        "POST",
-        "https://app-sjg.marketo.com/index.php/leadCapture/save2"
-      );
+      request.open("POST", "/marketo/submit");
       request.send(formData);
 
       request.onreadystatechange = () => {


### PR DESCRIPTION
## Done

- Replace `leadCapture/save2` with the marketo endpoint

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/advantage/subscribe
    - Be sure to test on mobile, tablet and desktop screen sizes
- Please check the submission is working properly on `/advantage/subscribe`
## Issue / Card

Fixes [#4733](https://github.com/canonical-web-and-design/web-squad/issues/4733)

## Help

[QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html) - [Commit guidelines](https://canonical-web-and-design.github.io/practices/workflow/commit-messages.html)
