### PR TITLE
Add link to IoT data sheet in 'App store commissioning'

### DIFF
--- a/templates/core/smartstart/guide/app-store-commissioning.md
+++ b/templates/core/smartstart/guide/app-store-commissioning.md
@@ -10,6 +10,8 @@ context:
 
 SMART START customers benefit from their own IoT app store. While app stores are hosted by Canonical, they are entirely operated by customers. This section describes the first steps a customer takes when commissioning their app store.
 
+<p><a href="https://assets.ubuntu.com/v1/d6d1d3fc-IoT+App+Store+Datasheet+v3.pdf" class="p-link--external">Read the IoT app store datasheet&nbsp;&rsaquo;</a></p>
+
 ## IoT app store overview
 
 <figure>


### PR DESCRIPTION
## Done

- Adds link to IoT data sheet in 'App store commissioning'

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001//core/smartstart/guide/app-store-commissioning
    - Be sure to test on mobile, tablet and desktop screen sizes

## Issue / Card

Fixes https://github.com/canonical-web-and-design/ubuntu.com/issues/11061

## Help

[QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html) - [Commit guidelines](https://canonical-web-and-design.github.io/practices/workflow/commit-messages.html)
