### PR TITLE
Fix CVE pagination

### DIFF
--- a/templates/security/cve/_pagination.html
+++ b/templates/security/cve/_pagination.html
@@ -67,15 +67,21 @@
       </li>
     {% endif %}
 
-    {% if current_page < total_pages - 2 and current_page <= 2 %}
+    {% if current_page < total_pages - 2 and current_page == 1 %}
       <li class="p-pagination__item">
         <a href="?{{ modify_query({'offset': (current_page + 2) * limit}) }}" class="p-pagination__link">{{ current_page + 3 }}</a>
       </li>
     {% endif %}
 
-    {% if current_page < total_pages - 6 and current_page <= 3 %}
+    {% if current_page < total_pages - 3 and current_page == 1 %}
       <li class="p-pagination__item">
         <a href="?{{ modify_query({'offset': (current_page + 3) * limit}) }}" class="p-pagination__link">{{ current_page + 4 }}</a>
+      </li>
+    {% endif %}
+
+    {% if current_page < total_pages - 3 and current_page == 2 %}
+      <li class="p-pagination__item">
+        <a href="?{{ modify_query({'offset': (current_page + 2) * limit}) }}" class="p-pagination__link">{{ current_page + 3 }}</a>
       </li>
     {% endif %}
 


### PR DESCRIPTION
## Done

- Fixes pagination on cve search to correctly display the available pages and use the appropriate offset.

## QA

- **Note** won't work in demos, you will need to run locally. If you need help setting up a local CVE database reach out to me or Albert. 
- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/security/cve or https://ubuntu-com-11208.demos.haus/security/cve
    - Be sure to test on mobile, tablet and desktop screen sizes
- Check the pagination work, and that no number are skipped.
- Hover your mouse over every pagination button and make sure the offset is correct.

## Issue / Card

Fixes https://github.com/canonical-web-and-design/ubuntu.com/issues/11188
