### PR TITLE
Engage: Fix spelling of “Español” in language selector

### DIFF
--- a/templates/engage/index.html
+++ b/templates/engage/index.html
@@ -33,7 +33,7 @@
           <option value="all">All languages</option>
           <option value="de">Deutsch</option>
           <option value="en">English</option>
-          <option value="es">Espa&nacute;ol</option>
+          <option value="es">Espa&ntilde;ol</option>
           <option value="fr">Fran&ccedil;ais</option>
           <option value="it">Italiano</option>
           <option value="pt">Portugu&ecirc;s</option>


### PR DESCRIPTION
Co-authored by: Adolfo Jayme-Barrientos <fito@libreoffice.org>

## Done

- Fixed a wrong entity for “ñ”

This was originally QAd in [this PR](https://github.com/canonical-web-and-design/ubuntu.com/pull/11262) before I rebased it with the flask-base update (which was causing the build to hang), force pushed to the branch and somehow lost the original commit.
