### PR TITLE
Add api class to consume security api

### DIFF
--- a/templates/security-error.html
+++ b/templates/security-error.html
@@ -1,0 +1,36 @@
+{% extends "templates/one-column_no_nav.html" %}
+{% block title %}500: Server error{% endblock %}
+
+
+{% block content %}
+<div class="p-strip is-deep">
+  <div class="row u-equal-height">
+    <div class="col-6 u-vertically-center u-align--center">
+      {{
+      image(
+      url="https://assets.ubuntu.com/v1/bcdcf2c8-image-404.svg",
+      alt="",
+      height="365",
+      width="360",
+      hi_def=True,
+      loading="auto"
+      ) | safe
+      }}
+    </div>
+    <div class="col-6 u-vertically-center">
+      <div>
+        <h1>Security API error</h1>
+        <p class="p-heading--4">The security API is down.</p>
+        {% if message %}<blockquote><code>{{ message }}</code></blockquote>{% endif %}
+        <p>
+          Try reloading the page.
+          If the error persists, please note that it may be a <a class="p-link--external"
+            href="https://github.com/canonical-websites/www.ubuntu.com/issues">known issue</a>.
+          If not, please <a class="p-link--external"
+            href="https://github.com/canonical-websites/www.ubuntu.com/issues/new">file a new issue</a>.
+        </p>
+      </div>
+    </div>
+  </div>
+</div>
+{% endblock content %} 

--- a/templates/security/cve/cve.html
+++ b/templates/security/cve/cve.html
@@ -286,7 +286,7 @@
           {% if cve.references %}
             {% for reference in cve.references %}
               
-                <li><a href="{{ cve.refrence }}">{{ reference }}</a></li>
+                <li><a href="{{ reference }}">{{ reference }}</a></li>
     
             {% endfor %}
           {% else %}

--- a/templates/security/cve/cve.html
+++ b/templates/security/cve/cve.html
@@ -140,16 +140,16 @@
               {% for status in package.statuses %}
                 <tr>
                   {% if status.release_codename %}
-                      <td rowspan="{{ releases | length }}">
-                        {% if loop.index == 1 %}
-                          <a href="/security/cves?q=&package={{ package["name"] }}">{{ package["name"] }}</a><br>
-                          <small>
-                          <a href="https://launchpad.net/distros/ubuntu/+source/{{ package["name"] }}">Launchpad</a>,
-                          <a href="https://packages.ubuntu.com/search?suite=all&section=all&arch=any&searchon=sourcenames&keywords={{ package["name"] }}">Ubuntu</a>,
-                          <a href="https://tracker.debian.org/{{ package["name"] }}">Debian</a>
-                          </small>
-                        {% endif %}
+                    {% if loop.index == 1 %}
+                      <td rowspan="{{ package.statuses | length }}">
+                        <a href="/security/cves?q=&package={{ package["name"] }}">{{ package["name"] }}</a><br>
+                        <small>
+                        <a href="https://launchpad.net/distros/ubuntu/+source/{{ package["name"] }}">Launchpad</a>,
+                        <a href="https://packages.ubuntu.com/search?suite=all&section=all&arch=any&searchon=sourcenames&keywords={{ package["name"] }}">Ubuntu</a>,
+                        <a href="https://tracker.debian.org/{{ package["name"] }}">Debian</a>
+                        </small>
                       </td>
+                    {% endif %}
                     <td>
                       {{ status.release_codename }}
                     </td>

--- a/templates/security/cve/cve.html
+++ b/templates/security/cve/cve.html
@@ -40,7 +40,7 @@
         <h1>{{ cve.id }}</h1>
 
         {% if cve.published %}
-        <p>Published: <strong>{{ cve.published.strftime("%d %B %Y") }}</strong></p>
+        <p>Published: <strong>{{ cve.published }}</strong></p>
         {% endif %}
 
         {% if cve.status == 'not-in-ubuntu' %}
@@ -136,66 +136,62 @@
             </tr>
           </thead>
           <tbody>
-            {% for package_name, statuses in cve.packages.items() %}
-              {% for release in releases %}
+            {% for package in cve.packages %}
+              {% for status in package.statuses %}
                 <tr>
-                  {% if release.codename in statuses %}
-                    {% if loop.index == 1 %}
+                  {% if status.release_codename %}
                       <td rowspan="{{ releases | length }}">
