### PR TITLE
Update chart headings in kernel support table

### DIFF
--- a/static/js/src/chart-data.js
+++ b/static/js/src/chart-data.js
@@ -1396,11 +1396,11 @@ export var kernelVersionNames = [
 ];
 
 export var kernelReleaseNames2004 = [
-  "Ubuntu 20.04.0 LTS",
-  "Ubuntu 20.04.1 LTS",
-  "Ubuntu 20.04.2 LTS",
-  "Ubuntu 20.04.3 LTS",
-  "Ubuntu 20.04.4 LTS",
+  "Ubuntu 20.04.0 LTS (v5.4)",
+  "Ubuntu 20.04.1 LTS (v5.4)",
+  "Ubuntu 20.04.2 LTS (v5.8)",
+  "Ubuntu 20.04.3 LTS (v5.11)",
+  "Ubuntu 20.04.4 LTS (v5.13)",
   "Ubuntu 20.04.5 LTS",
 ];
 
@@ -1449,12 +1449,12 @@ export var kernelReleaseNamesALL = [
   "Ubuntu 18.04.2 LTS (v4.18)",
   "Ubuntu 18.04.3 LTS (v5.0)",
   "Ubuntu 18.04.4 LTS (v5.3)",
-  "Ubuntu 20.04.0 LTS",
-  "Ubuntu 20.04.1 LTS",
+  "Ubuntu 20.04.0 LTS (v5.4)",
+  "Ubuntu 20.04.1 LTS (v5.4)",
   "Ubuntu 18.04.5 LTS (v5.4)",
-  "Ubuntu 20.04.2 LTS",
-  "Ubuntu 20.04.3 LTS",
-  "Ubuntu 20.04.4 LTS",
+  "Ubuntu 20.04.2 LTS (v5.8)",
+  "Ubuntu 20.04.3 LTS (v5.11)",
+  "Ubuntu 20.04.4 LTS (v5.13)",
   "Ubuntu 20.04.5 LTS",
 ];
 
@@ -1476,12 +1476,12 @@ export var kernelReleaseNamesLTS = [
   "Ubuntu 18.04.2 LTS (v4.18)",
   "Ubuntu 18.04.3 LTS (v5.0)",
   "Ubuntu 18.04.4 LTS (v5.3)",
-  "Ubuntu 20.04.0 LTS",
-  "Ubuntu 20.04.1 LTS",
+  "Ubuntu 20.04.0 LTS (v5.4)",
+  "Ubuntu 20.04.1 LTS (v5.4)",
   "Ubuntu 18.04.5 LTS (v5.4)",
-  "Ubuntu 20.04.2 LTS",
-  "Ubuntu 20.04.3 LTS",
-  "Ubuntu 20.04.4 LTS",
+  "Ubuntu 20.04.2 LTS (v5.8)",
+  "Ubuntu 20.04.3 LTS (v5.11)",
+  "Ubuntu 20.04.4 LTS (v5.13)",
   "Ubuntu 20.04.5 LTS",
 ];
 


### PR DESCRIPTION
## Done

- Updates headings in kernel support table at /kernel/lifecycle#support-all to match as follows:
Ubuntu 20.04.0 LTS (v5.4)
Ubuntu 20.04.1 LTS (v5.4)
Ubuntu 18.04.5 LTS (v5.4)
Ubuntu 20.04.2 LTS (v5.8)
Ubuntu 20.04.3 LTS (v5.11)
Ubuntu 20.04.4 LTS (v5.13)

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/kernel/lifecycle#support-all
    - Be sure to test on mobile, tablet and desktop screen sizes

## Issue / Card

Fixes https://github.com/canonical-web-and-design/ubuntu.com/issues/11288
