### PR TITLE
Fix "OpenStack" case typos

### DIFF
--- a/templates/about/index.html
+++ b/templates/about/index.html
@@ -82,7 +82,7 @@
       <p>Commercial users engage with Canonical to gain access to support, consulting, management tools, managed services and extended security maintenance.</p>
       <p><a href="/about/release-cycle">Find out more about the Ubuntu lifecycle&nbsp;&rsaquo;</a></p>
       <h3>Governance</h3>
-      <p>Canonical is the publisher of Ubuntu. Members of the Canonical team lead aspects of Ubuntu such as the kernel, default desktop, foundations, security, Openstack, and Kubernetes.</p>
+      <p>Canonical is the publisher of Ubuntu. Members of the Canonical team lead aspects of Ubuntu such as the kernel, default desktop, foundations, security, OpenStack, and Kubernetes.</p>
       <p>However, the <a href="/community/governance">governance of Ubuntu</a> is somewhat independent of Canonical, with volunteer leaders from around the world taking responsibility for many critical elements of the project. Mark Shuttleworth, as project founder, short-lists public nominees as candidates for the Community Council and Technical Board, and they in turn screen and nominate candidates for a wide range of boards, councils and teams that take responsibility for aspects of the project.</p>
       <p>It remains a key tenet of the Ubuntu Project that Ubuntu is a shared work between Canonical, other companies, and the thousands of volunteers who bring their expertise to bear on making it a world-class platform for anyone to use.</p>
       <h3>Ubuntu today</h3>

--- a/templates/ai/services.html
+++ b/templates/ai/services.html
@@ -48,7 +48,7 @@
       <h2>Support for your ML stack</h2>
       <p class="p-heading--4">Fully supported machine learning, from day-0 to day-1500</p>
       <p>24/7 support with guaranteed SLAs under Ubuntu Advantage.</p>
-      <p>Ubuntu Advantage for Infrastructure - Bare metal, OS, Kubernetes, Openstack. Ubuntu Advantage for Applications - Kafka, Cassandra, Spark, Kubeflow and more.</p>
+      <p>Ubuntu Advantage for Infrastructure - Bare metal, OS, Kubernetes, OpenStack. Ubuntu Advantage for Applications - Kafka, Cassandra, Spark, Kubeflow and more.</p>
       <p>Get your Ubuntu data science workstations supported from $25 per year.</p>
       <p>
         <a class="p-button--neutral" href="/support">Get UA support</a>

--- a/templates/ceph/index.html
+++ b/templates/ceph/index.html
@@ -97,7 +97,7 @@
         {{
           image(
             url="https://assets.ubuntu.com/v1/a6a44a86-Ceph_diagram_artboard.svg",
-            alt="Ubuntu, Openstack and Ceph support cadence",
+            alt="",
             height="198",
             width="799",
             hi_def=True,
@@ -105,7 +105,7 @@
           ) | safe
         }}
         <figcaption>
-          <small>Ubuntu, Openstack and Ceph support cadence</small>
+          <small>Ubuntu, OpenStack and Ceph support cadence</small>
         </figcaption>
       </figure>
     </div>
@@ -143,7 +143,7 @@
 
   <div class="row u-vertically-center">
     <div class="col-6">
-      <h4>Encryption at rest with Openstack</h4>
+      <h4>Encryption at rest with OpenStack</h4>
       <p>Charmed OpenStack allows for encryption at rest to be configured through our Ceph charms which provide data encryption and integrity assurance for Ceph OSDs.</p>
     </div>
     <div class="col-6 u-align--center u-hide--small">

--- a/templates/containers/index.html
+++ b/templates/containers/index.html
@@ -32,7 +32,7 @@
   <div class="row u-equal-height"> 
     <div class="col-7">
       <h2>Kubernetes &mdash; the multi-cloud operations layer for next-gen apps</h2>
-      <p class="p-heading--four">Kubernetes on Ubuntu supports VMware, Openstack, bare metal and every public cloud.</p>
+      <p class="p-heading--four">Kubernetes on Ubuntu supports VMware, OpenStack, bare metal and every public cloud.</p>
       <p>The new wave of cloud-native applications are being designed for Kubernetes operations. With high performance auto-scaling, healing, service meshes and built-in primitives for CI/CD, K8s is the most significant change in IT operations since the emergence of public cloud in 2009.</p>
       <p><a href="/kubernetes">Learn more about Kubernetes on Ubuntu&nbsp;&rsaquo;</a></p>
     </div>

--- a/templates/dell/index.html
+++ b/templates/dell/index.html
@@ -119,7 +119,7 @@
         Enterprise clouds with OpenStack
       </h3>
       <p>
