### PR TITLE
Update resource links on app store commissioning guide

### DIFF
--- a/templates/core/smartstart/guide/app-store-commissioning.md
+++ b/templates/core/smartstart/guide/app-store-commissioning.md
@@ -68,7 +68,8 @@ Store Administrators can create derivative IoT app stores hierarchically tied to
 
 ### Helpful resources
 
-- [IoT app stores](/internet-of-things/appstore)
+- [Read more about IoT app stores](/internet-of-things/appstore)
+- [IoT app store datasheet](https://assets.ubuntu.com/v1/d6d1d3fc-IoT+App+Store+Datasheet+v3.pdf)
 
 <footer class="p-article-pagination">
   <a class="p-article-pagination__link--previous" href="/core/smartstart/guide/snap-publishing">


### PR DESCRIPTION
## Done

- Updated list of resources according to changes in the [copy doc](https://docs.google.com/document/d/15WmVD7i1nZ8ntQjDKhEcBymaEAdTyqH4yrM62r0VIsM/edit#)

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/core/smartstart/guide/app-store-commissioning
    - Be sure to test on mobile, tablet and desktop screen sizes
- See that the list of resources at the end of the guide matches that of the copy doc, and that the links work
