### PR TITLE
Create purchase objects

### DIFF
--- a/templates/account/invoices/index.html
+++ b/templates/account/invoices/index.html
@@ -38,29 +38,40 @@
           <tbody>
             {% for invoice in invoices %}
               <tr>
-                <td data-heading="Service">{{ invoice.service }}{% if invoice.period %} ({{ invoice.period }}){% endif %}</td>
-                <td data-heading="Date">{{ invoice.date }}</td>
-                <td data-heading="Status">
-                  {% if invoice.status == "paid" %}
-                  <div class="p-label--new">Paid</div>
-                  {% elif invoice.status == "open" %}
-                  <div class="p-label--deprecated">Failed</div>
+                <td aria-label="Service">
+                  {% if invoice.marketplace == "canonical-ua"%}
+                    Canonical UA
+                  {% elif invoice.marketplace == "blender" %}
+                    Blender Support
+                  {% elif invoice.marketplace == "canonical-cube" %}
+                    Canonical CUBE 
+                  {% endif %}{% if invoice.period %} ({{ invoice.period }}){% endif %}</td>
+                <td aria-label="Date">{{ invoice.get_formatted_date() }}</td>
+                <td aria-label="Status">
+                  {% if invoice.invoice %}
+                    {% if invoice.invoice.status == "paid" %}
+                      <div class="p-label--new">Paid</div>
+                    {% elif invoice.invoice.status == "open" %}
+                      <div class="p-label--deprecated">Failed</div>
+                    {% else %}
+                      <div class="p-label">Pending</div>
+                    {% endif %}
                   {% else %}
-                  <div class="p-label">{{ invoice.status }}</div>
+                    <div class="p-label">Pending</div>
                   {% endif %}
                 </td>
-                <td class="u-align--right" data-heading="Total" style="padding-right: 5%">
-                  {% if invoice.total %}
+                <td class="u-align--right" aria-label="Total" style="padding-right: 5%">
+                  {% if invoice.invoice %}
                     <span class="js-format-price">
-                      {{ invoice.total }}
+                      {{ invoice.get_total() }}
                     </span>
                   {% else %}
                     -
                   {% endif %}
                 </td>
-                <td data-heading="Download PDF">
-                  {% if invoice.download_link %}
-                    <a href="{{ invoice.download_link }}{% if get_test_backend %}?test_backend=true{% endif %}" target="_blank">{{ invoice.download_file_name }}</a>
+                <td aria-label="Download PDF">
+                  {% if invoice.invoice %}
+                    <a href="invoices/download/{{ invoice.id }}{% if get_test_backend %}?test_backend=true{% endif %}" target="_blank">Download</a>
                   {% else %}
                     No invoice available
                   {% endif %}