-        Over 50% of all Openstack deployments use Ubuntu and Dell is the most-used hardware for deploying Openstack. Together we have designed, built, tested and certified a private cloud offering so you can move quickly, cost-effectively and reliably from pure virtualisation solution to a production-grade cloud platform like OpenStack.  Whether you are experienced and want to operate your OpenStack on your own, or need a fully managed option, you can choose the OpenStack package that best fits your needs.
+        Over 50% of all OpenStack deployments use Ubuntu and Dell is the most-used hardware for deploying OpenStack. Together we have designed, built, tested and certified a private cloud offering so you can move quickly, cost-effectively and reliably from pure virtualisation solution to a production-grade cloud platform like OpenStack.  Whether you are experienced and want to operate your OpenStack on your own, or need a fully managed option, you can choose the OpenStack package that best fits your needs.
       </p>
       <p>
         <a class="p-button" href="/engage/dell-openstack-reference-architecture">

--- a/templates/financial-services/index.html
+++ b/templates/financial-services/index.html
@@ -258,7 +258,7 @@
       <p>Watch the webinar for an overview of Charmed OpenStack - an enterprise grade OpenStack distribution from Canonical that leverages MAAS, Juju, and the OpenStack charmed operators to simplify the deployment and management of an OpenStack cloud.</p>
     </div>
     <div class="col-6 u-embedded-media u-vertically-center">
-      <iframe title="Charmed Openstack" class="u-embedded-media__element" src="https://player.vimeo.com/video/649943487?title=0&amp;byline=0&amp;portrait=0&amp;speed=0&amp;badge=0&amp;autopause=0&amp;player_id=0&amp;app_id=58479" allowfullscreen=""></iframe>
+      <iframe title="Charmed OpenStack" class="u-embedded-media__element" src="https://player.vimeo.com/video/649943487?title=0&amp;byline=0&amp;portrait=0&amp;speed=0&amp;badge=0&amp;autopause=0&amp;player_id=0&amp;app_id=58479" allowfullscreen=""></iframe>
     </div>
   </div>
 </section>

--- a/templates/kubernetes/compare.html
+++ b/templates/kubernetes/compare.html
@@ -251,7 +251,7 @@
           </td>
         </tr>
         <tr>
-          <td aria-label="Category">Native Openstack/VMware integration</td>
+          <td aria-label="Category">Native OpenStack/VMware integration</td>
           <td aria-label="Canonical Kubernetes" class="u-align--center">
             <img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" alt="Yes">
           </td>

--- a/templates/kubernetes/docs/1.16/charm-docker-registry.md
+++ b/templates/kubernetes/docs/1.16/charm-docker-registry.md
@@ -239,7 +239,7 @@ juju run-action --wait docker-registry/0 start
 | <a id="table-storage-read-only"> </a> storage-read-only | boolean | False | Enable/disable the "readonly" storage maintenance option. False, the default, disables this option in the registry config file.  |
 | <a id="table-storage-swift-authurl"> </a> storage-swift-authurl | string |  | The URL of the keystone used to authenticate to swift.  |
 | <a id="table-storage-swift-container"> </a> storage-swift-container | string | docker-registry | The name of the swift container that will hold the images.  |
-| <a id="table-storage-swift-domain"> </a> storage-swift-domain | string |  | Openstack Identity v3 API domain.  |
+| <a id="table-storage-swift-domain"> </a> storage-swift-domain | string |  | OpenStack Identity v3 API domain.  |
 | <a id="table-storage-swift-password"> </a> storage-swift-password | string |  | The password to use to access swift.  |
 | <a id="table-storage-swift-region"> </a> storage-swift-region | string |  | The region containing the swift service.  |
 | <a id="table-storage-swift-tenant"> </a> storage-swift-tenant | string |  | The tenant containing the swift service.  |
@@ -547,7 +547,7 @@ juju config docker-registry \
 
 >Note: If any of the above config options are set, then they must all be set. Optional params are noted below.
 
-It is possible to configure the swift backend with an Openstack domain name for Identity v3. To enable this, set the following optional config parameter:
+It is possible to configure the swift backend with an OpenStack domain name for Identity v3. To enable this, set the following optional config parameter:
 ```
 storage-swift-domain=<val>
 ```

--- a/templates/kubernetes/docs/1.17/charm-docker-registry.md
+++ b/templates/kubernetes/docs/1.17/charm-docker-registry.md
@@ -239,7 +239,7 @@ juju run-action --wait docker-registry/0 start
 | <a id="table-storage-read-only"> </a> storage-read-only | boolean | False | Enable/disable the "readonly" storage maintenance option. False, the default, disables this option in the registry config file.  |
 | <a id="table-storage-swift-authurl"> </a> storage-swift-authurl | string |  | The URL of the keystone used to authenticate to swift.  |
 | <a id="table-storage-swift-container"> </a> storage-swift-container | string | docker-registry | The name of the swift container that will hold the images.  |
-| <a id="table-storage-swift-domain"> </a> storage-swift-domain | string |  | Openstack Identity v3 API domain.  |
+| <a id="table-storage-swift-domain"> </a> storage-swift-domain | string |  | OpenStack Identity v3 API domain.  |
 | <a id="table-storage-swift-password"> </a> storage-swift-password | string |  | The password to use to access swift.  |
 | <a id="table-storage-swift-region"> </a> storage-swift-region | string |  | The region containing the swift service.  |
 | <a id="table-storage-swift-tenant"> </a> storage-swift-tenant | string |  | The tenant containing the swift service.  |
