### PR TITLE
Add why-certified link to menu

### DIFF
--- a/navigation.yaml
+++ b/navigation.yaml
@@ -1887,6 +1887,8 @@ certification:
   children:
     - title: Overview
       path: /certified
+    - title: Why Certified?
+      path: /certified/why-certified
     - title: Laptops
       path: /certified/laptops
     - title: Desktops


### PR DESCRIPTION
## Done

Add /why-certified to bubble menu

## QA

- Check https://ubuntu-com-11155.demos.haus/certified contains the bubble menu

![image](https://user-images.githubusercontent.com/14939793/149761260-bc75a5bc-d424-43e4-8c84-f94fe873971f.png)

## Issue / Card

Fixes https://github.com/canonical-web-and-design/web-squad/issues/4771

## Screenshots

![why-certified-menu](https://user-images.githubusercontent.com/14939793/149763061-a7cef69e-90be-4e7a-acdb-bdf1fadb8e36.png)



## Help

[QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html) - [Commit guidelines](https://canonical-web-and-design.github.io/practices/workflow/commit-messages.html)
