### PR TITLE
Update broken RPi imager download links

### DIFF
--- a/templates/appliance/shared/_steps_pi_imager_macos.html
+++ b/templates/appliance/shared/_steps_pi_imager_macos.html
@@ -3,7 +3,7 @@
     Install the Raspberry Pi Imaging Tool
   </h4>
   <p class="p-stepped-list__content">
-    <a class="p-link--external" href="https://downloads.raspberrypi.org/imager/imager.dmg">
+    <a class="p-link--external" href="https://downloads.raspberrypi.org/imager/imager_1.6.dmg">
       Download the Imaging Tool for macOS
     </a>
   </p>

--- a/templates/appliance/shared/_steps_pi_imager_ubuntu.html
+++ b/templates/appliance/shared/_steps_pi_imager_ubuntu.html
@@ -3,7 +3,7 @@
     Install the Raspberry Pi Imaging Tool
   </h4>
   <p class="p-stepped-list__content">
-    <a class="p-link--external" href="https://downloads.raspberrypi.org/imager/imager_amd64.deb">
+    <a class="p-link--external" href="https://downloads.raspberrypi.org/imager/imager_1.6_amd64.deb">
       Download the Imaging Tool for Ubuntu
     </a>
   </p>

--- a/templates/appliance/shared/_steps_pi_imager_windows.html
+++ b/templates/appliance/shared/_steps_pi_imager_windows.html
@@ -3,7 +3,7 @@
     Install the Raspberry Pi Imaging Tool
   </h4>
   <p class="p-stepped-list__content">
-    <a class="p-link--external" href="https://downloads.raspberrypi.org/imager/imager.exe">
+    <a class="p-link--external" href="https://downloads.raspberrypi.org/imager/imager_1.6.exe">
       Download the Imaging Tool for Windows
     </a>
   </p>


### PR DESCRIPTION
## Done

- Fixed broken links to Raspberry Pi imager tools for each OS

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://localhost:8001/appliance/plex/raspberry-pi2#macos
    - Be sure to test on mobile, tablet and desktop screen sizes
- Under "Installation Instructions", check that the link in Step 1 of each OS tab works

## Issue / Card

Fixes #11180 