-                        <a href="/security/cves?q=&package={{ package_name }}">{{ package_name }}</a><br>
-                        <small>
-                        <a href="https://launchpad.net/distros/ubuntu/+source/{{ package_name }}">Launchpad</a>,
-                        <a href="https://packages.ubuntu.com/search?suite=all&section=all&arch=any&searchon=sourcenames&keywords={{ package_name }}">Ubuntu</a>,
-                        <a href="https://tracker.debian.org/{{ package_name }}">Debian</a>
-                        </small>
+                        {% if loop.index == 1 %}
+                          <a href="/security/cves?q=&package={{ package["name"] }}">{{ package["name"] }}</a><br>
+                          <small>
+                          <a href="https://launchpad.net/distros/ubuntu/+source/{{ package["name"] }}">Launchpad</a>,
+                          <a href="https://packages.ubuntu.com/search?suite=all&section=all&arch=any&searchon=sourcenames&keywords={{ package["name"] }}">Ubuntu</a>,
+                          <a href="https://tracker.debian.org/{{ package["name"] }}">Debian</a>
+                          </small>
+                        {% endif %}
                       </td>
-                    {% endif %}
                     <td>
-                      {% if release.name == "Upstream" %}
-                        {{ release.name }}
-                      {% else %}
-                        Ubuntu {{ release.version }} {{ release.support_tag }} ({{ release.name }})
-                      {% endif %}
+                      {{ status.release_codename }}
                     </td>
-                    {% if statuses[release.codename].status == "DNE" or statuses[release.codename].status == "not-affected" %}
+                    {% if status.status == "DNE" or status.status == "not-affected" %}
                       <td class="cve-table-cell--muted">
                     {% else %}
                       <td class="cve-table-cell">
                     {% endif %}
-                    {% if statuses[release.codename].status == "DNE" %}
+                    {% if status.status == "DNE" %}
                       Does not exist
                       <div class="cve-color-strip--dne"></div>
-                    {% elif statuses[release.codename].status == "needs-triage" %}
+                    {% elif status.status == "needs-triage" %}
                       Needs triage
                       <div class="cve-color-strip--needs-triage"></div>
-                    {% elif statuses[release.codename].status == "not-affected" %}
+                    {% elif status.status == "not-affected" %}
                       Not vulnerable
                       <div class="cve-color-strip--not-affected"></div>
-                    {% elif statuses[release.codename].status == "needed" %}
+                    {% elif status.status == "needed" %}
                       Needed
                       <div class="cve-color-strip--needed"></div>
-                    {% elif statuses[release.codename].status == "deferred" %}
+                    {% elif status.status == "deferred" %}
                       Deferred
                       <div class="cve-color-strip--deferred"></div>
-                    {% elif statuses[release.codename].status == "ignored" %}
+                    {% elif status.status == "ignored" %}
                       Ignored
                       <div class="cve-color-strip--ignored"></div>
-                    {% elif statuses[release.codename].status == "pending" %}
+                    {% elif status.status == "pending" %}
                       Pending
                       <div class="cve-color-strip--pending"></div>
-                    {% elif statuses[release.codename].status == "released" %}
+                    {% elif status.status == "released" %}
                       <div class="cve-color-strip--released"></div>
                       Released
                     {% endif %}
-                    {% if statuses[release.codename].description %}
-                      ({{ statuses[release.codename].description }})
+                    {% if status.description %}
+                      ({{ status.description }})
                     {% endif %}
                     <br>
                     <small>
-                      {% if statuses[release.codename].pocket == "esm-infra" %}
+                      {% if status.pocket == "esm-infra" %}
                         Requires <a href="/advantage">Available with UA Infra or UA Apps</a>
                       {% endif %}
-                      {% if statuses[release.codename].pocket == "esm-apps" %}
+                      {% if status.pocket == "esm-apps" %}
                         Requires <a href="/advantage">Available with UA Apps</a>
                       {% endif %}
                     </small>
@@ -219,8 +215,8 @@
                           <a href="https://git.kernel.org/linus/{{ patch.content.fixed }}">{{ patch.content.fixed }}</a>
                         {% elif patch.type == "link" %}
                           {{ patch.content.prefix }}:
-                          {% if cve._clean_url(patch.content.suffix) %}
-                            <a href="{{ cve._clean_url(patch.content.suffix) }}">{{ patch.content.suffix }}</a>
+                          {% if patch.content.suffix %}
+                            <a href="{{ cve.patch.content.suffix }}">{{ patch.content.suffix }}</a>
                           {% else %}
                             {{ patch.content.suffix }}
                           {% endif %}
