### PR TITLE
/model-driven-observability: Update JAAS screenshot

### DIFF
--- a/templates/model-driven-operations/index.html
+++ b/templates/model-driven-operations/index.html
@@ -395,7 +395,7 @@
       <div class="u-hide--small u-align--center u-vertically-center">
         {{ 
           image (
-          url="https://assets.ubuntu.com/v1/1dfbab48-jaas.gif",
+          url="https://assets.ubuntu.com/v1/7dc04dfa-dashboard.png",
           alt="Model-driven operations in JAAS",
           width="1280",
           height="720",


### PR DESCRIPTION
## Done

- Change screenshot for JAAS as the one we currently have live refers to a UI that is deprecated.

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- [List additional steps to QA the new features or prove the bug has been resolved]

## Issue / Card

Fixes #

## Screenshots

[If relevant, please include a screenshot.]


## Help

[QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html) - [Commit guidelines](https://canonical-web-and-design.github.io/practices/workflow/commit-messages.html)
