### PR TITLE
Update robotics community news video

### DIFF
--- a/templates/robotics/community.html
+++ b/templates/robotics/community.html
@@ -49,7 +49,7 @@
       </p>
     </div>
     <div class="col-5 u-embedded-media u-hide--small">
-      <iframe title="Getting started with ROS" class="u-embedded-media__element" src="https://www.youtube.com/embed/G1hfSMH68eQ" allowfullscreen=""></iframe>
+      <iframe title="The State of Robotics - News from December 2021" class="u-embedded-media__element" src="https://www.youtube.com/embed/Lkqz13V5WCk" allowfullscreen=""></iframe>
     </div>
   </div>
 </section>


### PR DESCRIPTION
## Done

- Updated the community news video on /robotics/community according to the [copy doc](https://docs.google.com/document/d/1A3iBoD_AAoerI0VwbByl8fR55ljNOjamHtJlkOuaaeA/edit)

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/robotics/community
- See that the video that accompanies the "Keep up on the State of Robotics" section is from December, not November

## Issue / Card

Fixes https://github.com/canonical-web-and-design/web-squad/issues/4759