@@ -289,9 +285,9 @@
         <ul>
           {% if cve.references %}
             {% for reference in cve.references %}
-              {% if cve._clean_url(reference) %}
-                <li><a href="{{ cve._clean_url(reference) }}">{{ reference }}</a></li>
-              {% endif %}
+              
+                <li><a href="{{ cve.refrence }}">{{ reference }}</a></li>
+    
             {% endfor %}
           {% else %}
             <li>
@@ -319,9 +315,9 @@
           <h2>Bugs</h2>
           <ul>
             {% for bug in cve.bugs %}
-              {% if cve._clean_url(bug) %}
-                <li><a href="{{ cve._clean_url(bug) }}">{{ bug }}</a></li>
-              {% endif %}
+              
+                <li><a href="{{ cve.bug }}">{{ bug }}</a></li>
+
             {% endfor %}
           </ul>
         {% endif %}

--- a/templates/security/cve/cve.html
+++ b/templates/security/cve/cve.html
@@ -40,7 +40,7 @@
         <h1>{{ cve.id }}</h1>
 
         {% if cve.published %}
-        <p>Published: <strong>{{ cve.published }}</strong></p>
+        <p>Published: <strong>{{ date }}</strong></p>
         {% endif %}
 
         {% if cve.status == 'not-in-ubuntu' %}

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -27,6 +27,7 @@ from webapp.shop.api.ua_contracts.api import (
     UAContractsAPIError,
     UAContractsAPIErrorView,
 )
