### PR TITLE
fix complaint/compliant typo

### DIFF
--- a/templates/managed/apps/index.html
+++ b/templates/managed/apps/index.html
@@ -292,7 +292,7 @@ coverage.{% endblock meta_description %}
             ) | safe
           }}
           <h3>Security and certifications</h3>
-          <p>ISO 27000, GDPR complaint, SOC2 Type 2</p>
+          <p>ISO 27000, GDPR compliant, SOC2 Type 2</p>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Done

fix complaint/compliant typo on /managed/apps

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/managed/apps
    - Be sure to test on mobile, tablet and desktop screen sizes
- See that the typo in the copy doc has been fixed: https://docs.google.com/document/d/1fLRWW-Gtslaia2ypSrLJVBxZVHo5FY5Q84o97Gs2-w4/edit
