### PR TITLE
Fix categories for vendor pages

### DIFF
--- a/webapp/certified/views.py
+++ b/webapp/certified/views.py
@@ -628,6 +628,10 @@ def certified_vendors(vendor):
     )
 
     results = models["objects"]
+    for index, model in enumerate(results):
+        # Replace "Ubuntu Core" with "Device"
+        if model["category"] == "Ubuntu Core":
+            results[index]["category"] = "Device"
 
     total_results = models["meta"]["total_count"]
 


### PR DESCRIPTION
## Done

Replace category name ubuntu core to device for vendor pages

## QA

- Visit https://ubuntu-com-11309.demos.haus//certified/vendors/Advantech https://ubuntu-com-11309.demos.haus//certified/vendors/DFI and check that the categories column show "Device" instead of "Ubuntu Core" (compare with https://ubuntu.com/certified/vendors/Advantech)

## Issue / Card

Fixes https://github.com/canonical-web-and-design/ubuntu.com/issues/11308


## Help

[QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html) - [Commit guidelines](https://canonical-web-and-design.github.io/practices/workflow/commit-messages.html)