@@ -547,7 +547,7 @@ juju config docker-registry \
 
 >Note: If any of the above config options are set, then they must all be set. Optional params are noted below.
 
-It is possible to configure the swift backend with an Openstack domain name for Identity v3. To enable this, set the following optional config parameter:
+It is possible to configure the swift backend with an OpenStack domain name for Identity v3. To enable this, set the following optional config parameter:
 ```
 storage-swift-domain=<val>
 ```

--- a/templates/kubernetes/docs/1.17/release-notes.md
+++ b/templates/kubernetes/docs/1.17/release-notes.md
@@ -74,7 +74,7 @@ dashboards are also included to highlight these metrics with Prometheus/Grafana.
 ### Storage Classes created by default
 
 Storage classes will now be created if the `kubernetes-master` charm is related to an
-integrator charm. These classes are for AWS, GCE, Openstack, and Azure and are named cdk-ebs,
+integrator charm. These classes are for AWS, GCE, OpenStack, and Azure and are named cdk-ebs,
 cdk-gce-pd, cdk-cinder, and cdk-azure-disk, respectively.
 
 ### Support for etcd 3.3 and 3.4

--- a/templates/kubernetes/docs/1.18/charm-docker-registry.md
+++ b/templates/kubernetes/docs/1.18/charm-docker-registry.md
@@ -240,7 +240,7 @@ juju run-action --wait docker-registry/0 start
 | <a id="table-storage-read-only"> </a> storage-read-only | boolean | False | Enable/disable the "readonly" storage maintenance option. False, the default, disables this option in the registry config file.  |
 | <a id="table-storage-swift-authurl"> </a> storage-swift-authurl | string |  | The URL of the keystone used to authenticate to swift.  |
 | <a id="table-storage-swift-container"> </a> storage-swift-container | string | docker-registry | The name of the swift container that will hold the images.  |
-| <a id="table-storage-swift-domain"> </a> storage-swift-domain | string |  | Openstack Identity v3 API domain.  |
+| <a id="table-storage-swift-domain"> </a> storage-swift-domain | string |  | OpenStack Identity v3 API domain.  |
 | <a id="table-storage-swift-password"> </a> storage-swift-password | string |  | The password to use to access swift.  |
 | <a id="table-storage-swift-region"> </a> storage-swift-region | string |  | The region containing the swift service.  |
 | <a id="table-storage-swift-tenant"> </a> storage-swift-tenant | string |  | The tenant containing the swift service.  |
@@ -548,7 +548,7 @@ juju config docker-registry \
 
 >Note: If any of the above config options are set, then they must all be set. Optional params are noted below.
 
-It is possible to configure the swift backend with an Openstack domain name for Identity v3. To enable this, set the following optional config parameter:
+It is possible to configure the swift backend with an OpenStack domain name for Identity v3. To enable this, set the following optional config parameter:
 ```
 storage-swift-domain=<val>
 ```

--- a/templates/kubernetes/docs/1.19/charm-docker-registry.md
+++ b/templates/kubernetes/docs/1.19/charm-docker-registry.md
@@ -240,7 +240,7 @@ juju run-action --wait docker-registry/0 start
 | <a id="table-storage-read-only"> </a> storage-read-only | boolean | False | Enable/disable the "readonly" storage maintenance option. False, the default, disables this option in the registry config file.  |
 | <a id="table-storage-swift-authurl"> </a> storage-swift-authurl | string |  | The URL of the keystone used to authenticate to swift.  |
 | <a id="table-storage-swift-container"> </a> storage-swift-container | string | docker-registry | The name of the swift container that will hold the images.  |
-| <a id="table-storage-swift-domain"> </a> storage-swift-domain | string |  | Openstack Identity v3 API domain.  |
+| <a id="table-storage-swift-domain"> </a> storage-swift-domain | string |  | OpenStack Identity v3 API domain.  |
 | <a id="table-storage-swift-password"> </a> storage-swift-password | string |  | The password to use to access swift.  |
 | <a id="table-storage-swift-region"> </a> storage-swift-region | string |  | The region containing the swift service.  |
 | <a id="table-storage-swift-tenant"> </a> storage-swift-tenant | string |  | The tenant containing the swift service.  |
@@ -548,7 +548,7 @@ juju config docker-registry \
 
 >Note: If any of the above config options are set, then they must all be set. Optional params are noted below.
 
-It is possible to configure the swift backend with an Openstack domain name for Identity v3. To enable this, set the following optional config parameter:
+It is possible to configure the swift backend with an OpenStack domain name for Identity v3. To enable this, set the following optional config parameter:
 ```
 storage-swift-domain=<val>
 ```

