### PR TITLE
Fix /certified pagination

### DIFF
--- a/templates/security/cve/_pagination.html
+++ b/templates/security/cve/_pagination.html
@@ -79,7 +79,7 @@
       </li>
     {% endif %}
 
-    {% if current_page < total_pages - 3 and current_page == 2 %}
+    {% if current_page <= total_pages - 3 and current_page == 2 %}
       <li class="p-pagination__item">
         <a href="?{{ modify_query({'offset': (current_page + 2) * limit}) }}" class="p-pagination__link">{{ current_page + 3 }}</a>
       </li>


### PR DESCRIPTION
## Done

- Fixes a bug with the pagination on /certified search 

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/certified or https://ubuntu-com-11214.demos.haus/certified
    - Be sure to test on mobile, tablet and desktop screen sizes
- Go to /certified, try and search in the search bar near the top of the page.
- Check pagination behaves appropriately when changing pages and with different amounts of results.

## Issue / Card

Fixes https://github.com/canonical-web-and-design/ubuntu.com/issues/11188
