### PR TITLE
Surface actual number of machines

### DIFF
--- a/webapp/advantage/models.py
+++ b/webapp/advantage/models.py
@@ -64,6 +64,7 @@ class UserSubscription:
         type: str,
         start_date: str,
         number_of_machines: int,
+        current_number_of_machines: int,
         machine_type: str,
         marketplace: str,
         price: int,
@@ -84,6 +85,7 @@ class UserSubscription:
         self.start_date = start_date
         self.end_date = end_date
         self.number_of_machines = number_of_machines
+        self.current_number_of_machines = current_number_of_machines
         self.machine_type = machine_type
         self.marketplace = marketplace
         self.price = price

--- a/webapp/advantage/ua_contracts/builders.py
+++ b/webapp/advantage/ua_contracts/builders.py
@@ -12,6 +12,7 @@ from webapp.advantage.ua_contracts.helpers import (
     make_user_subscription_id,
     apply_entitlement_rules,
     group_shop_items,
+    get_current_number_of_machines,
 )
 from webapp.advantage.ua_contracts.primitives import (
     Contract,
@@ -197,6 +198,9 @@ def build_final_user_subscriptions(
         aggregated_values = get_items_aggregated_values(items, type)
         number_of_machines = aggregated_values.get("number_of_machines")
         end_date = aggregated_values.get("end_date")
+        current_number_of_machines = get_current_number_of_machines(
+            subscriptions, subscription_id, listing
+        )
         price_info = get_price_info(number_of_machines, items, listing)
         product_name = (
             contract.name if type != "free" else "Free Personal Token"
@@ -229,6 +233,7 @@ def build_final_user_subscriptions(
             start_date=aggregated_values.get("start_date"),
             end_date=end_date,
             number_of_machines=number_of_machines,
+            current_number_of_machines=current_number_of_machines,
             product_name=product_name,
             marketplace=marketplace,
             price=price_info.get("price"),

--- a/webapp/advantage/ua_contracts/helpers.py
+++ b/webapp/advantage/ua_contracts/helpers.py
@@ -66,6 +66,35 @@ def get_items_aggregated_values(items: List[ContractItem], type: str) -> Dict:
     }
 
 
+def get_current_number_of_machines(
+    subscriptions: List[Subscription] = None,
+    subscription_id: str = None,
+    listing: Listing = None,
+) -> int:
+    if not subscriptions or not subscription_id or not listing:
+        return 0
+
+    subscription = [
+        subscription
+        for subscription in subscriptions
+        if subscription.id == subscription_id
+    ]
+
+    if not subscription:
+        return 0
+
+    current_item = [
+        item
+        for item in subscription[0].items
+        if item.product_listing_id == listing.id
+    ]
+
+    if not current_item:
+        return 0
+
+    return current_item[0].value
+
+
 def get_price_info(
     number_of_machines: int = None,
     items: List[ContractItem] = None,


### PR DESCRIPTION
## Done

- Add `current_number_of_machines` as a property of the `user_subscription`. This value is the actual number of machines the user will have starting with the next billing cycle. It should also be used as the pre-filled value in the edit number of machines field.

## QA

- Go to https://ubuntu-com-11110.demos.haus or check out this feature branch 
- Do you have a stripe subscription that you can down-sell? If no, buy one.
- Down-sell the user subscription; you might have to manually refresh the page, as the front-end is not fully supporting the new kind of resizing
-  On /advantage you will still see the old value of machine numbers (as until the end of the billing period it won't change), but on /advantage/user-subscriptions you will see a new property called `current_number_of_machines` which will show you the next billing period's number of machines

## Issue / Card

Fixes #https://github.com/canonical-web-and-design/commercial-squad/issues/445