--- a/templates/kubernetes/docs/1.20/charm-docker-registry.md
+++ b/templates/kubernetes/docs/1.20/charm-docker-registry.md
@@ -239,7 +239,7 @@ juju run-action --wait docker-registry/0 start
 | <a id="table-storage-read-only"> </a> storage-read-only | boolean | False | Enable/disable the "readonly" storage maintenance option. False, the default, disables this option in the registry config file.  |
 | <a id="table-storage-swift-authurl"> </a> storage-swift-authurl | string |  | The URL of the keystone used to authenticate to swift.  |
 | <a id="table-storage-swift-container"> </a> storage-swift-container | string | docker-registry | The name of the swift container that will hold the images.  |
-| <a id="table-storage-swift-domain"> </a> storage-swift-domain | string |  | Openstack Identity v3 API domain.  |
+| <a id="table-storage-swift-domain"> </a> storage-swift-domain | string |  | OpenStack Identity v3 API domain.  |
 | <a id="table-storage-swift-password"> </a> storage-swift-password | string |  | The password to use to access swift.  |
 | <a id="table-storage-swift-region"> </a> storage-swift-region | string |  | The region containing the swift service.  |
 | <a id="table-storage-swift-tenant"> </a> storage-swift-tenant | string |  | The tenant containing the swift service.  |
@@ -547,7 +547,7 @@ juju config docker-registry \
 
 >Note: If any of the above config options are set, then they must all be set. Optional params are noted below.
 
-It is possible to configure the swift backend with an Openstack domain name for Identity v3. To enable this, set the following optional config parameter:
+It is possible to configure the swift backend with an OpenStack domain name for Identity v3. To enable this, set the following optional config parameter:
 ```
 storage-swift-domain=<val>
 ```

--- a/templates/kubernetes/docs/1.21/charm-docker-registry.md
+++ b/templates/kubernetes/docs/1.21/charm-docker-registry.md
@@ -239,7 +239,7 @@ juju run-action --wait docker-registry/0 start
 | <a id="table-storage-read-only"> </a> storage-read-only | boolean | False | Enable/disable the "readonly" storage maintenance option. False, the default, disables this option in the registry config file.  |
 | <a id="table-storage-swift-authurl"> </a> storage-swift-authurl | string |  | The URL of the keystone used to authenticate to swift.  |
 | <a id="table-storage-swift-container"> </a> storage-swift-container | string | docker-registry | The name of the swift container that will hold the images.  |
-| <a id="table-storage-swift-domain"> </a> storage-swift-domain | string |  | Openstack Identity v3 API domain.  |
+| <a id="table-storage-swift-domain"> </a> storage-swift-domain | string |  | OpenStack Identity v3 API domain.  |
 | <a id="table-storage-swift-password"> </a> storage-swift-password | string |  | The password to use to access swift.  |
 | <a id="table-storage-swift-region"> </a> storage-swift-region | string |  | The region containing the swift service.  |
 | <a id="table-storage-swift-tenant"> </a> storage-swift-tenant | string |  | The tenant containing the swift service.  |
@@ -547,7 +547,7 @@ juju config docker-registry \
 
 >Note: If any of the above config options are set, then they must all be set. Optional params are noted below.
 
-It is possible to configure the swift backend with an Openstack domain name for Identity v3. To enable this, set the following optional config parameter:
+It is possible to configure the swift backend with an OpenStack domain name for Identity v3. To enable this, set the following optional config parameter:
 ```
 storage-swift-domain=<val>
 ```

--- a/templates/kubernetes/docs/1.22/charm-docker-registry.md
+++ b/templates/kubernetes/docs/1.22/charm-docker-registry.md
@@ -239,7 +239,7 @@ juju run-action --wait docker-registry/0 start
 | <a id="table-storage-read-only"> </a> storage-read-only | boolean | False | Enable/disable the "readonly" storage maintenance option. False, the default, disables this option in the registry config file.  |
 | <a id="table-storage-swift-authurl"> </a> storage-swift-authurl | string |  | The URL of the keystone used to authenticate to swift.  |
 | <a id="table-storage-swift-container"> </a> storage-swift-container | string | docker-registry | The name of the swift container that will hold the images.  |
-| <a id="table-storage-swift-domain"> </a> storage-swift-domain | string |  | Openstack Identity v3 API domain.  |
+| <a id="table-storage-swift-domain"> </a> storage-swift-domain | string |  | OpenStack Identity v3 API domain.  |
 | <a id="table-storage-swift-password"> </a> storage-swift-password | string |  | The password to use to access swift.  |
 | <a id="table-storage-swift-region"> </a> storage-swift-region | string |  | The region containing the swift service.  |
 | <a id="table-storage-swift-tenant"> </a> storage-swift-tenant | string |  | The tenant containing the swift service.  |
@@ -547,7 +547,7 @@ juju config docker-registry \
 
 >Note: If any of the above config options are set, then they must all be set. Optional params are noted below.
 
-It is possible to configure the swift backend with an Openstack domain name for Identity v3. To enable this, set the following optional config parameter:
+It is possible to configure the swift backend with an OpenStack domain name for Identity v3. To enable this, set the following optional config parameter:
 ```
 storage-swift-domain=<val>
 ```

