### PR TITLE
Fix "Pay now" display for resizes

### DIFF
--- a/static/js/src/advantage/react/components/Subscriptions/SubscriptionEdit/SubscriptionEdit.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/SubscriptionEdit/SubscriptionEdit.tsx
@@ -88,6 +88,7 @@ type ResizeSummaryProps = {
   price: UserSubscription["price"];
   period: UserSubscription["period"];
   nextCycle: Date | null;
+  currentCycleNumberOfMachines: number;
 };
 
 const ResizeSummary = ({
@@ -97,6 +98,7 @@ const ResizeSummary = ({
   price,
   period,
   nextCycle,
+  currentCycleNumberOfMachines,
 }: ResizeSummaryProps) => {
   const absoluteDelta = Math.abs(newNumberOfMachines - oldNumberOfMachines);
   if (absoluteDelta === 0) {
@@ -106,6 +108,8 @@ const ResizeSummary = ({
   const isDecreasing = newNumberOfMachines - oldNumberOfMachines < 0;
   const isMonthly = period === UserSubscriptionPeriod.Monthly;
   const unitPrice = (price ?? 0) / 100 / oldNumberOfMachines;
+  const machinesToPayNow = newNumberOfMachines - currentCycleNumberOfMachines;
+
   return (
     <div>
       <p>
@@ -113,10 +117,10 @@ const ResizeSummary = ({
         {absoluteDelta > 1 ? "s" : ""}.
       </p>
       <p>
-        {!isDecreasing ? (
+        {!isDecreasing && machinesToPayNow > 0 ? (
           <>
             You will be charged{" "}
-            <b>{currencyFormatter.format(absoluteDelta * unitPrice)}</b> when
+            <b>{currencyFormatter.format(machinesToPayNow * unitPrice)}</b> when
             you click Resize.
             <br />
           </>
@@ -304,6 +308,7 @@ const SubscriptionEdit = ({
                   price={subscription.price}
                   period={subscription.period}
                   nextCycle={nextCycleStart}
+                  currentCycleNumberOfMachines={subscription.number_of_machines}
                 />
               </div>
               <div className="p-subscription__resize-actions u-align--right u-sv3">


### PR DESCRIPTION
## Done

- Only display "You will pay now $X" if the user will actually pay as a result of the resize
- Display the correct amount in the pay now paragraph if the user has downsized their subscription during the same cycle

## QA

- Go to [/advantage](https://ubuntu-com-11189.demos.haus/advantage?test_backend=true)
- log in with an account that has a monthly subscription
- downsize it
- the resize it again but up this time
- check that it states that you will pay when you click on resize only for an amount of machines greater than what you had initially

## Screenshots

![resize](https://user-images.githubusercontent.com/11927929/150980890-96d9db48-f4ab-4acb-b7b5-8812764366a0.gif)
