### PR TITLE
Use UK spelling of "optimise" and its derivatives

### DIFF
--- a/templates/ai/what-is-kubeflow.html
+++ b/templates/ai/what-is-kubeflow.html
@@ -144,7 +144,7 @@
       <p>Experiments, groups of <a href="https://www.kubeflow.org/docs/pipelines/pipelines-quickstart/#run-an-ml-pipeline">Kubeflow Pipeline 'Runs'</a> and <a href="https://www.kubeflow.org/docs/components/pipelines/overview/concepts/run/">Recurring Runs</a>, allow you to find the right parameters for your model, compare and replicate results.</p>
 
       <p class="p-heading--4">Hyperparameter tuning / AutoML</p>
-      <p>Kubeflow includes <a class="p-link--external" href="https://www.kubeflow.org/docs/components/katib/">Katib</a> for hyperparameter tuning. Katib runs pipelines with different hyperparameters (e.g. learning rate, # of hidden layers) optimizing for the best ML model.</p>
+      <p>Kubeflow includes <a class="p-link--external" href="https://www.kubeflow.org/docs/components/katib/">Katib</a> for hyperparameter tuning. Katib runs pipelines with different hyperparameters (e.g. learning rate, # of hidden layers) optimising for the best ML model.</p>
 
       <p class="p-heading--4">KFServing for inference serving</p>
       <p><a class="p-link--external" href="https://www.kubeflow.org/docs/components/serving/kfserving/">KFServing</a> is a multi-framework model deployment tool with serverless inferencing, canary roll-outs, pre & post-processing and explainability. <a href="/blog/what-is-kfserving">Learn more&nbsp;&rsaquo;</a></p>

--- a/templates/aws/fips.html
+++ b/templates/aws/fips.html
@@ -1,7 +1,7 @@
 {% extends "aws/base_aws.html" %}
 
 {% block title %}Ubuntu FIPS for AWS{% endblock %}
-{% block meta_description %}Ubuntu Pro FIPS for AWS is an Ubuntu Pro image with FIPS certified modules enabled by default for FedRAMP, HIPAA, PCI and ISO compliance. Ubuntu Pro FIPS images are secure and optimized for production on public cloud.{% endblock %}
+{% block meta_description %}Ubuntu Pro FIPS for AWS is an Ubuntu Pro image with FIPS certified modules enabled by default for FedRAMP, HIPAA, PCI and ISO compliance. Ubuntu Pro FIPS images are secure and optimied for production on public cloud.{% endblock %}
 {% block meta_copydoc %}https://docs.google.com/document/d/1RIUejzxrQwvT-qQGG_FhRIaTVzZb07o6mZeiYkaBdqk/edit#{% endblock meta_copydoc %}
 
 {% block content %}
@@ -125,7 +125,7 @@
   <div class="row p-divider">
     <div class="col-6 p-divider__block">
       <h3 class="p-heading--4">Ubuntu Pro FIPS 18.04 LTS</h3>
-      <p>Ubuntu Pro FIPS 18.04 LTS includes an aws-optimized FIPS-certified 4.15 kernel and other FIPS certified modules pre-enabled out of the box. Ubuntu Pro FIPS provides extended security maintenance through April 2028.</p>
+      <p>Ubuntu Pro FIPS 18.04 LTS includes an AWS-optimised FIPS-certified 4.15 kernel and other FIPS certified modules pre-enabled out of the box. Ubuntu Pro FIPS provides extended security maintenance through April 2028.</p>
       <p><a href="https://aws.amazon.com/marketplace/pp/B08GCSCZJK" class="p-button--positive"><span class="p-link--external">Launch now</span></a></p>
     </div>
     <div class="col-6 p-divider__block">

--- a/templates/aws/index.html
+++ b/templates/aws/index.html
@@ -1,7 +1,7 @@
 {% extends "aws/base_aws.html" %}
 
 {% block title %}Ubuntu on AWS{% endblock %}
-{% block meta_description %}Ubuntu is the operating system platform of choice for AWS. Run Ubuntu on AWS, benefit from our worldwide mirroring and publication and talk to Canonical about how we can help optimize your cloud workloads.{% endblock %}
+{% block meta_description %}Ubuntu is the operating system platform of choice for AWS. Run Ubuntu on AWS, benefit from our worldwide mirroring and publication and talk to Canonical about how we can help optimise your cloud workloads.{% endblock %}
 {% block meta_copydoc %}https://docs.google.com/document/d/1lkH-MSPmgjCMP4gI0FW29YIKVDvBuddxA63iQhmsYIU{% endblock meta_copydoc %}
 
 {% block content %}

--- a/templates/azure/fips.html
+++ b/templates/azure/fips.html
@@ -1,7 +1,7 @@
 {% extends "azure/base_azure.html" %}
 
 {% block title %}Ubuntu Pro FIPS for Azure{% endblock %}
-{% block meta_description %}Ubuntu Pro FIPS for Azure is an Ubuntu Pro image with FIPS certified modules enabled by default for FedRAMP, HIPAA, PCI and ISO compliance. Ubuntu Pro FIPS images are secure and optimized for production on public cloud.{% endblock %}
+{% block meta_description %}Ubuntu Pro FIPS for Azure is an Ubuntu Pro image with FIPS certified modules enabled by default for FedRAMP, HIPAA, PCI and ISO compliance. Ubuntu Pro FIPS images are secure and optimised for production on public cloud.{% endblock %}
 {% block meta_copydoc %}https://docs.google.com/document/d/1Djxdzjy78bau8ELM4-MNGoM2YRa_QjpN1xJ4H4GjFyw/edit#heading=h.c6wjbvvp8mcm{% endblock meta_copydoc %}
 
 {% block content %}
@@ -125,7 +125,7 @@
   <div class="row p-divider">
     <div class="col-6 p-divider__block">
       <h3 class="p-heading--4">Ubuntu Pro FIPS 18.04 LTS</h3>
-      <p>Ubuntu Pro FIPS 18.04 LTS includes an azure-optimized FIPS-certified 4.15 kernel and other FIPS certified modules pre-enabled out of the box. Ubuntu Pro FIPS provides extended security maintenance through April 2028.</p>
+      <p>Ubuntu Pro FIPS 18.04 LTS includes an Azure-optimised FIPS-certified 4.15 kernel and other FIPS certified modules pre-enabled out of the box. Ubuntu Pro FIPS provides extended security maintenance through April 2028.</p>
       <p><a href="https://azuremarketplace.microsoft.com/en-ca/marketplace/apps/canonical.0001-com-ubuntu-pro-bionic-fips" class="p-button--positive"><span class="p-link--external">Launch now</span></a></p>
     </div>
     <div class="col-6 p-divider__block">
@@ -293,7 +293,7 @@
         <tbody>
           <tr>
             <td aria-label="Instance">DS11V2</td>
-            <td aria-label="Category">Memory optimized</td>
+            <td aria-label="Category">Memory optimised</td>
             <td aria-label="Cores" class="u-align--right">2</td>
             <td aria-label="Ram" class="u-align--right">14GB</td>
             <td aria-label="Azure Infrastructure" class="u-align--right">$0.185</td>
@@ -320,7 +320,7 @@
           </tr>
           <tr>
             <td aria-label="Instance">E2SV3</td>
-            <td aria-label="Category">Memory optimized</td>
+            <td aria-label="Category">Memory optimised</td>
             <td aria-label="Cores" class="u-align--right">2</td>
             <td aria-label="Ram" class="u-align--right">16GB</td>
             <td aria-label="Azure Infrastructure" class="u-align--right">$0.146</td>
@@ -430,7 +430,7 @@
           ) | safe
         }}
       </a>
