### PR TITLE
Update azure private offer page

### DIFF
--- a/templates/azure/private-offer.html
+++ b/templates/azure/private-offer.html
@@ -1,61 +1,132 @@
 {% extends "azure/base_azure.html" %}
 
 {% block title %}Azure Private Offer{% endblock %}
-{% block meta_description %}Ubuntu on Azure Private Offer - Get exclusive services and support for your large scale linux operation{% endblock %}
+{% block meta_description %}Ubuntu on Azure Private Offer - Get exclusive services and support for your large scale Linux operation{% endblock %}
 {% block meta_copydoc %}https://docs.google.com/document/d/1ZgV1ZiyHJe3UNQkj0I-OCpZ4MIAWLHheig2Q2rclcuk/edit{% endblock meta_copydoc %}
 
+{% block head_extra %}
+  <style>
+    h2,
+    .p-heading--2 {
+      font-weight: 300;
+    }
+  </style>
+{% endblock %}
+
 {% block content %}
-<section class="p-strip p-engage-banner--grad">
+<section class="p-strip--suru-blog-header">
   <div class="row">
     <div class="col-7 u-vertically-center">
-      <h1>
-        Ubuntu on Azure Private&nbsp;Offer
-      </h1>
-      <p class="u-no-padding--top p-heading--4">
-        Get exclusive services and support for your large scale linux&nbsp;operation
+      <h1>Join cloud innovators today</h1>
+
+      <p class="u-no-padding--top p-heading--4">Free your mind so you can focus on what matters</p>
+
+      <p>
+        <a href="#private-offer-form" class="p-button--positive">Get the exclusive private offer</a>
       </p>
     </div>
     <div class="col-5 u-hide--small u-vertically-center u-align--center">