--- a/templates/kubernetes/docs/1.23/charm-docker-registry.md
+++ b/templates/kubernetes/docs/1.23/charm-docker-registry.md
@@ -239,7 +239,7 @@ juju run-action --wait docker-registry/0 start
 | <a id="table-storage-read-only"> </a> storage-read-only | boolean | False | Enable/disable the "readonly" storage maintenance option. False, the default, disables this option in the registry config file.  |
 | <a id="table-storage-swift-authurl"> </a> storage-swift-authurl | string |  | The URL of the keystone used to authenticate to swift.  |
 | <a id="table-storage-swift-container"> </a> storage-swift-container | string | docker-registry | The name of the swift container that will hold the images.  |
-| <a id="table-storage-swift-domain"> </a> storage-swift-domain | string |  | Openstack Identity v3 API domain.  |
+| <a id="table-storage-swift-domain"> </a> storage-swift-domain | string |  | OpenStack Identity v3 API domain.  |
 | <a id="table-storage-swift-password"> </a> storage-swift-password | string |  | The password to use to access swift.  |
 | <a id="table-storage-swift-region"> </a> storage-swift-region | string |  | The region containing the swift service.  |
 | <a id="table-storage-swift-tenant"> </a> storage-swift-tenant | string |  | The tenant containing the swift service.  |
@@ -547,7 +547,7 @@ juju config docker-registry \
 
 >Note: If any of the above config options are set, then they must all be set. Optional params are noted below.
 
-It is possible to configure the swift backend with an Openstack domain name for Identity v3. To enable this, set the following optional config parameter:
+It is possible to configure the swift backend with an OpenStack domain name for Identity v3. To enable this, set the following optional config parameter:
 ```
 storage-swift-domain=<val>
 ```

--- a/templates/kubernetes/docs/charm-docker-registry.md
+++ b/templates/kubernetes/docs/charm-docker-registry.md
@@ -239,7 +239,7 @@ juju run-action --wait docker-registry/0 start
 | <a id="table-storage-read-only"> </a> storage-read-only | boolean | False | Enable/disable the "readonly" storage maintenance option. False, the default, disables this option in the registry config file.  |
 | <a id="table-storage-swift-authurl"> </a> storage-swift-authurl | string |  | The URL of the keystone used to authenticate to swift.  |
 | <a id="table-storage-swift-container"> </a> storage-swift-container | string | docker-registry | The name of the swift container that will hold the images.  |
-| <a id="table-storage-swift-domain"> </a> storage-swift-domain | string |  | Openstack Identity v3 API domain.  |
+| <a id="table-storage-swift-domain"> </a> storage-swift-domain | string |  | OpenStack Identity v3 API domain.  |
 | <a id="table-storage-swift-password"> </a> storage-swift-password | string |  | The password to use to access swift.  |
 | <a id="table-storage-swift-region"> </a> storage-swift-region | string |  | The region containing the swift service.  |
 | <a id="table-storage-swift-tenant"> </a> storage-swift-tenant | string |  | The tenant containing the swift service.  |
@@ -547,7 +547,7 @@ juju config docker-registry \
 
 >Note: If any of the above config options are set, then they must all be set. Optional params are noted below.
 
-It is possible to configure the swift backend with an Openstack domain name for Identity v3. To enable this, set the following optional config parameter:
+It is possible to configure the swift backend with an OpenStack domain name for Identity v3. To enable this, set the following optional config parameter:
 ```
 storage-swift-domain=<val>
 ```

--- a/templates/kubernetes/docs/openstack-integration.md
+++ b/templates/kubernetes/docs/openstack-integration.md
@@ -26,7 +26,7 @@ granting permissions to dynamically create, for example, Cinder volumes.
 
 ### Prerequisites
 
-Openstack integration requires [Octavia][octavia] to be available in the
+OpenStack integration requires [Octavia][octavia] to be available in the
 underlying OpenStack cloud, both to support Kubernetes LoadBalancer services
 and to support creation of a load balancer for the Kubernetes API.
 

--- a/templates/kubernetes/docs/release-notes-historic.md
+++ b/templates/kubernetes/docs/release-notes-historic.md
@@ -226,7 +226,7 @@ dashboards are also included to highlight these metrics with Prometheus/Grafana.
 - Storage Classes created by default
 
 Storage classes will now be created if the `kubernetes-master` charm is related to an
-integrator charm. These classes are for AWS, GCE, Openstack, and Azure and are named cdk-ebs,
+integrator charm. These classes are for AWS, GCE, OpenStack, and Azure and are named cdk-ebs,
 cdk-gce-pd, cdk-cinder, and cdk-azure-disk, respectively.
 
 - Support for etcd 3.3 and 3.4
@@ -696,7 +696,7 @@ reside in the same namespace as the nginx deployment.
  - Added support for load-balancer failover 
  - Added always restart for etcd 
  - Added Xenial support to Azure integrator 
