### PR TITLE
Logo section update - part 1

### DIFF
--- a/templates/ai/services.html
+++ b/templates/ai/services.html
@@ -98,15 +98,15 @@
       }}
       <div>
         <p style="margin-top: -1rem;" class="p-muted-heading">IN PARTNERSHIP WITH:</p>
-          {{ image (
-            url="https://assets.ubuntu.com/v1/4566e59b-mavencode-logo.png",
-            alt="Mavencode",
-            width="155",
-            height="19",
-            hi_def=True,
-            loading="lazy"
-            ) | safe
-          }}
+        {{ image (
+          url="https://assets.ubuntu.com/v1/4566e59b-mavencode-logo.png",
+          alt="Mavencode",
+          width="155",
+          height="19",
+          hi_def=True,
+          loading="lazy"
+          ) | safe
+        }}
       </div>
       <p>
         <a class="p-link--external" href="https://canonical.com/partners/become-a-partner"><small>Become a trusted partner</small></a>
@@ -133,180 +133,191 @@
         <h2>Easy Kubeflow operations</h2>
         <p>Charmed Kubeflow integrates the 30+ apps that make up Kubeflow with ops code to provide the best Kubeflow experience, from deployment to day-2 operations. </p>
         <br />
-          <a class="p-link--external p-button--positive" href="https://charmed-kubeflow.io">Visit Charmed-Kubeflow.io</a>
-          <a class="p-link--external p-link--inverted" href="https://assets.ubuntu.com/v1/197d9867-Charmed_Kubeflow_Kubernetes_10.11.20+%282%29.pdf">Download datasheet</a>
+        <a class="p-link--external p-button--positive" href="https://charmed-kubeflow.io">Visit Charmed-Kubeflow.io</a>
+        <a class="p-link--external p-link--inverted" href="https://assets.ubuntu.com/v1/197d9867-Charmed_Kubeflow_Kubernetes_10.11.20+%282%29.pdf">Download datasheet</a>
       </div>
     </div>
     <div class="col-5 u-align--center u-hide--small">
       {{
         image(
-          url="https://assets.ubuntu.com/v1/20f5bfae-Kubeflow-nicely-packaged-simple-transparent.svg",
-          alt="",
-          width="212",
-          height="201",
-          hi_def=True,
-        ) | safe
-      }}
-  </div>
-</section>
-
-<section class="p-strip">
-  <div class="row u-vertically-center">
-    <div class="col-4 u-align--center u-hide--small">
-      {{ image (
-        url="https://assets.ubuntu.com/v1/431b4ca2-ubuntu+core+18+circular+.svg",
+        url="https://assets.ubuntu.com/v1/20f5bfae-Kubeflow-nicely-packaged-simple-transparent.svg",
         alt="",
-        width="249",
-        height="243",
+        width="212",
+        height="201",
         hi_def=True,
-        loading="lazy"
         ) | safe
       }}
     </div>
-    <div class="col-8">
-      <h2>Fully&ndash;managed Kubeflow</h2>
-      <p class="p-heading--4">MLOps with guaranteed uptime for hyper-focused data science</p>
-      <p>Bring models to production fast, while off-loading the management of Kubeflow.</p>
-      <p>Canonical provides a hands-off Kubeflow experience, taking care of the infrastructure while your team focuses on orchestrating success for your business.</p>
-      <p>Available on any CNCF conformant Kubernetes, including AKS, EKS, GKE, OpenShift, Rancher and Charmed Kubernetes.</p>
-      <p>
-        <a class="p-button js-invoke-modal" href="/ai/contact-us?product=ai-index">Contact us</a>
-      </p>
+  </section>
+  
+  <section class="p-strip">
+    <div class="row u-vertically-center">
+      <div class="col-4 u-align--center u-hide--small">
+        {{ image (
+          url="https://assets.ubuntu.com/v1/431b4ca2-ubuntu+core+18+circular+.svg",
+          alt="",
+          width="249",
+          height="243",
+          hi_def=True,
+          loading="lazy"
+          ) | safe
+        }}
+      </div>
+      <div class="col-8">
+        <h2>Fully&ndash;managed Kubeflow</h2>
+        <p class="p-heading--4">MLOps with guaranteed uptime for hyper-focused data science</p>
+        <p>Bring models to production fast, while off-loading the management of Kubeflow.</p>
+        <p>Canonical provides a hands-off Kubeflow experience, taking care of the infrastructure while your team focuses on orchestrating success for your business.</p>
+        <p>Available on any CNCF conformant Kubernetes, including AKS, EKS, GKE, OpenShift, Rancher and Charmed Kubernetes.</p>
+        <p>
+          <a class="p-button js-invoke-modal" href="/ai/contact-us?product=ai-index">Contact us</a>
+        </p>
+      </div>
     </div>
-  </div>
-</section>
-
-<section class="p-strip--light">
-  <div class="row u-vertically-center">
-    <div class="col-7">
-      <h2>Join our network of partners</h2>
-      <p>Canonical partners with highly regarded data science specialist firms to better serve its customers on consulting engagements.</p>
-      <p>If your company delivers excellence in AI/ML solutions, join our trusted partners program and grow the scale of your business.</p>
-      <p>
-        <a class="p-button p-link--external" href="https://canonical.com/partners/become-a-partner">Become a partner</a>
-      </p>
+  </section>
+  
+  <section class="p-strip--light">
+    <div class="row u-vertically-center">
+      <div class="col-7">
+        <h2>Join our network of partners</h2>
+        <p>Canonical partners with highly regarded data science specialist firms to better serve its customers on consulting engagements.</p>
+        <p>If your company delivers excellence in AI/ML solutions, join our trusted partners program and grow the scale of your business.</p>
+        <p>
+          <a class="p-button p-link--external" href="https://canonical.com/partners/become-a-partner">Become a partner</a>
+        </p>
+      </div>
+      <div class="col-4 col-start-large-8 u-align--center u-hide--small">
+        <div class="p-logo-section">
+          <div class="p-logo-section__items">
+            <div class="p-logo-section__item">
+              {{ image (
+                url="https://assets.ubuntu.com/v1/4566e59b-mavencode-logo.png",
+                alt="Mavencode",
+                width="185",
+                height="22",
+                hi_def=True,
+                loading="lazy"
+                ) | safe
+              }}
+            </div>
+            <div class="p-logo-section__item">
+              {{ image (
+                url="https://assets.ubuntu.com/v1/e9e4d429-Manceps.png",
+                alt="Manceps",
+                width="163",
+                height="34",
+                hi_def=True,
+                loading="lazy"
+                ) | safe
+              }}
+            </div>
+            <div class="p-logo-section__item">
+              {{ image (
+                url="https://assets.ubuntu.com/v1/7076871b-logo_czarne.png",
+                alt="deepsense.ai",
+                width="175",
+                height="34",
+                hi_def=True,
+                loading="lazy"
+                ) | safe
+              }}
+            </div>
+          </div>
+        </div>
+      </div>
     </div>
-    <div class="col-4 col-start-large-8 u-align--center u-hide--small">
-      <ul class="p-inline-images">
-        <li class="p-inline-images__item">
-          {{ image (
-            url="https://assets.ubuntu.com/v1/4566e59b-mavencode-logo.png",
-            alt="Mavencode",
-            width="185",
-            height="22",
-            hi_def=True,
-            loading="lazy"
-            ) | safe
-          }}
-        </li>
-        <li class="p-inline-images__item">
-          {{ image (
-            url="https://assets.ubuntu.com/v1/e9e4d429-Manceps.png",
-            alt="Manceps",
-            width="163",
-            height="34",
-            hi_def=True,
-            loading="lazy"
-            ) | safe
-          }}
-        </li>
-        <li class="p-inline-images__item">
-          {{ image (
-            url="https://assets.ubuntu.com/v1/7076871b-logo_czarne.png",
-            alt="deepsense.ai",
-            width="175",
-            height="34",
-            hi_def=True,
-            loading="lazy"
-            ) | safe
-          }}
-        </li>
-      </ul>
+    
+    <div class="u-fixed-width">
+      <hr class="p-separator" />
     </div>
+    
+    <div class="row">
+      <div class="p-logo-section">
+        <div class="p-logo-section__items">
+          <div class="p-logo-section__item">
+            {{ image (
+              url="https://assets.ubuntu.com/v1/de681426-aws-logo.png",
+              alt="Amazon Web Services",
+              width="288",
+              height="288",
+              hi_def=True,
+              loading="lazy",
+              attrs={"class": "p-logo-section__logo"}
+              ) | safe
+            }}
+          </div>
+          <div class="p-logo-section__item">
+            {{ image (
+              url="https://assets.ubuntu.com/v1/6ef81e08-microsoft-azure-new-logo.png",
+              alt="Microsoft Azure",
+              width="288",
+              height="288",
+              hi_def=True,
+              loading="lazy",
+              attrs={"class": "p-logo-section__logo"}
+              ) | safe
+            }}
+          </div>
+          <div class="p-logo-section__item">
+            {{ image (
+              url="https://assets.ubuntu.com/v1/560a216b-google-cloud-stacked-logo.png",
+              alt="Google Cloud",
+              width="288",
+              height="288",
+              hi_def=True,
+              loading="lazy",
+              attrs={"class": "p-logo-section__logo"}
+              ) | safe
+            }}
+          </div>
+          <div class="p-logo-section__item">
+            {{ image (
+              url="https://assets.ubuntu.com/v1/cd765ccc-nvidia-logo.png",
+              alt="Nvidia",
+              width="288",
+              height="288",
+              hi_def=True,
+              loading="lazy",
+              attrs={"class": "p-logo-section__logo"}
+              ) | safe
+            }}
+          </div>
+          <div class="p-logo-section__item">
+            {{ image (
+              url="https://assets.ubuntu.com/v1/67f81bfe-intel-new-logo.png",
+              alt="Intel",
+              width="288",
+              height="288",
+              hi_def=True,
+              loading="lazy",
+              attrs={"class": "p-logo-section__logo"}
+              ) | safe
+            }}
+          </div>
+          <div class="p-logo-section__item">
+            {{ image (
+              url="https://assets.ubuntu.com/v1/e7ee52ba-dell-emc-logo.png",
+              alt="Dell EMC",
+              width="288",
+              height="288",
+              hi_def=True,
+              loading="lazy",
+              attrs={"class": "p-logo-section__logo"}
+              ) | safe
+            }}
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  
+  {% include "ai/shared/_learn-more.html" %}
+  
+  {% with first_item="_cloud_bootstack", second_item="_cloud_ubuntu_advantage", third_item="_kubeflow_news_signup" %}{% include "shared/contextual_footers/_contextual_footer.html" %}{% endwith %}
+  
+  <!-- Set default Marketo information for contact form below-->
+  <div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/kubeflow" data-form-id="3231" data-lp-id="6279" data-return-url="https://ubuntu.com/ai/thank-you?product=ai-managed" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
   </div>