-      <h4>Optimized scaling in the cloud</h4>
+      <h4>Optimised scaling in the cloud</h4>
       <p>Building enterprise-grade infrastructure with open source quickly with stability seems impossible, but Ubuntu Pro for Azure allows organisations to do just that. Ubuntu Pro is a premium image delivering the most comprehensive security and compliance features and is suitable for small to large-scale Linux enterprise operations offering pay-as-you-go billing on a single invoice through Azure. This piece explains the new ways Ubuntu and Microsoft Azure are driving reliability and security at speed and scale.</p>
       <p><a class="p-button--positive p-link--external" href="https://assets.ubuntu.com/v1/a60c04fd-Optimized+Scaling+In+The+Cloud.pdf" >Download the e-book</a></p>
     </div>

--- a/templates/azure/index.html
+++ b/templates/azure/index.html
@@ -1,7 +1,7 @@
 {% extends "azure/base_azure.html" %}
 
 {% block title %}Ubuntu on Azure{% endblock %}
-{% block meta_description %}Ubuntu is the operating system platform of choice for Azure, powering innovation on public cloud in environments ranging from dev/test to mission-critical production. Run Ubuntu on Azure, benefit from our worldwide mirroring and publication and talk to Canonical about how we can help optimize your cloud workloads.{% endblock %}
+{% block meta_description %}Ubuntu is the operating system platform of choice for Azure, powering innovation on public cloud in environments ranging from dev/test to mission-critical production. Run Ubuntu on Azure, benefit from our worldwide mirroring and publication and talk to Canonical about how we can help optimise your cloud workloads.{% endblock %}
 {% block meta_copydoc %}https://docs.google.com/document/d/1GUlSATrqZmGrsk4DhP9W0s-gcOuFxpdKVgx7YE4g780/edit#{% endblock meta_copydoc %}
 
 {% block content %}

