### PR TITLE
Set MarkupSafe to version 2.0.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+MarkupSafe==2.0.1
 canonicalwebteam.flask-base==0.9.3
 alembic==1.7.5
 canonicalwebteam.http==1.0.3


### PR DESCRIPTION
## Done

- Set MarkupSafe to version 2.0.1

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- See that the site runs correctly 

## Issue / Card

Fixes https://github.com/canonical-web-and-design/ubuntu.com/issues/11260
