### PR TITLE
Call preview for resizes

### DIFF
--- a/static/js/src/advantage/api/contracts.js
+++ b/static/js/src/advantage/api/contracts.js
@@ -253,6 +253,41 @@ export async function resizeContract(
   let data = await response.json();
   return data;
 }
+export async function previewResizeContract(
+  accountId,
+  previousPurchaseId,
+  productId,
+  quantity,
+  period,
+  marketplace
+) {
+  const queryString = window.location.search; // Pass arguments to the flask backend eg. "test_backend=true"
+  let response = await fetch(`/advantage/subscribe/preview${queryString}`, {
+    method: "POST",
+    cache: "no-store",
+    credentials: "include",
+    headers: {
+      Accept: "application/json",
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      account_id: accountId,
+      previous_purchase_id: previousPurchaseId,
+      period: period,
+      products: [
+        {
+          product_listing_id: productId,
+          quantity: quantity,
+        },
+      ],
+      resizing: true,
+      marketplace: marketplace,
+    }),
+  });
+
+  let data = await response.json();
+  return data;
+}
 
 export async function postPurchasePreviewData(
   accountID,

--- a/static/js/src/advantage/react/components/Subscriptions/SubscriptionEdit/SubscriptionEdit.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/SubscriptionEdit/SubscriptionEdit.tsx
@@ -95,6 +95,7 @@ type ResizeSummaryProps = {
   period: UserSubscription["period"];
   nextCycle: Date | null;
   preview?: PreviewResizeContractResponse;
+  isPreviewLoading: boolean;
 };
 
 const ResizeSummary = ({
@@ -105,6 +106,7 @@ const ResizeSummary = ({
   period,
   nextCycle,
   preview,
+  isPreviewLoading,
 }: ResizeSummaryProps) => {
   const absoluteDelta = Math.abs(newNumberOfMachines - oldNumberOfMachines);
   if (absoluteDelta === 0) {
@@ -130,13 +132,20 @@ const ResizeSummary = ({
             <br />
           </>
         ) : null}
-        Your {isMonthly ? "monthly" : "yearly"} payment will be{" "}
-        <b>
-          {isDecreasing ? "reduced" : "increased"} by{" "}
-          {currencyFormatter.format(absoluteDelta * unitPrice)}, to{" "}
-          {currencyFormatter.format(newNumberOfMachines * unitPrice)} per{" "}
-          {isMonthly ? "month" : "year"}.
-        </b>
+        {!isPreviewLoading ? (
+          <>
+            Your {isMonthly ? "monthly" : "yearly"} payment will be{" "}
+            <b>
+              {isDecreasing ? "reduced" : "increased"} by{" "}
+              {currencyFormatter.format(
+                preview ? preview.amountDue / 100 : absoluteDelta * unitPrice
+              )}
+              .
+            </b>
+          </>
+        ) : (
+          <Spinner />
+        )}
         {isDecreasing && nextCycle ? (
           <>
             <br />
@@ -224,6 +233,7 @@ const SubscriptionEdit = ({
         subscription?.account_id,
       ]);
       onClose();
+      queryClient.removeQueries("preview");
       const newNumberOfMachines =
         resizeNumber + (subscription?.current_number_of_machines ?? 0);
       if (newNumberOfMachines > (subscription?.number_of_machines ?? 0)) {
@@ -331,6 +341,7 @@ const SubscriptionEdit = ({
                   period={subscription.period}
                   nextCycle={nextCycleStart}
                   preview={preview}
+                  isPreviewLoading={isPreviewLoading}
                 />
               </div>
               <div className="p-subscription__resize-actions u-align--right u-sv3">

--- a/static/js/src/advantage/react/hooks/index.ts
+++ b/static/js/src/advantage/react/hooks/index.ts
@@ -3,6 +3,7 @@ export { useContractToken } from "./useContractToken";
 export { useLastPurchaseIds } from "./useLastPurchaseIds";
 export { useLoadWindowData } from "./useLoadWindowData";
 export { useResizeContract } from "./useResizeContract";
+export { usePreviewResizeContract } from "./usePreviewResizeContract";
 export { useSetAutoRenewal } from "./useSetAutoRenewal";
 export { useStripePublishableKey } from "./useStripePublishableKey";
 export { useURLs } from "./useURLs";

--- a/static/js/src/advantage/react/hooks/usePreviewResizeContract.ts
+++ b/static/js/src/advantage/react/hooks/usePreviewResizeContract.ts
@@ -1,0 +1,65 @@
+import { useState } from "react";
+import { previewResizeContract } from "advantage/api/contracts";
+import { UserSubscription } from "advantage/api/types";
+import { useQuery } from "react-query";
+import { useLastPurchaseIds } from ".";
+import { selectPurchaseIdsByMarketplaceAndPeriod } from "./useLastPurchaseIds";
+
+export type PreviewResizeContractResponse = { amountDue: number };
+
+export const usePreviewResizeContract = (subscription?: UserSubscription) => {
+  const { data: lastPurchaseId } = useLastPurchaseIds(
+    subscription?.account_id,
+    {
+      select: selectPurchaseIdsByMarketplaceAndPeriod(
+        subscription?.marketplace,
+        subscription?.period
+      ),
+    }
+  );
+
+  const [quantity, setQuantity] = useState(0);
+
+  const {
+    isLoading,
+    isError,
+    isSuccess,
+    data,
+    error,
+  } = useQuery<PreviewResizeContractResponse>(
+    ["preview", quantity],
+    async () => {
+      const res = await previewResizeContract(
+        subscription?.account_id,
+        lastPurchaseId,
+        subscription?.listing_id,
+        quantity,
+        subscription?.period,
+        subscription?.marketplace
+      );
+
+      if (res.errors) {
+        if (
+          res.errors.includes("no invoice would be issued for this purchase") ||
+          res.errors.includes("purchase does not affect subscription")
+        ) {
+          return;
+        }
+        throw new Error(res.errors);
+      }
+      return res;
+    },
+    {
+      enabled: quantity > 0,
+    }
+  );
+
+  return {
+    isLoading: isLoading,
+    isError: isError,
+    isSuccess: isSuccess,
+    data: data,
+    error: error,
+    setQuantity: setQuantity,
+  };
+};

--- a/static/js/src/advantage/react/hooks/usePreviewResizeContract.ts
+++ b/static/js/src/advantage/react/hooks/usePreviewResizeContract.ts
@@ -27,7 +27,7 @@ export const usePreviewResizeContract = (subscription?: UserSubscription) => {
     data,
     error,
   } = useQuery<PreviewResizeContractResponse>(
-    ["preview", quantity],
+    ["preview", quantity, subscription?.id],
     async () => {
       const res = await previewResizeContract(
         subscription?.account_id,


### PR DESCRIPTION
## Done

- Added a resize preview call to the contracts API file
- created a hook that calls the preview endpoint on quantity change
- displays the correct (incl taxes) amount that will be charged when the user clicks "Resize"

## QA

- go to [/advantage](https://ubuntu-com-11215.demos.haus/advantage?test_backend=true)
- log in with an account that has a monthly subscription
- resize it up and down and up again and check that the correct amount is displayed each time

## Issue / Card

Fixes canonical-web-and-design/commercial-squad#488
