### PR TITLE
/model-driven-operations: Add "Why use Juju" diagrams

### DIFF
--- a/templates/model-driven-operations/index.html
+++ b/templates/model-driven-operations/index.html
@@ -38,6 +38,30 @@
       <a href="https://juju.is" class="p-button--positive">Learn more about Juju</a>
     </div>
   </div>
+  <div class="row">
+    <div class="col-6">
+      {{ image (
+        url="https://assets.ubuntu.com/v1/d3c7f21a-why-use-juju-diagram-left.svg",
+        alt="",
+        width="440",
+        height="779",
+        hi_def=True,
+        loading="auto"
+        ) | safe
+      }}
+    </div>
+    <div class="col-6">
+      {{ image (
+        url="https://assets.ubuntu.com/v1/43f8adf2-why-use-juju-diagram-right.svg",
+        alt="",
+        width="440",
+        height="779",
+        hi_def=True,
+        loading="auto"
+        ) | safe
+      }}
+    </div>
+  </div>
 </section>
 
 <section class="p-strip--light">

--- a/templates/model-driven-operations/index.html
+++ b/templates/model-driven-operations/index.html
@@ -41,7 +41,7 @@
   <div class="row">
     <div class="col-6">
       {{ image (
-        url="https://assets.ubuntu.com/v1/d3c7f21a-why-use-juju-diagram-left.svg",
+        url="https://assets.ubuntu.com/v1/0d754471-why-use-juju-diagram-left-update.svg",
         alt="",
         width="440",
         height="779",
@@ -52,7 +52,7 @@
     </div>
     <div class="col-6">
       {{ image (
-        url="https://assets.ubuntu.com/v1/43f8adf2-why-use-juju-diagram-right.svg",
+        url="https://assets.ubuntu.com/v1/ace14664-why-use-juju-diagram-right-update.svg",
         alt="",
         width="440",
         height="779",


### PR DESCRIPTION
## Done

- Use the adjusted "Why use Juju" diagrams for Jaas.ai provided by @waynecrosby 

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- [List additional steps to QA the new features or prove the bug has been resolved]

## Issue / Card

## Screenshots
![ubuntu com_model-driven-operations (1)](https://user-images.githubusercontent.com/1413534/148102087-e362cfa8-f632-4698-8c49-942672491ca8.png)