--- a/tests/shop/advantage/fixtures/purchase-3ds.json
+++ b/tests/shop/advantage/fixtures/purchase-3ds.json
@@ -1,0 +1,77 @@
+{
+    "accountID": "aAaBbCcDd", 
+    "createdAt": "2022-02-23T13:46:05.871Z", 
+    "createdBy": "email.address@canonical.com", 
+    "id": "pAaBbCcDd", 
+    "invoice": {
+      "amountDue": 27000, 
+      "currency": "usd", 
+      "customerAddress": {
+        "city": "London", 
+        "country": "GB", 
+        "line1": "Street", 
+        "line2": "", 
+        "postal_code": "123321", 
+        "state": ""
+      }, 
+      "customerEmail": "email.address@canonical.com", 
+      "customerName": "Email Address Name", 
+      "id": {
+        "IDs": [
+          "in_aAaBbCcDd"
+        ], 
+        "origin": "Stripe"
+      }, 
+      "identifier": "abcde", 
+      "lineItems": [
+        {
+          "currency": "usd", 
+          "description": "1 machine x UA Infrastructure - Essential (Physical) (at $225.00 / year)", 
+          "planID": {
+            "IDs": [
+              "123123"
+            ], 
+            "origin": "Stripe"
+          }, 
+          "proRatedAmount": 22500, 
+          "quantity": 1
+        }
+      ], 
+      "paymentStatus": {
+        "piClientSecret": "pi_aAbBcCdD", 
+        "status": "need_3ds_authorization"
+      }, 
+      "reason": "subscription_create", 
+      "status": "open", 
+      "subscriptionID": {
+        "IDs": [
+          "sub_aAbBcCdD"
+        ], 
+        "origin": "Stripe"
+      }, 
+      "taxAmount": 4500, 
+      "total": 27000, 
+      "url": "download.link"
+    }, 
+    "lastModified": "2022-02-23T13:46:07.954Z", 
+    "marketplace": "canonical-ua", 
+    "purchaseItems": [
+      {
+        "paidForInCycle": 1, 
+        "productListingID": "lAaBbCcDd", 
+        "value": 1
+      }
+    ], 
+    "status": "processing", 
+    "stripeInvoices": [
+      {
+        "id": "in_aAaBbCcDd", 
+        "last_update": "2022-02-23T13:46:09.758702Z", 
+        "pi_secret": "pi_aAbBcCdD", 
+        "pi_status": "requires_action", 
+        "subscription_status": "incomplete"
+      }
+    ], 
+    "subscriptionID": "sAaBbCcDd"
+  }
+  

--- a/tests/shop/advantage/fixtures/purchase-failed.json
+++ b/tests/shop/advantage/fixtures/purchase-failed.json
@@ -1,0 +1,76 @@
+{
+    "accountID": "aAbBcCdD", 
+    "createdAt": "2022-02-23T13:52:06.877Z", 
+    "createdBy": "email.address@canonical.com", 
+    "id": "pAaBbCcDd", 
+    "invoice": {
+      "amountDue": 22500, 
+      "currency": "usd", 
+      "customerAddress": {
+        "city": "London", 
+        "country": "GB", 
+        "line1": "Street", 
+        "line2": "", 
+        "postal_code": "123321", 
+        "state": ""
+      }, 
+      "customerEmail": "email.address@canonical.com", 
+      "customerName": "Email Address Name", 
+      "id": {
+        "IDs": [
+          "in_AaBbCcDd"
+        ], 
+        "origin": "Stripe"
+      }, 
+      "identifier": "123123", 
+      "lineItems": [
+        {
+          "currency": "usd", 
+          "description": "1 machine x UA Infrastructure - Essential (Physical) (at $225.00 / year)", 
+          "planID": {
+            "IDs": [
+              "1231222"
+            ], 
+            "origin": "Stripe"
+          }, 
+          "proRatedAmount": 22500, 
+          "quantity": 1
+        }
+      ], 
+      "paymentStatus": {
+        "lastPaymentError": "generic_decline", 
+        "status": "need_another_payment_method"
+      }, 
+      "reason": "subscription_create", 
+      "status": "open", 
+      "subscriptionID": {
+        "IDs": [
+          "sub_aAbBcCdD"
+        ], 
+        "origin": "Stripe"
+      }, 
+      "total": 22500, 
+      "url": "download.link"
+    }, 
+    "lastModified": "2022-02-23T13:52:09.42Z", 
+    "marketplace": "canonical-ua", 
+    "purchaseItems": [
+      {
+        "paidForInCycle": 1, 
+        "productListingID": "laAbBcCdD", 
+        "value": 1
+      }
+    ], 
+    "status": "processing", 
+    "stripeInvoices": [
+      {
+        "id": "in_AaBbCcDd", 
+        "last_update": "2022-02-23T13:52:16.244404Z", 
+        "pi_decline_code": "generic_decline", 
+        "pi_status": "requires_payment_method", 
+        "subscription_status": "incomplete"
+      }
+    ], 
+    "subscriptionID": "sAaBbCcDd"
+  }
+  

--- a/tests/shop/advantage/test_advantage_mapper.py
+++ b/tests/shop/advantage/test_advantage_mapper.py
@@ -7,7 +7,14 @@ from tests.shop.advantage.helpers import (
     make_client,
     get_fixture,
 )
