### PR TITLE
change p-icon--contextual-menu to p-icon--chevron-down

### DIFF
--- a/static/sass/_layout-tutorial.scss
+++ b/static/sass/_layout-tutorial.scss
@@ -160,7 +160,7 @@
   .l-tutorial__pagination-item--prev {
     @extend %l-tutorial-pagination-item;
 
-    .p-icon--contextual-menu {
+    .p-icon--chevron-down {
       transform: rotate(90deg);
     }
   }
@@ -168,7 +168,7 @@
   .l-tutorial__pagination-item--next {
     @extend %l-tutorial-pagination-item;
 
-    .p-icon--contextual-menu {
+    .p-icon--chevron-down {
       transform: rotate(-90deg);
     }
   }

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -526,7 +526,7 @@ summary {
       flex: 1.2;
     }
 
-    .p-icon--contextual-menu {
+    .p-icon--chevron-down {
       margin-left: 0.5rem;
     }
 
@@ -589,7 +589,7 @@ summary {
       white-space: nowrap;
       width: 100%;
 
-      .p-icon--contextual-menu {
+      .p-icon--chevron-down {
         position: absolute;
         right: 0.5rem;
         top: 1rem;
@@ -626,7 +626,7 @@ summary {
       position: relative;
       z-index: 11;
 
-      .p-icon--contextual-menu {
+      .p-icon--chevron-down {
         transform: rotate(180deg);
       }
     }

--- a/templates/advantage/table/_contract-name.html
+++ b/templates/advantage/table/_contract-name.html
@@ -10,7 +10,7 @@
       {% endif %}
     {% endif %}
     
-    {{ contract['contractInfo']['name'] }} &nbsp;<i class="p-icon--contextual-menu">Open</i>
+    {{ contract['contractInfo']['name'] }} &nbsp;<i class="p-icon--chevron-down">Open</i>
     
     {% if contract["renewal"] %}
       {% if contract["renewal"]["renewable"] or contract["renewal"]["actionable"] == false %}

--- a/templates/security/cve/_pagination.html
+++ b/templates/security/cve/_pagination.html
@@ -10,11 +10,11 @@
     <li class="p-pagination__item">
       {% if current_page > 1 %}
       <a class="p-pagination__link--previous" href="?{{ modify_query({'offset': offset - limit}) }}" title="Previous page">
-        <i class="p-icon--contextual-menu">Previous page</i>
+        <i class="p-icon--chevron-down">Previous page</i>
       </a>
       {% else %}
       <span class="p-pagination__link--previous is-disabled">
-        <i class="p-icon--contextual-menu">Previous page</i>
+        <i class="p-icon--chevron-down">Previous page</i>
       </span>
       {% endif %}
     </li>
@@ -88,11 +88,11 @@
     <li class="p-pagination__item">
       {% if current_page != total_pages %}
       <a class="p-pagination__link--next" href="?{{ modify_query({'offset': offset + limit}) }}" title="Next page">
-        <i class="p-icon--contextual-menu">Next page</i>
+        <i class="p-icon--chevron-down">Next page</i>
       </a>
       {% else %}
       <span class="p-pagination__link--next is-disabled">
-        <i class="p-icon--contextual-menu">Next page</i>
+        <i class="p-icon--chevron-down">Next page</i>
       </span>
       {% endif %}
     </li>

--- a/templates/shared/_pagination.html
+++ b/templates/shared/_pagination.html
@@ -4,11 +4,11 @@
       <li class="p-pagination__item">
         {% if current_page > 1 %}
           <a href="?{{ modify_query({'page': current_page - 1}) }}" class="p-pagination__link--previous">
-            <i class="p-icon--contextual-menu">Previous page</i>
+            <i class="p-icon--chevron-down">Previous page</i>
           </a>
         {% else %}
         <span class="p-pagination__link--previous is-disabled">
-          <i class="p-icon--contextual-menu">Previous page</i>
+          <i class="p-icon--chevron-down">Previous page</i>
         </span>
         {% endif %}
       </li>
@@ -76,11 +76,11 @@
       <li class="p-pagination__item">
         {% if current_page != total_pages %}
           <a href="?{{ modify_query({'page': current_page + 1}) }}" class="p-pagination__link--next">
-            <i class="p-icon--contextual-menu">Next page</i>
+            <i class="p-icon--chevron-down">Next page</i>
           </a>
         {% else %}
         <span class="p-pagination__link--next is-disabled">
-          <i class="p-icon--contextual-menu">Next page</i>
+          <i class="p-icon--chevron-down">Next page</i>
         </span>
         {% endif %}
       </li>

--- a/templates/tutorials/tutorial.html
+++ b/templates/tutorials/tutorial.html
@@ -165,21 +165,21 @@
           <div class="l-tutorial__pagination">
             {% if loop.first %}
               <button class="l-tutorial__pagination-item--prev p-button has-icon u-no-margin--bottom" disabled style="margin-right: 1rem;">
-                <i class="p-icon--contextual-menu">Previous step</i>
+                <i class="p-icon--chevron-down">Previous step</i>
               </button>
             {% else %}
               <a href="#{{ loop.index - 1 }}-{{ loop.previtem['slug'] }}" class="l-tutorial__pagination-item--prev p-button has-icon u-no-margin--bottom" style="margin-right: 1rem;">
-                <i class="p-icon--contextual-menu">Previous step</i>
+                <i class="p-icon--chevron-down">Previous step</i>
               </a>
             {% endif %}
 
             {% if loop.last %}
               <button class="l-tutorial__pagination-item--next p-button has-icon u-no-margin--bottom" disabled>
-                <i class="p-icon--contextual-menu">Next step</i>
+                <i class="p-icon--chevron-down">Next step</i>
               </button>
             {% else %}
               <a href="#{{ loop.index + 1 }}-{{ loop.nextitem['slug'] }}" class="l-tutorial__pagination-item--next p-button has-icon u-no-margin--bottom">
-                <i class="p-icon--contextual-menu">Next step</i>
+                <i class="p-icon--chevron-down">Next step</i>
               </a>
             {% endif %}
           </div>


### PR DESCRIPTION
## Done

- Changed p-icon--contextual-menu to p-icon--chevron-down

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/tutorials
- Select any tutorial
- See that the next/previous pagination icons are correct (compare them to live to confirm)

## Issue / Card

Fixes https://github.com/canonical-web-and-design/web-squad/issues/4862)
