### PR TITLE
Add version switcher to the docs template

### DIFF
--- a/templates/templates/docs/shared/_docs.html
+++ b/templates/templates/docs/shared/_docs.html
@@ -24,7 +24,7 @@
 {% endmacro %}
 
 {% block outer_content %}
-  {% with 
+  {% with
     search_action=search_action,
     siteSearch=siteSearch,
     placeholder=placeholder
@@ -35,6 +35,16 @@
 <div class="p-strip is-shallow">
   <div class="row">
     <aside class="col-3">
+      {% if versions | length > 1 %}
+      <label for="version-select" class="u-hide">Version</label>
+      <select name="version-select" id="version-select" onChange="window.location.href=this.value">
+      {% for version in versions %}
+        {% set active = docs_version == version['path'] %}
+        <option value="{{ version_paths[version['path']] }}"{% if active %} selected{% endif %}>Version {{ version['version'] }}</option>
+      {% endfor %}
+      <select>
+      {% endif %}
+
       <div class="p-side-navigation--raw-html" id="drawer">
         <a href="#drawer" class="p-side-navigation__toggle js-drawer-toggle" aria-controls="drawer">
           Toggle side navigation


### PR DESCRIPTION
## Done
- Add the version switcher conditionally to the docs template.

## QA
- Open the demo
- Go to /server/docs
- Check the version switcher is there.
- Check the version switcher works
- Check different screens sizes work and look ok
- Check navigating just using the keyboard

## Issue / Card
Fixes https://github.com/canonical-web-and-design/ubuntu.com/issues/11109

