### PR TITLE
Replace Ubuntu Server section on /cloud/private-cloud with MAAS section

### DIFF
--- a/templates/cloud/private-cloud.html
+++ b/templates/cloud/private-cloud.html
@@ -446,14 +446,14 @@
     <div class="p-card col-6">
       <div class="p-heading-icon--small">
         <div class="p-heading-icon__header">
-          <img class= "p-heading-icon__img" src="https://assets.ubuntu.com/v1/c4f35e06-products-hero-ubuntu.svg" alt="Ubuntu Logo" width="32" height="32" />
-          <h4 class="p-heading-icon__title">Ubuntu Server</h4>
+          <img class= "p-heading-icon__img" src="https://assets.ubuntu.com/v1/5f3d3c45-maas-logo-cropped.svg" alt="" width="32" height="32" />
+          <h4 class="p-heading-icon__title">MAAS</h4>
         </div>
       </div>
       <hr/>
       <div class="p-card__content">
-        <p>Ubuntu is the most popular Linux distribution across public clouds, data centres and the edge with a built-in security and compliance for enterprise customers.</p>
-        <p><a href="/server">Learn more about Ubuntu Server&nbsp;&rsaquo;</a></p>
+        <p>Build a bare metal cloud with MAAS. Deploy any OS on any hardware in minutes via API, just like in the cloud.</p>
+        <p><a href="https://maas.io/">Learn more about MAAS&nbsp;&rsaquo;</a></p>
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Done

- Replaced the Ubuntu Server card at the bottom of the page with a card about MAAS, as detailed in the [copy doc](https://docs.google.com/document/d/19g24YRYzF5dBpUKI1QzTG7fXKj1z0OvwgFll69dFoOs/edit#)

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/cloud/private-cloud
- See that the card at the bottom of the page matches the [copy doc](https://docs.google.com/document/d/19g24YRYzF5dBpUKI1QzTG7fXKj1z0OvwgFll69dFoOs/edit#)

## Issue / Card

Fixes [#4755](https://github.com/canonical-web-and-design/web-squad/issues/4755)
