### PR TITLE
Fix typo in UA service description legal page

### DIFF
--- a/templates/legal/ubuntu-advantage-service-description/_toc.html
+++ b/templates/legal/ubuntu-advantage-service-description/_toc.html
@@ -22,7 +22,7 @@
       </li>
       <li class="p-side-navigation__item">
         <ul class="p-side-navigation__list">
-          <li class="p-side-navigation__item"><a class="p-side-navigation__link" href="#uasd-esm">Extended Security Maintenane (ESM)</a></li>
+          <li class="p-side-navigation__item"><a class="p-side-navigation__link" href="#uasd-esm">Extended Security Maintenance (ESM)</a></li>
           <li class="p-side-navigation__item"><a class="p-side-navigation__link" href="#uasd-certified">Certified components for compliance, hardening and audit</a></li>
           <li class="p-side-navigation__item"><a class="p-side-navigation__link" href="#uasd-landscape">Landscape and knowledge base access</a></li>
           <li class="p-side-navigation__item"><a class="p-side-navigation__link" href="#uasd-livepatch">Kernel Livepatch</a></li>


### PR DESCRIPTION
## Done

Fix typo in UA service description legal page

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/legal/ubuntu-advantage-service-description
- Make sure the typo is corrected


## Issue / Card

Fixes #11181
