### PR TITLE
Update webinar link on /ceph pages

### DIFF
--- a/templates/ceph/managed.html
+++ b/templates/ceph/managed.html
@@ -25,9 +25,6 @@
 			</ul>
 			<p>Focus on your business applications, while Canonical takes care of your storage needs.</p>
       <a href="/ceph/contact-us" class="p-button--positive js-invoke-modal" >Get in touch</a>
-			<p>
-				<a href="https://www.brighttalk.com/webcast/6793/428078" class="p-link--external">Watch the webinar &mdash; Redefine your enterprise storage with Ceph</a>
-			</p>
     </div>
     <div class="col-5 u-align--center u-hide--small">
 			{{ image (

--- a/templates/ceph/what-is-ceph.html
+++ b/templates/ceph/what-is-ceph.html
@@ -18,7 +18,7 @@
           Ceph is an open source software-defined storage solution designed to address the block, file and object  storage needs of modern enterprises. Its highly scalable architecture sees it being adopted as the new norm for high-growth block storage, object stores, and data lakes. Ceph provides reliable and scalable storage while keeping CAPEX and OPEX costs in line with underlying commodity hardware prices.
         </p>
         <p><a href="/ceph/contact-us" class="p-button--positive js-invoke-modal" >Get in touch</a></p>
-        <p><a class="p-link--external" href=" https://www.brighttalk.com/webcast/6793/428078 ">Watch the webinar - Redefine your enterprise storage with Ceph</a></p>
+        <p><a class="p-link--external" href="https://www.brighttalk.com/webcast/6793/520582">Watch the webinar - Ceph for Enterprise</a></p>
       </div>
       <div class="col-5 u-align--center u-vertically-center u-hide--small">
         {{

--- a/templates/shared/_resources_ceph.html
+++ b/templates/shared/_resources_ceph.html
@@ -19,9 +19,7 @@
         </div>
       </div>
       <h3 class="p-heading--4">
-        <a class="p-link--external" href="https://www.brighttalk.com/webcast/6793/428078">
-          Redefine your enterprise storage with Ceph
-      </a>
+        <a class="p-link--external" href="https://www.brighttalk.com/webcast/6793/520582"> Ceph for Enterprise </a>
     </h3>
     </div>
     <div class="col-4 p-divider__block">


### PR DESCRIPTION
## Done

- Update webinar link on `/ceph`, `/ceph/consulting`, `/ceph/managed` and `/ceph/what-is-ceph`

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Please check page against copy doc and and resolve comments
    - https://docs.google.com/document/d/1gpEjTcdJor2yTGfMz7T_xIfs7BtV6rbBPFYfNZFe52Y/edit
    - https://docs.google.com/document/d/1gRuOAg6ZFBp-ikMq-DQBgQ4-BrXGeWOOe2cBxD3ohjE/edit
    - https://docs.google.com/document/d/1Ff3TDYBsukagu85dNZuK0FDdPRSjXEwS6Tv6JphXUvY/edit
    - https://docs.google.com/document/d/1LK8mut0O30Zk60mmbgCPFiQ2COR-BUnJnbASMMdyycU/edit 
- Demo
    - https://ubuntu-com-11153.demos.haus/ceph
    - https://ubuntu-com-11153.demos.haus/ceph/consulting
    - https://ubuntu-com-11153.demos.haus/ceph/managed
    - https://ubuntu-com-11153.demos.haus/ceph/what-is-ceph

## Issue / Card

Fixes [#4749](https://github.com/canonical-web-and-design/web-squad/issues/4749)



## Help

[QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html) - [Commit guidelines](https://canonical-web-and-design.github.io/practices/workflow/commit-messages.html)