-      {{
-      image(
-      url="https://assets.ubuntu.com/v1/a25fbd66-ubuntu-microsoft-azure-offer.png",
-      alt="Azure Offer",
-      width="323",
-      hi_def=True,
-      loading="lazy"
-      ) | safe
+      {{ image (
+        url="https://assets.ubuntu.com/v1/ee1049ee-Ubuntu+Pro+-+Private+offer+shield2.svg",
+        alt="",
+        width="206",
+        height="232",
+        hi_def=True,
+        loading="auto"
+        ) | safe
       }}
     </div>
   </div>
 </section>
-<section class="p-strip is-shallow is-bordered">
+
+{% include "azure/shared/_azure-logo-strip.html" %}
+
+<section class="p-strip--light">
   <div class="row">
     <div class="col-7">
-      <p>
-        <strong>Please complete the form to be contacted by Canonical and discuss how this private offer for Ubuntu Pro on Azure can meet your needs.</strong>
-      </p>
-      <p class="u-no-margin--bottom"><strong>Key Benefits:</strong> </p>
-      <ul class="p-list">
-        <li class="p-list__item is-ticked">Exclusive levels of support</li>
-        <li class="p-list__item is-ticked">Upgraded security and compliance</li>
-        <li class="p-list__item is-ticked">Volume based pricing</li>
-      </ul>
-      <p>
-        All industries including top banks, large telcos and leading retailers all rely on Ubuntu on Azure. They innovate on Ubuntu because they trust that their production and mission-critical workloads are reliable and available.
-      </p>
-      <p>
-        For businesses relying on Ubuntu, a new private offer has been created, to provide them with extra security, compliance and support: Ubuntu Pro with Support. Available through exclusive private offers, it is a tailored business arrangement for Ubuntu power-users to get the best of their Ubuntu investment.
-      </p>
+      <h2 class="p-heading--4">Canonical has the expertise to assist you in your project</h2>
 
-      <p>
-        <a href="/azure/pro">Learn more about Ubuntu Pro for Azure&nbsp;&rsaquo;</a>
-      </p>
+      <hr class="p-separator u-no-margin--top" />
+      
+      <h2>Get Azure integrated support with SLA from Canonical to gain 24/7 open-source expertise at your disposal with the private offer</h2>
+
+      <p>OS level support from Canonical enhances Microsoft support and utilises the existing workflows for Ubuntu-based operational or break-fix support issues.</p>
+
+      <p>Private offer also supports an ability to work from a set of images that have been hardened and optimised for security and operations for the whole organisation. This simplifies IT governance and allows all your internal users to seamlessly follow your strategy.</p>
     </div>
-    <div class="col-5">
-      {% with id="3888", returnURL="/azure/thank-you", cta="Contact Us" %}
-      {% include "engage/shared/_en_engage_form.html" %}
+    <div class="col-5" id="private-offer-form">
+      {% with id="4394", returnURL="/azure/thank-you", cta="Get the exclusive private offer" %}
+        {% include "engage/shared/_en_engage_form.html" %}
       {% endwith %}
     </div>
   </div>
 </section>
+
+<section class="p-strip">
+  <div class="row">
+    <div class="col-6">
+      <h2>Bonus! Retire on your MACC agreement with Microsoft</h2>
+
+      <p>If your organisation has a Microsoft Azure Commitment to Consume (MACC), Canonical's private offer in Microsoft's Azure Marketplace will help you retire quota on this commitment.</p>
+    </div>
+    <div class="col-6 u-vertically-center u-align--center u-hide--small">
+      {{ image (
+        url="https://assets.ubuntu.com/v1/da9a1344-Microsoft-Azure-logo_stacked_transparent.png",
+        alt="",
+        width="240",
+        height="68",
+        hi_def=True,
+        loading="lazy"
+        ) | safe
+      }}
+    </div>
+  </div>
+
+  <div class="u-fixed-width">
+    <hr class="p-separator" />
+  </div>
+
+  <div class="row">
+    <div class="col-6 u-vertically-center u-align--center u-hide--small">
+      {{ image (
+        url="https://assets.ubuntu.com/v1/c7f65894-Ubuntu+Pro+benefits+diagram.svg",
+        alt="",
+        width="308",
+        height="236",
+        hi_def=True,
+        loading="lazy"
+        ) | safe
+      }}
+    </div>
+    <div class="col-6">
+      <h2>Uplevel Ubuntu journey by activating this private Azure Marketplace offer</h2>
+
+      <p>Already running Ubuntu on Microsoft Azure, or planning a migration to the public cloud?</p>
+
+      <p>Leverage Canonical's expertise and all features of Ubuntu Pro with this exclusive private offer.</p>
+
+      <p>Canonical has the expertise to assist you in your project, whether it involves compliance, application architecture, optimisation or streaming operations at scale.</p>
+
+      <p>
+        <a href="#private-offer-form" class="p-button--positive">Get the exclusive private offer</a>
+      </p>
+    </div>
+  </div>
+</section>
+
+<div class="p-strip--light">
+  {% include "azure/shared/_how-ubuntu-pro-helps-you.html" %}
+</div>
+
+<div class="p-strip p-engage-banner--grad">
+  <div class="u-fixed-width">
+    <h2>Claim your private Azure Marketplace offer from Canonical</h2>
+
+    <p>Upgrade to Ubuntu Pro + Support and get the protection your enterprise needs today</p>
+
+    <p>
+      <a href="#private-offer-form" class="p-button--positive">Claim private offer</a>
+    </p>
+  </div>
+</div>
 {% endblock %}

--- a/templates/azure/shared/_azure-logo-strip.html
+++ b/templates/azure/shared/_azure-logo-strip.html
@@ -1,0 +1,41 @@
+<section class="p-strip is-shallow u-no-padding">
+  <div class="u-fixed-width">
+    <div class="p-logo-section">
+      <div class="p-logo-section__items u-no-margin--bottom">
+        <div class="p-logo-section__item"> 
+          {{ image (
+            url="https://assets.ubuntu.com/v1/d5a5c48f-canonical-logo.png",
+            alt="Canonical",
+            width="288",
+            height="288",
+            hi_def=True,
+            loading="auto"
+            ) | safe
+          }}
+        </div>
+        <div class="p-logo-section__item">
+          {{ image (
+            url="https://assets.ubuntu.com/v1/6e9151f5-ubuntu-logo.png",
+            alt="Ubuntu",
+            width="288",
+            height="288",
+            hi_def=True,
+            loading="auto"
+            ) | safe
+          }}
+        </div>
+        <div class="p-logo-section__item">
+          {{ image (
+            url="https://assets.ubuntu.com/v1/6ef81e08-microsoft-azure-new-logo.png",
+            alt="Microsoft Azure",
+            width="288",
+            height="288",
+            hi_def=True,
+            loading="auto"
+            ) | safe
+          }}
+        </div>
+      </div>
+    </div>
+  </div>
+</section>

--- a/templates/azure/shared/_how-ubuntu-pro-helps-you.html
+++ b/templates/azure/shared/_how-ubuntu-pro-helps-you.html
@@ -1,0 +1,82 @@
+<div class="row">
+  <div class="col-12">
+    <h2>How Ubuntu Pro helps you</h2>
+  </div>
+
+  <div class="col-4">
+    {{ image (
+      url="https://assets.ubuntu.com/v1/ec3f53f7-extended-security-maintenance.svg",
+      alt="",
+      width="60",
+      height="60",
+      hi_def=True,
+      loading="lazy",
+      attrs={"class": "u-hide--small"}
+      ) | safe
+    }}
+
+    <p>Ubuntu Pro enables instant up-to-date security by default with security patches for thousands of open source applications</p>
+  </div>
+
+  <div class="col-4">
+    {{ image (
+      url="https://assets.ubuntu.com/v1/4f70dabc-Kernel.svg",
+      alt="",
+      width="52",
+      height="60",
+      hi_def=True,
+      loading="lazy",
+      attrs={"class": "u-hide--small"}
+      ) | safe
+    }}
+
+    <p>Azure-optimised kernel for improved performance</p>
+  </div>
+
+  <div class="col-4">
+    {{ image (
+      url="https://assets.ubuntu.com/v1/1d5f293c-compliance.svg",
+      alt="",
+      width="105",
+      height="60",
+      hi_def=True,
+      loading="lazy",
+      attrs={"class": "u-hide--small"}
+      ) | safe
+    }}
+
+    <p>Full compliance checklist. FIPS, HIPAA, PCI, ISO and DISA-STIGs.</p>
+  </div>
+
+  <div class="col-4">
+    {{ image (
+      url="https://assets.ubuntu.com/v1/b0af9ede-UA_24-7_Support.svg",
+      alt="",
+      width="60",
+      height="60",
+      hi_def=True,
+      loading="lazy",
+      attrs={"class": "u-hide--small"}
+      ) | safe
+    }}
+
+    <p>24/7 support straight from the publisher of Ubuntu*</p>
+
+    <small>* Only available with the private offer</small>
+  </div>
+
+  <div class="col-4">
+    {{ image (
+      url="https://assets.ubuntu.com/v1/ceb481d1-10+years.svg",
+      alt="",
+      width="60",
+      height="60",
+      hi_def=True,
+      loading="lazy",
+      attrs={"class": "u-hide--small"}
+      ) | safe
+    }}
+
+    <p>10 years of extended maintenance</p>
+  </div>
+</div>

--- a/templates/azure/shared/_how-ubuntu-pro-helps-you.html
+++ b/templates/azure/shared/_how-ubuntu-pro-helps-you.html
@@ -45,7 +45,7 @@
       ) | safe
     }}
 