--- a/templates/download/iot/intel-iotg.html
+++ b/templates/download/iot/intel-iotg.html
@@ -11,7 +11,7 @@
   <div class="row u-vertically-center">
     <div class="col-7">
       <h1>Download Ubuntu for Intel IoT platforms</h1>
-      <p class="p-heading--4">Ubuntu &mdash; now optimized for Intel's IOTG platforms</p>
+      <p class="p-heading--4">Ubuntu &mdash; now optimised for Intel's IOTG platforms</p>
       <p>Ubuntu Core 20 and Ubuntu Desktop 20.04 based images for Intel IoT platforms are currently available for download.</p>
       <p>Pick your chosen OS image and follow the install instruction to load it onto your board and away you go.</p>
       <p>If you have any questions about the supported Intel IOTG platforms or would like information about our certification program, please contact us.</p>

--- a/templates/gcp/index.html
+++ b/templates/gcp/index.html
@@ -1,7 +1,7 @@
 {% extends "gcp/base_gcp.html" %}
 
 {% block title %}Ubuntu on Google Cloud{% endblock %}
-{% block meta_description %}Ubuntu is the operating system platform of choice for GCP, powering innovation on public cloud in environments ranging from dev/test to mission-critical production. Run Ubuntu on Google Cloud, benefit from our worldwide mirroring and publication and talk to Canonical about how we can help optimize your cloud workloads.{% endblock %}
+{% block meta_description %}Ubuntu is the operating system platform of choice for GCP, powering innovation on public cloud in environments ranging from dev/test to mission-critical production. Run Ubuntu on Google Cloud, benefit from our worldwide mirroring and publication and talk to Canonical about how we can help optimise your cloud workloads.{% endblock %}
 {% block meta_copydoc %}https://docs.google.com/document/d/1Gvt9tNFDZkqkBcP0k79C6ueTJCmNZvwoXQoU19WEa8E/edit{% endblock meta_copydoc %}
 
 {% block content %}

--- a/templates/legal/data-privacy/2013-03-25/index.html
+++ b/templates/legal/data-privacy/2013-03-25/index.html
@@ -117,7 +117,7 @@
         <tr>
           <td headers="cookie" scope="row">Crazyegg</td>
           <td headers="cookie_name">is_returning</td>
-          <td headers="cookie_purpose">Crazyegg tracks javascript on some pages of our site to understand what links our visitors are clicking on. This helps us optimize our content for the best user experience. The Crazyegg script may store a cookie on your computer. This cookie may contain a session ID, a visitor ID and a few other dynamically created parameters that allow Crazyegg to track our site&#39;s traffic accurately. No personal information is stored within the cookie.</td>
+          <td headers="cookie_purpose">Crazyegg tracks javascript on some pages of our site to understand what links our visitors are clicking on. This helps us optimise our content for the best user experience. The Crazyegg script may store a cookie on your computer. This cookie may contain a session ID, a visitor ID and a few other dynamically created parameters that allow Crazyegg to track our site&#39;s traffic accurately. No personal information is stored within the cookie.</td>
           <td headers="cookie_info">For Crazy Egg&#39;s complete Privacy Policy please visit <a href="http://www.crazyegg.com/privacy">www.crazyegg.com/privacy</a>.</td>
         </tr>
         <tr>

