### PR TITLE
Russian engage pages

### DIFF
--- a/static/sass/_global-settings.scss
+++ b/static/sass/_global-settings.scss
@@ -10,4 +10,5 @@ $contrast-ratio: 5%;
 $color-whitepaper-accent: #772a54;
 $color-mid-x-light: #e5e5e5;
 $font-use-subset-latin: true;
+$font-allow-cyrillic-greek-latin: true;
 $font-display-option: fallback;

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -10,23 +10,10 @@
 // import cookie policy
 @import "@canonical/cookie-policy/build/css/cookie-policy";
 
-// Font display Vanilla override
-@font-face {
-  font-display: optional;
-  font-family: "UbtuOverride";
-  font-style: normal;
-  font-weight: 300;
-  src: url("https://assets.ubuntu.com/v1/e8c07df6-Ubuntu-L_W.woff2")
-      format("woff2"),
-    url("https://assets.ubuntu.com/v1/8619add2-Ubuntu-L_W.woff") format("woff");
-}
-
 // import vanilla-framework
 @import "vanilla-framework/scss/build";
 @import "vanilla-placeholders";
 
-// Vanilla framework overrides
-$font-base-family: '"UbtuOverride", -apple-system, "Segoe UI", "Roboto", "Oxygen", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif' !default;
 $color-shadow: rgba(0, 0, 0, 0.5) !default;
 
 // import site specific patterns and overrides

--- a/templates/engage/index.html
+++ b/templates/engage/index.html
@@ -37,6 +37,7 @@
           <option value="fr">Fran&ccedil;ais</option>
           <option value="it">Italiano</option>
           <option value="pt">Portugu&ecirc;s</option>
+          <option value="ru">Русс&#1082;&#1080;&#1081;</option>
         </select>
       </div>
     </div>


### PR DESCRIPTION
## Done

- Enabled display of cyrillic characters
- Added Russian ("Русский") as an option in the /engage index

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/engage
    - Be sure to test on mobile, tablet and desktop screen sizes
- Select "Русский" from the language dropdown, there should be four results
- Click any of them, the font on the engage page should look a lot better than it does on the live site, and the font family being used should be "UbuntuFullCharSet".
- Go to a non Russian engage page, inspect the text, the font family should be "Ubuntu"

## Screenshots

Before:

![Screenshot from 2022-02-07 16-59-54](https://user-images.githubusercontent.com/2376968/152835449-249ed1fc-8934-4d33-aaa6-30343e673b13.png)

After:

![Screenshot from 2022-02-07 17-00-06](https://user-images.githubusercontent.com/2376968/152835468-8efc4cd0-6f40-4e21-b6ca-4fcc9fffed38.png)


