### PR TITLE
Build page on /certified/why-certified

### DIFF
--- a/templates/certified/why-certified.html
+++ b/templates/certified/why-certified.html
@@ -25,13 +25,24 @@
         <a href="https://canonical.com/partners/find-a-partner" class="p-button"> Certify your device </a>
       </p>
     </div>
+    <div class="col-4 u-hide--small u-align--center">
+      {{ image (
+        url="https://assets.ubuntu.com/v1/a491f87c-Ubuntu+Certified+Hardware.svg",
+        alt="",
+        width="364",
+        height="297",
+        hi_def=True,
+        loading="auto"
+        ) | safe
+      }}
+    </div>
   </div>
 </section>
 <section class="p-strip--light">
   <div class="u-fixed-width">
     <div class="p-logo-section">
       <p class="p-logo-section__title u-align--center">
-        GET TO MARKET FAST WITH OUR PARTNERS
+        Get to market fast with our partners
       </p>
       <div class="p-logo-section__items">
         <div class="p-logo-section__item"><img class="p-logo-section__logo" src="https://assets.ubuntu.com/v1/de2ae4b5-logo-ibm.png" alt="IBM logo"></div>

--- a/templates/certified/why-certified.html
+++ b/templates/certified/why-certified.html
@@ -21,8 +21,7 @@
         <li class="p-list__item is-ticked"> Accelerate Time to Market </li>
       </ul>
       <p>
-        <a href="/security" class="p-button--positive"> Read the datasheet </a>
-        <a href="https://canonical.com/partners/find-a-partner" class="p-button"> Certify your device </a>
+        <a href="https://canonical.com/partners/become-a-partner" class="p-button"> Certify your device </a>
       </p>
     </div>
     <div class="col-4 u-hide--small u-align--center">
@@ -51,7 +50,7 @@
         <div class="p-logo-section__item"><img class="p-logo-section__logo" src="https://assets.ubuntu.com/v1/1ca57ae1-Lenovo.svg" alt="Lenovo logo"></div>
         <div class="p-logo-section__item"><img class="p-logo-section__logo" src="https://assets.ubuntu.com/v1/aeb4bd45-rasberry-pi.svg" alt="Rasberry pi logo" style="max-height: 80px"></div>
       </div>
-      <p class="u-align--center"><a href="https://canonical.com/partners" class="p-button--positive">See all of our partners</a></p>
+      <p class="u-align--center"><a href="https://canonical.com/partners/find-a-partner" class="p-button--positive">See all of our partners</a></p>
     </div>
   </div>
 </section>

--- a/templates/certified/why-certified.html
+++ b/templates/certified/why-certified.html
@@ -7,7 +7,7 @@
 
 {% block meta_copydoc %}https://docs.google.com/document/d/1q3rOtDgJ_7_seGCP5pbCKyJYzXLvY45y8gis2FSKxXI/edit{% endblock meta_copydoc %}
 
-{% block content %}
+{% block outer_content %}
 
 <section class="p-strip--suru-topped">
   <div class="row u-equal-height u-vertically-center">
@@ -157,4 +157,4 @@
     </div>
 </section>
 
-{% endblock content %}
+{% endblock %}

