### PR TITLE
Disabe email field if it was prepopulated

### DIFF
--- a/static/js/src/PurchaseModal/components/PaymentMethodForm.tsx
+++ b/static/js/src/PurchaseModal/components/PaymentMethodForm.tsx
@@ -13,6 +13,7 @@ import { CardElement } from "@stripe/react-stripe-js";
 import { debounce } from "lodash";
 
 import usePostCustomerInfoForPurchasePreview from "../hooks/usePostCustomerInfoForPurchasePreview";
+import useStripeCustomerInfo from "../hooks/useStripeCustomerInfo";
 import FormRow from "./FormRow";
 import {
   caProvinces,
@@ -38,6 +39,9 @@ function PaymentMethodForm({ setCardValid }: Props) {
   const [cardFieldHasFocus, setCardFieldFocus] = useState(false);
   const [cardFieldError, setCardFieldError] = useState<Error | null>(null);
   const mutation = usePostCustomerInfoForPurchasePreview();
+  const { data: userInfo } = useStripeCustomerInfo();
+
+  const isEmailPrepopulated = !!userInfo?.customerInfo?.email;
 
   const {
     errors,
@@ -203,6 +207,7 @@ function PaymentMethodForm({ setCardValid }: Props) {
         type="email"
         id="email"
         name="email"
+        disabled={isEmailPrepopulated}
         validate={validateEmail}
         error={touched?.email && errors?.email}
       />

--- a/static/js/src/PurchaseModal/hooks/useStripeCustomerInfo.jsx
+++ b/static/js/src/PurchaseModal/hooks/useStripeCustomerInfo.jsx
@@ -6,18 +6,24 @@ const useStripeCustomerInfo = () => {
     "paymentModalUserInfo",
     async () => {
       if (!window.accountId) {
-        throw new Error("MISSING ACCOUNT_ID");
+        const response = await fetch(`/account.json${window.location.search}`, {
+          cache: "no-store",
+        });
+        const res = await response.json();
+        return {
+          customerInfo: {
+            email: res.account.email,
+            name: res.account.fullname,
+          },
+        };
       }
       const res = await getCustomerInfo(window.accountId);
-
       if (res.data.code) {
         throw new Error(res.data.message);
       }
       return res.data;
     },
-    {
-      enabled: !!window.accountId,
-    }
+    {}
   );
 
   return {

--- a/static/js/src/navigation.js
+++ b/static/js/src/navigation.js
@@ -205,6 +205,7 @@ if (accountContainer && accountContainerSmall) {
         accountContainerSmall.innerHTML = `<a href="/login${queryString}" class="p-navigation__link-anchor">Sign in</a>`;
         accountContainer.innerHTML = `<a href="/login${queryString}" class="p-navigation__link-anchor" style="padding-right: 1rem;">Sign in</a>`;
       } else {
+        window.accountJSONRes = data.account;
         accountContainerSmall.innerHTML = `<span class="p-navigation__link-anchor">${data.account.fullname} (<a href="/logout${queryString}" class="p-link--inverted">logout</a>)</span>`;
         accountContainer.innerHTML = `<div class="p-navigation__dropdown-link p-subnav">
             <a href="" class="p-navigation__link-anchor p-subnav__toggle" aria-controls="user-menu" aria-expanded="false" aria-haspopup="true">${data.account.fullname}</a>


### PR DESCRIPTION
## Done

- If we can't fetch Stripe data, fall back on `account.json` to prepopulate the name and email fields
- disable email field if it was prepopulated 

## QA

- Go to [/advantage/subscribe](https://ubuntu-com-11205.demos.haus/advantage/subscribe?test_backend=true)
- Log in with a brand new SSO account
- your name and email should be prepopulated, email field should be disabled
- Log in with an account that already has made a purchase
- the same should happen

## Issue / Card

Fixes https://github.com/canonical-web-and-design/commercial-squad/issues/299

## Screenshots

![image](https://user-images.githubusercontent.com/11927929/151522533-f7900070-5393-4e31-90ab-1f7033548de2.png)
