### PR TITLE
Remove auth from pg db

### DIFF
--- a/.env
+++ b/.env
@@ -1,7 +1,7 @@
 PORT=8001
 FLASK_DEBUG=true
 DEVEL=true
-DATABASE_URL=postgres://postgres@localhost:5432/postgres
+DATABASE_URL=postgresql://postgres@localhost:5432/postgres
 SECRET_KEY=insecure_dev_key
 CONTRACTS_LIVE_API_URL=https://contracts.canonical.com/
 CONTRACTS_TEST_API_URL=https://contracts.staging.canonical.com/

--- a/.env
+++ b/.env
@@ -1,7 +1,7 @@
 PORT=8001
 FLASK_DEBUG=true
 DEVEL=true
-DATABASE_URL=postgres://postgres:@localhost:5432/postgres
+DATABASE_URL=postgres://postgres@localhost:5432/postgres
 SECRET_KEY=insecure_dev_key
 CONTRACTS_LIVE_API_URL=https://contracts.canonical.com/
 CONTRACTS_TEST_API_URL=https://contracts.staging.canonical.com/

--- a/.env
+++ b/.env
@@ -1,7 +1,7 @@
 PORT=8001
 FLASK_DEBUG=true
 DEVEL=true
-DATABASE_URL=postgres://postgres:pw@localhost:5432/postgres
+DATABASE_URL=postgres://postgres:@localhost:5432/postgres
 SECRET_KEY=insecure_dev_key
 CONTRACTS_LIVE_API_URL=https://contracts.canonical.com/
 CONTRACTS_TEST_API_URL=https://contracts.staging.canonical.com/

--- a/.github/workflows/a11y.yaml
+++ b/.github/workflows/a11y.yaml
@@ -1,7 +1,7 @@
 name: Accessibility checks
 env:
   SECRET_KEY: insecure_test_key
-  DATABASE_URL: postgres://postgres@localhost:5432/postgres
+  DATABASE_URL: postgresql://postgres@localhost:5432/postgres
   PORT: 8001
   CONTRACTS_LIVE_API_URL: contracts.canonical.com
 

--- a/.github/workflows/a11y.yaml
+++ b/.github/workflows/a11y.yaml
@@ -1,7 +1,7 @@
 name: Accessibility checks
 env:
   SECRET_KEY: insecure_test_key
-  DATABASE_URL: postgres://postgres:pw@localhost:5432/postgres
+  DATABASE_URL: postgres://postgres@localhost:5432/postgres
   PORT: 8001
   CONTRACTS_LIVE_API_URL: contracts.canonical.com
 
@@ -13,7 +13,7 @@ jobs:
       postgres:
         image: postgres
         env:
-          POSTGRES_PASSWORD: pw
+          POSTGRES_HOST_AUTH_METHOD: trust
         options: >-
           --health-cmd pg_isready
           --health-interval 10s

--- a/.github/workflows/cypress-main.yaml
+++ b/.github/workflows/cypress-main.yaml
@@ -1,7 +1,7 @@
 name: Cypress checks / main
 env:
   SECRET_KEY: insecure_test_key
-  DATABASE_URL: postgres://postgres@localhost:5432/postgres
+  DATABASE_URL: postgresql://postgres@localhost:5432/postgres
   PORT: 8001
   CONTRACTS_LIVE_API_URL: contracts.canonical.com
   CAPTCHA_TESTING_API_KEY: 6LeIxAcTAAAAAJcZVRqyHh71UMIEGNQ_MXjiZKhI

--- a/.github/workflows/cypress-main.yaml
+++ b/.github/workflows/cypress-main.yaml
@@ -1,7 +1,7 @@
 name: Cypress checks / main
 env:
   SECRET_KEY: insecure_test_key
-  DATABASE_URL: postgres://postgres:pw@localhost:5432/postgres
+  DATABASE_URL: postgres://postgres@localhost:5432/postgres
   PORT: 8001
   CONTRACTS_LIVE_API_URL: contracts.canonical.com
   CAPTCHA_TESTING_API_KEY: 6LeIxAcTAAAAAJcZVRqyHh71UMIEGNQ_MXjiZKhI
@@ -19,7 +19,7 @@ jobs:
       postgres:
         image: postgres
         env:
-          POSTGRES_PASSWORD: pw
+          POSTGRES_HOST_AUTH_METHOD: trust
 
         options: >-
           --health-cmd pg_isready

--- a/.github/workflows/cypress-pr.yaml
+++ b/.github/workflows/cypress-pr.yaml
@@ -1,7 +1,7 @@
 name: Cypress checks / PR
 env:
   SECRET_KEY: insecure_test_key
-  DATABASE_URL: postgres://postgres@localhost:5432/postgres
+  DATABASE_URL: postgresql://postgres@localhost:5432/postgres
   PORT: 8001
   CONTRACTS_LIVE_API_URL: contracts.canonical.com
   CAPTCHA_TESTING_API_KEY: 6LeIxAcTAAAAAJcZVRqyHh71UMIEGNQ_MXjiZKhI