--- a/templates/certified/why-certified.html
+++ b/templates/certified/why-certified.html
@@ -1,0 +1,160 @@
+{% extends "templates/base.html" %}
+
+
+{% block title %}Why Certified? | Certified hardware{% endblock %}
+
+{% block meta_description %}Ubuntu Certified Hardware has passed our extensive testing and review process, ensuring that Ubuntu runs optimally out of the box, ready for your organisation. Canonical provides continuous support throughout the lifecycle of the Ubuntu release to ensure quality, functionality, and maintenance for up to 10 years{% endblock %}
+
+{% block meta_copydoc %}https://docs.google.com/document/d/1q3rOtDgJ_7_seGCP5pbCKyJYzXLvY45y8gis2FSKxXI/edit{% endblock meta_copydoc %}
+
+{% block content %}
+
+<section class="p-strip--suru-topped">
+  <div class="row u-equal-height u-vertically-center">
+    <div class="col-8">
+      <h1>Why Ubuntu Certified Hardware?</h1>
+      <p>Machines you can trust with Ubuntu</p>
+      <ul class="p-list">
+        <li class="p-list__item is-ticked"> Hardware running Ubuntu out-of-the-box </li>
+        <li class="p-list__item is-ticked"> Extensive hardware testing </li>
+        <li class="p-list__item is-ticked"> Reliable long term support </li>
+        <li class="p-list__item is-ticked"> Accelerate Time to Market </li>
+      </ul>
+      <p>
+        <a href="/security" class="p-button--positive"> Read the datasheet </a>
+        <a href="https://canonical.com/partners/find-a-partner" class="p-button"> Certify your device </a>
+      </p>
+    </div>
+  </div>
+</section>
+<section class="p-strip--light">
+  <div class="u-fixed-width">
+    <div class="p-logo-section">
+      <p class="p-logo-section__title u-align--center">
+        GET TO MARKET FAST WITH OUR PARTNERS
+      </p>
+      <div class="p-logo-section__items">
+        <div class="p-logo-section__item"><img class="p-logo-section__logo" src="https://assets.ubuntu.com/v1/de2ae4b5-logo-ibm.png" alt="IBM logo"></div>
+        <div class="p-logo-section__item"><img class="p-logo-section__logo" src="https://assets.ubuntu.com/v1/5ddba83a-logo-dell.svg" alt="Dell logo" style="max-height: 80px"></div>
+        <div class="p-logo-section__item"><img class="p-logo-section__logo" src="https://assets.ubuntu.com/v1/185a14f4-Avnet.png" alt="AVNET logo"></div>
+        <div class="p-logo-section__item"><img class="p-logo-section__logo" src="https://assets.ubuntu.com/v1/1ca57ae1-Lenovo.svg" alt="Lenovo logo"></div>
+        <div class="p-logo-section__item"><img class="p-logo-section__logo" src="https://assets.ubuntu.com/v1/aeb4bd45-rasberry-pi.svg" alt="Rasberry pi logo" style="max-height: 80px"></div>
+      </div>
+      <p class="u-align--center"><a href="https://canonical.com/partners" class="p-button--positive">See all of our partners</a></p>
+    </div>
+  </div>
+</section>
+<section class="p-strip">
+  <div class="row u-vertically-center">
+    <div class="col-8">
+      <h2>Certification processes you can trust</h2>
+      <h3 class="p-heading--4">Every aspect of the system is checked and verified</h3>
+      <p>Canonical has developed rigorous certification tests to ensure compatibility between hardware and the Ubuntu operating system. A full battery of tests is performed on each hardware and software component for robustness before a device earns the distinction of being Ubuntu Certified.</p>
+      <p>With regular regression testing, Ubuntu Certified hardware is continuously tested in the lab to ensure the latest updates work well on the certified device. </p>
+    </div>
+    <div class="col-4 u-align--center u-hide--small">
+      {{ image (
+        url="https://assets.ubuntu.com/v1/d127abd7-safety+reliability.svg",
+        alt="",
+        width="150",
+        height="150",
+        hi_def=True,
+        loading="lazy"
+        ) | safe
+      }}
+    </div>
+  </div>
+</section>
+<section class="p-strip--light">
+  <div class="u-fixed-width">
+    <div class="row u-vertically-center">
+      <div class="col-8">
+        <h2>Up to 10 years security update commitment</h2>
+        <h3 class="p-heading--4">Canonical’s support is the solution to your sleepless nights</h3>
+        <p>No system is 100% secure and vulnerabilities will always arise. What matters is the speed and success with which they are resolved — and nobody makes fixes available faster than Canonical.</p>
+        <p>Security updates are provided for up to ten years for long term support (LTS) releases. With the default configuration for unattended upgrades, these updates get applied to your system automatically.</p>
+        <p>We perform regression testing for every single security update and any required fixes are made before they are released.</p>
+        <p><a href="/security/esm">Learn more about ESM&nbsp;&rsaquo; </a></p>
+      </div>
+      <div class="col-4 u-align--center u-hide--small">
+        {{ image (
+          url="https://assets.ubuntu.com/v1/0091c970-1C-10+year.svg",
+          alt="",
+          width="150",
+          height="150",
+          hi_def=True,
+          loading="lazy"
+          ) | safe
+        }}
+      </div>
+    </div>
+  </div>
+</section>
+<section class="p-strip">
+  <div class="row u-vertically-center">
+    <div class="col-8">
+      <h2>Save time and reduce operational costs</h2>
+      <h3 class="p-heading--4">Accelerate time-to-market by choosing deployment-ready devices</h3>
+      <p>When you use non-certified hardware Ubuntu may not work as intended and require extra enablement engineering. Canonical guarantees that Ubuntu Certified hardware will integrate smoothly with Ubuntu. You can leverage our diverse and growing portfolio of certified hardware and focus on developing your solution. </p>
+      <p>Also, long term security maintenance is a commitment that requires a substantial level of investment in human resources, infrastructure, and engineering. You can reduce operating expenses and maintenance costs by using Ubuntu Certified hardware and get support for up to 10 years.</p>
+      <p><a href="/engage/embedded-linux-make-or-buy">Embedded Linux: make or buy?&nbsp;&rsaquo; </a></p>
+    </div>
+    <div class="col-4 u-align--center u-hide--small">
+      {{ image (
+        url="https://assets.ubuntu.com/v1/a0f23d1b-Savings.svg",
+        alt="",
+        width="123",
+        height="150",
+        hi_def=True,
+        loading="lazy"
+        ) | safe
+      }}
+    </div>
+  </div>
+</section>
+<section class="p-strip--light">
+  <div class="row u-vertically-center">
+    <div class="col-8">
+      <h2>Become Ubuntu Certified!</h2>
+      <p>Becoming Ubuntu Certified is your top choice for differentiation, reliability, and product visibility. When your hardware is certified, they can carry the Ubuntu Certified Hardware logo on websites and product packaging. The “Ubuntu Certified Hardware” sticker increases customer confidence that your products integrate seamlessly with Ubuntu, which in turn increases traffic to your products.</p>
+      <p>
+        <a href="https://canonical.com/partners/become-a-partner" class="p-link--external"> Learn more </a>
+      </p>
+    </div>
+    <div class="col-4 u-align--center u-hide--small">
+      {{ image (
+        url="https://assets.ubuntu.com/v1/20a610ea-Ubuntu_Certified_Hardware_partner.svg",
+        alt="",
+        width="102",
+        height="150",
+        hi_def=True,
+        loading="lazy"
+        ) | safe
+      }}
+    </div>
+  </div>
+</section>
+<section class="p-strip">
+  <div class="u-fixed-width">
+    <h2 class="u-sv3">Certification reference</h2>
+  </div>
+  <div class="row p-divider">
+    <div class="col-4 p-divider__block">
+      <p class="p-heading--4">Webinar</p>
+      <p><a href="https://www.brighttalk.com/webcast/6793/497538" class="p-link--external">Why Ubuntu Certification Matters for AIoT</a></p>
+      <p><a href="https://www.brighttalk.com/webcast/6793/514263" class="p-link--external"> “Industrial Pi” Use Cases With Ubuntu and AMD </a></p>
+    </div>
+    <div class="col-4 p-divider__block">
+      <p class="p-heading--4">Further reading</p>
+      <p><a href="/blog/people-and-processes-behind-ubuntu-certified-devices">People and processes behind “Ubuntu certified” devices</a></p>
+      <p><a href="/blog/ubuntu-20-04-lts-is-certified-for-the-raspberry-pi">Ubuntu 20.04 LTS is certified for the Raspberry Pi</a></p>
+      <p><a href="/blog/why-you-should-buy-a-pre-installed-ubuntu-workstation">Why you should buy a pre-installed Ubuntu workstation</a></p>
+    </div>
+    <div class="col-4 p-divider__block">
+      <p class="p-heading--4">Contact Us</p>
+      <p>Becoming Ubuntu Certified is your top choice for differentiation, reliability, and product visibility. Talk to us about certifying your products.</p>
+      <p><a href="https://canonical.com/partners/become-a-partner" class="p-link--external">Learn more</a></p>
+    </div>
+</section>
+
+{% endblock content %}