-
-  <div class="u-fixed-width">
-    <hr class="p-separator" />
-  </div>
-
-  <div class="row">
-    <ul class="p-inline-images">
-      <li class="p-inline-images__item">
-        {{ image (
-          url="https://assets.ubuntu.com/v1/8e5cc412-AWS.svg",
-          alt="AWS",
-          width="86",
-          height="51",
-          hi_def=True,
-          loading="lazy"
-          ) | safe
-        }}
-      </li>
-      <li class="p-inline-images__item">
-        {{ image (
-          url="https://assets.ubuntu.com/v1/da9a1344-Microsoft-Azure-logo_stacked_transparent.png",
-          alt="Microsoft Azure",
-          width="144",
-          height="40",
-          hi_def=True,
-          loading="lazy"
-          ) | safe
-        }}
-      </li>
-      <li class="p-inline-images__item">
-        {{ image (
-          url="https://assets.ubuntu.com/v1/6e176d9a-Google+Cloud+stacked.svg",
-          alt="Google cloud",
-          width="86",
-          height="70",
-          hi_def=True,
-          loading="lazy"
-          ) | safe
-        }}
-      </li>
-      <li class="p-inline-images__item">
-        {{ image (
-          url="https://assets.ubuntu.com/v1/cb6924a9-Nvidia_image_logo.svg",
-          alt="Nvidia",
-          width="85",
-          height="57",
-          hi_def=True,
-          loading="lazy"
-          ) | safe
-        }}
-      </li>
-      <li class="p-inline-images__item">
-        {{ image (
-          url="https://assets.ubuntu.com/v1/e0ef0377-intel-logo-2-1.png",
-          alt="Intel",
-          width="91",
-          height="35",
-          hi_def=True,
-          loading="lazy"
-          ) | safe
-        }}
-      </li>
-      <li class="p-inline-images__item">
-        {{ image (
-          url="https://assets.ubuntu.com/v1/5c2662f7-dellemc.png",
-          alt="DellEMC",
-          width="139",
-          height="24",
-          hi_def=True,
-          loading="lazy"
-          ) | safe
-        }}
-      </li>
-    </ul>
-  </div>
-</section>
-
-{% include "ai/shared/_learn-more.html" %}
-
-{% with first_item="_cloud_bootstack", second_item="_cloud_ubuntu_advantage", third_item="_kubeflow_news_signup" %}{% include "shared/contextual_footers/_contextual_footer.html" %}{% endwith %}
-
-<!-- Set default Marketo information for contact form below-->
-<div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/kubeflow" data-form-id="3231" data-lp-id="6279" data-return-url="https://ubuntu.com/ai/thank-you?product=ai-managed" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
-</div>
-
-{% endblock content %}
+  
+  {% endblock content %}
+  

--- a/templates/automotive/index.html
+++ b/templates/automotive/index.html
@@ -27,12 +27,12 @@
     <div class="col-8 u-align--center u-vertically-center u-hide--small">
       {{
         image(
-          url="https://assets.ubuntu.com/v1/86148922-Automotive-in-car-cockpit-cropped.svg",
-          alt="",
-          width="605",
-          height="380",
-          hi_def=True,
-          loading="auto",
+        url="https://assets.ubuntu.com/v1/86148922-Automotive-in-car-cockpit-cropped.svg",
+        alt="",
+        width="605",
+        height="380",
+        hi_def=True,
+        loading="auto",
         ) | safe
       }}
     </div>
@@ -42,125 +42,116 @@
 <section class="p-strip">
   <div class="u-fixed-width">
     <h2 class="p-muted-heading u-align--center u-sv3">Accelerating on Ubuntu</h2>
-    <ul class="p-inline-images u-no-margin--bottom">
-      <li class="p-inline-images__item">
-          {{
-            image(
-              url="https://assets.ubuntu.com/v1/4f0688c6-Toyota_Logo_silver.png",
-              alt="Toyota",
-              height="88",
-              width="105",
-              hi_def=True,
-              loading="lazy",
-              attrs={"class": "p-inline-images__logo"},
-            ) | safe
-          }}
-      </li>
-      <li class="p-inline-images__item">
-          {{
-            image(
-              url="https://assets.ubuntu.com/v1/1e265e27-bmw-new-2020.svg",
-              alt="BMW",
-              height="88",
-              width="88",
-              hi_def=True,
-              loading="lazy",
-              attrs={"class": "p-inline-images__logo"},
-            ) | safe
-          }}
-      </li>
-      <li class="p-inline-images__item">
-          {{
-            image(
-              url="https://assets.ubuntu.com/v1/578dbfb5-Volkswagen_logo_2019.svg.png",
-              alt="Volkswagen",
-              height="88",
-              width="88",
-              hi_def=True,
-              loading="lazy",
-              attrs={"class": "p-inline-images__logo"},
-            ) | safe
-          }}
-      </li>
-      <li class="p-inline-images__item">
-          {{
-            image(
-              url="https://assets.ubuntu.com/v1/9a0de5dd-Ford-Logo.svg",
-              alt="Ford",
-              height="55",
-              width="144",
-              hi_def=True,
-              loading="lazy",
-              attrs={"class": "p-inline-images__logo"},
-            ) | safe
-          }}
-      </li>
-      <li class="p-inline-images__item">
-          {{
-            image(
-              url="https://assets.ubuntu.com/v1/9320c145-Scania_Logo-Symbol.svg",
-              alt="Scania",
-              height="88",
-              width="92",
-              hi_def=True,
-              loading="lazy",
-              attrs={"class": "p-inline-images__logo"},
-            ) | safe
-          }}
-      </li>
-      <li class="p-inline-images__item">
-          {{
-            image(
-              url="https://assets.ubuntu.com/v1/e99b843a-Bosch_Logo-flat.svg",
-              alt="Bosch",
-              height="31",
-              width="144",
-              hi_def=True,
-              loading="lazy",
-              attrs={"class": "p-inline-images__logo"},
-            ) | safe
-          }}
-      </li>
-      <li class="p-inline-images__item">
-          {{
-            image(
-              url="https://assets.ubuntu.com/v1/d1da96af-Continental-Logo.svg",
-              alt="Continental",
-              height="54",
-              width="144",
-              hi_def=True,
-              loading="lazy",
-              attrs={"class": "p-inline-images__logo"},
-            ) | safe
-          }}
-      </li>
-      <li class="p-inline-images__item">
-          {{
-            image(
-              url="https://assets.ubuntu.com/v1/547ef405-uber.svg",
-              alt="Uber",
-              height="50",
-              width="144",
-              hi_def=True,
-              loading="lazy",
-              attrs={"class": "p-inline-images__logo", "style": "max-width: 7rem;"},
-            ) | safe
-          }}
-      </li>
-      <li class="p-inline-images__item">
-          {{
-            image(
-              url="https://assets.ubuntu.com/v1/4a1c3691-lyft.svg",
-              alt="Eurotech logo",
-              height="88",
-              width="124",
-              hi_def=True,
-              loading="lazy",
-              attrs={"class": "p-inline-images__logo", "style": "max-width: 6rem;"},
-            ) | safe
-          }}
-      </li>
-    </ul>
+    <div class="p-logo-section__items u-no-margin--bottom">
+      <div class="p-logo-section__item">
+        {{ image (
+          url="https://assets.ubuntu.com/v1/85be122c-toyota-logo.png",
+          alt="Toyota",
+          width="288",
+          height="288",
+          hi_def=True,
+          loading="lazy",
+          attrs={"class": "p-logo-section__logo"}
+          ) | safe
+        }}
+      </div>
+      <div class="p-logo-section__item">
+        {{ image (
+          url="https://assets.ubuntu.com/v1/59af2c8f-bmw-logo.png",
+          alt="BMW",
+          width="288",
+          height="288",
+          hi_def=True,
+          loading="lazy",
+          attrs={"class": "p-logo-section__logo"}
+          ) | safe
+        }}
+      </div>
+      <div class="p-logo-section__item">
+        {{ image (
+          url="https://assets.ubuntu.com/v1/e10b8957-vw-logo.png",
+          alt="Volkswagen",
+          width="288",
+          height="288",
+          hi_def=True,
+          loading="lazy",
+          attrs={"class": "p-logo-section__logo"}
+          ) | safe
+        }}
+      </div>
+      <div class="p-logo-section__item">
+        {{ image (
+          url="https://assets.ubuntu.com/v1/3263fb35-ford-logo.png",
+          alt="Ford",
+          width="288",
+          height="288",
+          hi_def=True,
+          loading="lazy",
+          attrs={"class": "p-logo-section__logo"}
+          ) | safe
+        }}
+      </div>
+      <div class="p-logo-section__item">
+        {{ image (
+          url="https://assets.ubuntu.com/v1/52e19575-scania-logo.png",
+          alt="Scania",
+          width="288",
+          height="288",
+          hi_def=True,
+          loading="lazy",
+          attrs={"class": "p-logo-section__logo"}
+          ) | safe
+        }}
+      </div>
+      <div class="p-logo-section__item">
+        {{ image (
+          url="https://assets.ubuntu.com/v1/466c2690-bosch-logo.png",
+          alt="Bosch",
+          width="288",
+          height="288",
+          hi_def=True,
+          loading="lazy",
+          attrs={"class": "p-logo-section__logo"}
+          ) | safe
+        }}
+      </div>
+      <div class="p-logo-section__item">
+        {{ image (
+          url="https://assets.ubuntu.com/v1/7e3ec23a-continetal-logo.png",
+          alt="Continental",
+          width="288",
+          height="288",
+          hi_def=True,
+          loading="lazy",
+          attrs={"class": "p-logo-section__logo"}
+          ) | safe
+        }}
+      </div>
+      <div class="p-logo-section__item">
+        {{ image (
+          url="https://assets.ubuntu.com/v1/6889bfcb-uber-logo.png",
+          alt="Uber",
+          width="288",
+          height="288",
+          hi_def=True,
+          loading="lazy",
+          attrs={"class": "p-logo-section__logo"}
+          ) | safe
+        }}
+      </div>
+      <div class="p-logo-section__item">
+        {{ image (
+          url="https://assets.ubuntu.com/v1/dea8779e-eurotech-group-logo.png",
+          alt="Eurotech",
+          width="288",
+          height="288",
+          hi_def=True,
+          loading="lazy",
+          attrs={"class": "p-logo-section__logo"}
+          ) | safe
+        }}
+      </div>
+    </div>
   </div>
 </section>
 
@@ -179,11 +170,11 @@
     <div class="col-6 u-vertically-center u-align--center u-hide--small">
       {{
         image(
-          url="https://assets.ubuntu.com/v1/cef9fb09-automotive-business-software.svg",
-          alt="",
-          height="320",
-          width="420",
-          hi_def=True,
+        url="https://assets.ubuntu.com/v1/cef9fb09-automotive-business-software.svg",
+        alt="",
+        height="320",
+        width="420",
+        hi_def=True,
         ) | safe
       }}
     </div>