-    <p>Full compliance checklist. FIPS, HIPAA, PCI, ISO and DISA-STIGs.</p>
+    <p>Full compliance checklist: FIPS, HIPAA, PCI, ISO and DISA-STIGs</p>
   </div>
 
   <div class="col-4">


### PR DESCRIPTION
## Done

- Updated /azure/private offer according to the [design](https://github.com/canonical-web-and-design/web-squad/issues/4808#issuecomment-1039029837) and the [copy doc](https://docs.google.com/document/d/1ZgV1ZiyHJe3UNQkj0I-OCpZ4MIAWLHheig2Q2rclcuk/edit#)
  - this page was [originally part of a PR](https://github.com/canonical-web-and-design/web-squad/issues/4823) that included another, related page featuring an ebook download, but we're still waiting on the ebook asset, so I've created a new PR to unblock this page. I've added the Design +1 label, as it was given there, and the design hasn't changed in the process of creating this PR.

## QA

- View the site locally in your web browser at: https://ubuntu-com-11285.demos.haus/azure/private-offer
    - Be sure to test on mobile, tablet and desktop screen sizes
- See that the copy matches the [copy doc](https://docs.google.com/document/d/1ZgV1ZiyHJe3UNQkj0I-OCpZ4MIAWLHheig2Q2rclcuk/edit#)

## Issue / Card

Fixes https://github.com/canonical-web-and-design/web-squad/issues/4823