-from webapp.shop.api.ua_contracts.models import Listing, Offer
+from webapp.shop.api.ua_contracts.helpers import to_dict
+from webapp.shop.api.ua_contracts.models import (
+    Listing,
+    Offer,
+    Purchase,
+    PurchaseItem,
+    Invoice,
+)
 from webapp.shop.api.ua_contracts.advantage_mapper import AdvantageMapper
 from webapp.shop.api.ua_contracts.primitives import (
     Account,
@@ -109,6 +116,191 @@ class TestGetAccountSubscriptions(unittest.TestCase):
         self.assertIsInstance(response, List)
         for item in response:
             self.assertIsInstance(item, Subscription)
+
+
+class TestGetAccountPurchases(unittest.TestCase):
+    def test_returns_account_purchases(self):
+        session = Session(
+            response=Response(
+                status_code=200,
+                content=get_fixture("purchases"),
+            )
+        )
+        ua_contracts_api = make_client(session)
+        advantage_mapper = AdvantageMapper(ua_contracts_api)
+        response = advantage_mapper.get_account_purchases(
+            account_id="aABbCcdD",
+        )
+
+        self.assertIsInstance(response, List)
+        for item in response:
+            self.assertIsInstance(item, Purchase)
+
+
+class TestGetPurchase(unittest.TestCase):
+    def test_returns_purchase(self):
+        session = Session(
+            Response(
+                status_code=200,
+                content=get_fixture("purchase"),
+            )
+        )
+        ua_contracts_api = make_client(session)
+        advantage_mapper = AdvantageMapper(ua_contracts_api)
+        response = advantage_mapper.get_purchase("pAaBbCcDd")
+
+        self.assertIsInstance(response, Purchase)
+
+        expected_invoice = Invoice(
+            reason="subscription_update",
+            currency="usd",
+            status="open",
+            total=1200,
+            id="in_abcdef",
+            items=[
+                {
+                    "currency": "usd",
+                    "description": "Description",
+                    "pro_rated_amount": 1000,
+                    "quantity": 1,
+                }
+            ],
+            tax_amount=200,
+            payment_status={
+                "error": "generic_decline",
+                "status": "need_another_payment_method",
+            },
+            url="invoice.url",
+        )
+        self.assertEqual(to_dict(expected_invoice), to_dict(response.invoice))
+
+        expected_purchase = Purchase(
+            id="pAaBbCcDd",
+            account_id="aAaBbCcDdEeFfGg",
+            subscription_id="sAaBbCcDdEeFfGg",
+            marketplace="canonical-ua",
+            created_at="2020-01-01T10:00:00Z",
+            status="processing",
+            invoice=expected_invoice,
+            items=[
+                PurchaseItem(
+                    listing_id="lAaBbCcDdEeFfGg",
+                    value=1,
+                )
+            ],
+        )
+        self.assertEqual(to_dict(expected_purchase), to_dict(response))
+
+    def test_returns_3ds_purchase(self):
+        session = Session(
+            Response(
+                status_code=200,
+                content=get_fixture("purchase-3ds"),
+            )
+        )
+        ua_contracts_api = make_client(session)
+        advantage_mapper = AdvantageMapper(ua_contracts_api)
+        response = advantage_mapper.get_purchase("pAaBbCcDd")
+
+        self.assertIsInstance(response, Purchase)
+
+        expected_invoice = Invoice(
+            reason="subscription_create",
+            currency="usd",
+            status="open",
+            total=27000,
+            id="in_aAaBbCcDd",
+            items=[
+                {
+                    "currency": "usd",
+                    "description": (
+                        "1 machine x UA Infrastructure"
+                        " - Essential (Physical) (at $225.00 / year)"
+                    ),
+                    "pro_rated_amount": 22500,
+                    "quantity": 1,
+                }
+            ],
+            tax_amount=4500,
+            payment_status={
+                "pi_client_secret": "pi_aAbBcCdD",
+                "status": "need_3ds_authorization",
+            },
+            url="download.link",
+        )
+        self.assertEqual(to_dict(expected_invoice), to_dict(response.invoice))
+
+        expected_purchase = Purchase(
+            id="pAaBbCcDd",
+            account_id="aAaBbCcDd",
+            subscription_id="sAaBbCcDd",
+            marketplace="canonical-ua",
+            created_at="2022-02-23T13:46:05.871Z",
+            status="processing",
+            invoice=expected_invoice,
+            items=[
+                PurchaseItem(
+                    listing_id="lAaBbCcDd",
+                    value=1,
+                )
+            ],
+        )
+        self.assertEqual(to_dict(expected_purchase), to_dict(response))
+
+    def test_returns_failed_purchase(self):
+        session = Session(
+            Response(
+                status_code=200,
+                content=get_fixture("purchase-failed"),
+            )
+        )
+        ua_contracts_api = make_client(session)
+        advantage_mapper = AdvantageMapper(ua_contracts_api)
+        response = advantage_mapper.get_purchase("pAaBbCcDd")
+
+        self.assertIsInstance(response, Purchase)
+
+        expected_invoice = Invoice(
+            reason="subscription_create",
+            currency="usd",
+            status="open",
+            total=22500,
+            id="in_AaBbCcDd",
+            items=[
+                {
+                    "currency": "usd",
+                    "description": (
+                        "1 machine x UA Infrastructure"
+                        " - Essential (Physical) (at $225.00 / year)"
+                    ),
+                    "pro_rated_amount": 22500,
+                    "quantity": 1,
+                }
+            ],
+            payment_status={
+                "error": "generic_decline",
+                "status": "need_another_payment_method",
+            },
+            url="download.link",
+        )
+        self.assertEqual(to_dict(expected_invoice), to_dict(response.invoice))
+
+        expected_purchase = Purchase(
+            id="pAaBbCcDd",
+            account_id="aAbBcCdD",
+            subscription_id="sAaBbCcDd",
+            marketplace="canonical-ua",
+            created_at="2022-02-23T13:52:06.877Z",
+            status="processing",
+            invoice=expected_invoice,
+            items=[
+                PurchaseItem(
+                    listing_id="laAbBcCdD",
+                    value=1,
+                )
+            ],
+        )
+        self.assertEqual(to_dict(expected_purchase), to_dict(response))
 
 
 class TestGetPurchaseAccount(unittest.TestCase):

--- a/webapp/shop/api/ua_contracts/models.py
+++ b/webapp/shop/api/ua_contracts/models.py
@@ -1,5 +1,7 @@
 from typing import List
 
+from dateutil.parser import parse
+
 
 class Entitlement:
     def __init__(
@@ -127,3 +129,80 @@ class Offer:
         self.marketplace = marketplace
         self.created_at = created_at
         self.actionable = actionable
+
+
+class Invoice:
+    def __init__(
+        self,
+        reason: str,
+        currency: str,
+        status: str,
+        total: int,
+        id: str,
+        items: dict = None,
+        tax_amount: int = None,
+        payment_status: dict = None,
+        url: str = None,
+    ):
+        self.id = id
+        self.currency = currency
+        self.tax_amount = tax_amount
+        self.total = total
+        self.status = status
+        self.reason = reason
+        self.url = url
+        self.payment_status = payment_status
+        self.items = items
+
+
+class PurchaseItem:
+    def __init__(
+        self,
+        value: int,
+        listing_id: str,
+        listing: Listing = None,
+    ):
+        self.value = value
+        self.listing = listing
+        self.listing_id = listing_id
+
+
+class Purchase:
+    def __init__(
+        self,
+        account_id: str,
+        created_at: str,
+        id: str,
+        marketplace: str,
+        status: str,
+        subscription_id: str,
+        items: List[PurchaseItem],
+        invoice: Invoice = None,
+    ):
+        self.account_id = account_id
+        self.created_at = created_at
+        self.id = id
+        self.invoice = invoice
+        self.items = items
+        self.marketplace = marketplace
+        self.status = status
+        self.subscription_id = subscription_id
+
+    def get_period(self):
+        listing = self.items[0].listing
+        period = listing.period if listing else None
+
+        return "Monthly" if period == "monthly" else "Annual"
+
+    def get_formatted_date(self):
+        return parse(self.created_at).strftime("%d %B, %Y")
+
+    def get_total(self):
+        if self.invoice is None:
+            return None
+
+        if self.invoice.total:
+            cost = self.invoice.total / 100
+            currency = self.invoice.currency
+
+            return f"{cost} {currency}"

--- a/webapp/shop/api/ua_contracts/parsers.py
+++ b/webapp/shop/api/ua_contracts/parsers.py
@@ -26,7 +26,7 @@ def parse_product(raw_product: Dict) -> Product:
 
 
 def parse_product_listing(
-    raw_product_listing: Dict, raw_products: List[Dict]
+    raw_product_listing: Dict, raw_products: List[Dict] = None
 ) -> Listing:
     product = None
     raw_products = raw_products or []

--- a/webapp/shop/api/ua_contracts/schema.py
+++ b/webapp/shop/api/ua_contracts/schema.py
@@ -1,0 +1,67 @@
+from marshmallow import Schema, post_load, validate, EXCLUDE
+from marshmallow.fields import Function, String, Integer, Nested, List
+
+from webapp.shop.api.ua_contracts.models import Purchase, PurchaseItem, Invoice
+
+
+class BaseSchema(Schema):
+    class Meta:
+        unknown = EXCLUDE
+
+
+class InvoiceItemSchema(BaseSchema):
+    currency = String()
+    description = String()
+    proRatedAmount = Integer(attribute="pro_rated_amount")
+    quantity = Integer()
+
+
+class PaymentStatusSchema(BaseSchema):
+    status = String()
+    lastPaymentError = String(attribute="error")
+    piClientSecret = String(attribute="pi_client_secret")
+
+
+class InvoiceSchema(BaseSchema):
+    id = Function(deserialize=(lambda id: id.get("IDs")[0]), required=True)
+    reason = String(required=True)
+    status = String(required=True)
+    url = String()
+    currency = String(required=True)
+    total = Integer(required=True)
+    taxAmount = Integer(attribute="tax_amount")
+    paymentStatus = Nested(PaymentStatusSchema, attribute="payment_status")
+    lineItems = List(Nested(InvoiceItemSchema), attribute="items")
+
+    @post_load
+    def make_invoice(self, data, **kwargs) -> Invoice:
+        return Invoice(**data)
+
+
+class PurchaseItemSchema(BaseSchema):
+    productListingID = String(required=True, attribute="listing_id")
+    value = Integer(required=True)
+
+    @post_load
+    def make_purchase_item(self, data, **kwargs) -> PurchaseItem:
+        return PurchaseItem(**data)
+
+
+class PurchaseSchema(BaseSchema):
+    accountID = String(required=True, attribute="account_id")
+    id = String(required=True)
+    createdAt = String(required=True, attribute="created_at")
+    status = String(required=True)
+    subscriptionID = String(required=True, attribute="subscription_id")
+    invoice = Nested(InvoiceSchema)
+    purchaseItems = List(
+        Nested(PurchaseItemSchema), required=True, attribute="items"
+    )
+    marketplace = String(
+        validate=validate.OneOf(["canonical-ua", "canonical-cube", "blender"]),
+        required=True,
+    )
+
+    @post_load
+    def make_purchase(self, data, **kwargs) -> Purchase:
+        return Purchase(**data)


### PR DESCRIPTION
## Done

- Convert payment json responses to Payment objects
- For now we only convert /account/invoices and the download endpoints to use it
- The new payments endpoint will return Payment objects too

## QA

- Go to /account/invoices and download invoices 
- Does it work?
 
## Issue / Card

Fixes #https://github.com/canonical-web-and-design/commercial-squad/issues/514