- - Added Bionic support to Openstack integrator 
+ - Added Bionic support to OpenStack integrator 
  - Added support for ELB service-linked role 
  - Added ability to configure Docker install source 
  - Fixed EasyRSA does not run as an LXD container on 18.04 

--- a/templates/kubernetes/features.html
+++ b/templates/kubernetes/features.html
@@ -2,7 +2,7 @@
 
 {% block title %}Kubernetes features on Ubuntu{% endblock %}
 
-{% block meta_description %}Canonical allows you to compose your Kubernetes clusters on any infrastructure, such as Openstack, VMware and bare metal. Charmed Kubernetes unlocks the productivity of your DevOps and developer teams through its automation framework and rich tooling ecosystem.{% endblock meta_description %}
+{% block meta_description %}Canonical allows you to compose your Kubernetes clusters on any infrastructure, such as OpenStack, VMware and bare metal. Charmed Kubernetes unlocks the productivity of your DevOps and developer teams through its automation framework and rich tooling ecosystem.{% endblock meta_description %}
 
 {% block meta_copydoc %}https://docs.google.com/document/d/1mEOBW4pfsWJqTLm9Pn9myKtaslD-QB2RvUKcNQ52bXU/edit{% endblock meta_copydoc %}
 
@@ -137,7 +137,7 @@
 
   <div class="row">
     <div class="col-6">
-      <h2>Kubernetes on Openstack</h2>
+      <h2>Kubernetes on OpenStack</h2>
       <p>Build a multi-tenant, high-performing, cost-effective private cloud with Charmed Kubernetes on Charmed OpenStack. The Charmed Operator framework ensures your private cloud provides:</p>
       <ul class="p-list">
         <li class="p-list__item is-ticked">A single platform for containerised and workloads</li>
@@ -163,8 +163,8 @@
   </div>
   <div class="row">
     <div class="col-12">
-      <p><a href="/kubernetes/docs/openstack-integration">How to install Kubernetes on Openstack&nbsp;&rsaquo;</a></p>
-      <p><a href="/openstack">Learn more about Charmed Openstack&nbsp;&rsaquo;</a></p>
+      <p><a href="/kubernetes/docs/openstack-integration">How to install Kubernetes on OpenStack&nbsp;&rsaquo;</a></p>
+      <p><a href="/openstack">Learn more about Charmed OpenStack&nbsp;&rsaquo;</a></p>
     </div>
   </div>
 

--- a/templates/legal/ubuntu-advantage-service-description/index.md
+++ b/templates/legal/ubuntu-advantage-service-description/index.md
@@ -388,6 +388,6 @@ As a Standard or Advanced customer, you are entitled to all of the benefits of t
 
 **Valid Customisations:** configurations made through Horizon or the OpenStack API of the OpenStack Packages. For the avoidance of doubt, valid customizations do not include architectural changes that are not expressly executed or authorized by Canonical. Configuration options set during a Private Cloud Build should be considered critical to the health of the Cloud. Any changes to these may render the cloud unsupported. Requests for changes should be validated by Canonical to ensure continued support
 
-**Virtual Machine (VM):** a virtualized compute instance instantiated on a recognised hypervisor technology (KVM, VMWare ESXi, Openstack or public cloud)
+**Virtual Machine (VM):** a virtualized compute instance instantiated on a recognised hypervisor technology (KVM, VMWare ESXi, OpenStack or public cloud)
 
 <div class="p-top"><a href="#" class="p-top__link">Back to top</a></div>

--- a/templates/managed/apps/index.html
+++ b/templates/managed/apps/index.html
@@ -688,7 +688,7 @@ coverage.{% endblock meta_description %}
 <section class="p-strip--light is-deep">
   <div class="u-fixed-width">
     <h3>
-      Learn how Canonical deploys and runs Kubernetes and Openstack
+      Learn how Canonical deploys and runs Kubernetes and OpenStack
     </h3>
   </div>
 

