### PR TITLE
Fix cube interactive form cypress test

### DIFF
--- a/templates/cube/index.html
+++ b/templates/cube/index.html
@@ -30,6 +30,7 @@
     <a
       href="/cube/contact-us"
       class="p-button--positive cube-access js-invoke-modal"
+      data-testid="interactive-form-link"
       >Sign up</a
     >
   </div>

--- a/templates/shared/forms/interactive/cube-beta.html
+++ b/templates/shared/forms/interactive/cube-beta.html
@@ -129,7 +129,7 @@
                 </li>
                 <li class="p-list__item" id="comments">
                   <label for="Comments_from_lead__c" id="LblComments_from_lead__c" >Why do you want certification?</label>
-                  <textarea class="is-required" required="" id="Comments_from_lead__c" name="Comments_from_lead__c" rows="4" aria-labelledby="LblComments_from_lead__c InstructComments_from_lead__c" maxlength="2000" aria-required="true" ></textarea>
+                  <textarea class="is-required" required="" data-testid="form-comment" id="Comments_from_lead__c" name="Comments_from_lead__c" rows="4" aria-labelledby="LblComments_from_lead__c InstructComments_from_lead__c" maxlength="2000" aria-required="true" ></textarea>
                 </li>
               </ul>
             </fieldset>

--- a/tests/cypress/forms/forms_spec.js
+++ b/tests/cypress/forms/forms_spec.js
@@ -113,24 +113,17 @@ context("Interactive marketo forms", () => {
     () => {
       cy.visit("/cube");
       cy.acceptCookiePolicy();
-      cy.findByText(/Apply for access/).click();
-      cy.findByLabelText(/First name/).type("Test");
+      cy.findByTestId("interactive-form-link").click();
+      cy.findByLabelText(/First name:/).type("Test");
       cy.findByLabelText(/Last name:/).type("Test");
       cy.findByLabelText(/Work email:/).type("test@test.com");
       cy.findByLabelText(/Current employer:/).type("Test");
-      cy.findByLabelText(/Job role:/).select("Education");
+      cy.findByLabelText(/Employment level:/).select("Senior");
+      cy.findByLabelText(/Title:/).type("Test");
       cy.findByLabelText(/What is your experience with Ubuntu?/).select(
         "None or very minimal experience"
       );
-      cy.findByLabelText(/Does your workplace require Ubuntu?/).click({
-        force: true,
-      });
-      cy.findByLabelText(
-        /Which microcert are you most interested in taking?/
-      ).select("Ubuntu System Architecture");
-      cy.findByLabelText(/Why do you want CUBE certification?/).type(
-        "test test test test "
-      );
+      cy.findByTestId("form-comment").type("test test test test");
       cy.findByLabelText(/I agree to receive information/).click({
         force: true,
       });


### PR DESCRIPTION
## Done

-Fix cube interactive form cypress test

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- Please do `context.skip` or `it.skip` to save time and avoid making a bunch of spam submission
- Move the `/tests/cypress/forms/forms_spec.js` file to the /tests/cypress/integration folder
- Open another terminal and run yarn run cypress:open
- Click forms_spec.js in the cypress test window
- Check the test `interactive contact modal on /cube` passes

## Issue / Card

Fixes #


## Help

[QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html) - [Commit guidelines](https://canonical-web-and-design.github.io/practices/workflow/commit-messages.html)
