### PR TITLE
Fix bug links

### DIFF
--- a/templates/security/cve/cve.html
+++ b/templates/security/cve/cve.html
@@ -315,7 +315,9 @@
           <h2>Bugs</h2>
           <ul>
             {% for bug in cve.bugs %}
+              {% if 'http' in bug%}
                 <li><a href="{{ bug }}">{{ bug }}</a></li>
+              (% endif %)
             {% endfor %}
           </ul>
         {% endif %}

--- a/templates/security/cve/cve.html
+++ b/templates/security/cve/cve.html
@@ -316,7 +316,7 @@
           <ul>
             {% for bug in cve.bugs %}
               
-                <li><a href="{{ cve.bug }}">{{ bug }}</a></li>
+                <li><a href="{{ bug }}">{{ bug }}</a></li>
 
             {% endfor %}
           </ul>

--- a/templates/security/cve/cve.html
+++ b/templates/security/cve/cve.html
@@ -315,9 +315,7 @@
           <h2>Bugs</h2>
           <ul>
             {% for bug in cve.bugs %}
-              {% if 'http' in bug  %}
                 <li><a href="{{ bug }}">{{ bug }}</a></li>
-              {% endif %}
             {% endfor %}
           </ul>
         {% endif %}

--- a/templates/security/cve/cve.html
+++ b/templates/security/cve/cve.html
@@ -315,9 +315,9 @@
           <h2>Bugs</h2>
           <ul>
             {% for bug in cve.bugs %}
-              {% if 'http' in bug%}
+              {% if 'http' in bug %}
                 <li><a href="{{ bug }}">{{ bug }}</a></li>
-              (% endif %)
+              {% endif %}
             {% endfor %}
           </ul>
         {% endif %}

--- a/templates/security/cve/cve.html
+++ b/templates/security/cve/cve.html
@@ -315,9 +315,9 @@
           <h2>Bugs</h2>
           <ul>
             {% for bug in cve.bugs %}
-              
+              {% if 'http' in bug  %}
                 <li><a href="{{ bug }}">{{ bug }}</a></li>
-
+              {% endif %}
             {% endfor %}
           </ul>
         {% endif %}


### PR DESCRIPTION
## Done

- Fixed empty href in bug section links 

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/security/cves
    - Be sure to test on mobile, tablet and desktop screen sizes
- Click on any cve and check that the links in the "Bugs" section work as expected

## Issue / Card

Fixes https://github.com/canonical-web-and-design/ubuntu.com/issues/11278