--- a/templates/legal/data-privacy/2016-02-08/index.html
+++ b/templates/legal/data-privacy/2016-02-08/index.html
@@ -1,7 +1,7 @@
 {% extends "legal/_base_legal.html" %}
 
 {% block title %}Privacy policy | Terms and policies{% endblock %}
-{% block meta_copydoc %}https://drive.google.com/drive/folders/0B3hNyKyLEnE6clUxQndBME5uRXM{% endblock meta_copydoc %}
+{% block meta_copydoc %}https://docs.google.com/document/d/1JaZomTAVAADxr1PT_1_4u2YBWxipGxqlbXjt3MCDrsY/edit{% endblock meta_copydoc %}
 
 {% block content %}
 
@@ -117,7 +117,7 @@
 
       <h4>Crazyegg</h4>
       <p><code>is_returning</code></p>
-      <p>Crazyegg tracks javascript on some pages of our site to understand what links our visitors are clicking on. This helps us optimize our content for the best user experience. The Crazyegg script may store a cookie on your computer. This cookie may contain a session ID, a visitor ID and a few other dynamically created parameters that allow Crazyegg to track our site&#39;s traffic accurately. No personal information is stored within the cookie.</p>
+      <p>Crazyegg tracks javascript on some pages of our site to understand what links our visitors are clicking on. This helps us optimise our content for the best user experience. The Crazyegg script may store a cookie on your computer. This cookie may contain a session ID, a visitor ID and a few other dynamically created parameters that allow Crazyegg to track our site&#39;s traffic accurately. No personal information is stored within the cookie.</p>
       <p><a class="p-link--external" href="https://www.crazyegg.com/privacy">Crazy Egg&#39;s complete Privacy Policy</a></p>
 
       <h4>Marketo Munchkin</h4>

--- a/templates/legal/data-privacy/index.html
+++ b/templates/legal/data-privacy/index.html
@@ -180,7 +180,7 @@
             <td>Crazyegg</td>
             <td><code>_ceir</code>, <code>is_returning</code>, <code>_CEFT</code>, <code>ceg.s</code>,<code>ceg.u</code></td>
             <td>
-              <p>Crazyegg tracks javascript on some pages of our site to understand what links our visitors are clicking on. This helps us optimize our content for the best user experience. The Crazyegg script may store a cookie on your computer. This cookie may contain a session ID, a visitor ID and a few other dynamically created parameters that allow Crazyegg to track our site's traffic accurately. No personal information is stored within the cookie.</p>
+              <p>Crazyegg tracks javascript on some pages of our site to understand what links our visitors are clicking on. This helps us optimise our content for the best user experience. The Crazyegg script may store a cookie on your computer. This cookie may contain a session ID, a visitor ID and a few other dynamically created parameters that allow Crazyegg to track our site's traffic accurately. No personal information is stored within the cookie.</p>
               <p><a class="p-link--external" href="https://www.crazyegg.com/privacy">Crazy Egg's privacy policy</a></p>
             </td>
           </tr>

--- a/templates/managed/apps/cassandra.html
+++ b/templates/managed/apps/cassandra.html
@@ -375,7 +375,7 @@
           </tr>
           <tr>
             <td><strong>Throughput</strong></td>
-            <td colspan="2">Optimized for your workload and environment</td>
+            <td colspan="2">Optimised for your workload and environment</td>
           </tr>
           <tr>
             <td><strong>Node size</strong></td>
@@ -383,7 +383,7 @@
           </tr>
           <tr>
             <td><strong>Latency</strong></td>
-            <td colspan="2">Optimized for your workload and environment</td>
+            <td colspan="2">Optimised for your workload and environment</td>
           </tr>
         </table>
       </div>

--- a/templates/security/fips.html
+++ b/templates/security/fips.html
@@ -93,7 +93,7 @@
 <section class="p-strip--light">
   <div class="u-fixed-width">
     <h2 id="public-cloud">Access FIPS images on the public cloud</h2>
