### PR TITLE
Run the site with 3 gunicorn workers

### DIFF
--- a/entrypoint
+++ b/entrypoint
@@ -2,7 +2,7 @@
 
 set -e
 
-RUN_COMMAND="talisker.gunicorn.gevent webapp.app:app --bind $1 --worker-class gevent --name talisker-`hostname`"
+RUN_COMMAND="talisker.gunicorn.gevent webapp.app:app --bind $1 --workers 3 --worker-class gevent --name talisker-`hostname`"
 
 if [ "${FLASK_DEBUG}" = true ] || [ "${FLASK_DEBUG}" = 1 ]; then
     {


### PR DESCRIPTION
The big question is - why 3? Well, there's quite a lot going on there.

Why 1 worker up to now?
---

Firstly, the reason we were running only 1 worker up to now was because of two misconceptions on my part:

1. That Docker containers are supposed to only have 1 process per container, as mentioned in [this SO answer](https://stackoverflow.com/a/51873337)
2. That gevent workers elastically create new workers as needed

Both of these are wrong, because:

1. The real point of the Docker container advice is not to run more than one *service* or *function* per container, and the official guidance wording has since been updated, as mentioned in [this SO answer](https://devops.stackexchange.com/a/451).
2. Gevent threads are not at all the same thing as workers (read about the [different sorts of concurrency](https://medium.com/building-the-system/gunicorn-3-means-of-concurrency-efbb547674b7) in Gunicorn).

The harm of using 1 worker
---

Using only 1 worker is really quite risky, as that worker could restart for a number of different reasons:

- The max-connections limit is reached
- The worker crashes
- The machine needs to free up memory

when the worker restarts, the service will be temporarily unavailable - we've seen this happen in quite a few places recently. Kubernetes will of course try to manage this by removing the pod from rotation, but it can't do this immediately - some clients are likely to see errors. So we should really be running *at least 2* workers to provide at least the tiniest amount of redundancy.

Why 3?
---

The official guidance [says](https://docs.gunicorn.org/en/stable/design.html#how-many-workers):

> Generally we recommend (2 x $num_cores) + 1 as the number of workers to start off with. While not overly scientific, the formula is based on the assumption that for a given core, one worker will be reading or writing from the socket while the other worker is processing a request.

According to this we should run 9 workers, as each Node in K8s has 4 cores.

However, does this make sense in something like Kubernetes? The rationale above clearly expects Gunicorn to basically have its own dedicated CPU cores. In Kubernetes (or any virtualisation hypervisor) this isn't the case. Many different applications will be running on a single node, sharing CPUs. And we know that resources can be scarce in Kubernetes, so we don't want to max things out without good reason.

Looking around the web, a bunch of articles on running Gunicorn in Kubernetes seem to use 3 workers (e.g. [this one](https://www.digitalocean.com/community/tutorials/how-to-deploy-a-scalable-and-secure-django-application-with-kubernetes)). 3 workers would be the equivalent of assuming that each Pod has access to the equivalent of a single core, which seems like a potentially reasonable approximation.

I also did some testing where I used [Siege](https://en.wikipedia.org/wiki/Siege_(software)) to hit a local version of the website, while using [htop](https://htop.dev/) to watch the load on each core. Increasing the number of cores didn't actually improve the performance of the site, but it did increase the load on each CPU core by *a lot*, when the site was under siege. So I think it would be wise to exercise caution and not go overboard with the number of workers.

All in all, this leads me to the conclusion that I should run 3 workers per Kubernetes pod.

QA
===

Check the site runs by visiting the demo. Beyond this, I don't think it's really possible to QA this change. We should just put it live and see how it performs over time. As long as you agree with the rationale above.