### PR TITLE
drop the beta invitation from /advantage

### DIFF
--- a/templates/advantage/index-no-login.html
+++ b/templates/advantage/index-no-login.html
@@ -9,16 +9,6 @@
 
     <div class="row">
       <div class="col-12">
-        <div class="p-notification">
-          <p class="p-notification__response" role="status">
-            Are you using Ubuntu in production? <a href="/support/contact-us" class="p-notification__action js-invoke-modal" data-testid="interactive-form-link">Join our free beta programme for Ubuntu Pro on prem&nbsp;&rsaquo;</a>
-          </p>
-        </div>
-      </div>
-    </div>
-
-    <div class="row">
-      <div class="col-12">
         <h1>Ubuntu Advantage for&nbsp;Infrastructure</h1>
         <p>Ubuntu Advantage for Infrastructure is the most comprehensive Linux enterprise subscription, covering all aspects of open infrastructure.</p>
         <h5>

--- a/templates/advantage/index.html
+++ b/templates/advantage/index.html
@@ -18,18 +18,6 @@
       });
     </script>
 
-    <div class="row">
-      <div class="col-12">
-        <div class="p-notification">
-          <p class="p-notification__response" role="status">
-            Are you using Ubuntu in production? <a href="/support/contact-us" data-testid="interactive-form-link"
-              class="p-notification__action js-invoke-modal">Join our free beta programme for Ubuntu Pro on
-              prem&nbsp;&rsaquo;</a>
-          </p>
-        </div>
-      </div>
-    </div>
-
     <div class="row u-equal-height u-sv3">
       <div class="col-5 u-vertically-center">
         <h1 class="p-subscriptions__header-title">Your subscriptions</h1>


### PR DESCRIPTION

## Done

- Removed the beta invite from the top of /advantage

## QA

- Go to https://ubuntu-com-11202.demos.haus/advantage
- check that the beta invite is gone
- log in
- check that it's still gone

## Issue / Card

Fixes #11196

## Screenshots

