### PR TITLE
Fix "Ubuntu certified" case on /certified

### DIFF
--- a/templates/certified/index.html
+++ b/templates/certified/index.html
@@ -9,9 +9,9 @@
 <section class="p-strip--suru-bottomed">
   <div class="row u-vertically-center">
     <div class="col-7">
-      <h1>Ubuntu Certified hardware</h1>
+      <h1>Ubuntu Certified Hardware</h1>
       <p class="p-heading--4">Machines you can trust with Ubuntu</p>
-      <p>Ubuntu Certified hardware has passed our extensive testing and review process, ensuring that Ubuntu runs well out of the box, ready for your organisation. We work closely with OEMs to jointly make Ubuntu available on a wide range of desktops, laptops, servers, IoT, and SoC hardware.</p>
+      <p>Ubuntu certified hardware has passed our extensive testing and review process, ensuring that Ubuntu runs well out of the box, ready for your organisation. We work closely with OEMs to jointly make Ubuntu available on a wide range of desktops, laptops, servers, IoT, and SoC hardware.</p>
       <p><a href="/certified/why-certified">Why Certified?</a></p>
     </div>
     <div class="col-5 u-hide--small u-align--center">
@@ -45,7 +45,7 @@
 <section class="p-strip">
   <div class="row u-equal-height">
    <div class="col-8">
-      <h2>Ubuntu Certified desktops</h2>
+      <h2>Ubuntu certified desktops</h2>
       <p>Many of the world's biggest PC manufacturers certify their desktops for Ubuntu, ensuring these systems always run as smoothly as their millions of users expect. Ubuntu is fast, reliable, packed with great software, and free of viruses. That’s why you’ll find Ubuntu preloaded on desktops across government, education, enterprise, and in homes around the world.</p>
       <p class="u-text--muted u-no-margin--bottom">Vendor:</p>
       <ul class="p-inline-list--midline" style="margin-bottom: 0.5rem;">
@@ -93,7 +93,7 @@
       }}
     </div>
     <div class="col-8">
-      <h2>Ubuntu Certified laptops</h2>
+      <h2>Ubuntu certified laptops</h2>
       <p>Just like desktops, manufacturers choose to certify their laptops for Ubuntu, ensuring they work beautifully and reliably, just as you would expect.</p>
       <p class="u-text--muted u-no-margin--bottom">Vendor:</p>
       <ul class="p-inline-list--midline" style="margin-bottom: 0.5rem;">
@@ -119,9 +119,9 @@
 
   <div class="row u-equal-height">
     <div class="col-8">
-      <h2>Ubuntu Certified servers</h2>
+      <h2>Ubuntu certified servers</h2>
       <p>Ubuntu Server and Canonical’s tools give you the ability to deploy your workloads as easily and repeatably on bare metal as if they were in the cloud.</p>
-      <p>Deploying on Ubuntu Certified servers saves you time in choosing and testing what hardware you will use from a single server instance to the largest scale-out data-center environments.</p>
+      <p>Deploying on Ubuntu certified servers saves you time in choosing and testing what hardware you will use from a single server instance to the largest scale-out data-center environments.</p>
       <p class="u-text--muted u-no-margin--bottom">Vendor:</p>
       <ul class="p-inline-list--midline" style="margin-bottom: 0.5rem;">
         {% for server_vendor in server_vendors %}
@@ -171,7 +171,7 @@
       }}
     </div>
     <div class="col-8">
-      <h2>Ubuntu Certified IoT devices</h2>
+      <h2>Ubuntu certified IoT devices</h2>
       <p>A number of IoT vendors rely on Ubuntu for their devices, from drones and robots to edge gateways and development boards. They certify their devices to offer users the guarantee of a stable, secure, and optimised Ubuntu, either pre-loaded or as a build-your-own option.</p>
       <p>Canonical's certification program offers you the peace of mind that all your Internet of Things devices will remain secure and regularly updated.</p>
       <p class="u-text--muted u-no-margin--bottom">Vendor:</p>
@@ -190,8 +190,8 @@
 
   <div class="row u-equal-height">
     <div class="col-8">
-      <h2>Ubuntu Certified SoCs</h2>
-      <p>64-bit ARM based System on a Chip (SoC) hardware is re-defining the future of sustainable data centers. Featuring high core counts and lower power consumption and cooling needs, Ubuntu Certified Servers that utilize certified System on Chip hardware can lower your costs while allowing you to scale up and out to meet customer demand.</p>
+      <h2>Ubuntu certified SoCs</h2>
+      <p>64-bit ARM based System on a Chip (SoC) hardware is re-defining the future of sustainable data centers. Featuring high core counts and lower power consumption and cooling needs, Ubuntu certified Servers that utilize certified System on Chip hardware can lower your costs while allowing you to scale up and out to meet customer demand.</p>
       <p>Canonical's certification program offers server manufacturers a selection of SoCs officially supported and maintained in Ubuntu to choose from for their products.</p>
       <p class="u-text--muted u-no-margin--bottom">Vendor:</p>
       <ul class="p-inline-list--midline">
@@ -219,8 +219,8 @@
 <section class="p-strip--light">
   <div class="row u-vertically-center">
     <div class="col-7">