--- a/templates/certified/why-certified.html
+++ b/templates/certified/why-certified.html
@@ -77,27 +77,25 @@
   </div>
 </section>
 <section class="p-strip--light">
-  <div class="u-fixed-width">
-    <div class="row u-vertically-center">
-      <div class="col-8">
-        <h2>Up to 10 years security update commitment</h2>
-        <h3 class="p-heading--4">Canonical’s support is the solution to your sleepless nights</h3>
-        <p>No system is 100% secure and vulnerabilities will always arise. What matters is the speed and success with which they are resolved — and nobody makes fixes available faster than Canonical.</p>
-        <p>Security updates are provided for up to ten years for long term support (LTS) releases. With the default configuration for unattended upgrades, these updates get applied to your system automatically.</p>
-        <p>We perform regression testing for every single security update and any required fixes are made before they are released.</p>
-        <p><a href="/security/esm">Learn more about ESM&nbsp;&rsaquo; </a></p>
-      </div>
-      <div class="col-4 u-align--center u-hide--small">
-        {{ image (
-          url="https://assets.ubuntu.com/v1/0091c970-1C-10+year.svg",
-          alt="",
-          width="150",
-          height="150",
-          hi_def=True,
-          loading="lazy"
-          ) | safe
-        }}
-      </div>
+  <div class="row u-vertically-center">
+    <div class="col-8">
+    <h2>Up to 10 years security update commitment</h2>
+    <h3 class="p-heading--4">Canonical’s support is the solution to your sleepless nights</h3>
+    <p>No system is 100% secure and vulnerabilities will always arise. What matters is the speed and success with which they are resolved — and nobody makes fixes available faster than Canonical.</p>
+    <p>Security updates are provided for up to ten years for long term support (LTS) releases. With the default configuration for unattended upgrades, these updates get applied to your system automatically.</p>
+    <p>We perform regression testing for every single security update and any required fixes are made before they are released.</p>
+    <p><a href="/security/esm">Learn more about ESM&nbsp;&rsaquo; </a></p>
+    </div>
+    <div class="col-4 u-align--center u-hide--small">
+    {{ image (
+        url="https://assets.ubuntu.com/v1/0091c970-1C-10+year.svg",
+        alt="",
+        width="150",
+        height="150",
+        hi_def=True,
+        loading="lazy"
+        ) | safe
+    }}
     </div>
   </div>
 </section>

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -143,6 +143,7 @@ from webapp.certified.views import (
     certified_servers,
     certified_devices,
     certified_socs,
+    certified_why,
 )
 
 
