### PR TITLE
add MWC banner to /telco

### DIFF
--- a/templates/telco/index.html
+++ b/templates/telco/index.html
@@ -216,6 +216,41 @@
   </div>
 </section>
 
+<section class="p-strip--suru-blog-header">
+  <div class="row">
+    <div class="col-7 u-vertically-center">
+      <h2>Join us at MWC in Barcelona</h2>
+
+      <h3>February 28th - March 3rd 2022</h3>
+
+      <p>Meet our experts there and see exciting live demos on:</p>
+
+      <ul>
+        <li>Anbox Cloud</li>
+        <li>Open source private mobile networks with Magma and OpenRAN</li>
+        <li>Modern CNF infrastructure for the edge</li>
+      </ul>
+
+      <p>
+        <a href="/engage/canonical-ubuntu-mwc-2022" class="p-button--positive">Schedule a meeting</a>
+      </p>
+    </div>
+
+    <div class="col-5 u-vertically-center u-align--center u-align--left-medium u-hide--small">
+      {{
+        image(
+          url="https://assets.ubuntu.com/v1/a900a84a-MWC-logo-2022.svg",
+          alt="",
+          height="88",
+          width="330",
+          hi_def=True,
+          loading="lazy",
+        ) | safe
+      }}
+    </div>
+  </div>
+</section>
+
 <section class="p-strip">
   <div class="row">
     <div class="col-6">
@@ -321,6 +356,7 @@
     </div>
     <hr class="p-separator" />
   </div>
+
   <div class="row">
     <div class="col-6">
       <h2>VNF onboarding, day 1 and day 2 operations with ETSI OSM</h2>


### PR DESCRIPTION
## Done

- added an MWC banner to /telco

## QA

- View the site in your web browser at: https://ubuntu-com-11282.demos.haus/telco
    - Be sure to test on mobile, tablet and desktop screen sizes
- See that the banner matches the [design](https://github.com/canonical-web-and-design/web-squad/issues/4832)

## Issue / Card

Fixes #https://github.com/canonical-web-and-design/web-squad/issues/4833

## Screenshots

![Screenshot from 2022-02-24 15-20-55](https://user-images.githubusercontent.com/2376968/155553325-6d4fd48b-5def-4492-9897-e17e7129fd5a.png)

