### PR TITLE
Roll sqlalchemy to back to 1.3.23

### DIFF
--- a/.env
+++ b/.env
@@ -1,7 +1,7 @@
 PORT=8001
 FLASK_DEBUG=true
 DEVEL=true
-DATABASE_URL=postgresql://postgres:pw@localhost:5432/postgres
+DATABASE_URL=postgres://postgres:pw@localhost:5432/postgres
 SECRET_KEY=insecure_dev_key
 CONTRACTS_LIVE_API_URL=https://contracts.canonical.com/
 CONTRACTS_TEST_API_URL=https://contracts.staging.canonical.com/

--- a/.github/workflows/a11y.yaml
+++ b/.github/workflows/a11y.yaml
@@ -1,7 +1,7 @@
 name: Accessibility checks
 env:
   SECRET_KEY: insecure_test_key
-  DATABASE_URL: postgresql://postgres:pw@localhost:5432/postgres
+  DATABASE_URL: postgres://postgres:pw@localhost:5432/postgres
   PORT: 8001
   CONTRACTS_LIVE_API_URL: contracts.canonical.com
 

--- a/.github/workflows/cypress-main.yaml
+++ b/.github/workflows/cypress-main.yaml
@@ -1,7 +1,7 @@
 name: Cypress checks / main
 env:
   SECRET_KEY: insecure_test_key
-  DATABASE_URL: postgresql://postgres:pw@localhost:5432/postgres
+  DATABASE_URL: postgres://postgres:pw@localhost:5432/postgres
   PORT: 8001
   CONTRACTS_LIVE_API_URL: contracts.canonical.com
   CAPTCHA_TESTING_API_KEY: 6LeIxAcTAAAAAJcZVRqyHh71UMIEGNQ_MXjiZKhI

--- a/.github/workflows/cypress-pr.yaml
+++ b/.github/workflows/cypress-pr.yaml
@@ -1,7 +1,7 @@
 name: Cypress checks / PR
 env:
   SECRET_KEY: insecure_test_key
-  DATABASE_URL: postgresql://postgres:pw@localhost:5432/postgres
+  DATABASE_URL: postgres://postgres:pw@localhost:5432/postgres
   PORT: 8001
   CONTRACTS_LIVE_API_URL: contracts.canonical.com
   CAPTCHA_TESTING_API_KEY: 6LeIxAcTAAAAAJcZVRqyHh71UMIEGNQ_MXjiZKhI

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -2,7 +2,7 @@ name: PR checks
 on: [push, pull_request]
 env:
   SECRET_KEY: insecure_test_key
-  DATABASE_URL: postgresql://postgres:pw@localhost:5432/postgres
+  DATABASE_URL: postgres://postgres:pw@localhost:5432/postgres
 
 jobs:
   run-image:
@@ -29,7 +29,7 @@ jobs:
 
       - name: Run image
         run: |
-          docker run --detach --env SECRET_KEY=insecure_secret_key --network host --env DATABASE_URL=postgresql://postgres:pw@localhost:5432/postgres ubuntu-com
+          docker run --detach --env SECRET_KEY=insecure_secret_key --network host --env DATABASE_URL=postgres://postgres:pw@localhost:5432/postgres ubuntu-com
           sleep 1
           curl --head --fail --retry-delay 1 --retry 30 --retry-connrefused http://localhost
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ pymacaroons==0.13.0
 pybreaker==0.7.0
 Flask-WTF==0.15.1
 requests==2.27.0
-sqlalchemy==1.4.29
+sqlalchemy==1.3.23
 marshmallow==3.14.1
 mistune==0.8.4
 psycopg2-binary==2.9.3


### PR DESCRIPTION
## Done

- After merging a large batch of dependency updates (https://github.com/canonical-web-and-design/ubuntu.com/pull/11081), we ran into a number of issues with the dependency update on sqlalchemy while building the Jenkins job on staging:
  - [AttributeError: 'BaseFilterQuery' object has no attribute '_mapper_zero](https://pastebin.canonical.com/p/gQ7cmw6sq6/) when trying to view /security/cve
  - We realised we needed to update a secret in k8s to use the new URL format, `postgresql://` rather than `postgres://`

The first issue needs more investigation, so this is to unblock deploys until we can make time for that.

## QA

- Checks should pass.
