### PR TITLE
Fix /cube/contact-us cypress test

### DIFF
--- a/templates/shared/_cube-contact-us-form.html
+++ b/templates/shared/_cube-contact-us-form.html
@@ -128,7 +128,7 @@
             </li>
             <li  class="p-list__item  " id="comments">
               <label for="Comments_from_lead__c" id="LblComments_from_lead__c"  >Why do you want certification?</label>
-              <textarea class="is-required" required="" id="Comments_from_lead__c" name="Comments_from_lead__c" rows="4" aria-labelledby="LblComments_from_lead__c InstructComments_from_lead__c" maxlength="2000" aria-required="true" ></textarea>
+              <textarea class="is-required" required="" data-testid="form-comment" id="Comments_from_lead__c" name="Comments_from_lead__c" rows="4" aria-labelledby="LblComments_from_lead__c InstructComments_from_lead__c" maxlength="2000" aria-required="true" ></textarea>
             </li>
           </ul>
         </fieldset>

--- a/tests/cypress/forms/forms_spec.js
+++ b/tests/cypress/forms/forms_spec.js
@@ -68,19 +68,12 @@ context("Static marketo forms", () => {
     cy.findByLabelText(/Last name:/).type("Test");
     cy.findByLabelText(/Work email:/).type("test@test.com");
     cy.findByLabelText(/Current employer:/).type("Test");
-    cy.findByLabelText(/Job role:/).select("Education");
+    cy.findByLabelText(/Employment level:/).select("Senior");
+    cy.findByLabelText(/Title:/).type("Test");
     cy.findByLabelText(/What is your experience with Ubuntu?/).select(
       "None or very minimal experience"
     );
-    cy.findByLabelText(/Does your workplace require Ubuntu?/).click({
-      force: true,
-    });
-    cy.findByLabelText(
-      /Which microcert are you most interested in taking?/
-    ).select("Ubuntu System Architecture");
-    cy.findByLabelText(/Why do you want CUBE certification?/).type(
-      "test test test test "
-    );
+    cy.findByTestId("form-comment").type("test test test test");
     cy.findByLabelText(/I agree to receive information/).click({
       force: true,
     });


### PR DESCRIPTION
## Done

- Fix `/cube/contact-us` cypress test in `/forms_spec.js`

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- Please do `context.skip` or `it.skip` to save time and avoid making a bunch of spam submission
- Move the `/tests/cypress/forms/forms_spec.js` file to the `/tests/cypress/integration` folder
- Open another terminal and run `yarn run cypress:open`
- Click `forms_spec.js` in the cypress test window
- Check the test for the `/cube/contact-us` passes

## Issue / Card

Fixes #

## Help

[QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html) - [Commit guidelines](https://canonical-web-and-design.github.io/practices/workflow/commit-messages.html)
