### PR TITLE
Add UTM inheritance script, apply to Azure marketplace links

### DIFF
--- a/build.js
+++ b/build.js
@@ -30,6 +30,7 @@ let entries = {
   blenderStoreModal:
     "./static/js/src/advantage/subscribe/blender/blender-store-modal.js",
   tabbedContent: "./static/js/src/tabbed-content.js",
+  utmInheritance: "./static/js/src/utm-inheritance.js",
 };
 
 const isDev = process && process.env && process.env.NODE_ENV === "development";

--- a/static/js/src/utm-inheritance.js
+++ b/static/js/src/utm-inheritance.js
@@ -1,0 +1,28 @@
+function setupUtmInheritance(selector) {
+  const urlParams = new URLSearchParams(document.location.search);
+  const azureUtmParams = [
+    "utm_campaign",
+    "utm_content",
+    "utm_medium",
+    "utm_source",
+    "OCID",
+  ];
+
+  const links = document.querySelectorAll(selector);
+
+  links.forEach((link) => {
+    let url = new URL(link);
+
+    azureUtmParams.forEach((azureUtmParam) => {
+      let paramValue = urlParams.get(azureUtmParam);
+
+      if (paramValue) {
+        url.searchParams.set(azureUtmParam, paramValue);
+      }
+    });
+
+    link.href = url.href;
+  });
+}
+
+setupUtmInheritance('a[href*="https://azuremarketplace.microsoft.com"]');

--- a/templates/azure/index.html
+++ b/templates/azure/index.html
@@ -207,4 +207,6 @@
     </div>
   </div>
 </section>
+
+<script src="{{ versioned_static('js/dist/utmInheritance.js') }}"></script>
 {% endblock content %}

--- a/templates/azure/pro.html
+++ b/templates/azure/pro.html
@@ -392,4 +392,5 @@
   </div>
 </section>
 
+<script src="{{ versioned_static('js/dist/utmInheritance.js') }}"></script>
 {% endblock content %}


### PR DESCRIPTION
## Done

- Added the ability to persist UTM campaign parameters on links to the Azure Marketplace from our Azure pages

## QA

- View the site in your web browser at: 
  - https://ubuntu-com-11274.demos.haus/azure?OCID=7014K000000UZtoQAG&utm_source=linkedin_ad&utm_medium=banner&utm_campaign=7014K000000UZtoQAG&utm_content=q1_2022
  - https://ubuntu-com-11274.demos.haus/azure/pro?OCID=7014K000000UZtoQAG&utm_source=linkedin_ad&utm_medium=banner&utm_campaign=7014K000000UZtoQAG&utm_content=q1_2022
    - Be sure to test on mobile, tablet and desktop screen sizes
- See that any links to azuremarketplace.com include the `OCID`, `utm_campaign`, `utm_source`, `utm_medium` and `utm_content` parameters, and any other links do not.

## Issue / Card

Fixes https://github.com/canonical-web-and-design/web-squad/issues/4839