### PR TITLE
Adjust offer redirect

### DIFF
--- a/webapp/advantage/decorators.py
+++ b/webapp/advantage/decorators.py
@@ -74,6 +74,17 @@ def advantage_decorator(permission=None, response="json"):
 
             if permission == "user" and response == "html":
                 if not user_info(flask.session):
+                    if flask.request.path == "/advantage/offers":
+                        if is_test_backend:
+                            return flask.redirect(
+                                "/login?test_backend=true&"
+                                "next=/advantage/offers?test_backend=true"
+                            )
+
+                        return flask.redirect(
+                            "/login?next=/advantage/offers"
+                        )
+
                     if flask.request.path != "/advantage":
                         return flask.redirect(
                             "/advantage?test_backend=true"

--- a/webapp/advantage/decorators.py
+++ b/webapp/advantage/decorators.py
@@ -81,9 +81,7 @@ def advantage_decorator(permission=None, response="json"):
                                 "next=/advantage/offers?test_backend=true"
                             )
 
-                        return flask.redirect(
-                            "/login?next=/advantage/offers"
-                        )
+                        return flask.redirect("/login?next=/advantage/offers")
 
                     if flask.request.path != "/advantage":
                         return flask.redirect(

--- a/webapp/advantage/views.py
+++ b/webapp/advantage/views.py
@@ -795,6 +795,11 @@ def get_account_offers():
 
 
 @advantage_decorator(permission="user", response="html")
+def get_advantage_offers():
+    return flask.render_template("advantage/offers/index.html")
+
+
+@advantage_decorator(permission="user", response="html")
 def account_view():
     email = flask.session["openid"]["email"]
 

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -107,6 +107,7 @@ from webapp.advantage.views import (
     blender_shop_view,
     support,
     post_offer,
+    get_advantage_offers,
 )
 
 from webapp.login import login_handler, logout, user_info, empty_session
@@ -414,6 +415,12 @@ app.add_url_rule(
 app.add_url_rule(
     "/advantage/subscribe/blender/thank-you",
     view_func=blender_thanks_view,
+)
+
+app.add_url_rule(
+    "/advantage/offers",
+    view_func=get_advantage_offers,
+    methods=["GET"],
 )
 
 app.add_url_rule(


### PR DESCRIPTION
## Done

- Send people to login if hitting /advantage/offers logged out

## QA

- use demo
- go to /advantage/offers?test_backend=true
- it will redirect you to login with staging account and then send you back to /advantage/offers?test_backend=true
- do the same but without the test flag, it should work the same

## Issue / Card

Fixes #https://github.com/canonical-web-and-design/commercial-squad/issues/471