### PR TITLE
Fix email keyerror in marketo forms

### DIFF
--- a/webapp/views.py
+++ b/webapp/views.py
@@ -679,8 +679,12 @@ def marketo_submit():
         ],
     }
 
-    # Enrichment data for global enrichment form (id:4198)
-    enrichment_fields = {"email": form_fields["email"]}
+    enrichment_fields = None
+
+    if "email" in form_fields:
+        # Enrichment data for global enrichment form (id:4198)
+        enrichment_fields = {"email": form_fields["email"]}
+
     try:
         ip_location = ip_reader.get(client_ip)
         if ip_location and "country" in ip_location:


### PR DESCRIPTION
## Done

Fix `KeyError: 'email'`

## QA

- Sentry error points to this engage page https://ubuntu.com/engage/wellcome-sanger-case-study as the referrer, but it probably will not fail even without this check.

## Issue / Card

Fixes https://github.com/canonical-web-and-design/ubuntu.com/issues/11143

## Help

[QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html) - [Commit guidelines](https://canonical-web-and-design.github.io/practices/workflow/commit-messages.html)