@@ -195,11 +186,11 @@
     <div class="col-6 u-vertically-center u-align--center u-hide--small">
       {{
         image(
-          url="https://assets.ubuntu.com/v1/af98e3d6-automotive_car-network.svg",
-          alt="",
-          height="210",
-          width="360",
-          hi_def=True,
+        url="https://assets.ubuntu.com/v1/af98e3d6-automotive_car-network.svg",
+        alt="",
+        height="210",
+        width="360",
+        hi_def=True,
         ) | safe
       }}
     </div>
@@ -226,11 +217,11 @@
     <div class="col-6 u-vertically-center u-align--center u-hide--small">
       {{
         image(
-          url="https://assets.ubuntu.com/v1/22007291-DevOps.svg",
-          alt="",
-          height="200",
-          width="350",
-          hi_def=True,
+        url="https://assets.ubuntu.com/v1/22007291-DevOps.svg",
+        alt="",
+        height="200",
+        width="350",
+        hi_def=True,
         ) | safe
       }}
     </div>
@@ -242,11 +233,11 @@
     <div class="col-6 u-vertically-center u-align--center u-hide--small">
       {{
         image(
-          url="https://assets.ubuntu.com/v1/0631c9dc-FinancialServicesPage-GetStarted-AI_2020.svg",
-          alt="",
-          height="230",
-          width="252",
-          hi_def=True,
+        url="https://assets.ubuntu.com/v1/0631c9dc-FinancialServicesPage-GetStarted-AI_2020.svg",
+        alt="",
+        height="230",
+        width="252",
+        hi_def=True,
         ) | safe
       }}
     </div>
@@ -271,15 +262,15 @@
     </div>
     <div class="col-6 u-vertically-center u-align--center u-hide--small">
       <a href="https://www.brighttalk.com/webcast/6793/416900/mastering-multicloud-with-slurm-and-juju">
-      {{
-        image(
+        {{
+          image(
           url="https://assets.ubuntu.com/v1/d1b5ac75-Automotive-Masters-vid-screen.png",
           alt="",
           height="229",
           width="400",
           hi_def=True,
-        ) | safe
-      }}
+          ) | safe
+        }}
       </a>
     </div>
   </div>
@@ -290,11 +281,11 @@
     <div class="col-6 u-vertically-center u-align--center u-hide--small">
       {{
         image(
-          url="https://assets.ubuntu.com/v1/2bd31151-Automotive-in-car-cockpit-sized.svg",
-          alt="",
-          height="250",
-          width="429",
-          hi_def=True,
+        url="https://assets.ubuntu.com/v1/2bd31151-Automotive-in-car-cockpit-sized.svg",
+        alt="",
+        height="250",
+        width="429",
+        hi_def=True,
         ) | safe
       }}
     </div>
@@ -321,11 +312,11 @@
     <div class="col-6 u-vertically-center u-align--center u-hide--small">
       {{
         image(
-          url="https://assets.ubuntu.com/v1/8998cab5-control-thin.svg",
-          alt="",
-          height="326",
-          width="326",
-          hi_def=True,
+        url="https://assets.ubuntu.com/v1/8998cab5-control-thin.svg",
+        alt="",
+        height="326",
+        width="326",
+        hi_def=True,
         ) | safe
       }}
     </div>
@@ -337,11 +328,11 @@
     <div class="col-6 u-vertically-center u-align--center u-hide--small">
       {{
         image(
-          url="https://assets.ubuntu.com/v1/0be66895-Automotive-car-sensor.svg",
-          alt="",
-          height="260",
-          width="455",
-          hi_def=True,
+        url="https://assets.ubuntu.com/v1/0be66895-Automotive-car-sensor.svg",
+        alt="",
+        height="260",
+        width="455",
+        hi_def=True,
         ) | safe
       }}
     </div>
@@ -368,9 +359,9 @@
     </div>
     <div class="col-6 u-vertically-center u-align--center u-hide--small">
       {% include "automotive/_chassis_animation.html" %}
-      </div>
     </div>
   </div>
+</div>
 </section>
 
 <section class="p-strip">
