### PR TITLE
Add "HPE", "Lenovo" and "Dell" vendor links to server block on /certified

### DIFF
--- a/templates/certified/index.html
+++ b/templates/certified/index.html
@@ -9,9 +9,9 @@
 <section class="p-strip--suru-bottomed">
   <div class="row u-vertically-center">
     <div class="col-7">
-      <h1>Ubuntu certified hardware</h1>
+      <h1>Ubuntu Certified hardware</h1>
       <p class="p-heading--4">Machines you can trust with Ubuntu</p>
-      <p>Ubuntu certified hardware has passed our extensive testing and review process, ensuring that Ubuntu runs well out of the box, ready for your organisation. We work closely with OEMs to jointly make Ubuntu available on a wide range of desktops, laptops, servers, IoT, and SoC hardware.</p>
+      <p>Ubuntu Certified hardware has passed our extensive testing and review process, ensuring that Ubuntu runs well out of the box, ready for your organisation. We work closely with OEMs to jointly make Ubuntu available on a wide range of desktops, laptops, servers, IoT, and SoC hardware.</p>
       <p><a href="/certified/why-certified">Why Certified?</a></p>
     </div>
     <div class="col-5 u-hide--small u-align--center">
@@ -45,7 +45,7 @@
 <section class="p-strip">
   <div class="row u-equal-height">
    <div class="col-8">
-      <h2>Ubuntu certified desktops</h2>
+      <h2>Ubuntu Certified desktops</h2>
       <p>Many of the world's biggest PC manufacturers certify their desktops for Ubuntu, ensuring these systems always run as smoothly as their millions of users expect. Ubuntu is fast, reliable, packed with great software, and free of viruses. That’s why you’ll find Ubuntu preloaded on desktops across government, education, enterprise, and in homes around the world.</p>
       <p class="u-text--muted u-no-margin--bottom">Vendor:</p>
       <ul class="p-inline-list--midline" style="margin-bottom: 0.5rem;">
@@ -119,7 +119,7 @@
 
   <div class="row u-equal-height">
     <div class="col-8">
-      <h2>Ubuntu certified servers</h2>
+      <h2>Ubuntu Certified servers</h2>
       <p>Ubuntu Server and Canonical’s tools give you the ability to deploy your workloads as easily and repeatably on bare metal as if they were in the cloud.</p>
       <p>Deploying on Ubuntu Certified servers saves you time in choosing and testing what hardware you will use from a single server instance to the largest scale-out data-center environments.</p>
       <p class="u-text--muted u-no-margin--bottom">Vendor:</p>

--- a/templates/certified/index.html
+++ b/templates/certified/index.html
@@ -122,6 +122,17 @@
       <h2>Ubuntu certified servers</h2>
       <p>Ubuntu Server and Canonical’s tools give you the ability to deploy your workloads as easily and repeatably on bare metal as if they were in the cloud.</p>
       <p>Deploying on Ubuntu Certified servers saves you time in choosing and testing what hardware you will use from a single server instance to the largest scale-out data-center environments.</p>
+      <p class="u-text--muted u-no-margin--bottom">Vendor:</p>
+      <ul class="p-inline-list--midline" style="margin-bottom: 0.5rem;">
+        {% for server_vendor in server_vendors %}
+          {% if server_vendor.vendor in ['Dell', 'Lenovo', 'HPE'] %}
+            <li class="p-inline-list__item">
+              <a href="/certified/servers?vendor={{ server_vendor.vendor }}">{{ server_vendor.vendor }}&nbsp;({{ server_vendor.total }})</a>
+            </li>
+          {% endif %}
+        {% endfor %}
+      </ul>
+
       <p class="u-text--muted u-no-margin--bottom">Certified for:</p>
       <ul class="p-inline-list--midline">
         {% for server_release, total in server_releases.items() %}

--- a/templates/certified/index.html
+++ b/templates/certified/index.html
@@ -34,8 +34,8 @@
         <div class="p-form__group">
           <div class="p-search-box">
             <input class="p-search-box__input" type="text" name="q" id="text" value="{{ query or '' }}" placeholder="Search" required>
-            <button type="reset" class="p-search-box__reset"><i class="p-icon--close"></i></button>
-            <button type="submit" class="p-search-box__button"><i class="p-icon--search"></i></button>
+            <button type="reset" class="p-search-box__reset"><i class="p-icon--close">Reset</i></button>
+            <button type="submit" class="p-search-box__button"><i class="p-icon--search">Submit</i></button>
           </div>
         </div>
       </div>

--- a/webapp/certified/views.py
+++ b/webapp/certified/views.py
@@ -387,6 +387,7 @@ def certified_home():
             desktop_releases=desktop_releases,
             desktop_vendors=desktop_vendors,
             server_releases=server_releases,
+            server_vendors=server_vendors,
             iot_releases=iot_releases,
             iot_vendors=iot_vendors,
             soc_releases=soc_releases,


### PR DESCRIPTION
## Done

- Add "HPE", "Lenovo" and "Dell" vendor links to server block on /certified
- Drive by: added missing names to search action buttons

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: https://ubuntu-com-11199.demos.haus/certified
    - Be sure to test on mobile, tablet and desktop screen sizes
- See that "Ubuntu certified servers" contains 3 vendor links, which all work

## Issue / Card

Fixes #9828 
