### PR TITLE
Tidy up security routing

### DIFF
--- a/konf/site.yaml
+++ b/konf/site.yaml
@@ -515,7 +515,7 @@ staging:
         - name: SENTRY_DSN
           value: https://0293bb7fc3104e56bafd2422e155790c@sentry.is.canonical.com//13
 
-    - paths: [/server/docs, /ceph/docs, /core/docs, /openstack/docs, /engage, /takeovers\.json, /security/livepatch/docs]
+    - paths: [/server/docs, /ceph/docs, /core/docs, /openstack/docs, /engage, /takeovers\.json, /security/livepatch/docs, /security/certifications/docs]
       name: ubuntu-com-discourse
       app_name: ubuntu.com-discourse
       image: prod-comms.docker-registry.canonical.com/ubuntu.com
@@ -548,7 +548,7 @@ staging:
     - paths: [/security/cves\.json, /security/cves/.*\.json, /security/notices\.json, /security/notices/.*\.json, /security/releases\.json, /security/releases/.*\.json]
       service_name: ubuntu-com-security-api
 
-    - paths: [/security]
+    - paths: [/security/notices, /security/cves]
       name: ubuntu-com-security
       app_name: ubuntu.com-security
       image: prod-comms.docker-registry.canonical.com/ubuntu.com

--- a/navigation.yaml
+++ b/navigation.yaml
@@ -1683,7 +1683,7 @@ security:
           path: /security/certifications/docs
 
     - title: CVEs
-      path: /security/cve
+      path: /security/cves
     - title: Notices
       path: /security/notices
       persist: True

--- a/redirects.yaml
+++ b/redirects.yaml
@@ -910,4 +910,4 @@ nvidia: /engage/ubuntu-at-nvidia-gtc-2021
 
 # Move /securtiy/cve to /security/cves
 security/cve: /security/cves
-
+security/cve/sitemap(?P<suffix>.*).xml: /security/cves/sitemap{suffix}.xml

--- a/redirects.yaml
+++ b/redirects.yaml
@@ -907,3 +907,8 @@ blog/topic: /blog
 
 # Marketing redirects to become pages in time
 nvidia: /engage/ubuntu-at-nvidia-gtc-2021
+
+# Move /securtiy/cve to /security/cves
+security/cve: /security/cves
+security/cve/(?P<cve_id>.*)/?: /security/cves/{cve_id}
+

--- a/redirects.yaml
+++ b/redirects.yaml
@@ -910,5 +910,4 @@ nvidia: /engage/ubuntu-at-nvidia-gtc-2021
 
 # Move /securtiy/cve to /security/cves
 security/cve: /security/cves
-security/cve/(?P<cve_id>.*)/?: /security/cves/{cve_id}
 

--- a/templates/legal/ubuntu-advantage-service-description/index.md
+++ b/templates/legal/ubuntu-advantage-service-description/index.md
@@ -346,7 +346,7 @@ As a Standard or Advanced customer, you are entitled to all of the benefits of t
 
 **Covered Hypervisor:** any of: KVM | Qemu | Bochs, VMWare ESXi, LXD | LXC, Xen, Hyper-V, VirtualBox, z/VM, Docker. All Nodes in the cluster have to be subscribed to the service in order to benefit from the unlimited VM support
 
-**CVEs (High and Critical):** High and Critical Common Vulnerabilities and Exposures as assessed by the Ubuntu Security Team. More details can be found at https://ubuntu.com/security/cve
+**CVEs (High and Critical):** High and Critical Common Vulnerabilities and Exposures as assessed by the Ubuntu Security Team. More details can be found at https://ubuntu.com/security/cves
 
 **DSE:** a Canonical dedicated support engineer assigned to work full-time for a single customer acting as an extension of the customer’s support organization with a primary focus on integrating and supporting Canonicals offerings within the customer’s environment
 

--- a/templates/legal/ubuntu-advantage-service-description/ja/index.html
+++ b/templates/legal/ubuntu-advantage-service-description/ja/index.html
@@ -525,7 +525,7 @@
 <p><strong>クラウトゲスト</strong>: Ubuntuサーバーのゲストインスタンスまたはコンテナインスタンス</p>
 <p><strong>コンテナインスタンス</strong>: クラスタ上で動くコンテナインスタンス</p>
 <p><strong>対象ハイパーバイザー</strong>: 以下のいずれか: KVM | Qemu | Bochs、VMWare ESXi、LXD | LXC、Xen、Hyper-V、VirtualBox、z/VM、Docker。無制限のVMサポートを利用するには、クラスタ内の全てのノードが、サービスに加入している必要があります</p>
