### PR TITLE
Remove 21.04 from /download/raspberry-pi

### DIFF
--- a/templates/download/raspberry-pi/index.html
+++ b/templates/download/raspberry-pi/index.html
@@ -69,24 +69,6 @@
         </a>
       </p>
     </div>
-
-{# desktop 21.04 #}
-    <div class="col-6">
-      <h3>
-        Ubuntu Desktop 21.04
-      </h3>
-      <p>
-        The previous development release of Ubuntu with support until February 2022.
-      </p>
-      <p>
-        <a
-        class="p-button--positive"
-        href="/download/raspberry-pi/thank-you?version=21.04&amp;architecture=desktop-arm64+raspi"
-        onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'Raspberry Pi 64-bit - desktop', 'eventLabel' : '21.04', 'eventValue' : undefined });">
-          Download 64-bit
-        </a>
-      </p>
-    </div>
   </div>
 
   <div class="row u-hide--medium u-hide--large">


### PR DESCRIPTION
## Done

- Ubuntu 21.04 is now out of support, so this is to remove it from the Raspberry Pi downloads.
- I also updated the copy doc

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/download/raspberry-pi
    - Be sure to test on mobile, tablet and desktop screen sizes
- [List additional steps to QA the new features or prove the bug has been resolved]


## Screenshots

![image](https://user-images.githubusercontent.com/441217/150505701-fb88c302-4bc4-4511-959a-aae01e6b6376.png)