-    <p class="u-sv3">FIPS can be enabled on Ubuntu Pro cloud images, while Ubuntu Pro FIPS cloud images simplify the experience as they come preconfigured with FIPS 140 certified packages optimized for the cloud. You can quickly navigate on the marketplace FIPS-enabled images below.</p>
+    <p class="u-sv3">FIPS can be enabled on Ubuntu Pro cloud images, while Ubuntu Pro FIPS cloud images simplify the experience as they come preconfigured with FIPS 140 certified packages optimised for the cloud. You can quickly navigate on the marketplace FIPS-enabled images below.</p>
   </div>
   <div class="row">
     <div class="col-3">

--- a/templates/support/community-support.html
+++ b/templates/support/community-support.html
@@ -30,7 +30,7 @@
   <div class="row u-equal-height">
     <div class="col-4 p-card">
       <h3><a href="https://discourse.ubuntu.com/t/community-support/709" class="p-link--external">Find community support</a></h3>
-      <p><a href="https://askubuntu.com/" class="p-link--external">Ask Ubuntu</a> and <a href="https://ubuntuforums.org/" class="p-link--external">Ubuntu Forums</a> are great sources of answers to common questions about installing, troubleshooting and optimizing Ubuntu. For more info on support forums, including IRC channels, see <a href="https://discourse.ubuntu.com/t/community-support/709" class="p-link--external">our Discourse site</a>.</p>
+      <p><a href="https://askubuntu.com/" class="p-link--external">Ask Ubuntu</a> and <a href="https://ubuntuforums.org/" class="p-link--external">Ubuntu Forums</a> are great sources of answers to common questions about installing, troubleshooting and optimising Ubuntu. For more info on support forums, including IRC channels, see <a href="https://discourse.ubuntu.com/t/community-support/709" class="p-link--external">our Discourse site</a>.</p>
     </div>
     <div class="col-4 p-card">
       <h3><a href="https://help.ubuntu.com/" class="p-link--external">Read the docs</a></h3>

--- a/templates/telco/openran.html
+++ b/templates/telco/openran.html
@@ -77,8 +77,8 @@
     </div>
     <div class="col-6">
       <h2>Vendor neutral</h2>
-      <h4>We work with all major hardware vendors to make optimizations</h4>
-      <p>Ubuntu, Kubernetes, OpenStack, MAAS, LXD are all optimized for OpenRAN RU, CU and DU workloads thanks to our collaboration with hardware and software platform vendors.</p>
+      <h4>We work with all major hardware vendors to make optimisations</h4>
+      <p>Ubuntu, Kubernetes, OpenStack, MAAS, LXD are all optimised for OpenRAN RU, CU and DU workloads thanks to our collaboration with hardware and software platform vendors.</p>
       <p>
         <a href="/server">Read more&nbsp;&rsaquo;</a>
       </p>


### PR DESCRIPTION
## Done

- Fixed the change requested in this issue: https://github.com/canonical-web-and-design/web-squad/issues/4852
- As a drive by, updated every instance I could find of optimize/optimized/optimizing/optimization in the project, as long as it was within copy, and not a URL/third party package/config etc

## QA

- View the site your web browser at: https://ubuntu-com-11303.demos.haus/download/iot/intel-iotg
- See that the typo pointed out in the copy doc has been updated
- Visit:
  - https://ubuntu-com-11303.demos.haus/ai/what-is-kubeflow
  - https://ubuntu-com-11303.demos.haus/aws/fips
  - https://ubuntu-com-11303.demos.haus/aws
  - https://ubuntu-com-11303.demos.haus/azure/fips
  - https://ubuntu-com-11303.demos.haus/azure
  - https://ubuntu-com-11303.demos.haus/gcp
  - https://ubuntu-com-11303.demos.haus/legal/data-privacy/2013-03-25
  - https://ubuntu-com-11303.demos.haus/legal/data-privacy/2016-02-08
  - https://ubuntu-com-11303.demos.haus/legal/data-privacy
  - https://ubuntu-com-11303.demos.haus/managed/apps/cassandra
  - https://ubuntu-com-11303.demos.haus/security/fips
  - https://ubuntu-com-11303.demos.haus/support/community-support
  - https://ubuntu-com-11303.demos.haus/telco/openran
- Search each page for "optimiz" (should be zero), whereas "optimis" will return some results.
- Using the extension, check the copy docs and see that each one has been updated 

## Issue / Card

Fixes https://github.com/canonical-web-and-design/web-squad/issues/4852