@@ -379,20 +370,20 @@
       <div class="p-logo-header u-hide--small">
         {{
           image(
-            url="https://assets.ubuntu.com/v1/f6a59799-partner-logo-arm.svg",
-            alt="ARM",
-            height="17",
-            width="56",
-            hi_def=True,
+          url="https://assets.ubuntu.com/v1/f6a59799-partner-logo-arm.svg",
+          alt="ARM",
+          height="17",
+          width="56",
+          hi_def=True,
           ) | safe
         }}    
         {{
           image(
-            url="https://assets.ubuntu.com/v1/52d4cc16-Nvidia_Logo_Horizontal.svg",
-            alt="Nvidia",
-            height="26",
-            width="136",
-            hi_def=True,
+          url="https://assets.ubuntu.com/v1/52d4cc16-Nvidia_Logo_Horizontal.svg",
+          alt="Nvidia",
+          height="26",
+          width="136",
+          hi_def=True,
           ) | safe
         }}        
         {{ image (
@@ -420,12 +411,12 @@
     <div class="col-6">
       {{
         image(
-          url="https://assets.ubuntu.com/v1/b2b4d912-community-support-thin.svg",
-          alt="",
-          height="120",
-          width="96",
-          hi_def=True,
-          attrs={"class": "u-hide--small"},
+        url="https://assets.ubuntu.com/v1/b2b4d912-community-support-thin.svg",
+        alt="",
+        height="120",
+        width="96",
+        hi_def=True,
+        attrs={"class": "u-hide--small"},
         ) | safe
       }}
       <h2 class="p-heading--5">Open source 2.0</h2>
@@ -438,12 +429,12 @@
     <div class="col-6">
       {{
         image(
-          url="https://assets.ubuntu.com/v1/c53664cd-Security_updates.svg",
-          alt="",
-          height="120",
-          width="201",
-          hi_def=True,
-          attrs={"class": "u-hide--small"}
+        url="https://assets.ubuntu.com/v1/c53664cd-Security_updates.svg",
+        alt="",
+        height="120",
+        width="201",
+        hi_def=True,
+        attrs={"class": "u-hide--small"}
         ) | safe
       }}
       <h2 class="p-heading--5">Safety first</h2>
@@ -455,12 +446,12 @@
     <div class="col-6">
       {{
         image(
-          url="https://assets.ubuntu.com/v1/f880a3bd-Enterprise+support.svg",
-          alt="",
-          height="120",
-          width="120",
-          hi_def=True,
-          attrs={"class": "u-hide--small"},
+        url="https://assets.ubuntu.com/v1/f880a3bd-Enterprise+support.svg",
+        alt="",
+        height="120",
+        width="120",
+        hi_def=True,
+        attrs={"class": "u-hide--small"},
         ) | safe
       }}
       <h2 class="p-heading--5">Long term support</h2>
@@ -475,12 +466,12 @@
     <div class="col-6">
       {{
         image(
-          url="https://assets.ubuntu.com/v1/1d5f293c-compliance.svg",
-          alt="",
-          height="120",
-          width="198",
-          hi_def=True,
-          attrs={"class": "u-hide--small"},
+        url="https://assets.ubuntu.com/v1/1d5f293c-compliance.svg",
+        alt="",
+        height="120",
+        width="198",
+        hi_def=True,
+        attrs={"class": "u-hide--small"},
         ) | safe
       }}
       <h2 class="p-heading--5">Open source licensing</h2>
@@ -492,12 +483,12 @@
     <div class="col-6">
       {{
         image(
-          url="https://assets.ubuntu.com/v1/338124d1-shields-security.svg",
-          alt="",
-          height="120",
-          width="210",
-          hi_def=True,
-          attrs={"class": "u-hide--small"},
+        url="https://assets.ubuntu.com/v1/338124d1-shields-security.svg",
+        alt="",
+        height="120",
+        width="210",
+        hi_def=True,
+        attrs={"class": "u-hide--small"},
         ) | safe
       }}
       <h2 class="p-heading--5">Connected car security</h2>
@@ -515,11 +506,11 @@
     <div class="col-6">
       {{
         image(
-          url="https://assets.ubuntu.com/v1/8dd99b80-ubuntu-logo14.png",
-          alt="",
-          height="100",
-          width="223",
-          hi_def=True,
+        url="https://assets.ubuntu.com/v1/8dd99b80-ubuntu-logo14.png",
+        alt="",
+        height="100",
+        width="223",
+        hi_def=True,
         ) | safe
       }}
       <h2 class="p-heading--5">Software strategy acceleration</h2>
@@ -533,11 +524,11 @@
     <div class="col-6">
       {{
         image(
-          url="https://assets.ubuntu.com/v1/7de55930-canonical-logo1.png",
-          alt="",
-          height="100",
-          width="223",
-          hi_def=True,
+        url="https://assets.ubuntu.com/v1/7de55930-canonical-logo1.png",
+        alt="",
+        height="100",
+        width="223",
+        hi_def=True,
         ) | safe
       }}
       <h2 class="p-heading--5">Domain experts</h2>
@@ -547,17 +538,18 @@
         <li class="p-list__item is-ticked">Get to market faster.</li>
         <li class="p-list__item is-ticked">Drive down infra costs.</li>
         <li class="p-list__item is-ticked">Accelerate innovation.</li>
-      <p>
-        <a class="js-invoke-modal" href="/internet-of-things/contact-us?product=automotive">
-          Get in touch&nbsp;&rsaquo;
-        </a>
-      </p>
+        <p>
+          <a class="js-invoke-modal" href="/internet-of-things/contact-us?product=automotive">
+            Get in touch&nbsp;&rsaquo;
+          </a>
+        </p>
+      </div>
     </div>
+  </section>
+  
+  <!-- Set default Marketo information for contact form below-->
+  <div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/embedded" data-form-id="1266" data-lp-id="2551" data-return-url="https://ubuntu.com/internet-of-things/thank-you?product=iot" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
   </div>
-</section>
-
-<!-- Set default Marketo information for contact form below-->
-<div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/embedded" data-form-id="1266" data-lp-id="2551" data-return-url="https://ubuntu.com/internet-of-things/thank-you?product=iot" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
-</div>
-
-{% endblock content %}
+  
+  {% endblock content %}
+  

--- a/templates/aws/index.html
+++ b/templates/aws/index.html
@@ -18,12 +18,12 @@
       <div class="col-5 u-align--center u-vertically-center u-hide--small">
         {{
           image(
-            url="https://assets.ubuntu.com/v1/a82add58-profile-aws.svg",
-            alt="",
-            width="200",
-            height="119",
-            hi_def=True,
-            loading="auto",
+          url="https://assets.ubuntu.com/v1/a82add58-profile-aws.svg",
+          alt="",
+          width="200",
+          height="119",
+          hi_def=True,
+          loading="auto",
           ) | safe
         }}
       </div>
@@ -32,63 +32,60 @@
 </section>
 
 <section class="p-strip--light">
-  <div class="row">
-    <div class="col-12">
-      <h2 class="p-muted-heading u-align--center">UBUNTU ON AWS POWERS CLOUD LEADERS LIKE</h2>
-      <ul class="p-inline-images u-no-margin--bottom">
-        <li class="p-inline-images__item">
-          {{
-            image(
-              url="https://assets.ubuntu.com/v1/1d3f5d21-Netflix_2015_logo.svg",
-              alt="Netflix",
-              width="144",
-              height="39",
-              hi_def=True,
-              loading="lazy",
-              attrs={"class": "p-inline-images__logo"},
+  <div class="u-fixed-width">
+    <div class="p-logo-section">
+      <h2 class="p-logo-section__title u-align--center">Ubuntu on Azure powers cloud leaders like</h2>
+      <div class="p-logo-section__items u-no-margin--bottom">
+        <div class="p-logo-section__item">
+          {{ image (
+            url="https://assets.ubuntu.com/v1/f0e4551b-netflix-logo.png",
+            alt="Netflix",
+            width="288",
+            height="288",
+            hi_def=True,
+            loading="lazy",
+            attrs={"class": "p-logo-section__logo"}
             ) | safe
           }}
-        </li>
-        <li class="p-inline-images__item">
-          {{
-            image(
-              url="https://assets.ubuntu.com/v1/0c18b0ae-paypal_logo.svg",
-              alt="Paypal",
-              width="141",
-              height="36",
-              hi_def=True,
-              loading="lazy",
-              attrs={"class": "p-inline-images__logo"},
+          
+        </div>
+        <div class="p-logo-section__item">
+          {{ image (
+            url="https://assets.ubuntu.com/v1/a6d62ef1-paypal-logo.png",
+            alt="PayPal",
+            width="288",
+            height="288",
+            hi_def=True,
+            loading="lazy",
+            attrs={"class": "p-logo-section__logo"}
             ) | safe
           }}
-        </li>
-        <li class="p-inline-images__item">
-          {{
-            image(
-              url="https://assets.ubuntu.com/v1/2133a97d-heroku-logo+copy.svg",
-              alt="Heroku",
-              width="144",
-              height="41",
-              hi_def=True,
-              loading="lazy",
-              attrs={"class": "p-inline-images__logo"},
+        </div>
+        <div class="p-logo-section__item">
+          {{ image (
+            url="https://assets.ubuntu.com/v1/584eb90e-heroku-logo.png",
+            alt="Heroku",
+            width="288",
+            height="288",
+            hi_def=True,
+            loading="lazy",
+            attrs={"class": "p-logo-section__logo"}
             ) | safe
           }}
-        </li>
-        <li class="p-inline-images__item">
-          {{
-            image(
-              url="https://assets.ubuntu.com/v1/95b783ed-acquia.svg",
-              alt="Acquia",
-              width="144",
-              height="55",
-              hi_def=True,
-              loading="lazy",
-              attrs={"class": "p-inline-images__logo"},
+        </div>
+        <div class="p-logo-section__item">
+          {{ image (
+            url="https://assets.ubuntu.com/v1/5f2fc96d-acquia-logo.png",
+            alt="Aquia",
+            width="288",
+            height="288",
+            hi_def=True,
+            loading="lazy",
+            attrs={"class": "p-logo-section__logo"}
             ) | safe
           }}
-        </li>
-      </ul>
+        </div>
+      </div>
     </div>
   </div>
 </section>
@@ -100,7 +97,7 @@
       <p>Select between the standard Ubuntu Server and the Pro edition, which includes expanded security, compliance and AWS integration:</p>
     </div>
   </div>
-
+  
   <div class="row u-equal-height">
     <div class="col-6 p-card">
       <h3 class="p-card__title">Ubuntu</h3>

--- a/templates/azure/index.html
+++ b/templates/azure/index.html
@@ -26,12 +26,12 @@
       <div class="col-5 u-align--center u-vertically-center u-hide--small">
         {{
           image(
-            url="https://assets.ubuntu.com/v1/da9a1344-Microsoft-Azure-logo_stacked_transparent.png",
-            alt="",
-            width="350",
-            height="100",
-            hi_def=True,
-            loading="auto",
+          url="https://assets.ubuntu.com/v1/da9a1344-Microsoft-Azure-logo_stacked_transparent.png",
+          alt="",
+          width="350",
+          height="100",
+          hi_def=True,
+          loading="auto",
           ) | safe
         }}
       </div>
@@ -42,61 +42,59 @@
 <section class="p-strip--light">
   <div class="row">
     <div class="col-12">
-      <h2 class="p-muted-heading u-align--center">UBUNTU ON AZURE POWERS CLOUD LEADERS LIKE</h2>
-      <ul class="p-inline-images u-no-margin--bottom">
-        <li class="p-inline-images__item">
-          {{
-            image(
-              url="https://assets.ubuntu.com/v1/b3315d88-walmart.svg",
+      <div class="p-logo-section">
+        <h2 class="p-logo-section__title u-align--center">Ubuntu on Azure powers cloud leaders like</h2>
+        <div class="p-logo-section__items u-no-margin--bottom">
+          <div class="p-logo-section__item">
+            {{ image (
+              url="https://assets.ubuntu.com/v1/92cf9e91-walmart-logo.png",
               alt="Walmart",
-              height=60,
-              width=200,
+              width="288",
+              height="288",
               hi_def=True,
               loading="lazy",
-              attrs={"class": "p-inline-images__logo"},
-            ) | safe
-          }}
-        </li>
-        <li class="p-inline-images__item">
-          {{
-            image(
-              url="https://assets.ubuntu.com/v1/0143bd92-AT%26T_logo_2016.svg",
-              alt="AT&amp;T",
-              height=60,
-              width=200,
+              attrs={"class": "p-logo-section__logo"}
+              ) | safe
+            }}
+          </div>
+          <div class="p-logo-section__item">
+            {{ image (
+              url="https://assets.ubuntu.com/v1/6cd78b57-at%26t-logo.png",
+              alt="AT&T",
+              width="288",
+              height="288",
               hi_def=True,
               loading="lazy",
-              attrs={"class": "p-inline-images__logo"},
-            ) | safe
-          }}
-        </li>
-        <li class="p-inline-images__item">
-          {{
-            image(
-              url="https://assets.ubuntu.com/v1/278dae25-Deloitte_logo.svg",
+              attrs={"class": "p-logo-section__logo"}
+              ) | safe
+            }}
+          </div>
+          <div class="p-logo-section__item">
+            {{ image (
+              url="https://assets.ubuntu.com/v1/8812e5ee-deloitte-logo.png",
               alt="Deloitte",
-              height=43,
-              width=200,
+              width="288",
+              height="288",
               hi_def=True,
               loading="lazy",
-              attrs={"class": "p-inline-images__logo"},
-            ) | safe
-          }}
-        </li>
-        <li class="p-inline-images__item">
-          {{
-            image(
-              url="https://assets.ubuntu.com/v1/0e40e1aa-Avaya_Logo.svg",
+              attrs={"class": "p-logo-section__logo"}
+              ) | safe
+            }}
+          </div>
+          <div class="p-logo-section__item">
+            {{ image (
+              url="https://assets.ubuntu.com/v1/aa7918a3-avaya-logo.png",
               alt="Avaya",
-              height=57,
-              width=200,
+              width="288",
+              height="288",
               hi_def=True,
               loading="lazy",
-              attrs={"class": "p-inline-images__logo"},
-            ) | safe
-          }}
-        </li>
-      </ul>
+              attrs={"class": "p-logo-section__logo"}
+              ) | safe
+            }}
+          </div>
+        </div>
+      </div>
     </div>
   </div>
 </section>
@@ -108,7 +106,7 @@
       <p>Select between the standard Ubuntu Server and the Pro edition, which includes expanded security, compliance and Azure integration:</p>
     </div>
   </div>
-
+  
   <div class="row u-equal-height">
     <div class="col-6 p-card">
       <h3 class="p-card__title">Ubuntu</h3>

--- a/templates/base_index.html
+++ b/templates/base_index.html
@@ -75,14 +75,14 @@
       </ul>
     </div>
   </div>
-
+  
   <div class="u-fixed-width">
     <hr class="p-separator" />
   </div>
 </section>
 
 {% with section_classes='p-strip u-no-padding--top', spotlight='True' %}
-  {% include "shared/_latest_news_strip.html" %}
+{% include "shared/_latest_news_strip.html" %}
 {% endwith %}
 
 <section class="p-strip--light">
@@ -147,7 +147,7 @@
       Secure your open source apps. Patch the full stack, from kernel to library and applications, for CVE compliance. Governments and auditors certify Ubuntu for FedRAMP, FISMA and HITECH.
     </p>
   </div>
-
+  
   <div class="p-strip is-shallow">
     <div class="row">
       <ul class="p-list is-split">
@@ -180,75 +180,73 @@
       </p>
     </div>
   </div>
-
-  <div class="row">
-    <ul class="p-inline-images u-no-margin--bottom">
-      <li class="p-inline-images__item">
-        {{
-          image(
-          url="https://assets.ubuntu.com/v1/ebb66d41-NIST.png",
-          alt="NIST logo",
-          width="375",
-          height="240",
-          hi_def=True,
-          loading="lazy",
-          attrs={"class": "p-inline-images__logo"},
-          ) | safe
-        }}
-      </li>
-      <li class="p-inline-images__item">
-        {{
-          image(
-          url="https://assets.ubuntu.com/v1/3291d4ed-%40SEC.png",
-          alt="@sec logo",
-          width="375",
-          height="240",
-          hi_def=True,
-          loading="lazy",
-          attrs={"class": "p-inline-images__logo"},
-          ) | safe
-        }}
-      </li>
-      <li class="p-inline-images__item">
-        {{
-          image(
-          url="https://assets.ubuntu.com/v1/60fff85c-DISA.png",
-          alt="DISA logo",
-          width="375",
-          height="240",
-          hi_def=True,
-          loading="lazy",
-          attrs={"class": "p-inline-images__logo"},
-          ) | safe
-        }}
-      </li>
-      <li class="p-inline-images__item">
-        {{
-          image(
-          url="https://assets.ubuntu.com/v1/6ecbc2b2-CIS.png",
-          alt="CIS logo",
-          width="375",
-          height="240",
-          hi_def=True,
-          loading="lazy",
-          attrs={"class": "p-inline-images__logo"},
-          ) | safe
-        }}
-      </li>
-      <li class="p-inline-images__item">
-        {{
-          image(
-          url="https://assets.ubuntu.com/v1/0d160777-Csec.png",
-          alt="CSEC logo",
-          width="375",
-          height="240",
-          hi_def=True,
-          loading="lazy",
-          attrs={"class": "p-inline-images__logo"},
-          ) | safe
-        }}
-      </li>
-    </ul>
+  
+  <div class="u-fixed-width">
+    <div class="p-logo-section">
+      <div class="p-logo-section__items u-no-margin--bottom">
+        <div class="p-logo-section__item">
+          {{ image (
+            url="https://assets.ubuntu.com/v1/a94b7c55-nist-logo.png",
+            alt="NIST",
+            width="288",
+            height="288",
+            hi_def=True,
+            loading="lazy",
+            attrs={"class": "p-logo-section__logo"}
+            ) | safe
+          }}
+        </div>
+        <div class="p-logo-section__item">
+          {{ image (
+            url="https://assets.ubuntu.com/v1/d05ddc19-%40sec-logo.png",
+            alt="atsec",
+            width="288",
+            height="288",
+            hi_def=True,
+            loading="lazy",
+            attrs={"class": "p-logo-section__logo"}
+            ) | safe
+          }}
+          
+        </div>
+        <div class="p-logo-section__item">
+          {{ image (
+            url="https://assets.ubuntu.com/v1/d16880fe-disa-logo.png",
+            alt="DISA",
+            width="288",
+            height="288",
+            hi_def=True,
+            loading="lazy",
+            attrs={"class": "p-logo-section__logo"}
+            ) | safe
+          }}
+        </div>
+        <div class="p-logo-section__item">
+          {{ image (
+            url="https://assets.ubuntu.com/v1/00644094-cis-logo.png",
+            alt="CIS",
+            width="288",
+            height="288",
+            hi_def=True,
+            loading="lazy",
+            attrs={"class": "p-logo-section__logo"}
+            ) | safe
+          }}
+        </div>
+        <div class="p-logo-section__item">
+          {{ image (
+            url="https://assets.ubuntu.com/v1/b3f94804-csec-logo.png",
+            alt="CSEC",
+            width="288",
+            height="288",
+            hi_def=True,
+            loading="lazy",
+            attrs={"class": "p-logo-section__logo"}
+            ) | safe
+          }}
+        </div>
+      </div>
+    </div>
   </div>
 </section>
 
@@ -373,75 +371,72 @@
       </ul>
     </div>
   </div>
-
-  <div class="row">
-    <ul class="p-inline-images--small u-no-margin--bottom">
-      <li class="p-inline-images__item">
-        {{
-          image(
-          url="https://assets.ubuntu.com/v1/ae0456eb-Netflix_logo.svg",
-          alt="Netflix logo",
-          width="130",
-          height="36",
-          hi_def=True,
-          loading="lazy",
-          attrs={"class": "p-inline-images__logo"},
-          ) | safe
-        }}
-      </li>
-      <li class="p-inline-images__item">
-        {{
-          image(
-          url="https://assets.ubuntu.com/v1/77bfd25b-Uber_Logo.svg",
-          alt="Uber logo",
-          width="120",
-          height="42",
-          hi_def=True,
-          loading="lazy",
-          attrs={"class": "p-inline-images__logo"},
-          ) | safe
-        }}
-      </li>
-      <li class="p-inline-images__item">
-        {{
-          image(
-          url="https://assets.ubuntu.com/v1/1688fbe0-Spotify_logo.svg",
-          alt="Spotify logo",
-          width="130",
-          height="39",
-          hi_def=True,
-          loading="lazy",
-          attrs={"class": "p-inline-images__logo"},
-          ) | safe
-        }}
-      </li>
-      <li class="p-inline-images__item">
-        {{
-          image(
-          url="https://assets.ubuntu.com/v1/c911ed42-walmart_logo.svg",
-          alt="Walmart logo",
-          width="131",
-          height="32",
-          hi_def=True,
-          loading="lazy",
-          attrs={"class": "p-inline-images__logo is-wide"},
-          ) | safe
-        }}
-      </li>
-      <li class="p-inline-images__item">
-        {{
-          image(
-          url="https://assets.ubuntu.com/v1/40b42dd2-bnp-paribas_logo.svg",
-          alt="BNP Paribas logo",
-          width="224",
-          height="50",
-          hi_def=True,
-          loading="lazy",
-          attrs={"class": "p-inline-images__logo is-wide"},
-          ) | safe
-        }}
-      </li>
-    </ul>
+  
+  <div class="u-fixed-width">
+    <div class="p-logo-section">
+      <div class="p-logo-section__items u-no-margin--bottom">
+        <div class="p-logo-section__item">
+          {{ image (
+            url="https://assets.ubuntu.com/v1/f0e4551b-netflix-logo.png",
+            alt="Netflix",
+            width="288",
+            height="288",
+            hi_def=True,
+            loading="lazy",
+            attrs={"class": "p-logo-section__logo"}
+            ) | safe
+          }}
+        </div>
+        <div class="p-logo-section__item">
+          {{ image (
+            url="https://assets.ubuntu.com/v1/6889bfcb-uber-logo.png",
+            alt="Uber",
+            width="288",
+            height="288",
+            hi_def=True,
+            loading="lazy",
+            attrs={"class": "p-logo-section__logo"}
+            ) | safe
+          }}
+        </div>
+        <div class="p-logo-section__item">
+          {{ image (
+            url="https://assets.ubuntu.com/v1/2ef9f6ff-spotify-logo.png",
+            alt="Spotify",
+            width="288",
+            height="288",
+            hi_def=True,
+            loading="lazy",
+            attrs={"class": "p-logo-section__logo"}
+            ) | safe
+          }}
+        </div>
+        <div class="p-logo-section__item">
+          {{ image (
+            url="https://assets.ubuntu.com/v1/92cf9e91-walmart-logo.png",
+            alt="Walmart",
+            width="288",
+            height="288",
+            hi_def=True,
+            loading="lazy",
+            attrs={"class": "p-logo-section__logo"}
+            ) | safe
+          }}
+        </div>
+        <div class="p-logo-section__item">
+          {{ image (
+            url="https://assets.ubuntu.com/v1/2b6c1718-bmp-paribas-logo.png",
+            alt="BNP Paribas",
+            width="288",
+            height="288",
+            hi_def=True,
+            loading="lazy",
+            attrs={"class": "p-logo-section__logo"}
+            ) | safe
+          }}
+        </div>
+      </div>
+    </div>
   </div>
 </section>
 
@@ -456,7 +451,7 @@
       </p>
     </div>
   </div>
-
+  
   <div class="p-strip is-shallow">
     <div class="row">
       <ul class="p-list is-split">
@@ -508,87 +503,84 @@
       </ul>
     </div>
   </div>
-
-  <div class="row">
-    <ul class="p-inline-images--small u-no-margin--bottom">
-      <li class="p-inline-images__item">
-        {{
-          image(
-          url="https://assets.ubuntu.com/v1/7c97efb0-BT_logo.svg",
-          alt="BT logo",
-          width="80",
-          height="80",
-          hi_def=True,
-          loading="lazy",
-          attrs={"class": "p-inline-images__logo"},
-          ) | safe
-        }}
-      </li>
-      <li class="p-inline-images__item">
-        {{
-          image(
-          url="https://assets.ubuntu.com/v1/ef4f489e-Deutsche_Telekom-Logo.svg",
-          alt="Deutsche Telekom logo",
-          width="130",
-          height="30",
-          hi_def=True,
-          loading="lazy",
-          attrs={"class": "p-inline-images__logo is-wide"},
-          ) | safe
-        }}
-      </li>
-      <li class="p-inline-images__item">
-        {{
-          image(
-          url="https://assets.ubuntu.com/v1/ee5d503f-rabobank-4.svg",
-          alt="Rabobank logo",
-          width="150",
-          height="27",
-          hi_def=True,
-          loading="lazy",
-          attrs={"class": "p-inline-images__logo"},
-          ) | safe
-        }}
-      </li>
-      <li class="p-inline-images__item">
-        {{
-          image(
-          url="https://assets.ubuntu.com/v1/1d34393a-best-buy_logo.svg",
-          alt="Best Buy logo",
-          width="100",
-          height="73",
-          hi_def=True,
-          loading="lazy",
-          attrs={"class": "p-inline-images__logo"},
-          ) | safe
-        }}
-      </li>
-      <li class="p-inline-images__item">
-        {{
-          image(
-          url="https://assets.ubuntu.com/v1/7538babd-Bloomberg_logo.svg",
-          alt="Bloomberg logo",
-          width="130",
-          height="26",
-          hi_def=True,
-          loading="lazy",
-          attrs={"class": "p-inline-images__logo is-wide"},
-          ) | safe
-        }}
-      </li>
-      <li class="p-inline-images__item">
-        {{
-          image(
-          url="https://assets.ubuntu.com/v1/b76ad53c-AT%26T_logo.svg",
-          alt="AT&T logo",
-          width="130",
-          height="54",
-          hi_def=True,
-          attrs={"class": "p-inline-images__logo"},
-          ) | safe
-        }}
-      </li>
-    </ul>
+  
+  <div class="u-fixed-width">
+    <div class="p-logo-section">
+      <div class="p-logo-section__items u-no-margin--bottom">
+        <div class="p-logo-section__item">
+          {{ image (
+            url="https://assets.ubuntu.com/v1/bd2a3282-bt-logo.png",
+            alt="BT",
+            width="288",
+            height="288",
+            hi_def=True,
+            loading="lazy",
+            attrs={"class": "p-logo-section__logo"}
+            ) | safe
+          }}
+        </div>
+        <div class="p-logo-section__item">
+          {{ image (
+            url="https://assets.ubuntu.com/v1/c6e197c4-deutsche-telekom-logo.png",
+            alt="Deutsche Telecom",
+            width="288",
+            height="288",
+            hi_def=True,
+            loading="lazy",
+            attrs={"class": "p-logo-section__logo"}
+            ) | safe
+          }}
+        </div>
+        <div class="p-logo-section__item">
+          {{ image (
+            url="https://assets.ubuntu.com/v1/6143a8ce-rabobank-logo.png",
+            alt="Rabobank",
+            width="288",
+            height="288",
+            hi_def=True,
+            loading="lazy",
+            attrs={"class": "p-logo-section__logo"}
+            ) | safe
+          }}
+        </div>
+        <div class="p-logo-section__item">
+          {{ image (
+            url="https://assets.ubuntu.com/v1/698f7a58-best-buy-logo.png",
+            alt="Best Buy",
+            width="288",
+            height="288",
+            hi_def=True,
+            loading="lazy",
+            attrs={"class": "p-logo-section__logo"}
+            ) | safe
+          }}
+        </div>
+        <div class="p-logo-section__item">
+          {{ image (
+            url="https://assets.ubuntu.com/v1/b1e3d2d2-bloomberg-logo.png",
+            alt="Bloomberg",
+            width="288",
+            height="288",
+            hi_def=True,
+            loading="lazy",
+            attrs={"class": "p-logo-section__logo"}
+            ) | safe
+          }}
+        </div>
+        <div class="p-logo-section__item">
+          {{ image (
+            url="https://assets.ubuntu.com/v1/6cd78b57-at%26t-logo.png",
+            alt="AT&T",
+            width="288",
+            height="288",
+            hi_def=True,
+            loading="lazy",
+            attrs={"class": "p-logo-section__logo"}
+            ) | safe
+          }}
+        </li>
+      </div>
+    </div>
   </div>
 </section>
 
@@ -601,7 +593,7 @@
       <a title="external link - docs.microsoft.com/en-us/azure/aks/cluster-configuration" href="https://docs.microsoft.com/en-us/azure/aks/cluster-configuration">AKS.</a> <a title="external link - cloud-images.ubuntu.com/docs/aws/eks" href="https://cloud-images.ubuntu.com/docs/aws/eks">EKS.</a> <a title="external link - cloud.google.com/kubernetes-engine/docs/concepts/node-images#ubuntu" href="https://cloud.google.com/kubernetes-engine/docs/concepts/node-images#ubuntu">GKE.</a> Kubeadm. <a title="external link - microk8s.io" href="https://microk8s.io">MicroK8s.</a> <a href="/kubernetes/features">Charmed Kubernetes.</a> All on Ubuntu.
     </p>
   </div>
-
+  
   <div class="p-strip is-shallow">
     <div class="row">
       <ul class="p-list is-split">
@@ -654,75 +646,72 @@
       </ul>
     </div>
   </div>
-
-  <div class="row">
-    <ul class="p-inline-images--small u-no-margin--bottom">
-      <li class="p-inline-images__item">
-        {{
-          image(
-          url="https://assets.ubuntu.com/v1/a82add58-profile-aws.svg",
-          alt="Amazon Web Services logo",
-          width="84",
-          height="50",
-          hi_def=True,
-          loading="lazy",
-          attrs={"class": "p-inline-images__logo"},
-          ) | safe
-        }}
-      </li>
-      <li class="p-inline-images__item">
-        {{
-          image(
-          url="https://assets.ubuntu.com/v1/22fd6473-MicrosoftAzure_logo.svg",
-          alt="Microsoft Azure logo",
-          width="130",
-          height="38",
-          hi_def=True,
-          loading="lazy",
-          attrs={"class": "p-inline-images__logo"},
-          ) | safe
-        }}
-      </li>
-      <li class="p-inline-images__item">
-        {{
-          image(
-          url="https://assets.ubuntu.com/v1/e795fc84-Google_Cloud_Logo.svg",
-          alt="Google Cloud Platform logo",
-          width="259",
-          height="40",
-          hi_def=True,
-          loading="lazy",
-          attrs={"class": "p-inline-images__logo is-wide"},
-          ) | safe
-        }}
-      </li>
-      <li class="p-inline-images__item">
-        {{
-          image(
-          url="https://assets.ubuntu.com/v1/2f1934f0-Liberty-Global-Logo.svg",
-          alt="Liberty Global logo",
-          width="116",
-          height="70",
-          hi_def=True,
-          loading="lazy",
-          attrs={"class": "p-inline-images__logo"},
-          ) | safe
-        }}
-      </li>
-      <li class="p-inline-images__item">
-        {{
-          image(
-          url="https://assets.ubuntu.com/v1/2616b34f-ACI-Universal-Payments.svg",
-          alt="ACI logo",
-          width="120",
-          height="60",
-          hi_def=True,
-          loading="lazy",
-          attrs={"class": "p-inline-images__logo"},
-          ) | safe
-        }}
-      </li>
-    </ul>
+  
+  <div class="u-fixed-width">
+    <div class="p-logo-section">
+      <div class="p-logo-section__items u-no-margin--bottom">
+        <div class="p-logo-section__item">
+          {{ image (
+            url="https://assets.ubuntu.com/v1/de681426-aws-logo.png",
+            alt="Amazon Web Services",
+            width="288",
+            height="288",
+            hi_def=True,
+            loading="lazy",
+            attrs={"class": "p-logo-section__logo"}
+            ) | safe
+          }}
+        </div>
+        <div class="p-logo-section__item">
+          {{ image (
+            url="https://assets.ubuntu.com/v1/6ef81e08-microsoft-azure-new-logo.png",
+            alt="Microsoft Azure",
+            width="288",
+            height="288",
+            hi_def=True,
+            loading="lazy",
+            attrs={"class": "p-logo-section__logo"}
+            ) | safe
+          }}
+        </div>
+        <div class="p-logo-section__item">
+          {{ image (
+            url="https://assets.ubuntu.com/v1/d174f7bf-google-cloud-logo.png",
+            alt="Goggle Cloud",
+            width="288",
+            height="288",
+            hi_def=True,
+            loading="lazy",
+            attrs={"class": "p-logo-section__logo"}
+            ) | safe
+          }}
+        </div>
+        <div class="p-logo-section__item">
+          {{ image (
+            url="https://assets.ubuntu.com/v1/d493514f-liberty-global-logo.png",
+            alt="Liberty Global",
+            width="288",
+            height="288",
+            hi_def=True,
+            loading="lazy",
+            attrs={"class": "p-logo-section__logo"}
+            ) | safe
+          }}
+        </div>
+        <div class="p-logo-section__item">
+          {{ image (
+            url="https://assets.ubuntu.com/v1/aed42949-aci-universal-payments-logo.png",
+            alt="ACI",
+            width="288",
+            height="288",
+            hi_def=True,
+            loading="lazy",
+            attrs={"class": "p-logo-section__logo"}
+            ) | safe
+          }}
+        </div>
+      </div>
+    </div>
   </div>
 </section>
 
@@ -735,7 +724,7 @@
       <a href="/appliance">Ubuntu Core Appliances</a> with transactional updates <a href="/embedded">for a better embedded Linux</a>.
     </p>
   </div>
-
+  
   <div class="p-strip is-shallow">
     <div class="row">
       <ul class="p-list is-split">
@@ -784,75 +773,72 @@
       </ul>
     </div>
   </div>
-
-  <div class="row">
-    <ul class="p-inline-images--small u-no-margin--bottom">
-      <li class="p-inline-images__item">
-        {{
-          image(
-          url="https://assets.ubuntu.com/v1/093c43ef-intel_logo.svg",
-          alt="Intel logo",
-          width="121",
-          height="80",
-          hi_def=True,
-          loading="lazy",
-          attrs={"class": "p-inline-images__logo"},
-          ) | safe
-        }}
-      </li>
-      <li class="p-inline-images__item">
-        {{
-          image(
-          url="https://assets.ubuntu.com/v1/156ddbf8-rexroth_logo.svg",
-          alt="Rexroth logo",
-          width="131",
-          height="53",
-          hi_def=True,
-          loading="lazy",
-          attrs={"class": "p-inline-images__logo"},
-          ) | safe
-        }}
-      </li>
-      <li class="p-inline-images__item">
-        {{
-          image(
-          url="https://assets.ubuntu.com/v1/0e4d0d27-arm_logo.svg",
-          alt="ARM logo",
-          width="120",
-          height="36",
-          hi_def=True,
-          loading="lazy",
-          attrs={"class": "p-inline-images__logo"},
-          ) | safe
-        }}
-      </li>
-      <li class="p-inline-images__item">
-        {{
-          image(
-          url="https://assets.ubuntu.com/v1/c0ee6182-dell_logo.svg",
-          alt="Dell logo",
-          width="90",
-          height="90",
-          hi_def=True,
-          loading="lazy",
-          attrs={"class": "p-inline-images__logo"},
-          ) | safe
-        }}
-      </li>
-      <li class="p-inline-images__item">
-        {{
-          image(
-          url="https://assets.ubuntu.com/v1/1f876369-advantech.svg",
-          alt="Advantech logo",
-          width="250",
-          height="51",
-          hi_def=True,
-          loading="lazy",
-          attrs={"class": "p-inline-images__logo is-wide"},
-          ) | safe
-        }}
-      </li>
-    </ul>
+  
+  <div class="u-fixed-width">
+    <div class="p-logo-section">
+      <div class="p-logo-section__items u-no-margin--bottom">
+        <div class="p-logo-section__item">
+          {{ image (
+            url="https://assets.ubuntu.com/v1/67f81bfe-intel-new-logo.png",
+            alt="Intel",
+            width="288",
+            height="288",
+            hi_def=True,
+            loading="lazy",
+            attrs={"class": "p-logo-section__logo"}
+            ) | safe
+          }}
+        </div>
+        <div class="p-logo-section__item">
+          {{ image (
+            url="https://assets.ubuntu.com/v1/5e075792-rexroth-logo.png",
+            alt="Bosch Rexroth",
+            width="288",
+            height="288",
+            hi_def=True,
+            loading="lazy",
+            attrs={"class": "p-logo-section__logo"}
+            ) | safe
+          }}
+        </div>
+        <div class="p-logo-section__item">
+          {{ image (
+            url="https://assets.ubuntu.com/v1/711be910-arm-logo.png",
+            alt="ARM",
+            width="288",
+            height="288",
+            hi_def=True,
+            loading="lazy",
+            attrs={"class": "p-logo-section__logo"}
+            ) | safe
+          }}
+        </div>
+        <div class="p-logo-section__item">
+          {{ image (
+            url="https://assets.ubuntu.com/v1/987acdaa-dell-logo.png",
+            alt="Dell",
+            width="288",
+            height="288",
+            hi_def=True,
+            loading="lazy",
+            attrs={"class": "p-logo-section__logo"}
+            ) | safe
+          }}
+        </div>
+        <div class="p-logo-section__item">
+          {{ image (
+            url="https://assets.ubuntu.com/v1/2b253402-advantech-logo.png",
+            alt="Advantech",
+            width="288",
+            height="288",
+            hi_def=True,
+            loading="lazy",
+            attrs={"class": "p-logo-section__logo"}
+            ) | safe
+          }}
+        </div>
+      </div>
+    </div>
   </div>
 </section>
 
@@ -909,88 +895,85 @@
       </ul>
     </div>
   </div>
-
-  <div class="row">
-    <ul class="p-inline-images--small u-no-margin--bottom">
-      <li class="p-inline-images__item">
-        {{
-          image(
-          url="https://assets.ubuntu.com/v1/9081f01d-hp_logo.svg",
-          alt="HP logo",
-          width="90",
-          height="90",
-          hi_def=True,
-          loading="lazy",
-          attrs={"class": "p-inline-images__logo"},
-          ) | safe
-        }}
-      </li>
-      <li class="p-inline-images__item">
-        {{
-          image(
-          url="https://assets.ubuntu.com/v1/d2a8c2f4-lenovo_logo.svg",
-          alt="Lenovo logo",
-          width="131",
-          height="27",
-          hi_def=True,
-          loading="lazy",
-          attrs={"class": "p-inline-images__logo is-wide"},
-          ) | safe
-        }}
-      </li>
-      <li class="p-inline-images__item">
-        {{
-          image(
-          url="https://assets.ubuntu.com/v1/093c43ef-intel_logo.svg",
-          alt="Intel logo",
-          width="121",
-          height="80",
-          hi_def=True,
-          loading="lazy",
-          attrs={"class": "p-inline-images__logo"},
-          ) | safe
-        }}
-      </li>
-      <li class="p-inline-images__item">
-        {{
-          image(
-          url="https://assets.ubuntu.com/v1/1ac0e434-Nvidia_Logo_Horizontal.svg",
-          alt="Nvidia logo",
-          width="152",
-          height="29",
-          hi_def=True,
-          loading="lazy",
-          attrs={"class": "p-inline-images__logo is-wide"},
-          ) | safe
-        }}
-      </li>
-      <li class="p-inline-images__item">
-        {{
-          image(
-          url="https://assets.ubuntu.com/v1/4dbc1a2d-amd_logo.svg",
-          alt="AMD logo",
-          width="132",
-          height="31",
-          hi_def=True,
-          loading="lazy",
-          attrs={"class": "p-inline-images__logo"},
-          ) | safe
-        }}
-      </li>
-      <li class="p-inline-images__item">
-        {{
-          image(
-          url="https://assets.ubuntu.com/v1/c0ee6182-dell_logo.svg",
-          alt="Dell logo",
-          width="90",
-          height="90",
-          hi_def=True,
-          loading="lazy",
-          attrs={"class": "p-inline-images__logo"},
-          ) | safe
-        }}
-      </li>
-    </ul>
+  
+  <div class="u-fixed-width">
+    <div class="p-logo-section">
+      <div class="p-logo-section__items u-no-margin--bottom">
+        <div class="p-logo-section__item">
+          {{ image (
+            url="https://assets.ubuntu.com/v1/11814428-hp-logo.png",
+            alt="Hewlett Packard",
+            width="288",
+            height="288",
+            hi_def=True,
+            loading="lazy",
+            attrs={"class": "p-logo-section__logo"}
+            ) | safe
+          }}
+        </div>
+        <div class="p-logo-section__item">
+          {{ image (
+            url="https://assets.ubuntu.com/v1/c70b529e-lenovo-logo.png",
+            alt="Lenovo",
+            width="288",
+            height="288",
+            hi_def=True,
+            loading="lazy",
+            attrs={"class": "p-logo-section__logo"}
+            ) | safe
+          }}
+        </div>
+        <div class="p-logo-section__item">
+          {{ image (
+            url="https://assets.ubuntu.com/v1/67f81bfe-intel-new-logo.png",
+            alt="Intel",
+            width="288",
+            height="288",
+            hi_def=True,
+            loading="lazy",
+            attrs={"class": "p-logo-section__logo"}
+            ) | safe
+          }}
+        </div>
+        <div class="p-logo-section__item">
+          {{ image (
+            url="https://assets.ubuntu.com/v1/cd765ccc-nvidia-logo.png",
+            alt="Nvidia",
+            width="288",
+            height="288",
+            hi_def=True,
+            loading="lazy",
+            attrs={"class": "p-logo-section__logo"}
+            ) | safe
+          }}
+        </div>
+        <div class="p-logo-section__item">
+          {{ image (
+            url="https://assets.ubuntu.com/v1/6079d02b-amd-logo.png",
+            alt="AMD",
+            width="288",
+            height="288",
+            hi_def=True,
+            loading="lazy",
+            attrs={"class": "p-logo-section__logo"}
+            ) | safe
+          }}
+        </div>
+        <div class="p-logo-section__item">
+          {{ image (
+            url="https://assets.ubuntu.com/v1/987acdaa-dell-logo.png",
+            alt="Dell",
+            width="288",
+            height="288",
+            hi_def=True,
+            loading="lazy",
+            attrs={"class": "p-logo-section__logo"}
+            ) | safe
+          }}
+          
+        </div>
+      </div>
+    </div>
   </div>
 </section>
 
@@ -1051,88 +1034,82 @@
       </ul>
     </div>
   </div>
-
-  <div class="row">
-    <ul class="p-inline-images--small u-no-margin--bottom">
-      <li class="p-inline-images__item" style="margin: 1.5rem;">
-        {{
-          image(
-          url="https://assets.ubuntu.com/v1/f92b472c-Verizon_logo.svg",
-          alt="Verizon logo",
-          width="130",
-          height="30",
+  
+  <div class="u-fixed-width">
+    <div class="p-logo-section__items u-no-margin--bottom">
+      <div class="p-logo-section__item">
+        {{ image (
+          url="https://assets.ubuntu.com/v1/0352e974-verizon-logo.png",
+          alt="Verizon",
+          width="288",
+          height="288",
           hi_def=True,
           loading="lazy",
-          attrs={"class": "p-inline-images__logo"},
+          attrs={"class": "p-logo-section__logo"}
           ) | safe
         }}
-      </li>
-      <li class="p-inline-images__item" style="margin: 1.5rem;">
-        {{
-          image(
-          url="https://assets.ubuntu.com/v1/17a1b35b-telefonica_logo.svg",
-          alt="Telefonica logo",
-          width="131",
-          height="39",
+      </div>
+      <div class="p-logo-section__item">
+        {{ image (
+          url="https://assets.ubuntu.com/v1/ea3bc2f7-telefonica-logo.png",
+          alt="Telefónica",
+          width="288",
+          height="288",
           hi_def=True,
           loading="lazy",
-          attrs={"class": "p-inline-images__logo"},
+          attrs={"class": "p-logo-section__logo"}
           ) | safe
         }}
-      </li>
-      <li class="p-inline-images__item" style="margin: 1.5rem;">
-        {{
-          image(
-          url="https://assets.ubuntu.com/v1/18ea2f90-Tele2_logo.svg",
-          alt="Tele2 logo",
-          width="91",
-          height="35",
+      </div>
+      <div class="p-logo-section__item">
+        {{ image (
+          url="https://assets.ubuntu.com/v1/ce15a4d1-tele2-logo.png",
+          alt="TELE2",
+          width="288",
+          height="288",
           hi_def=True,
           loading="lazy",
-          attrs={"class": "p-inline-images__logo"},
+          attrs={"class": "p-logo-section__logo"}
           ) | safe
         }}
-      </li>
-      <li class="p-inline-images__item" style="margin: 1.5rem;">
-        {{
-          image(
-          url="https://assets.ubuntu.com/v1/8f264340-telecom-italia_logo.svg",
-          alt="Telecom Italia logo",
-          width="131",
-          height="28",
+      </div>
+      <div class="p-logo-section__item">
+        {{ image (
+          url="https://assets.ubuntu.com/v1/756e9ef4-telecom-italia-logo.png",
+          alt="Telecom Italia",
+          width="288",
+          height="288",
           hi_def=True,
           loading="lazy",
-          attrs={"class": "p-inline-images__logo"},
+          attrs={"class": "p-logo-section__logo"}
           ) | safe
         }}
-      </li>
-      <li class="p-inline-images__item" style="margin: 1.5rem;">
-        {{
-          image(
-          url="https://assets.ubuntu.com/v1/e854cf72-nec_logo.svg",
-          alt="NEC logo",
-          width="101",
-          height="29",
+      </div>
+      <div class="p-logo-section__item">
+        {{ image (
+          url="https://assets.ubuntu.com/v1/83fb74ae-nec-logo.png",
+          alt="NEC",
+          width="288",
+          height="288",
           hi_def=True,
           loading="lazy",
-          attrs={"class": "p-inline-images__logo"},
+          attrs={"class": "p-logo-section__logo"}
           ) | safe
         }}
-      </li>
-      <li class="p-inline-images__item" style="margin: 1.5rem;">
-        {{
-          image(
-          url="https://assets.ubuntu.com/v1/af1a572f-barclays_logo.svg",
-          alt="Barclays logo",
-          width="130",
-          height="23",
+      </div>
+      <div class="p-logo-section__item">
+        {{ image (
+          url="https://assets.ubuntu.com/v1/4af3ad39-barclays-logo.png",
+          alt="Barclays",
+          width="288",
+          height="288",
           hi_def=True,
           loading="lazy",
-          attrs={"class": "p-inline-images__logo"},
+          attrs={"class": "p-logo-section__logo"}
           ) | safe
-        }}
-      </li>
-    </ul>
+        }}   
+      </div>
+    </div>
   </div>
 </section>
 
@@ -1145,7 +1122,7 @@
       From turtles to trucks, <a href="/robotics">Ubuntu drives the robot revolution</a>.
     </p>
   </div>
-
+  
   <div class="p-strip is-shallow">
     <div class="row">
       <ul class="p-list is-split">
@@ -1185,88 +1162,84 @@
       </ul>
     </div>
   </div>
-
-  <div class="row">
-    <ul class="p-inline-images--small u-no-margin--bottom">
-      <li class="p-inline-images__item">
-        {{
-          image(
-          url="https://assets.ubuntu.com/v1/59280c0e-abb-logo.svg",
-          alt="ABB logo",
-          width="90",
-          height="34",
-          hi_def=True,
-          loading="lazy",
-          attrs={"class": "p-inline-images__logo"},
-          ) | safe
-        }}
-      </li>
-      <li class="p-inline-images__item">
-        {{
-          image(
-          url="https://assets.ubuntu.com/v1/f5dc1d41-pal-logo.svg",
-          alt="PAL logo",
-          width="130",
-          height="51",
-          hi_def=True,
-          loading="lazy",
-          attrs={"class": "p-inline-images__logo"},
-          ) | safe
-        }}
-      </li>
-      <li class="p-inline-images__item">
-        {{
-          image(
-          url="https://assets.ubuntu.com/v1/ec8fff79-KUKA_logo.svg",
-          alt="Kuka logo",
-          width="130",
-          height="22",
-          hi_def=True,
-          loading="lazy",
-          attrs={"class": "p-inline-images__logo"},
-          ) | safe
-        }}
-      </li>
-      <li class="p-inline-images__item">
-        {{
-          image(
-          url="https://assets.ubuntu.com/v1/b577ada7-apollo-logo.svg",
-          alt="Apollo logo",
-          width="130",
-          height="43",
-          hi_def=True,
-          loading="lazy",
-          attrs={"class": "p-inline-images__logo"},
-          ) | safe
-        }}
-      </li>
-      <li class="p-inline-images__item">
-        {{
-          image(
-          url="https://assets.ubuntu.com/v1/e99b843a-Bosch_Logo-flat.svg",
-          alt="Bosch logo",
-          width="250",
-          height="54",
-          hi_def=True,
-          loading="lazy",
-          attrs={"class": "p-inline-images__logo"},
-          ) | safe
-        }}
-      </li>
-      <li class="p-inline-images__item">
-        {{
-          image(
-          url="https://assets.ubuntu.com/v1/1e265e27-bmw-new-2020.svg",
-          alt="BMW logo",
-          width="70",
-          height="70",
-          hi_def=True,
-          loading="lazy",
-          attrs={"class": "p-inline-images__logo"},
-          ) | safe
-        }}
-      </li>
-    </ul>
+  
+  <div class="u-fixed-width">
+    <div class="p-logo-section">
+      <div class="p-logo-section__items u-no-margin--bottom">
+        <div class="p-logo-section__item">
+          {{ image (
+            url="https://assets.ubuntu.com/v1/e796fb76-abb-logo.png",
+            alt="ABB",
+            width="288",
+            height="288",
+            hi_def=True,
+            loading="lazy",
+            attrs={"class": "p-logo-section__logo"}
+            ) | safe
+          }}
+        </div>
+        <div class="p-logo-section__item">
+          {{ image (
+            url="https://assets.ubuntu.com/v1/2437987f-pal-robotics-logo.png",
+            alt="PAL Robotics",
+            width="288",
+            height="288",
+            hi_def=True,
+            loading="lazy",
+            attrs={"class": "p-logo-section__logo"}
+            ) | safe
+          }}
+        </div>
+        <div class="p-logo-section__item">
+          {{ image (
+            url="https://assets.ubuntu.com/v1/01e8486f-kuka-logo.png",
+            alt="KUKA",
+            width="288",
+            height="288",
+            hi_def=True,
+            loading="lazy",
+            attrs={"class": "p-logo-section__logo"}
+            ) | safe
+          }}
+        </div>
+        <div class="p-logo-section__item">
+          {{ image (
+            url="https://assets.ubuntu.com/v1/7e4f929b-apollo-logo.png",
+            alt="Apollo",
+            width="288",
+            height="288",
+            hi_def=True,
+            loading="lazy",
+            attrs={"class": "p-logo-section__logo"}
+            ) | safe
+          }}
+        </div>
+        <div class="p-logo-section__item">
+          {{ image (
+            url="https://assets.ubuntu.com/v1/466c2690-bosch-logo.png",
+            alt="Bosch",
+            width="288",
+            height="288",
+            hi_def=True,
+            loading="lazy",
+            attrs={"class": "p-logo-section__logo"}
+            ) | safe
+          }}
+        </div>
+        <div class="p-logo-section__item">
+          {{ image (
+            url="https://assets.ubuntu.com/v1/59af2c8f-bmw-logo.png",
+            alt="BMW",
+            width="288",
+            height="288",
+            hi_def=True,
+            loading="lazy",
+            attrs={"class": "p-logo-section__logo"}
+            ) | safe
+          }}
+        </div>
+      </div>
+    </div>
   </div>
 </section>
 
@@ -1279,7 +1252,7 @@
       <a href="https://juju.is/" class="p-link--external">Universal model-driven operators for classic</a> and <a href="https://jaas.ai/kubernetes" class="p-link--external">Kubernetes estate</a>.
     </p>
   </div>
-
+  
   <div class="p-strip is-shallow">
     <div class="row">
       <ul class="p-list is-split">
@@ -1309,63 +1282,61 @@
       </p>
     </div>
   </div>
-
-    <div class="row">
-      <ul class="p-inline-images--small u-no-margin--bottom">
-        <li class="p-inline-images__item">
-          {{
-            image(
-            url="https://assets.ubuntu.com/v1/1f395c09-Panasonic-Logo.svg",
-            alt="Panasonic logo",
-            width="130",
-            height="21",
+  
+  <div class="u-fixed-width">
+    <div class="p-logo-section">
+      <div class="p-logo-section__items u-no-margin--bottom">
+        <div class="p-logo-section__item">
+          {{ image (
+            url="https://assets.ubuntu.com/v1/1dc7af1e-panasonic-logo.png",
+            alt="Panasonic",
+            width="288",
+            height="288",
             hi_def=True,
             loading="lazy",
-            attrs={"class": "p-inline-images__logo is-wide"},
+            attrs={"class": "p-logo-section__logo"}
             ) | safe
           }}
-        </li>
-        <li class="p-inline-images__item">
-          {{
-            image(
-            url="https://assets.ubuntu.com/v1/7bbfb1d0-Scania_logo.svg",
-            alt="Scania logo",
-            width="153",
-            height="40",
+        </div>
+        <div class="p-logo-section__item">
+          {{ image (
+            url="https://assets.ubuntu.com/v1/52e19575-scania-logo.png",
+            alt="Scania",
+            width="288",
+            height="288",
             hi_def=True,
             loading="lazy",
-            attrs={"class": "p-inline-images__logo is-wide"},
+            attrs={"class": "p-logo-section__logo"}
             ) | safe
           }}
-        </li>
-        <li class="p-inline-images__item">
-          {{
-            image(
-            url="https://assets.ubuntu.com/v1/b41ec3f5-SBI-Bits_logo.png",
-            alt="SBI Bits logo",
-            width="132",
-            height="40",
+        </div>
+        <div class="p-logo-section__item">
+          {{ image (
+            url="https://assets.ubuntu.com/v1/6a3b49ef-sbi-bits-logo.png",
+            alt="SBI BITS",
+            width="288",
+            height="288",
             hi_def=True,
             loading="lazy",
-            attrs={"class": "p-inline-images__logo"},
+            attrs={"class": "p-logo-section__logo"}
             ) | safe
           }}
-        </li>
-        <li class="p-inline-images__item">
-          {{
-            image(
-            url="https://assets.ubuntu.com/v1/890ffa71-Swissquote_logo.svg",
-            alt="Swissquote logo",
-            width="210",
-            height="40",
+        </div>
+        <div class="p-logo-section__item">
+          {{ image (
+            url="https://assets.ubuntu.com/v1/de8ab04f-swissquote-logo.png",
+            alt="Swissquote",
+            width="288",
+            height="288",
             hi_def=True,
             loading="lazy",
-            attrs={"class": "p-inline-images__logo is-wide"},
+            attrs={"class": "p-logo-section__logo"}
             ) | safe
           }}
-        </li>
-      </ul>
+        </div>
+      </div>
     </div>
+  </div>
 </section>
 
 {% block footer_content %}
@@ -1381,30 +1352,30 @@
     * infer the parent language - e.g. for "en-GB", infer "en"
     */
     var language = navigator.language || navigator.userLanguage || navigator.browserLanguage || navigator.systemLanguage;
-
+    
     if (language.indexOf('-') !== -1 ) {
       if (language !== "zh-TW") {
         language = language.split('-')[0];
       }
     }
-
+    
     return language
   };
-
+  
   // get the users language and remove any extra detail suffix (e.g. -gb)
   var primaryParentLanguage = getPrimaryParentLanguage();
-
+  
   // get notices matching the user language
   var notices = document.querySelectorAll(".notice[lang=" + primaryParentLanguage + "]");
-
+  
   // display only one matching notice
   if (notices.length > 0) {
     notices[0].classList.remove("u-hide")
   }
-
+  
   var baseTakeover = document.getElementById('takeover');
   var takeoverAnimation = document.getElementById("takeover-animaition");
-
+  
   if (window.localStorage && baseTakeover) {
     /**
     * Choose a takeover
@@ -1414,25 +1385,25 @@
     * choose one (that matches the client's language), and replace the
     * base template with it.
     */
-
+    
     var xhr = new XMLHttpRequest();
     if (window.ActiveXObject) {
       xhr = new ActiveXObject('Microsoft.XMLHTTP');
     }
-
+    
     xhr.onreadystatechange = function() {
       if (xhr.readyState == XMLHttpRequest.DONE) {
         if (xhr.status === 200) {
           var takeovers = JSON.parse(xhr.responseText);
-
+          
           // Get the selected takeovers based on the primary language
           var selectedTakeovers = takeovers.filter(function(item) {
             return item.lang === primaryParentLanguage || item.lang === ""
           })
-
+          
           if (selectedTakeovers && selectedTakeovers.length > 0) {
             var selectedIndex = null;
-
+            
             if (window.localStorage.getItem('selected_takeover_index') !== null) {
               // If we previously visited a takeover, increment the number to show the next takeover
               var nextIndex = parseInt(window.localStorage.getItem('selected_takeover_index')) + 1
@@ -1442,7 +1413,7 @@
               selectedIndex = Math.floor(Math.random() * selectedTakeovers.length);
             }
             showTakeover(selectedTakeovers, selectedIndex);
-
+            
             // Store the current takeover index
             localStorage.setItem('selected_takeover_index', selectedIndex)
           }
@@ -1452,16 +1423,16 @@
         }
       }
     };
-
+    
     xhr.open("GET", "/takeovers.json", true);
     xhr.send();
     takeoverAnimation.className +=  " is-loading";
   }
-
+  
   function showTakeover(takeovers, index) {
     // Default parameter
     index = typeof index !== 'undefined' ? index : 0;
-
+    
     // Get HTML elements
     var takeover = document.getElementById("takeover");
     var title = document.getElementById("takeover-title");
@@ -1469,17 +1440,17 @@
     var image = document.getElementById("takeover-image");
     var primaryUrl = document.getElementById("takeover-primary-url");
     var secondaryUrl = document.getElementById("takeover-secondary-url");
-
+    
     // Set values to homepage takeover
     var selectedTakeover = takeovers[index];
-
+    
     takeover.className = "";
     takeover.removeAttribute("style");
-
+    
     // Add takeover classes
     var classNameString = "js-takeover p-takeover--" + selectedTakeover.class;
     takeover.className += classNameString;
-
+    
     // Set language attributes
     if (selectedTakeover.lang) {
       takeover.setAttribute("lang", selectedTakeover.lang);
@@ -1487,7 +1458,7 @@
     if (selectedTakeover.lang_skip) {
       takeover.setAttribute("lang-skip", selectedTakeover.lang_skip);
     }
-
+    
     // Set takeover content
     title.textContent = selectedTakeover.title;
     subtitle.textContent = selectedTakeover.subtitle;
@@ -1499,7 +1470,7 @@
         takeoverAnimation.className +=  " is-loaded";
       }
     }
-
+    
     image.removeAttribute("style");
     image.width = selectedTakeover.image_width;
     image.height = selectedTakeover.image_height;
@@ -1511,7 +1482,7 @@
     } else {
       secondaryUrl.remove();
     }
-
+    
     dataLayer.push({
       event: "NonInteractiveGAEvent",
       eventCategory: "www.ubuntu.com-impression-takeover",


### PR DESCRIPTION
## Done

- Updated the logo section with the [new Vanilla logo section pattern](https://vanillaframework.io/docs/patterns/logo-section) on:
  - homepage
  - /aws
  - /azure
  - /automotive
  - /ai/services

There will be a few of these PRs to come, there are logo sections all over the project that need updating, and would make for one massive PR otherwise.

Also - I used VSCode's auto indent tool to help me out while pasting in the many new logo image templates, it made unrelated indent adjustments in a number of places throughout the files that were updated.

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site at https://ubuntu-com-11184.demos.haus
- See that the logo sections look good
- Do the same for:
  - https://ubuntu-com-11184.demos.haus/aws
  - https://ubuntu-com-11184.demos.haus/azure
  - https://ubuntu-com-11184.demos.haus/automotive
  - https://ubuntu-com-11184.demos.haus/ai/services
- Be sure to test on mobile, tablet and desktop screen sizes

## Issue / Card

Partially fixes #11130 
