### PR TITLE
K8s doc fixes

### DIFF
--- a/templates/kubernetes/docs/1.23/charm-azure-integrator.md
+++ b/templates/kubernetes/docs/1.23/charm-azure-integrator.md
@@ -177,25 +177,15 @@ relations:
 
 | name | type   | Default      | Description                               |
 |------|--------|--------------|-------------------------------------------|
-
 | <a id="table-credentials"> </a> credentials | string |  | [See notes](#credentials-description) |
-
 | <a id="table-extra_packages"> </a> extra_packages | string |  | Space separated list of extra deb packages to install. |
-
 | <a id="table-install_keys"> </a> install_keys | string | [See notes](#install_keys-default) | [See notes](#install_keys-description) |
-
 | <a id="table-install_sources"> </a> install_sources | string | [See notes](#install_sources-default) | [See notes](#install_sources-description) |
-
 | <a id="table-package_status"> </a> package_status | string | install | The status of service-affecting packages will be set to this value in the dpkg database. Valid values are "install" and "hold". |
-
 | <a id="table-subnetName"> </a> subnetName | string | juju-internal-subnet | Vnet's subnet to be used by azure cloud-integration. This config must be set at deployment and cannot be changed later. |
-
 | <a id="table-vnetName"> </a> vnetName | string | [See notes](#vnetName-default) | VnetName to be passed via cloud-integration. This config must be set at deployment and cannot be changed later. |
-
 | <a id="table-vnetResourceGroup"> </a> vnetResourceGroup | string |  | Vnet's resource group to be passed via cloud-integration. This config must be set at deployment and cannot be changed later. |
-
 | <a id="table-vnetSecurityGroup"> </a> vnetSecurityGroup | string | juju-internal-nsg | Default network sec group (NSG) to be used by azure cloud integration. This config must be set at deployment and cannot be changed later. |
-
 | <a id="table-vnetSecurityGroupResourceGroup"> </a> vnetSecurityGroupResourceGroup | string |  | Default network sec group (NSG) to be used by azure cloud integration. This config must be set at deployment and cannot be changed later. |
 
 

--- a/templates/kubernetes/docs/1.23/charm-calico.md
+++ b/templates/kubernetes/docs/1.23/charm-calico.md
@@ -52,45 +52,25 @@ juju add-relation calico kubernetes-worker
 
 | name | type   | Default      | Description                               |
 |------|--------|--------------|-------------------------------------------|
-
 | <a id="table-bgp-service-cluster-ips"> </a> bgp-service-cluster-ips | string |  | [See notes](#bgp-service-cluster-ips-description) |
-
 | <a id="table-bgp-service-external-ips"> </a> bgp-service-external-ips | string |  | [See notes](#bgp-service-external-ips-description) |
-
 | <a id="table-calico-node-image"> </a> calico-node-image | string | [See notes](#calico-node-image-default) | The image id to use for calico/node. |
-
 | <a id="table-calico-policy-image"> </a> calico-policy-image | string | [See notes](#calico-policy-image-default) | The image id to use for calico/kube-controllers. |
-
 | <a id="table-cidr"> </a> cidr | string | 192.168.0.0/16 | Network CIDR assigned to Calico. This is applied to the default Calico pool, and is also communicated to the Kubernetes charms for use in kube-proxy configuration. |
-
 | <a id="table-disable-vxlan-tx-checksumming"> </a> disable-vxlan-tx-checksumming | boolean | True | [See notes](#disable-vxlan-tx-checksumming-description) |
-
 | <a id="table-global-as-number"> </a> global-as-number | int | 64512 | Global AS number. |
-
 | <a id="table-global-bgp-peers"> </a> global-bgp-peers | string | [] | List of global BGP peers. Each BGP peer is specified with an address and an as-number.  Example value: "[{address: 10.0.0.1, as-number: 65000}, {address: 10.0.0.2, as-number: 65001}]" |
-
 | <a id="table-ignore-loose-rpf"> </a> ignore-loose-rpf | boolean | False | Enable or disable IgnoreLooseRPF for Calico Felix.  This is only used when rp_filter is set to a value of 2. |
-
 | <a id="table-ipip"> </a> ipip | string | Never | IPIP encapsulation mode. Must be one of "Always", "CrossSubnet", or "Never". This is incompatible with VXLAN encapsulation. If VXLAN encapsulation is enabled, then this must be set to "Never". |
-
 | <a id="table-manage-pools"> </a> manage-pools | boolean | True | If true, a default pool is created using the cidr and ipip charm configuration values.  Warning: When manage-pools is enabled, the charm will delete any pools that are unrecognized. |
-
 | <a id="table-nat-outgoing"> </a> nat-outgoing | boolean | True | NAT outgoing traffic |
-
 | <a id="table-node-to-node-mesh"> </a> node-to-node-mesh | boolean | True | When enabled, each Calico node will peer with every other Calico node in the cluster. |
-
 | <a id="table-route-reflector-cluster-ids"> </a> route-reflector-cluster-ids | string | {} | Mapping of unit IDs to route reflector cluster IDs. Assigning a route reflector cluster ID allows the node to function as a route reflector.  Example value: "{0: 224.0.0.1, 2: 224.0.0.1}" |
-
 | <a id="table-subnet-as-numbers"> </a> subnet-as-numbers | string | {} | [See notes](#subnet-as-numbers-description) |
-
 | <a id="table-subnet-bgp-peers"> </a> subnet-bgp-peers | string | {} | [See notes](#subnet-bgp-peers-description) |
-
 | <a id="table-unit-as-numbers"> </a> unit-as-numbers | string | {} | [See notes](#unit-as-numbers-description) |
-
 | <a id="table-unit-bgp-peers"> </a> unit-bgp-peers | string | {} | [See notes](#unit-bgp-peers-description) |
-
 | <a id="table-veth-mtu"> </a> veth-mtu | int | None | [See notes](#veth-mtu-description) |
-
 | <a id="table-vxlan"> </a> vxlan | string | Never | VXLAN encapsulation mode. Must be one of "Always", "CrossSubnet", or "Never". This is incompatible with IPIP encapsulation. If IPIP encapsulation is enabled, then this must be set to "Never". |
 
 

--- a/templates/kubernetes/docs/1.23/charm-containerd.md
+++ b/templates/kubernetes/docs/1.23/charm-containerd.md
@@ -62,25 +62,15 @@ principal charm.
 
 | name | type   | Default      | Description                               |
 |------|--------|--------------|-------------------------------------------|
-
 | <a id="table-custom-registry-ca"> </a> custom-registry-ca | string |  | Base64 encoded Certificate Authority (CA) bundle. Setting this config allows container runtimes to pull images from registries with TLS certificates signed by an external CA. |
-
 | <a id="table-custom_registries"> </a> custom_registries | string | [] | [See notes](#custom_registries-description) |
-
 | <a id="table-disable-juju-proxy"> </a> disable-juju-proxy | boolean | False | Ignore juju-http(s) proxy settings on this charm. If set to true, all juju https proxy settings will be ignored |
-
 | <a id="table-enable-cgroups"> </a> enable-cgroups | boolean | False | Enable GRUB cgroup overrides cgroup_enable=memory swapaccount=1. WARNING changing this option will reboot the host - use with caution on production services. |
-
 | <a id="table-gpu_driver"> </a> gpu_driver | string | auto | Override GPU driver installation.  Options are "auto", "nvidia", "none". |
-
 | <a id="table-http_proxy"> </a> http_proxy | string |  | URL to use for HTTP_PROXY to be used by Containerd. Useful in egress-filtered environments where a proxy is the only option for accessing the registry to pull images. |
-
 | <a id="table-https_proxy"> </a> https_proxy | string |  | URL to use for HTTPS_PROXY to be used by Containerd. Useful in egress-filtered environments where a proxy is the only option for accessing the registry to pull images. |
-
 | <a id="table-no_proxy"> </a> no_proxy | string |  | [See notes](#no_proxy-description) |
-
 | <a id="table-runtime"> </a> runtime | string | auto | Set a custom containerd runtime.  Set "auto" to select based on hardware. |
-
 | <a id="table-shim"> </a> shim | string | containerd-shim | Set a custom containerd shim. |
 
 

--- a/templates/kubernetes/docs/1.23/charm-docker.md
+++ b/templates/kubernetes/docs/1.23/charm-docker.md
@@ -64,39 +64,22 @@ principal charm.
 
 | name | type   | Default      | Description                               |
 |------|--------|--------------|-------------------------------------------|
-
 | <a id="table-apt-key-server"> </a> apt-key-server | string | [See notes](#apt-key-server-default) | APT Key Server |
-
 | <a id="table-cuda_repo"> </a> cuda_repo | string | 10.0.130-1 | The cuda-repo package version to install. |
-
 | <a id="table-custom-registry-ca"> </a> custom-registry-ca | string |  | Base64 encoded Certificate Authority (CA) bundle. Setting this config allows container runtimes to pull images from registries with TLS certificates signed by an external CA. |
-
 | <a id="table-disable-juju-proxy"> </a> disable-juju-proxy | boolean | False | Ignore juju-http(s) proxy settings on this charm. If set to true, all juju https proxy settings will be ignored |
-
 | <a id="table-docker-ce-package"> </a> docker-ce-package | string | [See notes](#docker-ce-package-default) | The pinned version of docker-ce package installed with nvidia-docker. |
-
 | <a id="table-docker-logins"> </a> docker-logins | string | [] | [See notes](#docker-logins-description) |
-
 | <a id="table-docker-opts"> </a> docker-opts | string |  | Extra options to pass to the Docker daemon. e.g. --insecure-registry. |
-
 | <a id="table-docker_runtime"> </a> docker_runtime | string | auto | [See notes](#docker_runtime-description) |
-
 | <a id="table-docker_runtime_key_url"> </a> docker_runtime_key_url | string |  | Custom Docker repository validation key URL. |
-
 | <a id="table-docker_runtime_package"> </a> docker_runtime_package | string |  | Custom Docker repository package name. |
-
 | <a id="table-docker_runtime_repo"> </a> docker_runtime_repo | string |  | [See notes](#docker_runtime_repo-description) |
-
 | <a id="table-enable-cgroups"> </a> enable-cgroups | boolean | False | Enable GRUB cgroup overrides cgroup_enable=memory swapaccount=1. WARNING changing this option will reboot the host - use with caution on production services. |
-
 | <a id="table-http_proxy"> </a> http_proxy | string |  | URL to use for HTTP_PROXY to be used by Docker. Useful in egress-filtered environments where a proxy is the only option for accessing the registry to pull images. |
-
 | <a id="table-https_proxy"> </a> https_proxy | string |  | URL to use for HTTPS_PROXY to be used by Docker. Useful in egress-filtered environments where a proxy is the only option for accessing the registry to pull images. |
-
 | <a id="table-no_proxy"> </a> no_proxy | string |  | [See notes](#no_proxy-description) |
-
 | <a id="table-nvidia-container-runtime-package"> </a> nvidia-container-runtime-package | string | [See notes](#nvidia-container-runtime-package-default) | The pinned version of nvidia-container-runtime package. |
-
 | <a id="table-nvidia-docker-package"> </a> nvidia-docker-package | string | [See notes](#nvidia-docker-package-default) | The pinned version of nvidia-docker2 package. |
 
 

--- a/templates/kubernetes/docs/1.23/charm-kubernetes-master.md
+++ b/templates/kubernetes/docs/1.23/charm-kubernetes-master.md
@@ -94,85 +94,45 @@ section on [configuring K8s services](#k8s-services).
 
 | name | type   | Default      | Description                               |
 |------|--------|--------------|-------------------------------------------|
-
 | <a id="table-allow-privileged"> </a> allow-privileged | string | auto | [See notes](#allow-privileged-description) |
-
 | <a id="table-api-extra-args"> </a> api-extra-args | string |  | [See notes](#api-extra-args-description) |
-
 | <a id="table-audit-policy"> </a> audit-policy | string | [See notes](#audit-policy-default) | Audit policy passed to kube-apiserver via --audit-policy-file. For more info, please refer to the upstream documentation at https://kubernetes.io/docs/tasks/debug-application-cluster/audit/ |
-
 | <a id="table-audit-webhook-config"> </a> audit-webhook-config | string |  | Audit webhook config passed to kube-apiserver via --audit-webhook-config-file. For more info, please refer to the upstream documentation at https://kubernetes.io/docs/tasks/debug-application-cluster/audit/ |
-
 | <a id="table-authn-webhook-endpoint"> </a> authn-webhook-endpoint | string |  | [See notes](#authn-webhook-endpoint-description) |
-
 | <a id="table-authorization-mode"> </a> authorization-mode | string | Node,RBAC | Comma separated authorization modes. Allowed values are "RBAC", "Node", "Webhook", "ABAC", "AlwaysDeny" and "AlwaysAllow". |
-
 | <a id="table-cephfs-mounter"> </a> cephfs-mounter | string | default | The client driver used for cephfs based storage. Options are "fuse", "kernel" and "default". |
-
 | <a id="table-channel"> </a> channel | string | 1.22/stable | Snap channel to install Kubernetes master services from |
-
 | <a id="table-client_password"> </a> client_password | string |  | Password to be used for admin user (leave empty for random password). |
-
 | <a id="table-controller-manager-extra-args"> </a> controller-manager-extra-args | string |  | [See notes](#controller-manager-extra-args-description) |
-
 | <a id="table-dashboard-auth"> </a> dashboard-auth | string | auto | [See notes](#dashboard-auth-description) |
-
 | <a id="table-default-cni"> </a> default-cni | string |  | [See notes](#default-cni-description) |
-
 | <a id="table-default-storage"> </a> default-storage | string | auto | The storage class to make the default storage class. Allowed values are "auto", "none", "ceph-xfs", "ceph-ext4", "cephfs". Note: Only works in Kubernetes >= 1.10 |
-
 | <a id="table-dns-provider"> </a> dns-provider | string | auto | [See notes](#dns-provider-description) |
-
 | <a id="table-dns_domain"> </a> dns_domain | string | cluster.local | The local domain for cluster dns |
-
 | <a id="table-enable-dashboard-addons"> </a> enable-dashboard-addons | boolean | True | Deploy the Kubernetes Dashboard |
-
 | <a id="table-enable-keystone-authorization"> </a> enable-keystone-authorization | boolean | False | If true and the Keystone charm is related, users will authorize against the Keystone server. Note that if related, users will always authenticate against Keystone. |
-
 | <a id="table-enable-metrics"> </a> enable-metrics | boolean | True | If true the metrics server for Kubernetes will be deployed onto the cluster. |
-
 | <a id="table-enable-nvidia-plugin"> </a> enable-nvidia-plugin | string | auto | Load the nvidia device plugin daemonset. Supported values are "auto" and "false". When "auto", the daemonset will be loaded only if GPUs are detected. When "false" the nvidia device plugin will not be loaded. |
-
 | <a id="table-extra_packages"> </a> extra_packages | string |  | Space separated list of extra deb packages to install. |
-
 | <a id="table-extra_sans"> </a> extra_sans | string |  | Space-separated list of extra SAN entries to add to the x509 certificate created for the master nodes. |
-
 | <a id="table-ha-cluster-dns"> </a> ha-cluster-dns | string |  | DNS entry to use with the HA Cluster subordinate charm. Mutually exclusive with ha-cluster-vip. |
-
 | <a id="table-ha-cluster-vip"> </a> ha-cluster-vip | string |  | Virtual IP for the charm to use with the HA Cluster subordinate charm Mutually exclusive with ha-cluster-dns. Multiple virtual IPs are separated by spaces. |
-
 | <a id="table-image-registry"> </a> image-registry | string | [See notes](#image-registry-default) | Container image registry to use for CDK. This includes addons like the Kubernetes dashboard, metrics server, ingress, and dns along with non-addon images including the pause container and default backend image. |
-
 | <a id="table-install_keys"> </a> install_keys | string |  | [See notes](#install_keys-description) |
-
 | <a id="table-install_sources"> </a> install_sources | string |  | [See notes](#install_sources-description) |
-
 | <a id="table-keystone-policy"> </a> keystone-policy | string | [See notes](#keystone-policy-default) | Policy for Keystone authorization. This is used when a Keystone charm is related to kubernetes-master in order to provide authorization for Keystone users on the Kubernetes cluster. |
-
 | <a id="table-keystone-ssl-ca"> </a> keystone-ssl-ca | string |  | Keystone certificate authority encoded in base64 for securing communications to Keystone. For example: `juju config kubernetes-master keystone-ssl-ca=$(base64 /path/to/ca.crt)` |
-
 | <a id="table-loadbalancer-ips"> </a> loadbalancer-ips | string |  | [See notes](#loadbalancer-ips-description) |
-
 | <a id="table-nagios_context"> </a> nagios_context | string | juju | [See notes](#nagios_context-description) |
-
 | <a id="table-nagios_servicegroups"> </a> nagios_servicegroups | string |  | A comma-separated list of nagios servicegroups. If left empty, the nagios_context will be used as the servicegroup |
-
 | <a id="table-package_status"> </a> package_status | string | install | The status of service-affecting packages will be set to this value in the dpkg database. Valid values are "install" and "hold". |
-
 | <a id="table-proxy-extra-args"> </a> proxy-extra-args | string |  | [See notes](#proxy-extra-args-description) |
-
 | <a id="table-require-manual-upgrade"> </a> require-manual-upgrade | boolean | True | When true, master nodes will not be upgraded until the user triggers it manually by running the upgrade action. |
-
 | <a id="table-scheduler-extra-args"> </a> scheduler-extra-args | string |  | [See notes](#scheduler-extra-args-description) |
-
 | <a id="table-service-cidr"> </a> service-cidr | string | 10.152.183.0/24 | CIDR to use for Kubernetes services. After deployment it is only possible to increase the size of the IP range. It is not possible to change or shrink the address range after deployment. |
-
 | <a id="table-snapd_refresh"> </a> snapd_refresh | string | max | [See notes](#snapd_refresh-description) |
-
 | <a id="table-storage-backend"> </a> storage-backend | string | auto | The storage backend for kube-apiserver persistence. Can be "etcd2", "etcd3", or "auto". Auto mode will select etcd3 on new installations, or etcd2 on upgrades. |
-
 | <a id="table-sysctl"> </a> sysctl | string | [See notes](#sysctl-default) | [See notes](#sysctl-description) |
-
 
 ---
 

--- a/templates/kubernetes/docs/1.23/charm-kubernetes-worker.md
+++ b/templates/kubernetes/docs/1.23/charm-kubernetes-worker.md
@@ -95,39 +95,23 @@ for other settings relating to Kubernetes services.
 |------|--------|--------------|-------------------------------------------|
 
 | <a id="table-channel"> </a> channel | string | 1.22/stable | Snap channel to install Kubernetes worker services from |
-
 | <a id="table-default-backend-image"> </a> default-backend-image | string | auto | Docker image to use for the default backend. Auto will select an image based on architecture. |
-
 | <a id="table-ingress"> </a> ingress | boolean | True | [See notes](#ingress-description) |
-
 | <a id="table-ingress-default-ssl-certificate"> </a> ingress-default-ssl-certificate | string |  | [See notes](#ingress-default-ssl-certificate-description) |
-
 | <a id="table-ingress-default-ssl-key"> </a> ingress-default-ssl-key | string |  | [See notes](#ingress-default-ssl-key-description) |
-
 | <a id="table-ingress-ssl-chain-completion"> </a> ingress-ssl-chain-completion | boolean | False | [See notes](#ingress-ssl-chain-completion-description) |
 
 | <a id="table-ingress-ssl-passthrough"> </a> ingress-ssl-passthrough | boolean | False | Enable ssl passthrough on ingress server. This allows passing the ssl connection through to the workloads and not terminating it at the ingress controller. |
-
 | <a id="table-ingress-use-forwarded-headers"> </a> ingress-use-forwarded-headers | boolean | False | [See notes](#ingress-use-forwarded-headers-description) |
-
 | <a id="table-kubelet-extra-args"> </a> kubelet-extra-args | string |  | [See notes](#kubelet-extra-args-description) |
-
 | <a id="table-kubelet-extra-config"> </a> kubelet-extra-config | string | {} | [See notes](#kubelet-extra-config-description) |
-
 | <a id="table-labels"> </a> labels | string |  | Labels can be used to organize and to select subsets of nodes in the cluster. Declare node labels in key=value format, separated by spaces. |
-
 | <a id="table-nagios_context"> </a> nagios_context | string | juju | [See notes](#nagios_context-description) |
-
 | <a id="table-nagios_servicegroups"> </a> nagios_servicegroups | string |  | A comma-separated list of nagios servicegroups. If left empty, the nagios_context will be used as the servicegroup |
-
 | <a id="table-nginx-image"> </a> nginx-image | string | auto | [See notes](#nginx-image-description) |
-
 | <a id="table-proxy-extra-args"> </a> proxy-extra-args | string |  | [See notes](#proxy-extra-args-description) |
-
 | <a id="table-require-manual-upgrade"> </a> require-manual-upgrade | boolean | True | When true, worker services will not be upgraded until the user triggers it manually by running the upgrade action. |
-
 | <a id="table-snapd_refresh"> </a> snapd_refresh | string | max | [See notes](#snapd_refresh-description) |
-
 | <a id="table-sysctl"> </a> sysctl | string | [See notes](#sysctl-default) | [See notes](#sysctl-description) |
 
 

--- a/templates/kubernetes/docs/1.23/charm-openstack-integrator.md
+++ b/templates/kubernetes/docs/1.23/charm-openstack-integrator.md
@@ -134,45 +134,25 @@ watch kubectl get svc hello -o wide
 
 | name | type   | Default      | Description                               |
 |------|--------|--------------|-------------------------------------------|
-
 | <a id="table-auth-url"> </a> auth-url | string |  | The URL of the keystone API used to authenticate. On OpenStack control panels, this can be found at Access and Security > API Access > Credentials. |
-
 | <a id="table-bs-version"> </a> bs-version | string | None | [See notes](#bs-version-description) |
-
 | <a id="table-credentials"> </a> credentials | string |  | [See notes](#credentials-description) |
-
 | <a id="table-endpoint-tls-ca"> </a> endpoint-tls-ca | string |  | [See notes](#endpoint-tls-ca-description) |
-
 | <a id="table-floating-network-id"> </a> floating-network-id | string |  | [See notes](#floating-network-id-description) |
-
 | <a id="table-ignore-volume-az"> </a> ignore-volume-az | boolean | None | [See notes](#ignore-volume-az-description) |
-
 | <a id="table-lb-floating-network"> </a> lb-floating-network | string |  | If set, this charm will assign a floating IP in this network (name or ID) for load balancers created for other charms related on the loadbalancer endpoint. |
-
 | <a id="table-lb-method"> </a> lb-method | string | ROUND_ROBIN | [See notes](#lb-method-description) |
-
 | <a id="table-lb-port"> </a> lb-port | int | 443 | Port to use for load balancers created by this charm for other charms related on the loadbalancer endpoint. |
-
 | <a id="table-lb-subnet"> </a> lb-subnet | string |  | [See notes](#lb-subnet-description) |
-
 | <a id="table-manage-security-groups"> </a> manage-security-groups | boolean | False | [See notes](#manage-security-groups-description) |
-
 | <a id="table-password"> </a> password | string |  | Password of a valid user set in keystone. |
-
 | <a id="table-project-domain-name"> </a> project-domain-name | string |  | Name of the project domain where you want to create your resources. |
-
 | <a id="table-project-name"> </a> project-name | string |  | Name of project where you want to create your resources. |
-
 | <a id="table-region"> </a> region | string |  | Name of the region where you want to create your resources. |
-
 | <a id="table-snapd_refresh"> </a> snapd_refresh | string |  | [See notes](#snapd_refresh-description) |
-
 | <a id="table-subnet-id"> </a> subnet-id | string |  | [See notes](#subnet-id-description) |
-
 | <a id="table-trust-device-path"> </a> trust-device-path | boolean | None | [See notes](#trust-device-path-description) |
-
 | <a id="table-user-domain-name"> </a> user-domain-name | string |  | Name of the user domain where you want to create your resources. |
-
 | <a id="table-username"> </a> username | string |  | Username of a valid user set in keystone. |
 
 

--- a/templates/kubernetes/docs/1.23/charm-tigera-secure-ee.md
+++ b/templates/kubernetes/docs/1.23/charm-tigera-secure-ee.md
@@ -42,25 +42,15 @@ properly deploy.
 
 | name | type   | Default      | Description                               |
 |------|--------|--------------|-------------------------------------------|
-
 | <a id="table-calico-node-image"> </a> calico-node-image | string | [See notes](#calico-node-image-default) | The image id to use for cnx node. |
-
 | <a id="table-calicoctl-image"> </a> calicoctl-image | string | [See notes](#calicoctl-image-default) | The image id to use for calicoctl. |
-
 | <a id="table-enable-elasticsearch-operator"> </a> enable-elasticsearch-operator | boolean | True | [See notes](#enable-elasticsearch-operator-description) |
-
 | <a id="table-ignore-loose-rpf"> </a> ignore-loose-rpf | boolean | False | Enable or disable IgnoreLooseRPF for Calico Felix.  This is only used when rp_filter is set to a value of 2. |
-
 | <a id="table-ipip"> </a> ipip | string | Never | IPIP mode. Must be one of "Always", "CrossSubnet", or "Never". |
-
 | <a id="table-license-key"> </a> license-key | string |  | Tigera EE license key, base64-encoded. Example:  juju config tigera-secure-ee license-key=$(base64 -w0 license.yaml) |
-
 | <a id="table-nat-outgoing"> </a> nat-outgoing | boolean | True | NAT outgoing traffic |
-
 | <a id="table-registry"> </a> registry | string |  | Registry to use for images. If unspecified, defaults will be used: docker.io, quay.io, docker.elastic.co |
-
 | <a id="table-registry-credentials"> </a> registry-credentials | string |  | Private docker registry credentials, in the form of a base64-encoded docker config.json file. Example:  juju config tigera-secure-ee registry-credentials=$(base64 -w0 config.json) |
-
 
 ---
 

--- a/templates/kubernetes/docs/1.23/components.md
+++ b/templates/kubernetes/docs/1.23/components.md
@@ -62,7 +62,7 @@ release. These charms are maintained by the Charmed Kubernetes team.
   <td> <a href="/kubernetes/docs/1.23/charm-aws-iam">docs</a> </td>
   <td> <a href="https://github.com/charmed-kubernetes/charm-aws-iam"> source </a> </td>
   <td> <a href="https://bugs.launchpad.net/charmed-kubernetes"> bugs</a> </td>
-  <td> <a href="https://jaas.ai/u/containers/aws-iam/115"> 115 </a> </td>
+  <td> 115 </td>
   <td> -- </td>
 </tr>
 <tr>
@@ -71,7 +71,7 @@ release. These charms are maintained by the Charmed Kubernetes team.
   <td> <a href="/kubernetes/docs/1.23/charm-aws-integrator">docs</a> </td>
   <td> <a href="https://github.com/juju-solutions/charm-aws-integrator"> source </a> </td>
   <td> <a href="https://bugs.launchpad.net/charmed-kubernetes"> bugs</a> </td>
-  <td> <a href="https://jaas.ai/u/containers/aws-integrator/174"> 174 </a> </td>
+  <td> 174 </td>
   <td> -- </td>
 </tr>
 <tr>
@@ -80,7 +80,7 @@ release. These charms are maintained by the Charmed Kubernetes team.
   <td> <a href="/kubernetes/docs/1.23/charm-azure-integrator">docs</a> </td>
   <td> <a href="https://github.com/juju-solutions/charm-azure-integrator"> source </a> </td>
   <td> <a href="https://bugs.launchpad.net/charmed-kubernetes"> bugs</a> </td>
-  <td> <a href="https://jaas.ai/u/containers/azure-integrator/160"> 160 </a> </td>
+  <td> 160 </td>
   <td> -- </td>
 </tr>
 <tr>
@@ -89,7 +89,7 @@ release. These charms are maintained by the Charmed Kubernetes team.
   <td> <a href="/kubernetes/docs/1.23/charm-calico">docs</a> </td>
   <td> <a href="https://github.com/juju-solutions/layer-calico"> source </a> </td>
   <td> <a href="https://bugs.launchpad.net/charmed-kubernetes"> bugs</a> </td>
-  <td> <a href="https://jaas.ai/u/containers/calico/860"> 860 </a> </td>
+  <td> 860 </td>
   <td> -- </td>
 </tr>
 <tr>
@@ -98,7 +98,7 @@ release. These charms are maintained by the Charmed Kubernetes team.
   <td> <a href="/kubernetes/docs/1.23/charm-canal">docs</a> </td>
   <td> <a href="https://github.com/juju-solutions/layer-canal"> source </a> </td>
   <td> <a href="https://bugs.launchpad.net/charmed-kubernetes"> bugs</a> </td>
-  <td> <a href="https://jaas.ai/u/containers/canal/859"> 859 </a> </td>
+  <td> 859 </td>
   <td> -- </td>
 </tr>
 <tr>
@@ -107,7 +107,7 @@ release. These charms are maintained by the Charmed Kubernetes team.
   <td> <a href="/kubernetes/docs/1.23/charm-containerd">docs</a> </td>
   <td> <a href="https://github.com/charmed-kubernetes/charm-containerd"> source </a> </td>
   <td> <a href="https://bugs.launchpad.net/charmed-kubernetes"> bugs</a> </td>
-  <td> <a href="https://jaas.ai/u/containers/containerd/200"> 200 </a> </td>
+  <td> 200 </td>
   <td> -- </td>
 </tr>
 <tr>
@@ -116,7 +116,7 @@ release. These charms are maintained by the Charmed Kubernetes team.
   <td> <a href="/kubernetes/docs/1.23/charm-docker">docs</a> </td>
   <td> <a href="https://github.com/juju-solutions/layer-docker"> source </a> </td>
   <td> <a href="https://bugs.launchpad.net/charmed-kubernetes"> bugs</a> </td>
-  <td> <a href="https://jaas.ai/u/containers/docker/153"> 153 </a> </td>
+  <td> 153 </td>
   <td> -- </td>
 </tr>
 <tr>
@@ -125,7 +125,7 @@ release. These charms are maintained by the Charmed Kubernetes team.
   <td> <a href="/kubernetes/docs/1.23/charm-docker-registry">docs</a> </td>
   <td> <a href="https://github.com/CanonicalLtd/docker-registry-charm"> source </a> </td>
   <td> <a href="https://bugs.launchpad.net/charmed-kubernetes"> bugs</a> </td>
-  <td> <a href="https://jaas.ai/u/containers/docker-registry/240"> 240 </a> </td>
+  <td> 240 </td>
   <td> -- </td>
 </tr>
 <tr>
@@ -134,7 +134,7 @@ release. These charms are maintained by the Charmed Kubernetes team.
   <td> <a href="/kubernetes/docs/1.23/charm-easyrsa">docs</a> </td>
   <td> <a href="https://github.com/charmed-kubernetes/layer-easyrsa"> source </a> </td>
   <td> <a href="https://bugs.launchpad.net/charmed-kubernetes"> bugs</a> </td>
-  <td> <a href="https://jaas.ai/u/containers/easyrsa/441"> 441 </a> </td>
+  <td> 441 </td>
   <td> -- </td>
 </tr>
 <tr>
@@ -143,7 +143,7 @@ release. These charms are maintained by the Charmed Kubernetes team.
   <td> <a href="/kubernetes/docs/1.23/charm-etcd">docs</a> </td>
   <td> <a href="https://github.com/charmed-kubernetes/layer-etcd"> source </a> </td>
   <td> <a href="https://bugs.launchpad.net/charmed-kubernetes"> bugs</a> </td>
-  <td> <a href="https://jaas.ai/u/containers/etcd/655"> 655 </a> </td>
+  <td> 655 </td>
   <td> -- </td>
 </tr>
 <tr>
@@ -152,7 +152,7 @@ release. These charms are maintained by the Charmed Kubernetes team.
   <td> <a href="/kubernetes/docs/1.23/charm-flannel">docs</a> </td>
   <td> <a href="https://github.com/coreos/flannel"> source </a> </td>
   <td> <a href="https://bugs.launchpad.net/charmed-kubernetes"> bugs</a> </td>
-  <td> <a href="https://jaas.ai/u/containers/flannel/619"> 619 </a> </td>
+  <td> 619 </td>
   <td> -- </td>
 </tr>
 <tr>
@@ -161,7 +161,7 @@ release. These charms are maintained by the Charmed Kubernetes team.
   <td> <a href="/kubernetes/docs/1.23/charm-gcp-integrator">docs</a> </td>
   <td> <a href="https://github.com/juju-solutions/charm-gcp-integrator"> source </a> </td>
   <td> <a href="https://bugs.launchpad.net/charmed-kubernetes"> bugs</a> </td>
-  <td> <a href="https://jaas.ai/u/containers/gcp-integrator/166"> 166 </a> </td>
+  <td> 166 </td>
   <td> -- </td>
 </tr>
 <tr>
@@ -170,7 +170,7 @@ release. These charms are maintained by the Charmed Kubernetes team.
   <td> <a href="/kubernetes/docs/1.23/charm-kata">docs</a> </td>
   <td> <a href="https://github.com/charmed-kubernetes/charm-kata"> source  </a> </td>
   <td> <a href="https://bugs.launchpad.net/charmed-kubernetes"> bugs</a> </td>
-  <td> <a href="https://jaas.ai/u/containers/kata/160"> 160 </a> </td>
+  <td> 160 </td>
   <td> -- </td>
 </tr>
 <tr>
@@ -179,7 +179,7 @@ release. These charms are maintained by the Charmed Kubernetes team.
   <td> <a href="/kubernetes/docs/1.23/charm-keepalived">docs</a> </td>
   <td> <a href="https://github.com/juju-solutions/charm-keepalived"> source </a> </td>
   <td> <a href="https://bugs.launchpad.net/charmed-kubernetes"> bugs</a> </td>
-  <td> <a href="https://jaas.ai/u/containers/keepalived/131"> 131 </a> </td>
+  <td> 131 </td>
   <td> -- </td>
 </tr>
 <tr>
@@ -188,7 +188,7 @@ release. These charms are maintained by the Charmed Kubernetes team.
   <td> <a href="/kubernetes/docs/1.23/charm-kubeapi-load-balancer">docs</a> </td>
   <td> <a href="https://nginx.org/en/"> source </a> </td>
   <td> <a href="https://bugs.launchpad.net/charmed-kubernetes"> bugs</a> </td>
-  <td> <a href="https://jaas.ai/u/containers/kubeapi-load-balancer/866"> 866 </a> </td>
+  <td> 866 </td>
   <td> -- </td>
 </tr>
 <tr>
@@ -197,7 +197,7 @@ release. These charms are maintained by the Charmed Kubernetes team.
   <td> <a href="/kubernetes/docs/1.23/charm-kubernetes-master">docs</a> </td>
   <td> <a href="https://github.com/charmed-kubernetes/charm-kubernetes-master"> source </a> </td>
   <td> <a href="https://bugs.launchpad.net/charmed-kubernetes"> bugs</a> </td>
-  <td> <a href="https://jaas.ai/u/containers/kubernetes-master/1106"> 1106 </a> </td>
+  <td> 1106 </td>
   <td> -- </td>
 </tr>
 <tr>
@@ -206,7 +206,7 @@ release. These charms are maintained by the Charmed Kubernetes team.
   <td> <a href="/kubernetes/docs/1.23/charm-kubernetes-worker">docs</a> </td>
   <td> <a href="https://github.com/charmed-kubernetes/charm-kubernetes-worker"> source </a> </td>
   <td> <a href="https://bugs.launchpad.net/charmed-kubernetes"> bugs</a> </td>
-  <td> <a href="https://jaas.ai/u/containers/kubernetes-worker/838"> 838 </a> </td>
+  <td> 838 </td>
   <td> -- </td>
 </tr>
 <tr>
@@ -215,7 +215,7 @@ release. These charms are maintained by the Charmed Kubernetes team.
   <td> <a href="/kubernetes/docs/1.23/charm-openstack-integrator">docs</a> </td>
   <td> <a href="https://github.com/juju-solutions/charm-openstack-integrator"> source </a> </td>
   <td> <a href="https://bugs.launchpad.net/charmed-kubernetes"> bugs</a> </td>
-  <td> <a href="https://jaas.ai/u/containers/openstack-integrator/204"> 204 </a> </td>
+  <td> 204 </td>
   <td> -- </td>
 </tr>
 <tr>
@@ -224,7 +224,7 @@ release. These charms are maintained by the Charmed Kubernetes team.
   <td> <a href="/kubernetes/docs/1.23/charm-tigera-secure-ee">docs</a> </td>
   <td> <a href="https://github.com/charmed-kubernetes/layer-tigera-secure-ee"> </a> source </td>
   <td> <a href="https://bugs.launchpad.net/charmed-kubernetes"> bugs</a> </td>
-  <td> <a href="https://jaas.ai/u/containers/tigera-secure-ee/252"> 252 </a> </td>
+  <td> 252 </td>
   <td> -- </td>
 </tr>
 <tr>
@@ -233,7 +233,7 @@ release. These charms are maintained by the Charmed Kubernetes team.
   <td> <a href="/kubernetes/docs/1.23/charm-vsphere-integrator">docs</a> </td>
   <td> <a href="https://github.com/juju-solutions/charm-vsphere-integrator"> source </a> </td>
   <td> <a href="https://bugs.launchpad.net/charmed-kubernetes"> bugs</a> </td>
-  <td> <a href="https://jaas.ai/u/containers/vsphere-integrator/144"> 144 </a> </td>
+  <td> 144 </td>
   <td> -- </td>
 </tr>
  </tbody>

--- a/templates/kubernetes/docs/charm-azure-integrator.md
+++ b/templates/kubernetes/docs/charm-azure-integrator.md
@@ -177,25 +177,15 @@ relations:
 
 | name | type   | Default      | Description                               |
 |------|--------|--------------|-------------------------------------------|
-
 | <a id="table-credentials"> </a> credentials | string |  | [See notes](#credentials-description) |
-
 | <a id="table-extra_packages"> </a> extra_packages | string |  | Space separated list of extra deb packages to install. |
-
 | <a id="table-install_keys"> </a> install_keys | string | [See notes](#install_keys-default) | [See notes](#install_keys-description) |
-
 | <a id="table-install_sources"> </a> install_sources | string | [See notes](#install_sources-default) | [See notes](#install_sources-description) |
-
 | <a id="table-package_status"> </a> package_status | string | install | The status of service-affecting packages will be set to this value in the dpkg database. Valid values are "install" and "hold". |
-
 | <a id="table-subnetName"> </a> subnetName | string | juju-internal-subnet | Vnet's subnet to be used by azure cloud-integration. This config must be set at deployment and cannot be changed later. |
-
 | <a id="table-vnetName"> </a> vnetName | string | [See notes](#vnetName-default) | VnetName to be passed via cloud-integration. This config must be set at deployment and cannot be changed later. |
-
 | <a id="table-vnetResourceGroup"> </a> vnetResourceGroup | string |  | Vnet's resource group to be passed via cloud-integration. This config must be set at deployment and cannot be changed later. |
-
 | <a id="table-vnetSecurityGroup"> </a> vnetSecurityGroup | string | juju-internal-nsg | Default network sec group (NSG) to be used by azure cloud integration. This config must be set at deployment and cannot be changed later. |
-
 | <a id="table-vnetSecurityGroupResourceGroup"> </a> vnetSecurityGroupResourceGroup | string |  | Default network sec group (NSG) to be used by azure cloud integration. This config must be set at deployment and cannot be changed later. |
 
 

--- a/templates/kubernetes/docs/charm-calico.md
+++ b/templates/kubernetes/docs/charm-calico.md
@@ -52,47 +52,26 @@ juju add-relation calico kubernetes-worker
 
 | name | type   | Default      | Description                               |
 |------|--------|--------------|-------------------------------------------|
-
 | <a id="table-bgp-service-cluster-ips"> </a> bgp-service-cluster-ips | string |  | [See notes](#bgp-service-cluster-ips-description) |
-
 | <a id="table-bgp-service-external-ips"> </a> bgp-service-external-ips | string |  | [See notes](#bgp-service-external-ips-description) |
-
 | <a id="table-calico-node-image"> </a> calico-node-image | string | [See notes](#calico-node-image-default) | The image id to use for calico/node. |
-
 | <a id="table-calico-policy-image"> </a> calico-policy-image | string | [See notes](#calico-policy-image-default) | The image id to use for calico/kube-controllers. |
-
 | <a id="table-cidr"> </a> cidr | string | 192.168.0.0/16 | Network CIDR assigned to Calico. This is applied to the default Calico pool, and is also communicated to the Kubernetes charms for use in kube-proxy configuration. |
-
 | <a id="table-disable-vxlan-tx-checksumming"> </a> disable-vxlan-tx-checksumming | boolean | True | [See notes](#disable-vxlan-tx-checksumming-description) |
-
 | <a id="table-global-as-number"> </a> global-as-number | int | 64512 | Global AS number. |
-
 | <a id="table-global-bgp-peers"> </a> global-bgp-peers | string | [] | List of global BGP peers. Each BGP peer is specified with an address and an as-number.  Example value: "[{address: 10.0.0.1, as-number: 65000}, {address: 10.0.0.2, as-number: 65001}]" |
-
 | <a id="table-ignore-loose-rpf"> </a> ignore-loose-rpf | boolean | False | Enable or disable IgnoreLooseRPF for Calico Felix.  This is only used when rp_filter is set to a value of 2. |
-
 | <a id="table-ipip"> </a> ipip | string | Never | IPIP encapsulation mode. Must be one of "Always", "CrossSubnet", or "Never". This is incompatible with VXLAN encapsulation. If VXLAN encapsulation is enabled, then this must be set to "Never". |
-
 | <a id="table-manage-pools"> </a> manage-pools | boolean | True | If true, a default pool is created using the cidr and ipip charm configuration values.  Warning: When manage-pools is enabled, the charm will delete any pools that are unrecognized. |
-
 | <a id="table-nat-outgoing"> </a> nat-outgoing | boolean | True | NAT outgoing traffic |
-
 | <a id="table-node-to-node-mesh"> </a> node-to-node-mesh | boolean | True | When enabled, each Calico node will peer with every other Calico node in the cluster. |
-
 | <a id="table-route-reflector-cluster-ids"> </a> route-reflector-cluster-ids | string | {} | Mapping of unit IDs to route reflector cluster IDs. Assigning a route reflector cluster ID allows the node to function as a route reflector.  Example value: "{0: 224.0.0.1, 2: 224.0.0.1}" |
-
 | <a id="table-subnet-as-numbers"> </a> subnet-as-numbers | string | {} | [See notes](#subnet-as-numbers-description) |
-
 | <a id="table-subnet-bgp-peers"> </a> subnet-bgp-peers | string | {} | [See notes](#subnet-bgp-peers-description) |
-
 | <a id="table-unit-as-numbers"> </a> unit-as-numbers | string | {} | [See notes](#unit-as-numbers-description) |
-
 | <a id="table-unit-bgp-peers"> </a> unit-bgp-peers | string | {} | [See notes](#unit-bgp-peers-description) |
-
 | <a id="table-veth-mtu"> </a> veth-mtu | int | None | [See notes](#veth-mtu-description) |
-
 | <a id="table-vxlan"> </a> vxlan | string | Never | VXLAN encapsulation mode. Must be one of "Always", "CrossSubnet", or "Never". This is incompatible with IPIP encapsulation. If IPIP encapsulation is enabled, then this must be set to "Never". |
-
 
 ---
 

--- a/templates/kubernetes/docs/charm-containerd.md
+++ b/templates/kubernetes/docs/charm-containerd.md
@@ -62,25 +62,15 @@ principal charm.
 
 | name | type   | Default      | Description                               |
 |------|--------|--------------|-------------------------------------------|
-
 | <a id="table-custom-registry-ca"> </a> custom-registry-ca | string |  | Base64 encoded Certificate Authority (CA) bundle. Setting this config allows container runtimes to pull images from registries with TLS certificates signed by an external CA. |
-
 | <a id="table-custom_registries"> </a> custom_registries | string | [] | [See notes](#custom_registries-description) |
-
 | <a id="table-disable-juju-proxy"> </a> disable-juju-proxy | boolean | False | Ignore juju-http(s) proxy settings on this charm. If set to true, all juju https proxy settings will be ignored |
-
 | <a id="table-enable-cgroups"> </a> enable-cgroups | boolean | False | Enable GRUB cgroup overrides cgroup_enable=memory swapaccount=1. WARNING changing this option will reboot the host - use with caution on production services. |
-
 | <a id="table-gpu_driver"> </a> gpu_driver | string | auto | Override GPU driver installation.  Options are "auto", "nvidia", "none". |
-
 | <a id="table-http_proxy"> </a> http_proxy | string |  | URL to use for HTTP_PROXY to be used by Containerd. Useful in egress-filtered environments where a proxy is the only option for accessing the registry to pull images. |
-
 | <a id="table-https_proxy"> </a> https_proxy | string |  | URL to use for HTTPS_PROXY to be used by Containerd. Useful in egress-filtered environments where a proxy is the only option for accessing the registry to pull images. |
-
 | <a id="table-no_proxy"> </a> no_proxy | string |  | [See notes](#no_proxy-description) |
-
 | <a id="table-runtime"> </a> runtime | string | auto | Set a custom containerd runtime.  Set "auto" to select based on hardware. |
-
 | <a id="table-shim"> </a> shim | string | containerd-shim | Set a custom containerd shim. |
 
 

--- a/templates/kubernetes/docs/charm-docker-registry.md
+++ b/templates/kubernetes/docs/charm-docker-registry.md
@@ -239,7 +239,7 @@ juju run-action --wait docker-registry/0 start
 | <a id="table-storage-read-only"> </a> storage-read-only | boolean | False | Enable/disable the "readonly" storage maintenance option. False, the default, disables this option in the registry config file.  |
 | <a id="table-storage-swift-authurl"> </a> storage-swift-authurl | string |  | The URL of the keystone used to authenticate to swift.  |
 | <a id="table-storage-swift-container"> </a> storage-swift-container | string | docker-registry | The name of the swift container that will hold the images.  |
-| <a id="table-storage-swift-domain"> </a> storage-swift-domain | string |  | Openstack Identity v3 API domain.  |
+| <a id="table-storage-swift-domain"> </a> storage-swift-domain | string |  | OpenStack Identity v3 API domain.  |
 | <a id="table-storage-swift-password"> </a> storage-swift-password | string |  | The password to use to access swift.  |
 | <a id="table-storage-swift-region"> </a> storage-swift-region | string |  | The region containing the swift service.  |
 | <a id="table-storage-swift-tenant"> </a> storage-swift-tenant | string |  | The tenant containing the swift service.  |
@@ -547,7 +547,7 @@ juju config docker-registry \
 
 >Note: If any of the above config options are set, then they must all be set. Optional params are noted below.
 
-It is possible to configure the swift backend with an Openstack domain name for Identity v3. To enable this, set the following optional config parameter:
+It is possible to configure the swift backend with an OpenStack domain name for Identity v3. To enable this, set the following optional config parameter:
 ```
 storage-swift-domain=<val>
 ```

--- a/templates/kubernetes/docs/charm-docker-registry.md
+++ b/templates/kubernetes/docs/charm-docker-registry.md
@@ -239,7 +239,7 @@ juju run-action --wait docker-registry/0 start
 | <a id="table-storage-read-only"> </a> storage-read-only | boolean | False | Enable/disable the "readonly" storage maintenance option. False, the default, disables this option in the registry config file.  |
 | <a id="table-storage-swift-authurl"> </a> storage-swift-authurl | string |  | The URL of the keystone used to authenticate to swift.  |
 | <a id="table-storage-swift-container"> </a> storage-swift-container | string | docker-registry | The name of the swift container that will hold the images.  |
-| <a id="table-storage-swift-domain"> </a> storage-swift-domain | string |  | OpenStack Identity v3 API domain.  |
+| <a id="table-storage-swift-domain"> </a> storage-swift-domain | string |  | Openstack Identity v3 API domain.  |
 | <a id="table-storage-swift-password"> </a> storage-swift-password | string |  | The password to use to access swift.  |
 | <a id="table-storage-swift-region"> </a> storage-swift-region | string |  | The region containing the swift service.  |
 | <a id="table-storage-swift-tenant"> </a> storage-swift-tenant | string |  | The tenant containing the swift service.  |
@@ -547,7 +547,7 @@ juju config docker-registry \
 
 >Note: If any of the above config options are set, then they must all be set. Optional params are noted below.
 
-It is possible to configure the swift backend with an OpenStack domain name for Identity v3. To enable this, set the following optional config parameter:
+It is possible to configure the swift backend with an Openstack domain name for Identity v3. To enable this, set the following optional config parameter:
 ```
 storage-swift-domain=<val>
 ```

--- a/templates/kubernetes/docs/charm-docker.md
+++ b/templates/kubernetes/docs/charm-docker.md
@@ -64,39 +64,22 @@ principal charm.
 
 | name | type   | Default      | Description                               |
 |------|--------|--------------|-------------------------------------------|
-
 | <a id="table-apt-key-server"> </a> apt-key-server | string | [See notes](#apt-key-server-default) | APT Key Server |
-
 | <a id="table-cuda_repo"> </a> cuda_repo | string | 10.0.130-1 | The cuda-repo package version to install. |
-
 | <a id="table-custom-registry-ca"> </a> custom-registry-ca | string |  | Base64 encoded Certificate Authority (CA) bundle. Setting this config allows container runtimes to pull images from registries with TLS certificates signed by an external CA. |
-
 | <a id="table-disable-juju-proxy"> </a> disable-juju-proxy | boolean | False | Ignore juju-http(s) proxy settings on this charm. If set to true, all juju https proxy settings will be ignored |
-
 | <a id="table-docker-ce-package"> </a> docker-ce-package | string | [See notes](#docker-ce-package-default) | The pinned version of docker-ce package installed with nvidia-docker. |
-
 | <a id="table-docker-logins"> </a> docker-logins | string | [] | [See notes](#docker-logins-description) |
-
 | <a id="table-docker-opts"> </a> docker-opts | string |  | Extra options to pass to the Docker daemon. e.g. --insecure-registry. |
-
 | <a id="table-docker_runtime"> </a> docker_runtime | string | auto | [See notes](#docker_runtime-description) |
-
 | <a id="table-docker_runtime_key_url"> </a> docker_runtime_key_url | string |  | Custom Docker repository validation key URL. |
-
 | <a id="table-docker_runtime_package"> </a> docker_runtime_package | string |  | Custom Docker repository package name. |
-
 | <a id="table-docker_runtime_repo"> </a> docker_runtime_repo | string |  | [See notes](#docker_runtime_repo-description) |
-
 | <a id="table-enable-cgroups"> </a> enable-cgroups | boolean | False | Enable GRUB cgroup overrides cgroup_enable=memory swapaccount=1. WARNING changing this option will reboot the host - use with caution on production services. |
-
 | <a id="table-http_proxy"> </a> http_proxy | string |  | URL to use for HTTP_PROXY to be used by Docker. Useful in egress-filtered environments where a proxy is the only option for accessing the registry to pull images. |
-
 | <a id="table-https_proxy"> </a> https_proxy | string |  | URL to use for HTTPS_PROXY to be used by Docker. Useful in egress-filtered environments where a proxy is the only option for accessing the registry to pull images. |
-
 | <a id="table-no_proxy"> </a> no_proxy | string |  | [See notes](#no_proxy-description) |
-
 | <a id="table-nvidia-container-runtime-package"> </a> nvidia-container-runtime-package | string | [See notes](#nvidia-container-runtime-package-default) | The pinned version of nvidia-container-runtime package. |
-
 | <a id="table-nvidia-docker-package"> </a> nvidia-docker-package | string | [See notes](#nvidia-docker-package-default) | The pinned version of nvidia-docker2 package. |
 
 

--- a/templates/kubernetes/docs/charm-kubernetes-master.md
+++ b/templates/kubernetes/docs/charm-kubernetes-master.md
@@ -94,85 +94,45 @@ section on [configuring K8s services](#k8s-services).
 
 | name | type   | Default      | Description                               |
 |------|--------|--------------|-------------------------------------------|
-
 | <a id="table-allow-privileged"> </a> allow-privileged | string | auto | [See notes](#allow-privileged-description) |
-
 | <a id="table-api-extra-args"> </a> api-extra-args | string |  | [See notes](#api-extra-args-description) |
-
 | <a id="table-audit-policy"> </a> audit-policy | string | [See notes](#audit-policy-default) | Audit policy passed to kube-apiserver via --audit-policy-file. For more info, please refer to the upstream documentation at https://kubernetes.io/docs/tasks/debug-application-cluster/audit/ |
-
 | <a id="table-audit-webhook-config"> </a> audit-webhook-config | string |  | Audit webhook config passed to kube-apiserver via --audit-webhook-config-file. For more info, please refer to the upstream documentation at https://kubernetes.io/docs/tasks/debug-application-cluster/audit/ |
-
 | <a id="table-authn-webhook-endpoint"> </a> authn-webhook-endpoint | string |  | [See notes](#authn-webhook-endpoint-description) |
-
 | <a id="table-authorization-mode"> </a> authorization-mode | string | Node,RBAC | Comma separated authorization modes. Allowed values are "RBAC", "Node", "Webhook", "ABAC", "AlwaysDeny" and "AlwaysAllow". |
-
 | <a id="table-cephfs-mounter"> </a> cephfs-mounter | string | default | The client driver used for cephfs based storage. Options are "fuse", "kernel" and "default". |
-
 | <a id="table-channel"> </a> channel | string | 1.22/stable | Snap channel to install Kubernetes master services from |
-
 | <a id="table-client_password"> </a> client_password | string |  | Password to be used for admin user (leave empty for random password). |
-
 | <a id="table-controller-manager-extra-args"> </a> controller-manager-extra-args | string |  | [See notes](#controller-manager-extra-args-description) |
-
 | <a id="table-dashboard-auth"> </a> dashboard-auth | string | auto | [See notes](#dashboard-auth-description) |
-
 | <a id="table-default-cni"> </a> default-cni | string |  | [See notes](#default-cni-description) |
-
 | <a id="table-default-storage"> </a> default-storage | string | auto | The storage class to make the default storage class. Allowed values are "auto", "none", "ceph-xfs", "ceph-ext4", "cephfs". Note: Only works in Kubernetes >= 1.10 |
-
 | <a id="table-dns-provider"> </a> dns-provider | string | auto | [See notes](#dns-provider-description) |
-
 | <a id="table-dns_domain"> </a> dns_domain | string | cluster.local | The local domain for cluster dns |
-
 | <a id="table-enable-dashboard-addons"> </a> enable-dashboard-addons | boolean | True | Deploy the Kubernetes Dashboard |
-
 | <a id="table-enable-keystone-authorization"> </a> enable-keystone-authorization | boolean | False | If true and the Keystone charm is related, users will authorize against the Keystone server. Note that if related, users will always authenticate against Keystone. |
-
 | <a id="table-enable-metrics"> </a> enable-metrics | boolean | True | If true the metrics server for Kubernetes will be deployed onto the cluster. |
-
 | <a id="table-enable-nvidia-plugin"> </a> enable-nvidia-plugin | string | auto | Load the nvidia device plugin daemonset. Supported values are "auto" and "false". When "auto", the daemonset will be loaded only if GPUs are detected. When "false" the nvidia device plugin will not be loaded. |
-
 | <a id="table-extra_packages"> </a> extra_packages | string |  | Space separated list of extra deb packages to install. |
-
 | <a id="table-extra_sans"> </a> extra_sans | string |  | Space-separated list of extra SAN entries to add to the x509 certificate created for the master nodes. |
-
 | <a id="table-ha-cluster-dns"> </a> ha-cluster-dns | string |  | DNS entry to use with the HA Cluster subordinate charm. Mutually exclusive with ha-cluster-vip. |
-
 | <a id="table-ha-cluster-vip"> </a> ha-cluster-vip | string |  | Virtual IP for the charm to use with the HA Cluster subordinate charm Mutually exclusive with ha-cluster-dns. Multiple virtual IPs are separated by spaces. |
-
 | <a id="table-image-registry"> </a> image-registry | string | [See notes](#image-registry-default) | Container image registry to use for CDK. This includes addons like the Kubernetes dashboard, metrics server, ingress, and dns along with non-addon images including the pause container and default backend image. |
-
 | <a id="table-install_keys"> </a> install_keys | string |  | [See notes](#install_keys-description) |
-
 | <a id="table-install_sources"> </a> install_sources | string |  | [See notes](#install_sources-description) |
-
 | <a id="table-keystone-policy"> </a> keystone-policy | string | [See notes](#keystone-policy-default) | Policy for Keystone authorization. This is used when a Keystone charm is related to kubernetes-master in order to provide authorization for Keystone users on the Kubernetes cluster. |
-
 | <a id="table-keystone-ssl-ca"> </a> keystone-ssl-ca | string |  | Keystone certificate authority encoded in base64 for securing communications to Keystone. For example: `juju config kubernetes-master keystone-ssl-ca=$(base64 /path/to/ca.crt)` |
-
 | <a id="table-loadbalancer-ips"> </a> loadbalancer-ips | string |  | [See notes](#loadbalancer-ips-description) |
-
 | <a id="table-nagios_context"> </a> nagios_context | string | juju | [See notes](#nagios_context-description) |
-
 | <a id="table-nagios_servicegroups"> </a> nagios_servicegroups | string |  | A comma-separated list of nagios servicegroups. If left empty, the nagios_context will be used as the servicegroup |
-
 | <a id="table-package_status"> </a> package_status | string | install | The status of service-affecting packages will be set to this value in the dpkg database. Valid values are "install" and "hold". |
-
 | <a id="table-proxy-extra-args"> </a> proxy-extra-args | string |  | [See notes](#proxy-extra-args-description) |
-
 | <a id="table-require-manual-upgrade"> </a> require-manual-upgrade | boolean | True | When true, master nodes will not be upgraded until the user triggers it manually by running the upgrade action. |
-
 | <a id="table-scheduler-extra-args"> </a> scheduler-extra-args | string |  | [See notes](#scheduler-extra-args-description) |
-
 | <a id="table-service-cidr"> </a> service-cidr | string | 10.152.183.0/24 | CIDR to use for Kubernetes services. After deployment it is only possible to increase the size of the IP range. It is not possible to change or shrink the address range after deployment. |
-
 | <a id="table-snapd_refresh"> </a> snapd_refresh | string | max | [See notes](#snapd_refresh-description) |
-
 | <a id="table-storage-backend"> </a> storage-backend | string | auto | The storage backend for kube-apiserver persistence. Can be "etcd2", "etcd3", or "auto". Auto mode will select etcd3 on new installations, or etcd2 on upgrades. |
-
 | <a id="table-sysctl"> </a> sysctl | string | [See notes](#sysctl-default) | [See notes](#sysctl-description) |
-
 
 ---
 

--- a/templates/kubernetes/docs/charm-kubernetes-worker.md
+++ b/templates/kubernetes/docs/charm-kubernetes-worker.md
@@ -93,43 +93,24 @@ for other settings relating to Kubernetes services.
 
 | name | type   | Default      | Description                               |
 |------|--------|--------------|-------------------------------------------|
-
 | <a id="table-channel"> </a> channel | string | 1.22/stable | Snap channel to install Kubernetes worker services from |
-
 | <a id="table-default-backend-image"> </a> default-backend-image | string | auto | Docker image to use for the default backend. Auto will select an image based on architecture. |
-
 | <a id="table-ingress"> </a> ingress | boolean | True | [See notes](#ingress-description) |
-
 | <a id="table-ingress-default-ssl-certificate"> </a> ingress-default-ssl-certificate | string |  | [See notes](#ingress-default-ssl-certificate-description) |
-
 | <a id="table-ingress-default-ssl-key"> </a> ingress-default-ssl-key | string |  | [See notes](#ingress-default-ssl-key-description) |
-
 | <a id="table-ingress-ssl-chain-completion"> </a> ingress-ssl-chain-completion | boolean | False | [See notes](#ingress-ssl-chain-completion-description) |
-
 | <a id="table-ingress-ssl-passthrough"> </a> ingress-ssl-passthrough | boolean | False | Enable ssl passthrough on ingress server. This allows passing the ssl connection through to the workloads and not terminating it at the ingress controller. |
-
 | <a id="table-ingress-use-forwarded-headers"> </a> ingress-use-forwarded-headers | boolean | False | [See notes](#ingress-use-forwarded-headers-description) |
-
 | <a id="table-kubelet-extra-args"> </a> kubelet-extra-args | string |  | [See notes](#kubelet-extra-args-description) |
-
 | <a id="table-kubelet-extra-config"> </a> kubelet-extra-config | string | {} | [See notes](#kubelet-extra-config-description) |
-
 | <a id="table-labels"> </a> labels | string |  | Labels can be used to organize and to select subsets of nodes in the cluster. Declare node labels in key=value format, separated by spaces. |
-
 | <a id="table-nagios_context"> </a> nagios_context | string | juju | [See notes](#nagios_context-description) |
-
 | <a id="table-nagios_servicegroups"> </a> nagios_servicegroups | string |  | A comma-separated list of nagios servicegroups. If left empty, the nagios_context will be used as the servicegroup |
-
 | <a id="table-nginx-image"> </a> nginx-image | string | auto | [See notes](#nginx-image-description) |
-
 | <a id="table-proxy-extra-args"> </a> proxy-extra-args | string |  | [See notes](#proxy-extra-args-description) |
-
 | <a id="table-require-manual-upgrade"> </a> require-manual-upgrade | boolean | True | When true, worker services will not be upgraded until the user triggers it manually by running the upgrade action. |
-
 | <a id="table-snapd_refresh"> </a> snapd_refresh | string | max | [See notes](#snapd_refresh-description) |
-
 | <a id="table-sysctl"> </a> sysctl | string | [See notes](#sysctl-default) | [See notes](#sysctl-description) |
-
 
 ---
 

--- a/templates/kubernetes/docs/charm-openstack-integrator.md
+++ b/templates/kubernetes/docs/charm-openstack-integrator.md
@@ -134,47 +134,26 @@ watch kubectl get svc hello -o wide
 
 | name | type   | Default      | Description                               |
 |------|--------|--------------|-------------------------------------------|
-
 | <a id="table-auth-url"> </a> auth-url | string |  | The URL of the keystone API used to authenticate. On OpenStack control panels, this can be found at Access and Security > API Access > Credentials. |
-
 | <a id="table-bs-version"> </a> bs-version | string | None | [See notes](#bs-version-description) |
-
 | <a id="table-credentials"> </a> credentials | string |  | [See notes](#credentials-description) |
-
 | <a id="table-endpoint-tls-ca"> </a> endpoint-tls-ca | string |  | [See notes](#endpoint-tls-ca-description) |
-
 | <a id="table-floating-network-id"> </a> floating-network-id | string |  | [See notes](#floating-network-id-description) |
-
 | <a id="table-ignore-volume-az"> </a> ignore-volume-az | boolean | None | [See notes](#ignore-volume-az-description) |
-
 | <a id="table-lb-floating-network"> </a> lb-floating-network | string |  | If set, this charm will assign a floating IP in this network (name or ID) for load balancers created for other charms related on the loadbalancer endpoint. |
-
 | <a id="table-lb-method"> </a> lb-method | string | ROUND_ROBIN | [See notes](#lb-method-description) |
-
 | <a id="table-lb-port"> </a> lb-port | int | 443 | Port to use for load balancers created by this charm for other charms related on the loadbalancer endpoint. |
-
 | <a id="table-lb-subnet"> </a> lb-subnet | string |  | [See notes](#lb-subnet-description) |
-
 | <a id="table-manage-security-groups"> </a> manage-security-groups | boolean | False | [See notes](#manage-security-groups-description) |
-
 | <a id="table-password"> </a> password | string |  | Password of a valid user set in keystone. |
-
 | <a id="table-project-domain-name"> </a> project-domain-name | string |  | Name of the project domain where you want to create your resources. |
-
 | <a id="table-project-name"> </a> project-name | string |  | Name of project where you want to create your resources. |
-
 | <a id="table-region"> </a> region | string |  | Name of the region where you want to create your resources. |
-
 | <a id="table-snapd_refresh"> </a> snapd_refresh | string |  | [See notes](#snapd_refresh-description) |
-
 | <a id="table-subnet-id"> </a> subnet-id | string |  | [See notes](#subnet-id-description) |
-
 | <a id="table-trust-device-path"> </a> trust-device-path | boolean | None | [See notes](#trust-device-path-description) |
-
 | <a id="table-user-domain-name"> </a> user-domain-name | string |  | Name of the user domain where you want to create your resources. |
-
 | <a id="table-username"> </a> username | string |  | Username of a valid user set in keystone. |
-
 
 ---
 

--- a/templates/kubernetes/docs/charm-tigera-secure-ee.md
+++ b/templates/kubernetes/docs/charm-tigera-secure-ee.md
@@ -42,25 +42,15 @@ properly deploy.
 
 | name | type   | Default      | Description                               |
 |------|--------|--------------|-------------------------------------------|
-
 | <a id="table-calico-node-image"> </a> calico-node-image | string | [See notes](#calico-node-image-default) | The image id to use for cnx node. |
-
 | <a id="table-calicoctl-image"> </a> calicoctl-image | string | [See notes](#calicoctl-image-default) | The image id to use for calicoctl. |
-
 | <a id="table-enable-elasticsearch-operator"> </a> enable-elasticsearch-operator | boolean | True | [See notes](#enable-elasticsearch-operator-description) |
-
 | <a id="table-ignore-loose-rpf"> </a> ignore-loose-rpf | boolean | False | Enable or disable IgnoreLooseRPF for Calico Felix.  This is only used when rp_filter is set to a value of 2. |
-
 | <a id="table-ipip"> </a> ipip | string | Never | IPIP mode. Must be one of "Always", "CrossSubnet", or "Never". |
-
 | <a id="table-license-key"> </a> license-key | string |  | Tigera EE license key, base64-encoded. Example:  juju config tigera-secure-ee license-key=$(base64 -w0 license.yaml) |
-
 | <a id="table-nat-outgoing"> </a> nat-outgoing | boolean | True | NAT outgoing traffic |
-
 | <a id="table-registry"> </a> registry | string |  | Registry to use for images. If unspecified, defaults will be used: docker.io, quay.io, docker.elastic.co |
-
 | <a id="table-registry-credentials"> </a> registry-credentials | string |  | Private docker registry credentials, in the form of a base64-encoded docker config.json file. Example:  juju config tigera-secure-ee registry-credentials=$(base64 -w0 config.json) |
-
 
 ---
 


### PR DESCRIPTION
## Done

- removed blank lines causing tables not to render on some pages
- removed component links for charms not specifically accessible in CharmHub (which also removes some breaking links)

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes

