### PR TITLE
Change is cancelled condition

### DIFF
--- a/static/js/src/advantage/react/components/Subscriptions/SubscriptionList/RenewalSettings/RenewalSettings.test.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/SubscriptionList/RenewalSettings/RenewalSettings.test.tsx
@@ -142,6 +142,7 @@ describe("RenewalSettings", () => {
         subscription_id: subscriptionID,
         price: 2500,
         number_of_machines: 2,
+        current_number_of_machines: 2,
         statuses: userSubscriptionStatusesFactory.build({
           should_present_auto_renewal: true,
           is_subscription_auto_renewing: true,
@@ -152,6 +153,7 @@ describe("RenewalSettings", () => {
         subscription_id: "ghi",
         price: 250,
         number_of_machines: 100,
+        current_number_of_machines: 100,
         statuses: userSubscriptionStatusesFactory.build({
           should_present_auto_renewal: true,
           is_subscription_auto_renewing: true,
@@ -162,6 +164,7 @@ describe("RenewalSettings", () => {
         subscription_id: "def",
         price: 10000,
         number_of_machines: 3,
+        current_number_of_machines: 3,
         statuses: userSubscriptionStatusesFactory.build({
           should_present_auto_renewal: true,
           is_subscription_auto_renewing: true,
@@ -172,6 +175,7 @@ describe("RenewalSettings", () => {
         subscription_id: "jkl",
         price: 180000,
         number_of_machines: 1,
+        current_number_of_machines: 1,
         statuses: userSubscriptionStatusesFactory.build({
           should_present_auto_renewal: true,
           is_subscription_auto_renewing: true,

--- a/static/js/src/advantage/react/components/Subscriptions/SubscriptionList/RenewalSettings/RenewalSettings.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/SubscriptionList/RenewalSettings/RenewalSettings.tsx
@@ -117,7 +117,7 @@ function generateAutoRenewalToggles(
       filteredBillingSubscriptions.forEach((subscription) => {
         total += (subscription.price ?? 0) / 100;
         products.push(
-          `${subscription.number_of_machines}x ${subscription.product_name}`
+          `${subscription.current_number_of_machines}x ${subscription.product_name}`
         );
         if (!date) {
           date = subscription.end_date;

--- a/tests/shop/advantage/test_helpers.py
+++ b/tests/shop/advantage/test_helpers.py
@@ -947,9 +947,7 @@ class TestHelpers(unittest.TestCase):
                     "subscriptions": [
                         make_subscription(
                             id="sub-id-1",
-                            items=[
-                                make_subscription_item()
-                            ],
+                            items=[make_subscription_item()],
                         )
                     ],
                     "machines": 1,

--- a/tests/shop/advantage/test_helpers.py
+++ b/tests/shop/advantage/test_helpers.py
@@ -574,7 +574,7 @@ class TestHelpers(unittest.TestCase):
                     "type": "free",
                     "end_date": "2020-08-31T23:59:59Z",
                     "subscriptions": None,
-                    "listing": None,
+                    "machines": 1,
                 },
                 "expectations": {
                     "is_upsizeable": False,
@@ -605,7 +605,7 @@ class TestHelpers(unittest.TestCase):
                             id="abc", status="active", period="yearly"
                         )
                     ],
-                    "listing": None,
+                    "machines": 1,
                     "subscription_id": "abc",
                 },
                 "expectations": {
@@ -637,7 +637,7 @@ class TestHelpers(unittest.TestCase):
                             id="abc", status="active", period="yearly"
                         ),
                     ],
-                    "listing": None,
+                    "machines": 1,
                     "subscription_id": "abc",
                 },
                 "expectations": {
@@ -672,7 +672,7 @@ class TestHelpers(unittest.TestCase):
                             is_auto_renewing=True,
                         ),
                     ],
-                    "listing": None,
+                    "machines": 1,
                     "subscription_id": "abc",
                 },
                 "expectations": {
@@ -700,7 +700,7 @@ class TestHelpers(unittest.TestCase):
                     "type": "yearly",
                     "end_date": "2020-08-31T23:59:59Z",
                     "subscriptions": None,
-                    "listing": None,
+                    "machines": 1,
                 },
                 "expectations": {
                     "is_upsizeable": False,
@@ -730,15 +730,11 @@ class TestHelpers(unittest.TestCase):
                     "subscriptions": [
                         make_subscription(
                             id="sub-id-1",
-                            items=[
-                                make_subscription_item(
-                                    product_listing_id="listing-id"
-                                )
-                            ],
+                            items=[make_subscription_item()],
                             is_auto_renewing=True,
                         )
                     ],
-                    "listing": make_listing(id="listing-id"),
+                    "machines": 1,
                 },
                 "expectations": {
                     "is_upsizeable": True,
@@ -769,15 +765,11 @@ class TestHelpers(unittest.TestCase):
                     "subscriptions": [
                         make_subscription(
                             id="sub-id-1",
-                            items=[
-                                make_subscription_item(
-                                    product_listing_id="random-id"
-                                )
-                            ],
+                            items=[make_subscription_item()],
                             status="deactivated",
                         )
                     ],
-                    "listing": make_listing(id="listing-id"),
+                    "machines": 0,
                 },
                 "expectations": {
                     "is_upsizeable": False,
@@ -804,7 +796,7 @@ class TestHelpers(unittest.TestCase):
                     "type": "monthly",
                     "end_date": "2020-08-01T00:00:00Z",
                     "subscriptions": None,
-                    "listing": None,
+                    "machines": 1,
                 },
                 "expectations": {
                     "is_upsizeable": False,
@@ -837,7 +829,7 @@ class TestHelpers(unittest.TestCase):
                             status="active",
                         )
                     ],
-                    "listing": None,
+                    "machine": 1,
                 },
                 "expectations": {
                     "is_upsizeable": False,
@@ -868,7 +860,7 @@ class TestHelpers(unittest.TestCase):
                             pending_purchases=["pAaBbCcDdEeFfgG"]
                         )
                     ],
-                    "listing": None,
+                    "machines": 1,
                 },
                 "expectations": {
                     "is_upsizeable": False,
@@ -956,13 +948,11 @@ class TestHelpers(unittest.TestCase):
                         make_subscription(
                             id="sub-id-1",
                             items=[
-                                make_subscription_item(
-                                    product_listing_id="listing-id"
-                                )
+                                make_subscription_item()
                             ],
                         )
                     ],
-                    "listing": make_listing(id="listing-id"),
+                    "machines": 1,
                 },
                 "expectations": {
                     "is_upsizeable": True,
@@ -992,11 +982,11 @@ class TestHelpers(unittest.TestCase):
                     statuses = get_user_subscription_statuses(
                         account=parameters.get("account"),
                         type=parameters.get("type"),
+                        current_number_of_machines=parameters.get("machines"),
                         end_date=parameters.get("end_date"),
                         renewal=parameters.get("renewal"),
                         subscription_id=parameters.get("subscription_id"),
                         subscriptions=parameters.get("subscriptions"),
-                        listing=parameters.get("listing"),
                     )
 
                     self.assertEqual(statuses, scenario["expectations"])

--- a/webapp/shop/api/ua_contracts/builders.py
+++ b/webapp/shop/api/ua_contracts/builders.py
@@ -208,11 +208,11 @@ def build_final_user_subscriptions(
         statuses = get_user_subscription_statuses(
             account=account,
             type=type,
+            current_number_of_machines=current_number_of_machines,
             end_date=end_date,
             renewal=renewal,
             subscription_id=subscription_id,
             subscriptions=subscriptions or [],
-            listing=listing or None,
         )
 
         id = make_user_subscription_id(

--- a/webapp/shop/api/ua_contracts/helpers.py
+++ b/webapp/shop/api/ua_contracts/helpers.py
@@ -274,9 +274,9 @@ def get_user_subscription_statuses(
     if type == "monthly":
         is_cancelled = True if not current_number_of_machines else False
         statuses["is_cancelled"] = is_cancelled
-        statuses["should_present_auto_renewal"] = statuses[
-            "is_subscription_active"
-        ]
+        statuses["should_present_auto_renewal"] = (
+            statuses["is_subscription_active"] and not is_cancelled
+        )
 
         # If the subscription is set to auto-renew, we shouldn't alarm the
         # user.

--- a/webapp/shop/api/ua_contracts/helpers.py
+++ b/webapp/shop/api/ua_contracts/helpers.py
@@ -141,11 +141,11 @@ def is_trialling_user_subscription(items: List[ContractItem]) -> bool:
 def get_user_subscription_statuses(
     account: Account,
     type: str,
+    current_number_of_machines: int,
     end_date: str = None,
     renewal: Renewal = None,
     subscription_id: str = None,
     subscriptions: List[Subscription] = None,
-    listing: Listing = None,
 ) -> dict:
     # The explanations below use two concepts:
     # - user subscription: these maps 1:1 with ua-contracts' contract items,
@@ -272,9 +272,7 @@ def get_user_subscription_statuses(
             statuses["is_expiring"] = False
 
     if type == "monthly":
-        is_cancelled = is_user_subscription_cancelled(
-            listing, subscriptions, subscription_id
-        )
+        is_cancelled = True if not current_number_of_machines else False
         statuses["is_cancelled"] = is_cancelled
         statuses["should_present_auto_renewal"] = statuses[
             "is_subscription_active"


### PR DESCRIPTION
## Done

- Change is cancelled condition. A stripe subscription is cancelled if the `current_number_of_machines` is 0.

## QA

- Login using current code https://ubuntu.com/?test_backend=true
- Have a monthly subscription
- Cancel it
- You will be allowed to edit subscription anymore
- Login using demo
- Have a monthly subscription
- Cancel it
- You will be allowed to edit subscription anymore

## Issue / Card

Fixes #https://github.com/canonical-web-and-design/commercial-squad/issues/482