### PR TITLE
Adds #standard-pro anchor to /azure page

### DIFF
--- a/templates/azure/index.html
+++ b/templates/azure/index.html
@@ -99,7 +99,7 @@
   </div>
 </section>
 
-<section class="p-strip">
+<section class="p-strip" id="standard-pro">
   <div class="row">
     <div class="col-6">
       <h2>Choose the right Ubuntu for you</h2>


### PR DESCRIPTION
## Done

- Adding an anchor on the "Choose the right Ubuntu" section to help with a marketing campaign

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- Ensure /azure#standard-pro takes you down the page