--- a/templates/managed/index.html
+++ b/templates/managed/index.html
@@ -429,7 +429,7 @@
           {{
           image(
           url="https://assets.ubuntu.com/v1/dcb2963c-openstack+cloud+outlines.svg",
-          alt="Openstack cloud outlines",
+          alt="",
           width="263",
           height="150",
           hi_def=True,

--- a/templates/openstack/docs/search-results.html
+++ b/templates/openstack/docs/search-results.html
@@ -4,7 +4,7 @@
   results=results,
   search_action="/openstack/docs/search",
   siteSearch="https://ubuntu.com/openstack/docs",
-  placeholder="Search on Charmed Openstack Docs",
+  placeholder="Search on Charmed OpenStack Docs",
   forum_link="https://discourse.ubuntu.com/c/openstack/73"
 %}
     {% include "templates/docs/shared/_search-results.html" %}

--- a/templates/openstack/features.html
+++ b/templates/openstack/features.html
@@ -309,7 +309,7 @@
     <div class="col-6 u-align--center u-hide--small">
       {{ image (
         url="https://assets.ubuntu.com/v1/c4596e41-openstack-charm-diagram.png",
-        alt="Openstack charm diagram",
+        alt="",
         width="295",
         height="233",
         hi_def=True,

--- a/templates/openstack/tutorials.html
+++ b/templates/openstack/tutorials.html
@@ -1,7 +1,7 @@
 {% extends "openstack/_base_openstack.html" %}
 
 {% block title %}OpenStack tutorials on Ubuntu | OpenStack{% endblock %}
-{% block meta_description %}Free Openstack tutorials for beginners. No infrastructure needed. Get started on your workstation in 20 minutes!{% endblock meta_description %}
+{% block meta_description %}Free OpenStack tutorials for beginners. No infrastructure needed. Get started on your workstation in 20 minutes!{% endblock meta_description %}
 {% block meta_copydoc %}https://docs.google.com/document/d/1_4EJlX-fbcQBVC9Ojhjdbls6kbmITGvHKi5IEqw-HAA/edit#{% endblock meta_copydoc %}
 
 {% block content %}
@@ -29,7 +29,7 @@
     <div class="col-4 blog-p-card--post">
       <header class="blog-p-card__header--tutorial">
         <h5 class="p-muted-heading u-no-margin--bottom">
-          Openstack
+          OpenStack
         </h5>
       </header>
       <div class="blog-p-card__content">
@@ -44,7 +44,7 @@
     <div class="col-4 blog-p-card--post">
       <header class="blog-p-card__header--tutorial">
         <h5 class="p-muted-heading u-no-margin--bottom">
-          Openstack
+          OpenStack
         </h5>
       </header>
       <div class="blog-p-card__content">
@@ -59,7 +59,7 @@
     <div class="col-4 blog-p-card--post">
       <header class="blog-p-card__header--tutorial">
         <h5 class="p-muted-heading u-no-margin--bottom">
-          Openstack
+          OpenStack
         </h5>
       </header>
       <div class="blog-p-card__content">
@@ -74,7 +74,7 @@
     <div class="col-4 blog-p-card--post">
       <header class="blog-p-card__header--tutorial">
         <h5 class="p-muted-heading u-no-margin--bottom">
-          Openstack
+          OpenStack
         </h5>
       </header>
       <div class="blog-p-card__content">
@@ -89,7 +89,7 @@
     <div class="col-4 blog-p-card--post">
       <header class="blog-p-card__header--tutorial">
         <h5 class="p-muted-heading u-no-margin--bottom">
-          Openstack
+          OpenStack
         </h5>
       </header>
       <div class="blog-p-card__content">
@@ -104,7 +104,7 @@
     <div class="col-4 blog-p-card--post">
       <header class="blog-p-card__header--tutorial">
         <h5 class="p-muted-heading u-no-margin--bottom">
-          Openstack
+          OpenStack
         </h5>
       </header>
       <div class="blog-p-card__content">
@@ -119,7 +119,7 @@
     <div class="col-4 blog-p-card--post">
       <header class="blog-p-card__header--tutorial">
         <h5 class="p-muted-heading u-no-margin--bottom">
-          Openstack
+          OpenStack
         </h5>
       </header>
       <div class="blog-p-card__content">
@@ -134,7 +134,7 @@
     <div class="col-4 blog-p-card--post">
       <header class="blog-p-card__header--tutorial">
         <h5 class="p-muted-heading u-no-margin--bottom">
-          Openstack
+          OpenStack
         </h5>
       </header>
       <div class="blog-p-card__content">
@@ -149,7 +149,7 @@
     <div class="col-4 blog-p-card--post">
       <header class="blog-p-card__header--tutorial">
         <h5 class="p-muted-heading u-no-margin--bottom">
-          Openstack
+          OpenStack
         </h5>
       </header>
       <div class="blog-p-card__content">
@@ -164,7 +164,7 @@
     <div class="col-4 blog-p-card--post">
       <header class="blog-p-card__header--tutorial">
         <h5 class="p-muted-heading u-no-margin--bottom">
-          Openstack
+          OpenStack
         </h5>
       </header>
       <div class="blog-p-card__content">
@@ -179,7 +179,7 @@
     <div class="col-4 blog-p-card--post">
       <header class="blog-p-card__header--tutorial">
         <h5 class="p-muted-heading u-no-margin--bottom">
-          Openstack
+          OpenStack
         </h5>
       </header>
       <div class="blog-p-card__content">
@@ -194,7 +194,7 @@
     <div class="col-4 blog-p-card--post">
       <header class="blog-p-card__header--tutorial">
         <h5 class="p-muted-heading u-no-margin--bottom">
-          Openstack
+          OpenStack
         </h5>
       </header>
       <div class="blog-p-card__content">
@@ -209,7 +209,7 @@
   </div>
 
   <div class="u-fixed-width u-align--center">
-    <a href="https://assets.ubuntu.com/v1/8d3130a1-OpenStack.cheat.sheet.1.pdf" class="p-button--positive">Get Openstack cheat sheet</a>
+    <a href="https://assets.ubuntu.com/v1/8d3130a1-OpenStack.cheat.sheet.1.pdf" class="p-button--positive">Get OpenStack cheat sheet</a>
   </div>
 </section>
 

--- a/templates/shared/contextual_footers/_openstack_managed.html
+++ b/templates/shared/contextual_footers/_openstack_managed.html
@@ -1,5 +1,5 @@
 <div class="col-4 p-divider__block">
   <h3 class="p-heading--four">Want fully-managed OpenStack?</h3>
   <p>Canonical provides fully-managed service for OpenStack, including 24x7 monitoring, daily operations and maintenance tasks and regular OpenStack upgrades.</p>
-  <p><a class="p-button" href="/openstack/managed">Get Managed Openstack</a></p>
+  <p><a class="p-button" href="/openstack/managed">Get Managed OpenStack</a></p>
 </div>

--- a/templates/shared/pricing/_kubernetes-managed.html
+++ b/templates/shared/pricing/_kubernetes-managed.html
@@ -18,7 +18,7 @@
       <td class="p-table__cell--highlight u-align--center">$1,305/year</td>
     </tr>
     <tr>
-      <th>Price per node<sup>*</sup> combined with Managed Openstack</th>
+      <th>Price per node<sup>*</sup> combined with Managed OpenStack</th>
       <td class="p-table__cell--highlight u-align--center">$6,324/year</td>
     </tr>
     <tr>

--- a/templates/telco/osm/multi-cloud.html
+++ b/templates/telco/osm/multi-cloud.html
@@ -52,13 +52,13 @@
     </div>
     <div class="col-4">
       <h2 class="p-heading--4">Private cloud support</h2>
-      <p>Canonical's support for setting up private networks. Openstack, VMware and Kubernetes can be integrated with OSM to onboard the virtualized and containerized workloads respectively.</p>
+      <p>Canonical's support for setting up private networks. OpenStack, VMware and Kubernetes can be integrated with OSM to onboard the virtualized and containerized workloads respectively.</p>
       <h3 class="p-heading--5">Canonical provides:</h3>
       <ul class="p-list">
-        <li class="p-list__item is-ticked">Support for the deployment and maintenance for <a href="/openstack">Charmed Openstack</a></li>
+        <li class="p-list__item is-ticked">Support for the deployment and maintenance for <a href="/openstack">Charmed OpenStack</a></li>
         <li class="p-list__item is-ticked">Support for the deployment and maintenance for <a href="/kubernetes">Charmed Kubernetes</a></li>
-        <li class="p-list__item is-ticked">Support for the deployment of OSM and integration with Openstack, VMware, and K8s</li>
-        <li class="p-list__item is-ticked">Support for the deployment of Telco workloads in Openstack, K8s, or VMware</li>
+        <li class="p-list__item is-ticked">Support for the deployment of OSM and integration with OpenStack, VMware, and K8s</li>
+        <li class="p-list__item is-ticked">Support for the deployment of Telco workloads in OpenStack, K8s, or VMware</li>
       </ul>
     </div>
     <div class="col-4">

--- a/templates/telco/vnf.html
+++ b/templates/telco/vnf.html
@@ -1,6 +1,6 @@
 {% extends "telco/base_telco.html" %}
 
-{% block title %}VNF | Openstack{% endblock %}
+{% block title %}VNF | OpenStack{% endblock %}
 
 {% block meta_description %}Virtual Network Functions infrastructure with Charmed OpenStack{% endblock %}
 
@@ -181,7 +181,7 @@
 
 <section class="p-strip is-bordered is-deep">
   <div class="u-fixed-width">
-    <h2>Interesting Openstack Resources</h2>
+    <h2>Interesting OpenStack Resources</h2>
     <div class="row p-divider">
       <div class="col-4 p-divider__block">
         <div class="p-heading-icon--muted">

--- a/templates/training/index.html
+++ b/templates/training/index.html
@@ -51,7 +51,7 @@
   <div itemscope itemtype="https://schema.org/Product">
     <div class="u-fixed-width">
       <hr />
-      <h3 itemprop="name">On-site Openstack cloud training</h3>
+      <h3 itemprop="name">On-site OpenStack cloud training</h3>
     </div>
     <div class="row p-divider">
       <div class="col-7 p-divider__block">

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -503,8 +503,8 @@ def engage_thank_you(engage_pages):
 
 def openstack_install():
     """
-    Openstack install docs
-    Instructions for openstack installation pulled from Discourse
+    OpenStack install docs
+    Instructions for OpenStack installation pulled from Discourse
     """
     discourse_api = DiscourseAPI(
         base_url="https://discourse.ubuntu.com/", session=session


### PR DESCRIPTION
## Done

- Updated instances of "Openstack" and "openstack" across the site to consistently be "OpenStack"
- Removed a couple of image alt texts that were related to OpenStack, but are made redundant by neighbouring text.

## QA

- Check the git diff
- Check out this feature branch
- Case sensitively, search the codebase for other instances of "openstack" and "Openstack" within copy, there should be none.

## Issue / Card

Fixes #11080 