--- a/.github/workflows/cypress-pr.yaml
+++ b/.github/workflows/cypress-pr.yaml
@@ -1,7 +1,7 @@
 name: Cypress checks / PR
 env:
   SECRET_KEY: insecure_test_key
-  DATABASE_URL: postgres://postgres:pw@localhost:5432/postgres
+  DATABASE_URL: postgres://postgres@localhost:5432/postgres
   PORT: 8001
   CONTRACTS_LIVE_API_URL: contracts.canonical.com
   CAPTCHA_TESTING_API_KEY: 6LeIxAcTAAAAAJcZVRqyHh71UMIEGNQ_MXjiZKhI
@@ -16,7 +16,7 @@ jobs:
       postgres:
         image: postgres
         env:
-          POSTGRES_PASSWORD: pw
+          POSTGRES_HOST_AUTH_METHOD: trust
         options: >-
           --health-cmd pg_isready
           --health-interval 10s

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -29,7 +29,7 @@ jobs:
 
       - name: Run image
         run: |
-          docker run --detach --env SECRET_KEY=insecure_secret_key --network host --env DATABASE_URL=postgresql://postgres@localhost:5432/postgres ubuntu-com
+          docker run --env SECRET_KEY=insecure_secret_key --network host --env DATABASE_URL=postgresql://postgres@localhost:5432/postgres ubuntu-com &
           sleep 1
           curl --head --fail --retry-delay 1 --retry 30 --retry-connrefused http://localhost
 

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -2,7 +2,7 @@ name: PR checks
 on: [push, pull_request]
 env:
   SECRET_KEY: insecure_test_key
-  DATABASE_URL: postgres://postgres:pw@localhost:5432/postgres
+  DATABASE_URL: postgres://postgres@localhost:5432/postgres
 
 jobs:
   run-image:
@@ -12,7 +12,7 @@ jobs:
       postgres:
         image: postgres
         env:
-          POSTGRES_PASSWORD: pw
+          POSTGRES_HOST_AUTH_METHOD: trust
         ports:
           - 5432:5432
         options: >-
@@ -29,7 +29,7 @@ jobs:
 
       - name: Run image
         run: |
-          docker run --detach --env SECRET_KEY=insecure_secret_key --network host --env DATABASE_URL=postgres://postgres:pw@localhost:5432/postgres ubuntu-com
+          docker run --detach --env SECRET_KEY=insecure_secret_key --network host --env DATABASE_URL=postgres://postgres@localhost:5432/postgres ubuntu-com
           sleep 1
           curl --head --fail --retry-delay 1 --retry 30 --retry-connrefused http://localhost
 
@@ -40,7 +40,7 @@ jobs:
       postgres:
         image: postgres
         env:
-          POSTGRES_PASSWORD: pw
+          POSTGRES_HOST_AUTH_METHOD: trust
         ports:
           - 5432:5432
         options: >-
@@ -136,7 +136,7 @@ jobs:
       postgres:
         image: postgres
         env:
-          POSTGRES_PASSWORD: pw
+          POSTGRES_HOST_AUTH_METHOD: trust
         ports:
           - 5432:5432
         options: >-

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -2,7 +2,7 @@ name: PR checks
 on: [push, pull_request]
 env:
   SECRET_KEY: insecure_test_key
-  DATABASE_URL: postgres://postgres@localhost:5432/postgres
+  DATABASE_URL: postgresql://postgres@localhost:5432/postgres
 
 jobs:
   run-image:
@@ -29,7 +29,7 @@ jobs:
 
       - name: Run image
         run: |
-          docker run --detach --env SECRET_KEY=insecure_secret_key --network host --env DATABASE_URL=postgres://postgres@localhost:5432/postgres ubuntu-com
+          docker run --detach --env SECRET_KEY=insecure_secret_key --network host --env DATABASE_URL=postgresql://postgres@localhost:5432/postgres ubuntu-com
           sleep 1
           curl --head --fail --retry-delay 1 --retry 30 --retry-connrefused http://localhost
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -5,5 +5,5 @@ services:
     ports:
       - "5432:5432"
     environment:
-      - POSTGRES_PASSWORD=pw
+      - POSTGRES_HOST_AUTH_METHOD=trust
     image: postgres

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,3 +27,4 @@ macaroonbakery==1.3.1
 sortedcontainers==2.4.0
 vcrpy-unittest==0.1.7
 webargs==7.0.1
+markupsafe==2.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,3 +28,4 @@ sortedcontainers==2.4.0
 vcrpy-unittest==0.1.7
 webargs==7.0.1
 markupsafe==2.0.1
+itsdangerous==2.0.1


### PR DESCRIPTION
## Done

- Made pg db accessible without a password 

## QA

- Check out this feature branch
- Run the site using the command `dotrun`
- Ensure migrations run as expected
- View the site locally in your web browser at: http://0.0.0.0:8001/

## Issue / Card

Fixes https://github.com/canonical-web-and-design/ubuntu.com/issues/11258