### PR TITLE
Fix content overlapping meganav

### DIFF
--- a/static/sass/_pattern_subscriptions.scss
+++ b/static/sass/_pattern_subscriptions.scss
@@ -145,6 +145,7 @@
         padding: 0;
         position: relative;
         width: unset;
+        z-index: unset;
 
         .p-modal__dialog:not(.ua-dialog) {
           box-shadow: unset;


### PR DESCRIPTION

## Done

- prevented the subscription detail from overlapping the meganav

## QA

- go to https://ubuntu-com-11248.demos.haus/advantage
- open the meganav, it should display correctly
- switch to a small viewport size
- click on a subscription, it should display correctly

## Issue / Card

Fixes #11121

## Screenshots
![image](https://user-images.githubusercontent.com/11927929/154219420-1924652a-b67b-4d21-a988-ae4bba30062e.png)

![image](https://user-images.githubusercontent.com/11927929/154219479-5baceb94-5a32-4540-ae1a-cf137eece1fd.png)

