### PR TITLE
Match codename with release number (mixup)

### DIFF
--- a/templates/about/release-cycle.html
+++ b/templates/about/release-cycle.html
@@ -123,15 +123,15 @@
               <td>&nbsp;</td>
             </tr>
             <tr>
-              <td>21.10 (Hirsute Hippo)</td>
-              <td>Oct 2021</td>
-              <td>Jul 2022</td>
+              <td>21.04 (Hirsute Hippo)</td>
+              <td>Apr 2021</td>
+              <td>Jan 2022</td>
               <td>&nbsp;</td>
             </tr>
             <tr>
-              <td>21.04 (Impish Indri)</td>
-              <td>Apr 2021</td>
-              <td>Jan 2022</td>
+              <td>21.10 (Impish Indri)</td>
+              <td>Oct 2021</td>
+              <td>Jul 2022</td>
               <td>&nbsp;</td>
             </tr>
             <tr>


### PR DESCRIPTION
The 21.04 is named [Hirsute Hippo](https://releases.ubuntu.com/21.04/), not [Impish Indri](https://releases.ubuntu.com/21.10/).
These names got mixed up.
I flipped the order of the rows in the table, but kept the names intact.

## Done

- Corrected release name - version number mismatch in release-cycle.html.

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- Follow the Process as outlined in #11295.

## Issue / Card

Fixes #11295

## Screenshots

_No relevant screenshot, no styling changed, purely data._

## Help

[QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html) - [Commit guidelines](https://canonical-web-and-design.github.io/practices/workflow/commit-messages.html)

## Additional comment from contributor

I could not check the qa steps, nor the commit guidelines. The links are 404s.

I have enabled the _Allow edits by maintainers_ checkbox. I hereby grant all maintainers of the repository permission to edit all the content provided.