@@ -946,6 +947,10 @@ app.add_url_rule(
 app.add_url_rule(
     "/certified/socs",
     view_func=certified_socs,
+)
+app.add_url_rule(
+    "/certified/why-certified",
+    view_func=certified_why,
 )
 
 # Override openstack/install

--- a/webapp/certified/views.py
+++ b/webapp/certified/views.py
@@ -559,6 +559,10 @@ def certified_socs():
     view = create_category_views("Server SoC", "certified/socs.html")
     return view
 
+def certified_why():
+    view = create_category_views("Why Certified", "certified/why-certified.html")
+    return view
+
 
 def certified_devices():
     view = create_category_views("Ubuntu Core", "certified/devices.html")

--- a/webapp/certified/views.py
+++ b/webapp/certified/views.py
@@ -559,8 +559,9 @@ def certified_socs():
     view = create_category_views("Server SoC", "certified/socs.html")
     return view
 
+
 def certified_why():
-    view = create_category_views("Why Certified", "certified/why-certified.html")
+    view = create_category_views("Why", "certified/why-certified.html")
     return view
 
 


### PR DESCRIPTION
## Done
**BLOCKED:** waiting on a link to the data sheet 
- Build page on `/certified/why-certified`

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
-Please check page against [copy doc](https://docs.google.com/document/d/1q3rOtDgJ_7_seGCP5pbCKyJYzXLvY45y8gis2FSKxXI/edit#)
- Demo at https://ubuntu-com-11132.demos.haus/certified/why-certified

## Issue / Card

Fixes [#4728](https://github.com/canonical-web-and-design/web-squad/issues/4728)

## Screenshots
<img width="1440" alt="Why Certified? | Security | Ubuntu (2022-01-10 15-04-43)" src="https://user-images.githubusercontent.com/57550290/148788128-8262a0a5-df74-447a-8bca-ad6ff968acfa.png">


## Help

[QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html) - [Commit guidelines](https://canonical-web-and-design.github.io/practices/workflow/commit-messages.html)