-<p><strong>CVE（HighおよびCritical）</strong>: Ubuntuのセキュリティチームが査定する、HighおよびCriticalな一般的脆弱性およびエクスポージャー。詳細はhttps://ubuntu.com/security/cve でご覧になれます</p>
+<p><strong>CVE（HighおよびCritical）</strong>: Ubuntuのセキュリティチームが査定する、HighおよびCriticalな一般的脆弱性およびエクスポージャー。詳細はhttps://ubuntu.com/security/cves でご覧になれます</p>
 <p><strong>DSE</strong>: 顧客の環境内でのCanonical製品の統合とサポートに主な焦点を当て、顧客のサポート組織の延長として機能する単一の顧客のためにフルタイムで働くように割り当てられた1人のCanonical専任のサポートエンジニア</p>
 <p><strong>DTAM</strong>: 単一の顧客に向けてリモートかつフルタイムの勤務を行うCanonicalのサポートエンジニア</p>
 <p><strong>環境</strong>: 各サービス提供で該当するクラウドまたはクラスタ</p>

--- a/templates/security/cve/cve.html
+++ b/templates/security/cve/cve.html
@@ -22,7 +22,7 @@
           <a class="breadcrumbs__link p-link--soft" href="/security/notices">Notices</a>
         </li>
         <li class="breadcrumbs__item">
-          <a class="breadcrumbs__link p-link--active" href="/security/cve">CVEs</a>
+          <a class="breadcrumbs__link p-link--active" href="/security/cves">CVEs</a>
         </li>
       </ul>
     </div>
@@ -142,7 +142,7 @@
                   {% if release.codename in statuses %}
                     {% if loop.index == 1 %}
                       <td rowspan="{{ releases | length }}">
-                        <a href="/security/cve?q=&package={{ package_name }}">{{ package_name }}</a><br>
+                        <a href="/security/cves?q=&package={{ package_name }}">{{ package_name }}</a><br>
                         <small>
                         <a href="https://launchpad.net/distros/ubuntu/+source/{{ package_name }}">Launchpad</a>,
                         <a href="https://packages.ubuntu.com/search?suite=all&section=all&arch=any&searchon=sourcenames&keywords={{ package_name }}">Ubuntu</a>,

--- a/templates/security/docker-images.html
+++ b/templates/security/docker-images.html
@@ -52,7 +52,7 @@
       <h2>Critical CVE fixes in 24 hours</h2>
       <p>Scanning container images for vulnerabilities is now widespread, but fixing them requires dedicated skills and infrastructure. Trusted provenance is key.</p>
       <p>The LTS Docker Image Portfolio provides ready-to-use application base images, free of high and critical CVEs. Images are built on the same secure infrastructure that builds Ubuntu, and updated automatically when apps or dependencies are fixed.</p>
-      <a href="/security/cve">Explore our CVE-fixing track record&nbsp;&rsaquo;</a>
+      <a href="/security/cves">Explore our CVE-fixing track record&nbsp;&rsaquo;</a>
     </div>
   </div>
 </section>

--- a/templates/security/notices/usn.html
+++ b/templates/security/notices/usn.html
@@ -26,7 +26,7 @@
       <h2>Packages</h2>
       <ul class="p-list">
         {% for package_name, package_title in notice.package_descriptions.items() %}
-          <li class="p-list__item"><a href="/security/cve?package={{ package_name }}">{{ package_name }}</a> - {{ package_title }}</li>
+          <li class="p-list__item"><a href="/security/cves?package={{ package_name }}">{{ package_name }}</a> - {{ package_title }}</li>
         {% endfor %}
       </ul>
     </div>

--- a/templates/sitemap_index.xml
+++ b/templates/sitemap_index.xml
@@ -22,7 +22,7 @@
     <loc>https://ubuntu.com/security/notices/sitemap.xml</loc>
   </sitemap>
   <sitemap>
-    <loc>https://ubuntu.com/security/cve/sitemap.xml</loc>
+    <loc>https://ubuntu.com/security/cves/sitemap.xml</loc>
   </sitemap>
   <sitemap>
    <loc>https://ubuntu.com/security/livepatch/docs/sitemap.xml</loc>

--- a/templates/templates/navigation-developer-h.html
+++ b/templates/templates/navigation-developer-h.html
@@ -191,7 +191,7 @@
           <li class="p-inline-list__item"><a href="/security">Security</a></li>
           <li class="p-inline-list__item"><a href="/security/certifications">Certifications</a></li>
           <li class="p-inline-list__item"><a href="/security/notices">Notices</a></li>
