### PR TITLE
Fix grammar on /core

### DIFF
--- a/templates/core/index.html
+++ b/templates/core/index.html
@@ -1220,7 +1220,7 @@
   <div class="row p-divider">
     <div class="col-4 p-divider__block">
       <h4>Download Ubuntu Core</h4>
-      <p>Try Ubuntu Core 20 on one of a popular development board</p>
+      <p>Try Ubuntu Core 20 on a popular development board</p>
       <p><a class="p-button p-link--external" href="https://cdimage.ubuntu.com/ubuntu-core/20/stable/current/">Download and install Ubuntu Core 20</a></p>
     </div>
     <div class="col-4 p-divider__block">


### PR DESCRIPTION
## Done

- Grammar fixed based on the [issue](https://github.com/canonical-web-and-design/web-squad/issues/4780)

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/core or https://ubuntu-com-11167.demos.haus/core
    - Be sure to test on mobile, tablet and desktop screen sizes
- Check the grammar makes sense where it has been changed

## Issue / Card

Fixes https://github.com/canonical-web-and-design/web-squad/issues/4780

