### PR TITLE
Patch psycopg2 (for SQLAlchemy) with psycogreen

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,3 +74,4 @@ database.json
 database.json.1
 static/js/build/
 tests/cassettes/TestRoutes.test_ceph_docs.yaml
+*.swp

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,3 +27,4 @@ macaroonbakery==1.3.1
 sortedcontainers==2.4.0
 vcrpy-unittest==0.1.7
 webargs==7.0.1
+psycogreen==1.0.2

--- a/scripts/generate-sample-security-data.py
+++ b/scripts/generate-sample-security-data.py
@@ -1,0 +1,79 @@
+#! /usr/bin/env python3
+
+import os
+import sys
+
+sys.path.append(os.getcwd())
+
+from datetime import datetime
+
+from webapp.security.models import Notice, Release, Status, CVE, Package
+from webapp.security.database import db_session
+
+
+release = Release(
+    codename="some release",
+    name="00.00",
+    version="0.0.0",
+    lts=True,
+    development=False,
+    release_date=datetime.now(),
+    esm_expires=datetime.now(),
+    support_expires=datetime.now()
+)
+db_session.add(release)
+
+package = Package(
+    name="some package",
+    source="",
+    launchpad="",
+    ubuntu="",
+    debian=""
+)
+db_session.add(package)
+
+
+for usn_num in range(9999):
+    cves = []
+
+    for cve_num in range(5):
+        cve = CVE(
+            id=f"CVE-{usn_num}-{cve_num}",
+            published=datetime.now(),
+            description="",
+            ubuntu_description="",
+            notes={},
+            priority="unknown",
+            cvss3=2.3,
+            mitigation="",
+            references={},
+            patches={},
+            tags={},
+            bugs={},
+            status="active"
+        )
+        db_session.add(cve)
+        cves.append(cve)
+
+        status = Status(
+            status="pending",
+            cve=cve,
+            package=package,
+            release=release
+        )
+        db_session.add(status)
+
+    notice = Notice(
+        id=f"USN-{usn_num:04d}",
+        is_hidden=False,
+        published=datetime.now(),
+        summary="",
+        details="",
+        instructions="",
+        releases=[release],
+        cves=cves
+    )
+    db_session.add(notice)
+
+db_session.commit()
+

--- a/webapp/security/database.py
+++ b/webapp/security/database.py
@@ -1,9 +1,14 @@
 import os
 
-from sqlalchemy import create_engine
-from sqlalchemy.orm import scoped_session, sessionmaker
+# Patch psycopg2 for gevent before importing any sqlalchemy stuff
+from psycogreen.gevent import patch_psycopg
 
-from webapp.security.models import BaseFilterQuery
+patch_psycopg()
+
+from sqlalchemy import create_engine  # noqa: E402
+from sqlalchemy.orm import scoped_session, sessionmaker  # noqa: E402
+
+from webapp.security.models import BaseFilterQuery  # noqa: E402
 
 
 db_engine = create_engine(os.environ["DATABASE_URL"])


### PR DESCRIPTION
We run the site with Gunicorn's [gevent workers](https://docs.gunicorn.org/en/latest/design.html#async-workers). This means all parts of the code must be [compatible](https://stackoverflow.com/questions/23278482/compatibility-of-gevent-with-other-packages) with gevent's coroutines.

Psycopg2 is [not natively compatible](https://www.psycopg.org/docs/advanced.html#support-for-coroutine-libraries) with gevent coroutines, and so by default separate gevent threads making database calls will block each other leading to sub-par performance.

This commit patches psycopg2 with psycogreen, so that database calls can be made concurrently by separate gevent threads.

https://github.com/psycopg/psycogreen/
https://gist.github.com/pawl/0f0d87e7ee42f0a8eaf28f0d13629674

## QA

1. Pull down this branch and run it with `dotrun`.
2. Once the database has been created, in a separate terminal window import some sample data into the running database:
    ``` bash
    dotrun exec scripts/generate-sample-security-data.py  # This takes a while
    ```
3. Browse to http://127.0.0.1:8001/security/notices and http://127.0.0.1/security/cves, check it works (remembering that the dummy data will look rather odd, as most fields are empty)
4. MacOS will already have Apache Bench (`ab`) installed, but on Ubuntu it needs to be installed (`sudo apt install apache2-utils`)
5. Check the rate we can make DB requests (appropriately patched with psycogreen) for 100 concurrent requests for notices:
    ``` bash
    $ ab -n 100 -c 100 127.0.0.1:8001/security/notices | grep "Requests per second"
    Requests per second:    17.93 [#/sec] (mean)
    ```
6. Now switch back to the `main` branch, to remove the psycogreen patching:
    ``` bash
    git checkout main
    ```
7. Check the rate of DB requests again - this should be about half of what it was:
    ``` bash
    $ ab -n 100 -c 100 127.0.0.1:8001/security/notices | grep "Requests per second"
    Requests per second:    9.51 [#/sec] (mean)
    ```