+from webapp.security.api import SecurityAPIError
 from webapp.context import (
     current_year,
     descending_years,
@@ -193,6 +194,11 @@ discourse_api = DiscourseAPI(
 @app.errorhandler(400)
 def bad_request_error(error):
     return flask.render_template("400.html"), 400
+
+
+@app.errorhandler(SecurityAPIError)
+def security_api_error(error):
+    return flask.render_template("security-error.html"), 500
 
 
 @app.errorhandler(UAContractsValidationError)

--- a/webapp/security/api.py
+++ b/webapp/security/api.py
@@ -24,7 +24,7 @@ class SecurityAPI:
         uri = f"{self.base_url}{path}"
 
         response = self.session.get(uri, params=params)
-        
+
         try:
             response.raise_for_status()
         except HTTPError as error:

--- a/webapp/security/api.py
+++ b/webapp/security/api.py
@@ -1,4 +1,10 @@
 from requests import Session
+from requests.exceptions import HTTPError
+
+
+class SecurityAPIError(HTTPError):
+    def __init__(self, error: HTTPError):
+        super().__init__(request=error.request, response=error.response)
 
 
 class SecurityAPI:
@@ -18,8 +24,11 @@ class SecurityAPI:
         uri = f"{self.base_url}{path}"
 
         response = self.session.get(uri, params=params)
-
-        response.raise_for_status()
+        
+        try:
+            response.raise_for_status()
+        except HTTPError as error:
+            raise SecurityAPIError(error)
 
         return response
 

--- a/webapp/security/api.py
+++ b/webapp/security/api.py
@@ -6,13 +6,18 @@ class SecurityAPI:
   ):
     self.session = session
     self.base_url = base_url
-
+  
+  """
+  Defines get request set up, returns data if succesful, 
+  raises HTTP errors if not
+  """
   def _get(
     self, 
     path: str,
     params = {}
   ):
     uri=f"{self.base_url}{path}"
+
 
     response = self.session.get (
       uri, params=params
@@ -22,6 +27,10 @@ class SecurityAPI:
 
     return response
 
+  """
+  Makes request for specific cve_id, 
+  returns json object if found  
+  """
   def get_cve(
     self,
     id: str,
@@ -30,6 +39,10 @@ class SecurityAPI:
       f"cves/{id.upper()}.json"
     ).json()
 
+  """
+  Makes request for all releases with ongoing support, 
+  returns json object if found
+  """
   def get_releases(
     self,
   ):

--- a/webapp/security/api.py
+++ b/webapp/security/api.py
@@ -1,55 +1,42 @@
 from requests import Session
 
+
 class SecurityAPI:
-  def __init__(
-    self, session: Session, base_url: str, 
-  ):
-    self.session = session
-    self.base_url = base_url
-  
-  """
-  Defines get request set up, returns data if succesful, 
-  raises HTTP errors if not
-  """
-  def _get(
-    self, 
-    path: str,
-    params = {}
-  ):
-    uri=f"{self.base_url}{path}"
+    def __init__(
+        self,
+        session: Session,
+        base_url: str,
+    ):
+        self.session = session
+        self.base_url = base_url
 
+    def _get(self, path: str, params={}):
+        """
+        Defines get request set up, returns data if succesful,
+        raises HTTP errors if not
+        """
+        uri = f"{self.base_url}{path}"
 
-    response = self.session.get (
-      uri, params=params
-    )
+        response = self.session.get(uri, params=params)
 
-    response.raise_for_status()
+        response.raise_for_status()
 
-    return response
+        return response
 
-  """
-  Makes request for specific cve_id, 
-  returns json object if found  
-  """
-  def get_cve(
-    self,
-    id: str,
-  ):
-    return self._get(
-      f"cves/{id.upper()}.json"
-    ).json()
+    def get_cve(
+        self,
+        id: str,
+    ):
+        """
+        Makes request for specific cve_id,
+        returns json object if found
+        """
+        return self._get(f"cves/{id.upper()}.json").json()
 
-  """
-  Makes request for all releases with ongoing support, 
-  returns json object if found
-  """
-  def get_releases(
-    self,
-  ):
-    return self._get(
-      "releases.json"
-    ).json()
+    def get_releases(self):
+        """
+        Makes request for all releases with ongoing support,
+        returns json object if found
+        """
 
-    
-
-  
+        return self._get("releases.json").json()

--- a/webapp/security/api.py
+++ b/webapp/security/api.py
@@ -1,0 +1,42 @@
+from requests import Session
+
+class SecurityAPI:
+  def __init__(
+    self, session: Session, base_url: str, 
+  ):
+    self.session = session
+    self.base_url = base_url
+
+  def _get(
+    self, 
+    path: str,
+    params = {}
+  ):
+    uri=f"{self.base_url}{path}"
+
+    response = self.session.get (
+      uri, params=params
+    )
+
+    response.raise_for_status()
+
+    return response
+
+  def get_cve(
+    self,
+    id: str,
+  ):
+    return self._get(
+      f"cves/{id.upper()}.json"
+    ).json()
+
+  def get_releases(
+    self,
+  ):
+    return self._get(
+      "releases.json"
+    ).json()
+
+    
+
+  

--- a/webapp/security/views.py
+++ b/webapp/security/views.py
@@ -6,6 +6,7 @@ from math import ceil
 
 # Packages
 import flask
+import dateutil
 import talisker.requests
 from feedgen.entry import FeedEntry
 from feedgen.feed import FeedGenerator
@@ -723,11 +724,13 @@ def cve(cve_id):
 
     if not cve:
         flask.abort(404)
+    
+    date = dateutil.parser.parse(cve["published"]).strftime("%-d %B %Y")
 
     releases = security_api.get_releases()
 
     return flask.render_template(
-        "security/cve/cve.html", cve=cve, releases=releases
+        "security/cve/cve.html", cve=cve, releases=releases, date=date
     )
 
 

--- a/webapp/security/views.py
+++ b/webapp/security/views.py
@@ -724,7 +724,7 @@ def cve(cve_id):
 
     if not cve:
         flask.abort(404)
-    
+
     date = dateutil.parser.parse(cve["published"]).strftime("%-d %B %Y")
 
     releases = security_api.get_releases()

--- a/webapp/security/views.py
+++ b/webapp/security/views.py
@@ -716,7 +716,7 @@ def cve(cve_id):
 
     security_api = SecurityAPI(
         session=session,
-        base_url="http://192.168.178.51:8030/security/",
+        base_url="https://ubuntu.com/security/",
     )
 
     cve = security_api.get_cve(cve_id)

--- a/webapp/security/views.py
+++ b/webapp/security/views.py
@@ -716,7 +716,7 @@ def cve(cve_id):
 
     security_api = SecurityAPI(
         session=session,
-        base_url=f"http://192.168.178.51:8030/security/",
+        base_url="http://192.168.178.51:8030/security/",
     )
 
     cve = security_api.get_cve(cve_id)


### PR DESCRIPTION
## Done

- Wrote api class with functionality for get requests to security api (cve and releases)
- Refactored views to consume api 
- Refactored template to comply with new data format 
- Added an error page to offer more clarity when api is down 

**NOTE: Must be merged after https://github.com/canonical-web-and-design/ubuntu-com-security-api/pull/75** 

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/security/cves
-Click on any cve and check that table renders correctly

## Issue / Card

Fixes https://github.com/canonical-web-and-design/master-epics/issues/402, https://github.com/canonical-web-and-design/ubuntu.com/issues/11253
