### PR TITLE
[security/fips] Add recert module, update 140-3 grammar.

### DIFF
--- a/templates/security/fips.html
+++ b/templates/security/fips.html
@@ -151,7 +151,7 @@
             <a class="p-link--external" href="https://csrc.nist.gov/projects/cryptographic-module-validation-program/Certificate/3724">#3724</a>
           </td>
           <td>
-            <a class="p-link--external" href="https://csrc.nist.gov/projects/cryptographic-module-validation-program/Certificate/3647">#3647</a>, <a class="p-link--external" href="https://csrc.nist.gov/projects/cryptographic-module-validation-program/certificate/3664">#3664</a> (AWS),<br><a class="p-link--external" href="https://csrc.nist.gov/projects/cryptographic-module-validation-program/certificate/3683">#3683</a> (Azure), <a class="p-link--external" href="https://csrc.nist.gov/projects/cryptographic-module-validation-program/certificate/3954">#3954</a> (GCP)
+            <a class="p-link--external" href="https://csrc.nist.gov/projects/cryptographic-module-validation-program/Certificate/3647">#3647</a>, <a class="p-link--external" href="https://csrc.nist.gov/projects/cryptographic-module-validation-program/Certificate/4018">#4018</a>, <a class="p-link--external" href="https://csrc.nist.gov/projects/cryptographic-module-validation-program/certificate/3664">#3664</a> (AWS),<br><a class="p-link--external" href="https://csrc.nist.gov/projects/cryptographic-module-validation-program/certificate/3683">#3683</a> (Azure), <a class="p-link--external" href="https://csrc.nist.gov/projects/cryptographic-module-validation-program/certificate/3954">#3954</a> (GCP)
           </td>
           <td>
             <a class="p-link--external" href="https://csrc.nist.gov/projects/cryptographic-module-validation-program/certificate/3928">#3928</a>, <a class="p-link--external" href="https://csrc.nist.gov/projects/cryptographic-module-validation-program/certificate/4132">#4132</a> (AWS), <a class="p-link--external" href="https://csrc.nist.gov/projects/cryptographic-module-validation-program/certificate/4126">#4126</a> (Azure), <a class="p-link--external" href="https://csrc.nist.gov/projects/cryptographic-module-validation-program/certificate/4127">#4127</a> (GCP)  
@@ -239,7 +239,7 @@
 <section class="p-strip--light">
   <div class="u-fixed-width">
     <h2>FIPS 140-3 and Ubuntu</h2>
-    <p class="u-sv3">In September 2021 NIST is phasing out FIPS 140-2. Certifications under FIPS 140-2 remain valid no longer than September 2026, and new products are expected to be certified <a class="p-link--external" href="https://csrc.nist.gov/Projects/cryptographic-module-validation-program/fips-140-3-standards">under FIPS 140-3</a>. FIPS 140-3 is a combined effort of NIST and ISO with the Security and Testing requirements for cryptographic modules being published as ISO/IEC 19790 and ISO/IEC 24759. Canonical is preparing Ubuntu for the new certification, and intends to provide FIPS 140-3 certified cryptographic packages on a future LTS release of Ubuntu.</p>
+    <p class="u-sv3">In September 2021, NIST began phasing out FIPS 140-2. Certifications under FIPS 140-2 remain valid no longer than September 2026, and new products are expected to be certified <a class="p-link--external" href="https://csrc.nist.gov/Projects/cryptographic-module-validation-program/fips-140-3-standards">under FIPS 140-3</a>. FIPS 140-3 is a combined effort of NIST and ISO with the Security and Testing requirements for cryptographic modules being published as ISO/IEC 19790 and ISO/IEC 24759. Canonical is preparing Ubuntu for the new certification, and intends to provide FIPS 140-3 certified cryptographic packages on a future LTS release of Ubuntu.</p>
   </div>
 </section>
 


### PR DESCRIPTION
In templates/security/fips.html:
 - Update modules table to include a Bionic kernel recertification (FIPS module 4018) that had been omitted.
 - Change grammar in the "FIPS 140-3 and Ubuntu" section -- September 2021 has passed.

Relates to #11068 