### PR TITLE
K8s docs link fixes

### DIFF
--- a/templates/kubernetes/docs/install-offline.md
+++ b/templates/kubernetes/docs/install-offline.md
@@ -262,8 +262,8 @@ is covered in the [proxy documentation][].
 [juju-bundle]: https://juju.is/docs/sdk/bundles
 [juju-constraints]: https://juju.is/docs/olm/constraints
 [juju-docs]: https://juju.is/docs/olm/installing-juju
-[juju-gui]: https://juju.is/docs/olm/accessing-juju%E2%80%99s-web-interface
-[offline-mode]: https://juju.is/docs/t/offline-mode-strategies/1071
+[juju-gui]: https://juju.is/docs/olm/accessing-the-dashboard
+[offline-mode]: https://juju.is/docs/olm/configure-juju-for-offline-usage
 [on-prem-livepatch]: https://ubuntu.com/security/livepatch/docs/on_prem
 [overlays]: /kubernetes/docs/install-manual#overlay
 [quickstart]: /kubernetes/docs/quickstart

--- a/templates/kubernetes/docs/install-offline.md
+++ b/templates/kubernetes/docs/install-offline.md
@@ -262,7 +262,6 @@ is covered in the [proxy documentation][].
 [juju-bundle]: https://juju.is/docs/sdk/bundles
 [juju-constraints]: https://juju.is/docs/olm/constraints
 [juju-docs]: https://juju.is/docs/olm/installing-juju
-[juju-gui]: https://juju.is/docs/olm/accessing-the-dashboard
 [offline-mode]: https://juju.is/docs/olm/configure-juju-for-offline-usage
 [on-prem-livepatch]: https://ubuntu.com/security/livepatch/docs/on_prem
 [overlays]: /kubernetes/docs/install-manual#overlay

--- a/templates/kubernetes/docs/monitoring.md
+++ b/templates/kubernetes/docs/monitoring.md
@@ -34,6 +34,8 @@ See the [quickstart guide][quickstart] for more details on installing **Charmed 
 You can install **Charmed Kubernetes** with monitoring using the Juju bundle
 along with the following overlay file ([download it here][monitoring-pgt-overlay]):
 
+NOTE: Make sure the series is the same as the rest of your kubernetes bundle. Eg: all of series focal.
+
 ```yaml
 applications:
   prometheus:


### PR DESCRIPTION
## Done

Some very minor updates

- Fixes some broken links for updated juju docs
-  adds a note on monitoring

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