-      <h2>Become Ubuntu Certified!</h2>
-      <p>Becoming Ubuntu Certified is your top choice for differentiation, reliability, and product visibility. When your hardware is certified, they can carry the Ubuntu Certified Hardware logo on websites and product packaging. The “Ubuntu Certified Hardware” sticker increases customer confidence that your products integrate seamlessly with Ubuntu, which in turn increases traffic to your products.</p>
+      <h2>Become Ubuntu certified!</h2>
+      <p>Becoming Ubuntu certified is your top choice for differentiation, reliability, and product visibility. When your hardware is certified, they can carry the Ubuntu certified Hardware logo on websites and product packaging. The “Ubuntu Certified Hardware” sticker increases customer confidence that your products integrate seamlessly with Ubuntu, which in turn increases traffic to your products.</p>
       <a href="https://canonical.com/partners/become-a-partner" class="p-link--external">Learn more</a>
     </div>
     <div class="col-5 u-align--center u-hide--small">

--- a/templates/certified/index.html
+++ b/templates/certified/index.html
@@ -11,8 +11,8 @@
     <div class="col-7">
       <h1>Ubuntu Certified Hardware</h1>
       <p class="p-heading--4">Machines you can trust with Ubuntu</p>
-      <p>Ubuntu certified hardware has passed our extensive testing and review process, ensuring that Ubuntu runs well out of the box, ready for your organisation. We work closely with OEMs to jointly make Ubuntu available on a wide range of desktops, laptops, servers, IoT, and SoC hardware.</p>
-      <p><a href="/certified/why-certified">Why Certified?</a></p>
+      <p>Ubuntu certified hardware has passed our extensive testing and review process, ensuring that Ubuntu runs well out of the box, ready for your organisation. We work closely with OEMs to make Ubuntu available on a wide range of desktops, laptops, servers, IoT and SoC hardware.</p>
+      <p><a href="/certified/why-certified">Why get certified?</a></p>
     </div>
     <div class="col-5 u-hide--small u-align--center">
       {{ image (
@@ -46,7 +46,7 @@
   <div class="row u-equal-height">
    <div class="col-8">
       <h2>Ubuntu certified desktops</h2>
-      <p>Many of the world's biggest PC manufacturers certify their desktops for Ubuntu, ensuring these systems always run as smoothly as their millions of users expect. Ubuntu is fast, reliable, packed with great software, and free of viruses. That’s why you’ll find Ubuntu preloaded on desktops across government, education, enterprise, and in homes around the world.</p>
+      <p>Many of the world's biggest PC manufacturers certify their desktops for Ubuntu, ensuring these systems always run as smoothly as their millions of users expect. Ubuntu is fast, reliable, packed with great software and free of viruses. That's why you'll find Ubuntu preloaded on desktops across government, education, enterprise and in homes around the world.</p>
       <p class="u-text--muted u-no-margin--bottom">Vendor:</p>
       <ul class="p-inline-list--midline" style="margin-bottom: 0.5rem;">
         {% for desktop_vendor in desktop_vendors %}
@@ -120,8 +120,8 @@
   <div class="row u-equal-height">
     <div class="col-8">
       <h2>Ubuntu certified servers</h2>
-      <p>Ubuntu Server and Canonical’s tools give you the ability to deploy your workloads as easily and repeatably on bare metal as if they were in the cloud.</p>
-      <p>Deploying on Ubuntu certified servers saves you time in choosing and testing what hardware you will use from a single server instance to the largest scale-out data-center environments.</p>
+      <p>Ubuntu Server and Canonical&rsaquo;s tools give you the ability to deploy your workloads as easily and repeatably on bare metal as if they were in the cloud.</p>
+      <p>Deploying on Ubuntu certified servers saves you time in choosing and testing what hardware you will use from a single server instance to the largest scale-out data centre environments.</p>
       <p class="u-text--muted u-no-margin--bottom">Vendor:</p>
       <ul class="p-inline-list--midline" style="margin-bottom: 0.5rem;">
         {% for server_vendor in server_vendors %}
@@ -191,7 +191,7 @@
   <div class="row u-equal-height">
     <div class="col-8">
       <h2>Ubuntu certified SoCs</h2>
-      <p>64-bit ARM based System on a Chip (SoC) hardware is re-defining the future of sustainable data centers. Featuring high core counts and lower power consumption and cooling needs, Ubuntu certified Servers that utilize certified System on Chip hardware can lower your costs while allowing you to scale up and out to meet customer demand.</p>
+      <p>64-bit ARM based System on a Chip (SoC) hardware is re-defining the future of sustainable data centres. Featuring high core counts and lower power consumption and cooling needs, Ubuntu certified Servers that utilise certified System on Chip hardware can lower your costs while allowing you to scale up and out to meet customer demand.</p>
       <p>Canonical's certification program offers server manufacturers a selection of SoCs officially supported and maintained in Ubuntu to choose from for their products.</p>
       <p class="u-text--muted u-no-margin--bottom">Vendor:</p>
       <ul class="p-inline-list--midline">


### PR DESCRIPTION
## Done

- Fixed "Ubuntu certified" case on /certified
- Numerous small grammar tweaks requested in the [copy doc](https://docs.google.com/document/d/1Cq9RLNjSbX83WB5fFKYCFRvo_1JEfMydMecqrVeKBP8/edit#)

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/certified
    - Be sure to test on mobile, tablet and desktop screen sizes
- See that the word "certified" is only capitalised in the page heading, and that the comments in the copy doc have been addressed.
