### PR TITLE
Remove `tab=Overview` from Azure Marketplace links

### DIFF
--- a/static/js/src/utm-inheritance.js
+++ b/static/js/src/utm-inheritance.js
@@ -1,11 +1,11 @@
 function setupUtmInheritance(selector) {
   const urlParams = new URLSearchParams(document.location.search);
   const azureUtmParams = [
+    "OCID",
     "utm_campaign",
     "utm_content",
     "utm_medium",
     "utm_source",
-    "OCID",
   ];
 
   const links = document.querySelectorAll(selector);

--- a/templates/16-04/azure.html
+++ b/templates/16-04/azure.html
@@ -53,7 +53,7 @@
         You should <a class="p-link--external" href="https://info.microsoft.com/ww-ondemand-expert-tips-to-easily-migrate-your-ubuntu-stack-to-azure.html">evaluate if you can easily move your instances</a> to either Ubuntu 20.04 LTS or Ubuntu 18.04 LTS before April 30, 2021.
       </p>
       <p>
-        If you would like to keep using Ubuntu 16.04 LTS, Canonical is delighted to offer at least five-additional years of Extended Security Maintenance (ESM) available with the <a class="p-link--external" href="https://azuremarketplace.microsoft.com/en-gb/marketplace/apps/canonical.0001-com-ubuntu-pro-xenial?tab=overview">Ubuntu Pro 16.04 LTS premium image</a> or through an <a href="/advantage">Ubuntu Advantage  subscription</a>.
+        If you would like to keep using Ubuntu 16.04 LTS, Canonical is delighted to offer at least five-additional years of Extended Security Maintenance (ESM) available with the <a class="p-link--external" href="https://azuremarketplace.microsoft.com/en-gb/marketplace/apps/canonical.0001-com-ubuntu-pro-xenial">Ubuntu Pro 16.04 LTS premium image</a> or through an <a href="/advantage">Ubuntu Advantage  subscription</a>.
       </p>
       <p><a href="/tutorials/purchasing-and-applying-16-04-esm-from-the-azure-marketplace#2-find-the-subscriptions-containing-1604-with-azure-resource-graph-explorer">Find Ubuntu 16.04 instances with Azure Resource Graph Explorer&nbsp;&rsaquo;</a></p>
       <p>
@@ -95,7 +95,7 @@
         Ubuntu Pro includes security coverage for the entire collection of software packages shipped with Ubuntu, tracking high and critical CVEs. It is ideal for companies that have embraced open source for their new products.
       </p>
       <p>
-        <a class="p-button--positive p-link--external" href="https://azuremarketplace.microsoft.com/en-us/marketplace/apps/canonical.0001-com-ubuntu-pro-xenial?tab=Overview">Launch Ubuntu Pro 16.04 LTS on Azure</a>
+        <a class="p-button--positive p-link--external" href="https://azuremarketplace.microsoft.com/en-us/marketplace/apps/canonical.0001-com-ubuntu-pro-xenial">Launch Ubuntu Pro 16.04 LTS on Azure</a>
       </p>
     </div>
     <div class="col-5">
@@ -103,7 +103,7 @@
         Upgrading existing instances
       </h4>
       <p>
-        If you are looking to upgrade your existing Ubuntu 16.04 LTS Azure instances you can <a class="p-link--external" href="https://azuremarketplace.microsoft.com/uk-ua/marketplace/apps/Canonical.UbuntuAdvantageSupport?tab=Overview">enable the Ubuntu Advantage subscription directly from the Azure marketplace</a>.
+        If you are looking to upgrade your existing Ubuntu 16.04 LTS Azure instances you can <a class="p-link--external" href="https://azuremarketplace.microsoft.com/uk-ua/marketplace/apps/Canonical.UbuntuAdvantageSupport">enable the Ubuntu Advantage subscription directly from the Azure marketplace</a>.
       </p>
       <p>
         <a href="/tutorials/purchasing-and-applying-16-04-esm-from-the-azure-marketplace">See a tutorial for this process</a>. Please note that this will enable Ubuntu Advantage for all Ubuntu instances under the selected subscription.

--- a/templates/16-04/index.html
+++ b/templates/16-04/index.html
@@ -271,7 +271,7 @@
       <h3 class="p-heading--4">Upgrading Ubuntu 16.04 LTS on Azure, AWS</h3>
       <p>If you are looking to upgrade your Ubuntu 16.04 LTS public cloud instance, it is recommended to launch new, Ubuntu Pro images. Ubuntu Pro for <a href="/azure/pro">Azure</a> and <a href="/aws/pro">AWS</a> are premium images with security and compliance features built in, and optimised for the public cloud.</p>
       <p>Ubuntu Pro includes security coverage for the entire collection of software packages shipped with Ubuntu, tracking high and critical CVEs. Ideal for companies that have embraced open source for their new products.</p>
-      <p><a href="https://azuremarketplace.microsoft.com/en-us/marketplace/apps/canonical.0001-com-ubuntu-pro-xenial?tab=Overview" class="p-link--external">Launch Ubuntu Pro 16.04 LTS on Azure</a></p>
+      <p><a href="https://azuremarketplace.microsoft.com/en-us/marketplace/apps/canonical.0001-com-ubuntu-pro-xenial" class="p-link--external">Launch Ubuntu Pro 16.04 LTS on Azure</a></p>
       <p><a href="https://aws.amazon.com/marketplace/pp/B0821WW873" class="p-link--external">Launch Ubuntu Pro 16.04 LTS on AWS</a></p>
     </div>
   </div>

--- a/templates/azure/fips.html
+++ b/templates/azure/fips.html
@@ -13,8 +13,8 @@
         <p class="p-heading--3">For Azure compliance in production environments.</p>
         <p>Ubuntu Pro FIPS is the first and only FIPS 140-2 certified image for Azure. Built upon the enhanced stability and security features of <a href="https://ubuntu.com/azure/pro">Ubuntu Pro</a>, Ubuntu FIPS is a critical foundation for federal programs and government contractors.</p>
         <p>
-          <a href="https://azuremarketplace.microsoft.com/en-ca/marketplace/apps/canonical.0001-com-ubuntu-pro-bionic-fips?tab=Overview" class="p-button--positive"><span class="p-link--external">Launch Ubuntu Pro FIPS 18.04 LTS on Azure</span></a>
-          <a href="https://azuremarketplace.microsoft.com/en-ca/marketplace/apps/canonical.0001-com-ubuntu-pro-xenial-fips?tab=Overview" class="p-button--positive"><span class="p-link--external">Launch Ubuntu Pro FIPS 16.04 LTS on Azure</span></a>
+          <a href="https://azuremarketplace.microsoft.com/en-ca/marketplace/apps/canonical.0001-com-ubuntu-pro-bionic-fips" class="p-button--positive"><span class="p-link--external">Launch Ubuntu Pro FIPS 18.04 LTS on Azure</span></a>
+          <a href="https://azuremarketplace.microsoft.com/en-ca/marketplace/apps/canonical.0001-com-ubuntu-pro-xenial-fips" class="p-button--positive"><span class="p-link--external">Launch Ubuntu Pro FIPS 16.04 LTS on Azure</span></a>
         </p>
       </div>
       <div class="col-5 u-align--center u-vertically-center u-hide--small">
@@ -126,12 +126,12 @@
     <div class="col-6 p-divider__block">
       <h3 class="p-heading--4">Ubuntu Pro FIPS 18.04 LTS</h3>
       <p>Ubuntu Pro FIPS 18.04 LTS includes an azure-optimized FIPS-certified 4.15 kernel and other FIPS certified modules pre-enabled out of the box. Ubuntu Pro FIPS provides extended security maintenance through April 2028.</p>
-      <p><a href="https://azuremarketplace.microsoft.com/en-ca/marketplace/apps/canonical.0001-com-ubuntu-pro-bionic-fips?tab=Overview" class="p-button--positive"><span class="p-link--external">Launch now</span></a></p>
+      <p><a href="https://azuremarketplace.microsoft.com/en-ca/marketplace/apps/canonical.0001-com-ubuntu-pro-bionic-fips" class="p-button--positive"><span class="p-link--external">Launch now</span></a></p>
     </div>
     <div class="col-6 p-divider__block">
       <h3 class="p-heading--4">Ubuntu Pro FIPS 16.04 LTS</h3>
       <p>Ubuntu 16.04 LTS includes FIPS-certified 4.4  kernel and other FIPS certified modules pre-enabled out of the box. Ubuntu Pro FIPS provides extended security maintenance through April 2026.</p>
-      <p><a href="https://azuremarketplace.microsoft.com/en-ca/marketplace/apps/canonical.0001-com-ubuntu-pro-xenial-fips?tab=Overview" class="p-button--positive"><span class="p-link--external">Launch now</span></a></p>
+      <p><a href="https://azuremarketplace.microsoft.com/en-ca/marketplace/apps/canonical.0001-com-ubuntu-pro-xenial-fips" class="p-button--positive"><span class="p-link--external">Launch now</span></a></p>
     </div>
   </div>
 </section>
@@ -347,7 +347,7 @@
           </tr>
         </tbody>
       </table>
-      <p>For complete pricing, see <a href="https://azuremarketplace.microsoft.com/en-ca/marketplace/apps/canonical.0001-com-ubuntu-pro-bionic-fips?tab=Overview" class="p-link--external">Ubuntu Pro FIPS 18.04 LTS on the Azure Marketplace</a></p>
+      <p>For complete pricing, see <a href="https://azuremarketplace.microsoft.com/en-ca/marketplace/apps/canonical.0001-com-ubuntu-pro-bionic-fips" class="p-link--external">Ubuntu Pro FIPS 18.04 LTS on the Azure Marketplace</a></p>
     </div>
   </div>
 </section>
@@ -360,10 +360,10 @@
   </div>
   <div class="row p-divider is-dark">
     <div class="col-3 p-divider__block">
-      <h3 class="p-heading--4"><a href="https://azuremarketplace.microsoft.com/en-ca/marketplace/apps/canonical.0001-com-ubuntu-pro-bionic-fips?tab=Overview" class="p-link--inverted">18.04 LTS</a></h3>
+      <h3 class="p-heading--4"><a href="https://azuremarketplace.microsoft.com/en-ca/marketplace/apps/canonical.0001-com-ubuntu-pro-bionic-fips" class="p-link--inverted">18.04 LTS</a></h3>
     </div>
     <div class="col-3 p-divider__block">
-      <h3 class="p-heading--4"><a href="https://azuremarketplace.microsoft.com/en-ca/marketplace/apps/canonical.0001-com-ubuntu-pro-xenial-fips?tab=Overview" class="p-link--inverted">16.04 LTS</a></h3>
+      <h3 class="p-heading--4"><a href="https://azuremarketplace.microsoft.com/en-ca/marketplace/apps/canonical.0001-com-ubuntu-pro-xenial-fips" class="p-link--inverted">16.04 LTS</a></h3>
     </div>
   </div>
   <div class="row">

--- a/templates/azure/index.html
+++ b/templates/azure/index.html
@@ -120,7 +120,7 @@
           <li class="p-list__item is-ticked">Updates mirrored and images published in all Azure regions worldwide</li>
           <li class="p-list__item is-ticked">5-year lifetime</li>
         </ul>
-        <p>Run Ubuntu 18.04 LTS: <a href="https://azuremarketplace.microsoft.com/en-us/marketplace/apps/canonical.0001-com-ubuntu-server-bionic?tab=Overview" class="p-link--external">Standard</a></p>
+        <p>Run Ubuntu 18.04 LTS: <a href="https://azuremarketplace.microsoft.com/en-us/marketplace/apps/canonical.0001-com-ubuntu-server-bionic" class="p-link--external">Standard</a></p>
       </div>
     </div>
     <div class="col-6 p-card">
@@ -136,7 +136,7 @@
           <li class="p-list__item is-ticked">Integration with Azure security and compliance features</li>
           <li class="p-list__item is-ticked">10-year lifetime</li>
         </ul>
-        <p><a href="https://azuremarketplace.microsoft.com/en-us/marketplace/apps/canonical.0001-com-ubuntu-pro-bionic?tab=Overview" class="p-button--positive"><span class="p-link--external">Launch Ubuntu Pro 18.04 LTS</span></a></p>
+        <p><a href="https://azuremarketplace.microsoft.com/en-us/marketplace/apps/canonical.0001-com-ubuntu-pro-bionic" class="p-button--positive"><span class="p-link--external">Launch Ubuntu Pro 18.04 LTS</span></a></p>
         <p><a href="/azure/pro">More about Ubuntu Pro for Azure&nbsp;&rsaquo;</a></p>
       </div>
     </div>
@@ -173,10 +173,10 @@
   </div>
   <div class="row p-divider">
     <div class="col-3 p-divider__block">
-      <h3 class="p-heading--4"><a href="https://azuremarketplace.microsoft.com/en-us/marketplace/apps/canonical.0001-com-ubuntu-pro-focal?tab=Overview" class="p-link--external">20.04 LTS</a></h3>
+      <h3 class="p-heading--4"><a href="https://azuremarketplace.microsoft.com/en-us/marketplace/apps/canonical.0001-com-ubuntu-pro-focal" class="p-link--external">20.04 LTS</a></h3>
     </div>
     <div class="col-3 p-divider__block">
-      <h3 class="p-heading--4"><a href="https://azuremarketplace.microsoft.com/en-us/marketplace/apps/canonical.0001-com-ubuntu-pro-bionic?tab=Overview" class="p-link--external">18.04 LTS</a></h3>
+      <h3 class="p-heading--4"><a href="https://azuremarketplace.microsoft.com/en-us/marketplace/apps/canonical.0001-com-ubuntu-pro-bionic" class="p-link--external">18.04 LTS</a></h3>
     </div>
     <div class="col-3 p-divider__block">
       <h3 class="p-heading--4"><a href="https://azuremarketplace.microsoft.com/en-gb/marketplace/apps/canonical.0001-com-ubuntu-pro-xenial" class="p-link--external">16.04 LTS</a></h3>

--- a/templates/azure/pro.html
+++ b/templates/azure/pro.html
@@ -32,17 +32,17 @@
     <div class="col-4 p-divider__block">
       <h3 class="p-heading--4">Ubuntu Pro 20.04 LTS</h3>
       <p>The latest LTS release includes the 5.4 kernel out of the box. Ubuntu Pro 20.04 LTS provides extended maintenance through 2030.</p>
-      <p><a href="https://azuremarketplace.microsoft.com/en-us/marketplace/apps/canonical.0001-com-ubuntu-pro-focal?tab=Overview" class="p-button--positive"><span class="p-link--external">Launch now</span></a></p>
+      <p><a href="https://azuremarketplace.microsoft.com/en-us/marketplace/apps/canonical.0001-com-ubuntu-pro-focal" class="p-button--positive"><span class="p-link--external">Launch now</span></a></p>
     </div>
     <div class="col-4 p-divider__block">
       <h3 class="p-heading--4">Ubuntu Pro 18.04 LTS</h3>
       <p>Ubuntu 18.04 LTS release includes the 5.4 kernel and provides extended maintenance through 2028.</p>
-      <p><a href="https://azuremarketplace.microsoft.com/en-us/marketplace/apps/canonical.0001-com-ubuntu-pro-bionic?tab=Overview" class="p-button--positive"><span class="p-link--external">Launch now</span></a></p>
+      <p><a href="https://azuremarketplace.microsoft.com/en-us/marketplace/apps/canonical.0001-com-ubuntu-pro-bionic" class="p-button--positive"><span class="p-link--external">Launch now</span></a></p>
     </div>
     <div class="col-4 p-divider__block">
       <h3 class="p-heading--4">Ubuntu Pro 16.04 LTS</h3>
       <p>Ubuntu 16.04 LTS shipped in 2016 with the 4.04 kernel, and is covered with Ubuntu Pro through 2026.</p>
-      <p><a href="https://azuremarketplace.microsoft.com/en-us/marketplace/apps/canonical.0001-com-ubuntu-pro-xenial?tab=Overview" class="p-button--positive"><span class="p-link--external">Launch now</span></a></p>
+      <p><a href="https://azuremarketplace.microsoft.com/en-us/marketplace/apps/canonical.0001-com-ubuntu-pro-xenial" class="p-button--positive"><span class="p-link--external">Launch now</span></a></p>
     </div>
   </div>
   <div class="u-fixed-width">

--- a/templates/cloud/hybrid-cloud.html
+++ b/templates/cloud/hybrid-cloud.html
@@ -53,7 +53,7 @@
       <h5 class="u-no-margin--bottom u-no-padding--top">Is every hybrid cloud a multi-cloud?</h5>
       <p>No, imagine a <a href="/cloud">cloud architecture</a> that consists of <a href="https://aws.amazon.com/marketplace/pp/prodview-rhaqbfd6lepbw" class="p-link--external">AWS</a> and <a href="/aws/outposts">AWS Outposts</a> at the same time. It uses a public cloud and a private cloud infrastructure, but both are delivered by a single cloud provider.</p>
       <h5 class="u-no-margin--bottom u-no-padding--top">Is every multi-cloud a hybrid cloud?</h5>
-      <p>No, it is not. Multi-cloud also refers to using multiple public clouds (e.g. <a href="https://azuremarketplace.microsoft.com/en-gb/marketplace/apps/canonical.0001-com-ubuntu-pro-bionic?tab=overview" class="p-link--external">Azure</a> and <a href="https://cloud.google.com/blog/products/compute/ubuntu-pro-available-on-google-cloud" class="p-link--external">GCP</a>) or multiple private clouds (e.g. <a href="https://www.vmware.com/" class="p-link--external">VMware</a> and <a href="/openstack">OpenStack</a>) at the same time and this is not a hybrid cloud architecture.</p>
+      <p>No, it is not. Multi-cloud also refers to using multiple public clouds (e.g. <a href="https://azuremarketplace.microsoft.com/en-gb/marketplace/apps/canonical.0001-com-ubuntu-pro-bionic" class="p-link--external">Azure</a> and <a href="https://cloud.google.com/blog/products/compute/ubuntu-pro-available-on-google-cloud" class="p-link--external">GCP</a>) or multiple private clouds (e.g. <a href="https://www.vmware.com/" class="p-link--external">VMware</a> and <a href="/openstack">OpenStack</a>) at the same time and this is not a hybrid cloud architecture.</p>
     </div>
   </div>
 </section>

--- a/templates/cloud/multi-cloud.html
+++ b/templates/cloud/multi-cloud.html
@@ -53,7 +53,7 @@
       <h5 class="u-no-margin--bottom u-no-padding--top">Is every hybrid cloud a multi-cloud?</h5>
       <p>No, imagine a <a href="/cloud">cloud architecture</a> that consists of <a href="https://aws.amazon.com/marketplace/pp/prodview-rhaqbfd6lepbw" class="p-link--external">AWS</a> and <a href="/aws/outposts">AWS Outposts</a> at the same time. It uses a public cloud and a private cloud infrastructure, but both are delivered by a single cloud provider.</p>
       <h5 class="u-no-margin--bottom u-no-padding--top">Is every multi-cloud a hybrid cloud?</h5>
-      <p>No, it is not. Multi-cloud also refers to using multiple public clouds (e.g. <a href="https://azuremarketplace.microsoft.com/en-gb/marketplace/apps/canonical.0001-com-ubuntu-pro-bionic?tab=overview" class="p-link--external">Azure</a> and <a href="https://cloud.google.com/blog/products/compute/ubuntu-pro-available-on-google-cloud" class="p-link--external">GCP</a>) or multiple private clouds (e.g. <a href="https://www.vmware.com/" class="p-link--external">VMware</a> and <a href="/openstack">OpenStack</a>) at the same time and this is not a hybrid cloud architecture.</p>
+      <p>No, it is not. Multi-cloud also refers to using multiple public clouds (e.g. <a href="https://azuremarketplace.microsoft.com/en-gb/marketplace/apps/canonical.0001-com-ubuntu-pro-bionic" class="p-link--external">Azure</a> and <a href="https://cloud.google.com/blog/products/compute/ubuntu-pro-available-on-google-cloud" class="p-link--external">GCP</a>) or multiple private clouds (e.g. <a href="https://www.vmware.com/" class="p-link--external">VMware</a> and <a href="/openstack">OpenStack</a>) at the same time and this is not a hybrid cloud architecture.</p>
     </div>
   </div>
 </section>

--- a/templates/cloud/public-cloud.html
+++ b/templates/cloud/public-cloud.html
@@ -94,7 +94,7 @@
         <a class="p-link--external" href="https://aws.amazon.com/marketplace/pp/B087L1R4G4">Launch Ubuntu Pro 20.04 LTS for AWS</a>
       </p>
       <p>
-        <a class="p-link--external" href="https://azuremarketplace.microsoft.com/en-us/marketplace/apps/canonical.0001-com-ubuntu-pro-focal?tab=Overview">Launch Ubuntu Pro 20.04 LTS for Azure</a>
+        <a class="p-link--external" href="https://azuremarketplace.microsoft.com/en-us/marketplace/apps/canonical.0001-com-ubuntu-pro-focal">Launch Ubuntu Pro 20.04 LTS for Azure</a>
       </p>
       <p>
         <a class="p-link--external" href="https://console.cloud.google.com/marketplace/browse?q=ubuntu%20pro%20canonical">Launch Ubuntu Pro 20.04 LTS for GCP</a>

--- a/templates/security/fips.html
+++ b/templates/security/fips.html
@@ -103,7 +103,7 @@
         <a href="https://aws.amazon.com/marketplace/pp/prodview-wzhyxs72ie52u">
           <img src="https://assets.ubuntu.com/v1/8e5cc412-AWS.svg" style="height: 30px; width: 50px;" alt="aws logo">
         </a>
-        <a href="https://azuremarketplace.microsoft.com/en-us/marketplace/apps/canonical.0001-com-ubuntu-pro-xenial-fips?tab=Overview">
+        <a href="https://azuremarketplace.microsoft.com/en-us/marketplace/apps/canonical.0001-com-ubuntu-pro-xenial-fips">
           <img src="https://assets.ubuntu.com/v1/22fd6473-MicrosoftAzure_logo.svg" style="height: 30px; padding-left: 0.5rem; width: 104px;" alt="Microsoft Azure logo">
         </a>
       </div>
@@ -115,7 +115,7 @@
         <a href="https://aws.amazon.com/marketplace/pp/prodview-pfsgbblavhjc4">
           <img src="https://assets.ubuntu.com/v1/8e5cc412-AWS.svg" style="height: 30px; width: 50px;" alt="aws logo">
         </a>
-        <a href="https://azuremarketplace.microsoft.com/en-us/marketplace/apps/canonical.0001-com-ubuntu-pro-bionic-fips?tab=Overview">
+        <a href="https://azuremarketplace.microsoft.com/en-us/marketplace/apps/canonical.0001-com-ubuntu-pro-bionic-fips">
           <img src="https://assets.ubuntu.com/v1/22fd6473-MicrosoftAzure_logo.svg" style="height: 30px; padding-left: 0.5rem; width: 104px;" alt="Microsoft Azure logo">
         </a>
       </div>

--- a/templates/shared/_ubuntu_pro_on_public_cloud.html
+++ b/templates/shared/_ubuntu_pro_on_public_cloud.html
@@ -30,7 +30,7 @@
         <li class="p-list__item is-ticked">Free from licence fees, regardless of how many images you run</li>
       </ul>
       <a class="p-button p-link--external" href="https://aws.amazon.com/marketplace/pp/B087QQNGF1?qid=1591613411512&sr=0-2&ref_=srh_res_product_title">Ubuntu Server on AWS</a>
-      <a class="p-button p-link--external" href="https://azuremarketplace.microsoft.com/en-us/marketplace/apps/canonical.0001-com-ubuntu-server-focal?tab=Overview">Ubuntu Server on Azure</a>
+      <a class="p-button p-link--external" href="https://azuremarketplace.microsoft.com/en-us/marketplace/apps/canonical.0001-com-ubuntu-server-focal">Ubuntu Server on Azure</a>
       <a class="p-button p-link--external" href="https://console.cloud.google.com/marketplace/browse?q=ubuntu%20canonical">Ubuntu Server on GCP</a>
     </div>
   </div>


### PR DESCRIPTION
## Done

- The sequel to https://github.com/canonical-web-and-design/ubuntu.com/pull/11274
- @malina-i was given a [guide on how to implement campaign tracking](https://docs.google.com/document/d/1wMJvS_IzbxH3s61fh1WyszdZ0KVX-CE5BAc9nvaFvnA/edit) for Azure Marketplace links, including removing `tab=Overview` from existing links e.g.
  - https://azuremarketplace.microsoft.com/en-us/marketplace/apps/canonical.0001-com-ubuntu-pro-bionic?tab=Overview
  - https://azuremarketplace.microsoft.com/en-us/marketplace/apps/canonical.0001-com-ubuntu-pro-bionic

Both links lead to the same place, so this PR cleans up all such links across the project.

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- Visit:
  - https://ubuntu-com-11275.demos.haus/16-04/azure
  - https://ubuntu-com-11275.demos.haus/16-04
  - https://ubuntu-com-11275.demos.haus/azure/fips
  - https://ubuntu-com-11275.demos.haus/azure
  - https://ubuntu-com-11275.demos.haus/azure/pro
  - https://ubuntu-com-11275.demos.haus/cloud/hybrid-cloud
  - https://ubuntu-com-11275.demos.haus/cloud/public-cloud
  - https://ubuntu-com-11275.demos.haus/security/fips 
- See that the links to the Azure Marketplace all lead to an overview page
