### PR TITLE
Create Russian translation for engage form and thank you

### DIFF
--- a/templates/engage/shared/_ru_engage_form.html
+++ b/templates/engage/shared/_ru_engage_form.html
@@ -3,27 +3,27 @@
     <fieldset class="u-no-padding--top" style="border-bottom-width: 1px;">
         <ul class="p-list">
         <li class="p-list__item">
-            <label for="firstName">First name:</label>
+            <label for="firstName">Имя:</label>
             <input required id="firstName" name="firstName" maxlength="255" type="text">
         </li>
         <li>
-            <label for="lastName">Last name:</label>
+            <label for="lastName">Фамилия:</label>
             <input required id="lastName" name="lastName" maxlength="255" type="text">
         </li>
         <li>
-            <label for="email">Work email:</label>
+            <label for="email">Рабочая электронная почта:</label>
             <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$">
         </li>
         <li>
-            <label for="company">Company name:</label>
+            <label for="company">Компания:</label>
             <input required id="company" name="company" maxlength="255" type="text">
         </li>
         <li>
-            <label for="jobTitle">Job title:</label>
+            <label for="jobTitle">Должность:</label>
             <input required id="jobTitle" name="title" maxlength="255" type="text">
         </li>
         <li>
-            <label for="phone">Mobile/cell phone number:</label>
+            <label for="phone">Номер телефона:</label>
             <input required id="phone" name="phone" maxlength="255" type="tel">
         </li>
         <li>
@@ -39,10 +39,10 @@
         <li>
             <input name="canonicalUpdatesOptIn" aria-label="canonicalUpdatesOptIn" id="canonicalUpdatesOptIn" value="yes"
             type="checkbox">
-                <label for="canonicalUpdatesOptIn">I agree to receive information about Canonical's products and services.</label>
+                <label for="canonicalUpdatesOptIn">Я согласен получать информацию о продуктах и услугах Canonical.</label>
         </li>
         <li>
-            <p>In submitting this form, I confirm that I have read and agree to <a href="/legal/data-privacy/contact">Canonical's Privacy Notice</a> and <a href="/legal/data-privacy">Privacy Policy</a>.
+            <p>Отправляя эту форму, я подтверждаю, что прочитал и принимаю <a href="/legal/data-privacy/contact">Уведомление о конфиденциальности</a> and <a href="/legal/data-privacy">Политику конфиденциальности</a>.
             <input name="RichText" aria-label="RichText" type="hidden">
             </p>
         </li>
@@ -60,7 +60,7 @@
             <input name="Consent_to_Processing__c" aria-label="Consent" value="Yes" type="hidden">
         </li>
         <li>
-            <button type="submit" class="u-no-margin--bottom" >{% if cta %}{{ cta }}{% else %}Download the whitepaper{% endif %}</button>
+            <button type="submit" class="u-no-margin--bottom" >{% if cta %}{{ cta }}{% else %}Загрузить документ{% endif %}</button>
             <input name="formid" aria-label="formid" value="{{ id }}" type="hidden">
             <input type="hidden" name="returnURL" aria-label="returnURL" value="{{ returnURL }}" />
             <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" id="utm_campaign" value="" />

--- a/templates/engage/shared/_ru_thank-you.html
+++ b/templates/engage/shared/_ru_thank-you.html
@@ -1,6 +1,6 @@
 {% extends "engage/base_engage.html" %}
 
-{% block title %}Download {{ resource_name }} {% endblock %}
+{% block title %}Загрузить {{ resource_name }} {% endblock %}
 
 {% block head_extra%}<meta name="robots" content="noindex" />{% endblock %}
 
@@ -28,7 +28,7 @@
   <div class="row">
     <div class="col-8">
       <h1>
-        Thank you
+        Спасибо
       </h1>
     </div>
   </div>
@@ -39,10 +39,10 @@
     <div class="col-8">
       {% if 'pages.ubuntu.com' or 'assets.ubuntu.com' in resource_url %}
       <p>
-        The {{ resource_name }} is now ready to download.
+        {{ resource_name }} готов к загрузке.
       </p>
       <p>
-        <a class="p-button--positive" href="{{ resource_url }}">Download</a>
+        <a class="p-button--positive" href="{{ resource_url }}">Загрузить</a>
       </p>
       {% else %}
         <p>


### PR DESCRIPTION
## Done

*This PR is for the two issues listed below*
https://github.com/canonical-web-and-design/web-squad/issues/4659
https://github.com/canonical-web-and-design/web-squad/issues/4659

- Adds an engage form in Russian
- Adds thank you page in Russian

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: 
 1 . http://0.0.0.0:8001/engage/сравнение-платформ-red-hat-openstack-canonical-charmed-openstack or https://ubuntu-com-11103.demos.haus/engage/сравнение-платформ-red-hat-openstack-canonical-charmed-openstack
 2 .  http://0.0.0.0:8001/engage/сравнение-платформ-kubernetes or https://ubuntu-com-11103.demos.haus/engage/сравнение-платформ-kubernetes
    - Be sure to test on mobile, tablet and desktop screen sizes
- Check the language makes sense

## Issue / Card

1. https://github.com/canonical-web-and-design/web-squad/issues/4659
2. https://github.com/canonical-web-and-design/web-squad/issues/4659

## Help

[QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html) - [Commit guidelines](https://canonical-web-and-design.github.io/practices/workflow/commit-messages.html)