-          <li class="p-inline-list__item"><a href="/security/cve">CVEs</a></li>
+          <li class="p-inline-list__item"><a href="/security/cves">CVEs</a></li>
           <li class="p-inline-list__item"><a href="/esm">Extended Security Maintenance</a></li>
         </ul>
       </div>

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -510,11 +510,11 @@ app.add_url_rule(
 app.add_url_rule("/security/notices/sitemap.xml", view_func=notices_sitemap)
 
 app.add_url_rule(
-    "/security/cve/sitemap-<regex('[0-9]*'):offset>.xml",
+    "/security/cves/sitemap-<regex('[0-9]*'):offset>.xml",
     view_func=single_cves_sitemap,
 )
 
-app.add_url_rule("/security/cve/sitemap.xml", view_func=cves_sitemap)
+app.add_url_rule("/security/cves/sitemap.xml", view_func=cves_sitemap)
 
 app.add_url_rule(
     "/security/releases", view_func=create_release, methods=["POST"]
@@ -526,8 +526,8 @@ app.add_url_rule(
 )
 
 # cve section
-app.add_url_rule("/security/cve", view_func=cve_index)
-app.add_url_rule("/security/cve", view_func=bulk_upsert_cve, methods=["PUT"])
+app.add_url_rule("/security/cves", view_func=cve_index)
+app.add_url_rule("/security/cves", view_func=bulk_upsert_cve, methods=["PUT"])
 
 app.add_url_rule(
     r"/security/<regex('(cve-|CVE-)\d{4}-\d{4,7}'):cve_id>", view_func=cve

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -117,8 +117,6 @@ from webapp.security.views import (
     create_release,
     delete_release,
     notice,
-    read_notice,
-    read_notices,
     notices,
     notices_feed,
     update_notice,
@@ -487,14 +485,6 @@ app.add_url_rule(
 app.register_blueprint(build_blueprint(blog_views), url_prefix="/blog")
 
 # usn section
-app.add_url_rule(
-    "/security/api/notices/<notice_id>",
-    view_func=read_notice,
-)
-app.add_url_rule(
-    "/security/api/notices",
-    view_func=read_notices,
-)
 app.add_url_rule("/security/notices", view_func=notices)
 app.add_url_rule(
     "/security/notices", view_func=create_notice, methods=["POST"]

--- a/webapp/security/views.py
+++ b/webapp/security/views.py
@@ -256,50 +256,6 @@ def _update_notice_object(notice, data):
     return notice
 
 
-def read_notice(notice_id):
-    """
-    GET method to get notice by id
-    """
-
-    notice = db_session.query(Notice).get(notice_id)
-
-    if not notice:
-        return (
-            flask.jsonify({"message": f"Notice {notice_id} does not exist"}),
-            404,
-        )
-
-    return flask.jsonify({"data": notice.as_dict()}), 200
-
-
-def read_notices():
-    """
-    GET method to get notices
-    """
-
-    limit = flask.request.args.get("limit", default=20, type=int)
-    offset = flask.request.args.get("offset", default=0, type=int)
-
-    notices = (
-        db_session.query(Notice)
-        .order_by(Notice.published)
-        .offset(offset)
-        .limit(limit)
-        .all()
-    )
-
-    return (
-        flask.jsonify(
-            {
-                "data": [notice.as_dict() for notice in notices],
-                "limit": limit,
-                "offset": offset,
-            }
-        ),
-        200,
-    )
-
-
 def single_notices_sitemap(offset):
     notices = (
         db_session.query(Notice)


### PR DESCRIPTION
- Remove unused /security/api/notices endpoints
- Tidy up routing of /security section
  - Only route /security/notices and /security/cves to `ubuntu-com-security` service - this is because I want to isolate specifically the security database logic in this service, so problems with the database can be seen very clearly and won't effect other areas.
  - Route /security/certifications/docs to `ubuntu-com-discourse` (like other docs)
- change /security/cve URL to /security/cves
  - This is to match the API (/security/cves.json) and because all our other URLs follow this plural scheme, as well as this being the recommendation in [Web API Design](https://robinwinslow.uk/api-design-ebook-2012-03.pdf).

## QA

Can't really QA the k8s routing stuff, we have to put that on a k8s platform first. But you can QA the /security/cve -> /security/cves redirects are working ok.