### PR TITLE
Add notification on /advantage if offers are available

### DIFF
--- a/static/js/src/advantage/react/components/Subscriptions/Notifications/Notifications.test.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/Notifications/Notifications.test.tsx
@@ -47,8 +47,16 @@ describe("Notifications", () => {
     );
     expect(wrapper.find("[data-test='pendingPurchase']").exists()).toBe(false);
   });
+});
 
-  it("displays an offer notification", () => {
+describe("Offers Notifications", () => {
+  let queryClient: QueryClient;
+
+  beforeEach(() => {
+    queryClient = new QueryClient();
+  });
+
+  it("displays an offer notification if there are offers available", () => {
     queryClient.setQueryData("Offers", [OfferFactory.build()]);
     const wrapper = mount(
       <QueryClientProvider client={queryClient}>
@@ -56,5 +64,15 @@ describe("Notifications", () => {
       </QueryClientProvider>
     );
     expect(wrapper.find("[data-test='offers']").exists()).toBe(true);
+  });
+
+  it("does not display an offer notification if there are no offers available", () => {
+    queryClient.setQueryData("Offers", []);
+    const wrapper = mount(
+      <QueryClientProvider client={queryClient}>
+        <Notifications />
+      </QueryClientProvider>
+    );
+    expect(wrapper.find("[data-test='offers']").exists()).toBe(false);
   });
 });

--- a/static/js/src/advantage/react/components/Subscriptions/Notifications/Notifications.test.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/Notifications/Notifications.test.tsx
@@ -7,6 +7,7 @@ import {
   userSubscriptionFactory,
   userSubscriptionStatusesFactory,
 } from "advantage/tests/factories/api";
+import { OfferFactory } from "advantage/offers/tests/factories/offers";
 
 describe("Notifications", () => {
   let queryClient: QueryClient;
@@ -45,5 +46,15 @@ describe("Notifications", () => {
       </QueryClientProvider>
     );
     expect(wrapper.find("[data-test='pendingPurchase']").exists()).toBe(false);
+  });
+
+  it("displays an offer notification", () => {
+    queryClient.setQueryData("Offers", [OfferFactory.build()]);
+    const wrapper = mount(
+      <QueryClientProvider client={queryClient}>
+        <Notifications />
+      </QueryClientProvider>
+    );
+    expect(wrapper.find("[data-test='offers']").exists()).toBe(true);
   });
 });

--- a/static/js/src/advantage/react/components/Subscriptions/Notifications/Notifications.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/Notifications/Notifications.tsx
@@ -31,9 +31,19 @@ const Notifications = () => {
         </Notification>
       ) : null}
       {offers?.length > 0 ? (
-        <Notification data-test="offers" inline severity="information">
-          You have one or more Ubuntu Advantage offers to view.{" "}
-          <a href={urls.advantage.offers}>View your offers.</a>
+        <Notification
+          data-test="offers"
+          severity="information"
+          actions={[
+            {
+              label: "View your offers.",
+              onClick: () => {
+                location.href = urls.advantage.offers;
+              },
+            },
+          ]}
+        >
+          You have one or more Ubuntu Advantage offers to view.
         </Notification>
       ) : null}
       {statusesSummary ? (

--- a/static/js/src/advantage/react/components/Subscriptions/Notifications/Notifications.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/Notifications/Notifications.tsx
@@ -6,12 +6,14 @@ import { useUserSubscriptions } from "advantage/react/hooks";
 import { selectStatusesSummary } from "advantage/react/hooks/useUserSubscriptions";
 import ExpiryNotification from "../ExpiryNotification";
 import { ExpiryNotificationSize } from "../ExpiryNotification/ExpiryNotification";
+import useGetOffersList from "advantage/offers/hooks/useGetOffersList";
 
 const Notifications = () => {
   const urls = useURLs();
   const { data: statusesSummary } = useUserSubscriptions({
     select: selectStatusesSummary,
   });
+  const { data: offers } = useGetOffersList();
 
   return (
     <>
@@ -26,6 +28,12 @@ const Notifications = () => {
           <a href={urls.account.paymentMethods}>update your payment methods</a>{" "}
           to ensure there is no interruption to your Ubuntu Advantage
           subscriptions
+        </Notification>
+      ) : null}
+      {offers?.length > 0 ? (
+        <Notification data-test="offers" inline severity="information">
+          You have one or more Ubuntu Advantage offers to view.{" "}
+          <a href={urls.advantage.offers}>View your offers.</a>
         </Notification>
       ) : null}
       {statusesSummary ? (

--- a/static/js/src/advantage/react/components/Subscriptions/Notifications/Notifications.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/Notifications/Notifications.tsx
@@ -36,7 +36,7 @@ const Notifications = () => {
           severity="information"
           actions={[
             {
-              label: "View your offers.",
+              label: "View your offers",
               onClick: () => {
                 location.href = urls.advantage.offers;
               },

--- a/static/js/src/advantage/react/hooks/useURLs.ts
+++ b/static/js/src/advantage/react/hooks/useURLs.ts
@@ -6,6 +6,9 @@ export const APP_URLS = {
   account: {
     paymentMethods: "/account/payment-methods",
   },
+  advantage: {
+    offers: "/advantage/offers",
+  },
 };
 
 /**


### PR DESCRIPTION
## Done

Added a notification on /advantage to let users know if they have offers available 

## QA

- go to https://ubuntu-com-11159.demos.haus/advantage?test_backend=true
- log in with an account that has offers available
- check that the notification displays correctly
- click the link
- check that it takes you to the offers page

## Screenshots

![image](https://user-images.githubusercontent.com/11927929/149948248-1de05060-6c97-4d6a-b244-eddac27c70b4.png)

