### PR TITLE
Update notifications structure to new pattern - part 1

### DIFF
--- a/static/js/src/advantage/manage-subscription.js
+++ b/static/js/src/advantage/manage-subscription.js
@@ -16,13 +16,13 @@ const getMessage = (code, default_message) => {
     resizing_machines_fail:
       "<strong>Payment method:</strong> There was problem with your payment. Please <a href='/account/payment-methods'>update your payment methods</a> to retry.",
     subscription_missing:
-      "<strong>Could not cancel subscription:</strong> It could be that you have a pending payment that is blocking this action. Contact <a class='p-notification__action' href='https://ubuntu.com/contact-us'>Canonical sales</a> if the problem persists.",
+      "<strong>Could not cancel subscription:</strong> It could be that you have a pending payment that is blocking this action. Contact <a href='https://ubuntu.com/contact-us'>Canonical sales</a> if the problem persists.",
     cancelling_subscription_failed:
-      "<strong>Could not cancel subscription:</strong> Contact <a class='p-notification__action' href='https://ubuntu.com/contact-us'>Canonical sales</a> if the problem persists.",
+      "<strong>Could not cancel subscription:</strong> Contact <a href='https://ubuntu.com/contact-us'>Canonical sales</a> if the problem persists.",
     pending_purchase:
       "<strong>Error:</strong> You already have a pending purchase. Please go to <a href='/account/payment-methods'>payment methods</a> to retry.",
     unknown_error:
-      "<strong>Unknown error:</strong> Contact <a class='p-notification__action' href='https://ubuntu.com/contact-us'>Canonical sales</a> if the problem persists.",
+      "<strong>Unknown error:</strong> Contact <a href='https://ubuntu.com/contact-us'>Canonical sales</a> if the problem persists.",
   };
 
   if (map[code]) {

--- a/static/js/src/advantage/react/components/Subscriptions/SubscriptionCancel/SubscriptionCancel.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/SubscriptionCancel/SubscriptionCancel.tsx
@@ -46,11 +46,7 @@ const generateError = (error: CancelError | null) => {
           action.{" "}
         </>
       ) : null}
-      Contact{" "}
-      <a className="p-notification__action" href="/contact-us">
-        Canonical sales
-      </a>{" "}
-      if the problem persists.
+      Contact <a href="/contact-us">Canonical sales</a> if the problem persists.
     </>
   );
 };

--- a/static/js/src/ua-payment-methods.js
+++ b/static/js/src/ua-payment-methods.js
@@ -149,7 +149,7 @@ if (cardElement) {
   const handlePaymentMethodErrors = (message) => {
     paymentErrorElement.querySelector(
       ".p-notification__message"
-    ).innerHTML = `<strong>${message}</strong> Check the details and try again. Contact <a class='p-notification__action' href='https://ubuntu.com/contact-us'>Canonical sales</a> if the problem persists.`;
+    ).innerHTML = `<strong>${message}</strong> Check the details and try again. Contact <a href='https://ubuntu.com/contact-us'>Canonical sales</a> if the problem persists.`;
     paymentErrorElement.classList.remove("u-hide");
   };
 

--- a/templates/account/payment-methods/index.html
+++ b/templates/account/payment-methods/index.html
@@ -28,7 +28,7 @@
       <div id="payment-warnings" class="p-notification--caution u-hide">
         <p class="p-notification__response">
           <span class="p-notification__message">
-            You have one or more pending payments. Use your saved card to <a class="p-notification__action" id="try-again-button">retry payment</a>. <i id="try-again-spinner" class="p-icon--spinner u-animation--spin is-dark u-hide"></i></span>
+            You have one or more pending payments. Use your saved card to <a id="try-again-button">retry payment</a>. <i id="try-again-spinner" class="p-icon--spinner u-animation--spin is-dark u-hide"></i></span>
         </p>
       </div>
 

--- a/templates/account/payment-methods/index.html
+++ b/templates/account/payment-methods/index.html
@@ -14,22 +14,22 @@
     <div class="col-12">
 
       <div id="payment-success" class="p-notification--positive u-hide">
-        <p class="p-notification__response">
-          <span class="p-notification__message"></span>
-        </p>
+        <div class="p-notification__content">
+          <p class="p-notification__message"></p>
+        </div>
       </div>
 
       <div id="payment-errors" class="p-notification--negative u-hide">
-        <p class="p-notification__response">
-          <span class="p-notification__message"></span>
-        </p>
+        <div class="p-notification__content">
+          <p class="p-notification__message"></p>
+        </div>
       </div>
 
       <div id="payment-warnings" class="p-notification--caution u-hide">
-        <p class="p-notification__response">
-          <span class="p-notification__message">
-            You have one or more pending payments. Use your saved card to <a id="try-again-button">retry payment</a>. <i id="try-again-spinner" class="p-icon--spinner u-animation--spin is-dark u-hide"></i></span>
-        </p>
+        <div class="p-notification__content">
+          <p class="p-notification__message">
+            You have one or more pending payments. Use your saved card to <a id="try-again-button">retry payment</a>. <i id="try-again-spinner" class="p-icon--spinner u-animation--spin is-dark u-hide"></i></p>
+        </div>
       </div>
 
       <h1>Payment methods</h1>

--- a/templates/advantage/_stripe-modal.html
+++ b/templates/advantage/_stripe-modal.html
@@ -10,9 +10,9 @@
 
       <section class="p-strip is-shallow u-no-padding" style="overflow-x: visible;">
         <div id="payment-errors" class="p-notification--negative u-hide">
-          <p class="p-notification__response">
-            <span class="p-notification__message"></span>
-          </p>
+          <div class="p-notification__content">
+            <p class="p-notification__message"></p>
+          </div>
         </div>
 
         <form class="p-form p-form--stacked u-sv3" id="details-form">

--- a/templates/advantage/table/_free-trial.html
+++ b/templates/advantage/table/_free-trial.html
@@ -5,10 +5,11 @@
   <div class="row">
     {% if contract['contractInfo']['status'] == "expired" %}
 
-      <div class="p-notification--caution">
-        <p class="p-notification__response">
-         <span class="p-notification__status">Your free trial expired.</span>You will lose access to this Ubuntu Advantage subscription on {{ contract['contractInfo']['grace_period_end'] }}.
-        </p>
+      <div class="p-notification--caution is-inline">
+        <div class="p-notification__content">
+          <span class="p-notification__title">Your free trial expired.</span>
+          <p class="p-notification__message">You will lose access to this Ubuntu Advantage subscription on {{ contract['contractInfo']['grace_period_end'] }}.</p>
+        </div>
       </div>
 
     {% endif %}

--- a/templates/appliance/lxd/_next-steps.html
+++ b/templates/appliance/lxd/_next-steps.html
@@ -35,11 +35,11 @@ lxc list appliance:</pre>
           And you're away. For more information check out the <a class="p-link--external" href="https://linuxcontainers.org">LXD website</a> or read our <a class="p-link--external" href="https://discuss.linuxcontainers.org/t/lxd-cluster-on-raspberry-pi-4/9076">tutorial on turning the LXD Ubuntu Appliance into your own homelab</a>.
         </p>
         <div class="p-notification" id="notification">
-          <div class="p-notification__response">
-            <span class="p-notification__status">
+          <div class="p-notification__content">
+            <span class="p-notification__title">
               Note:
             </span>
-            <p>
+            <p class="p-notification__message">
               If there is a core update, the appliance will automatically update, then reboot. Typically this isn't an issue but some use cases should take note.
             </p>
           </div>

--- a/templates/appliance/mosquitto/_next-steps.html
+++ b/templates/appliance/mosquitto/_next-steps.html
@@ -32,9 +32,9 @@
         This is a very simple example but allows testing of the broker operation. Other things you may wish to try are subscribing to wildcard topics that include <code>#</code> or <code></code>, or subscribing to the <code>$SYS/#</code> topic to see the information the broker is publishing about itself.
       </p>
       <div class="p-notification" id="notification">
-        <div class="p-notification__response">
-          <span class="p-notification__status">Note:</span>
-          <p>The command line treats <code>#</code> as a special character, and <code>SSYS</code> will be expanded as an environment variable if you do not surround them with single quotes.
+        <div class="p-notification__content">
+          <span class="p-notification__title">Note:</span>
+          <p class="p-notification__message">The command line treats <code>#</code> as a special character, and <code>SSYS</code> will be expanded as an environment variable if you do not surround them with single quotes.
           </p>
         </div>
       </div>

--- a/templates/appliance/shared/_steps_pi_prep-sd-card.html
+++ b/templates/appliance/shared/_steps_pi_prep-sd-card.html
@@ -4,14 +4,9 @@
   </h4>
   <div class="p-stepped-list__content">
     <div class="p-notification--caution">
-      <div class="p-notification__response">
-        <p class="u-no-padding--top u-no-margin--bottom">
-          <strong>
-            Warning
-          </strong>
-          <br>
-          This will completely erase the microSD card.
-        </p>
+      <div class="p-notification__content">
+        <span class="p-notification__title">Warning</span>
+        <p class="p-notification__message">This will completely erase the microSD card.</p>
       </div>
     </div>
     <ul class="p-list">

--- a/templates/appliance/shared/_steps_setup-kvm.html
+++ b/templates/appliance/shared/_steps_setup-kvm.html
@@ -18,13 +18,15 @@
         <p>You can now launch a virtual machine with KVM, using the following command:</p>
         <pre><code>kvm -smp 2 -m 1500 -netdev user,id=mynet0,hostfwd=tcp::8022-:22,hostfwd=tcp::8090-:80 -device virtio-net-pci,netdev=mynet0 -vga qxl -drive file=ubuntu-core-16-amd64.img,format=raw</code></pre>
         <div class="p-notification" id="notification">
-          <div class="p-notification__response">
-            <span class="p-notification__status">Note:</span>
-            <p>This command sets up port redirections:</p>
-            <ul>
-              <li><code>localhost:8022</code> is redirecting to port 22 of the virtual machine for accessing it through SSH</li>
-              <li><code>localhost:8090</code> is redirecting to its port 3000</li>
-            </ul>
+          <div class="p-notification__content">
+            <span class="p-notification__title">Note:</span>
+            <span class="p-notification__message">
+              <p>This command sets up port redirections:</p>
+              <ul>
+                <li><code>localhost:8022</code> is redirecting to port 22 of the virtual machine for accessing it through SSH</li>
+                <li><code>localhost:8090</code> is redirecting to its port 3000</li>
+              </ul>
+            </span>
           </div>
         </div>
       </li>

--- a/templates/cube/study/index.md
+++ b/templates/cube/study/index.md
@@ -12,20 +12,21 @@ Refresh your understanding of key Ubuntu concepts and methods with the following
 
 Note that these study materials are not intended as a training program. Rather, they are meant to complement your existing knowledge. If any of the terms or procedures encountered in these materials feel unfamiliar, it may indicate that further preparation is needed in that subject area before attempting the corresponding CUBE exam.
 
-
 ## Further preparation
 
-For additional practise, enroll in Canonical’s Study Labs. The labs enhance the free study materials, adding new interactive exercises that feature virtual Ubuntu terminals. They offer a hands-on study experience that simulates working with the real thing. No more worrying about experimenting on your personal computer; use our simulated ones to avoid altering your own files. 
+For additional practise, enroll in Canonical’s Study Labs. The labs enhance the free study materials, adding new interactive exercises that feature virtual Ubuntu terminals. They offer a hands-on study experience that simulates working with the real thing. No more worrying about experimenting on your personal computer; use our simulated ones to avoid altering your own files.
 
 Our study labs provide terminal access via your browser and are formatted similarly to what you will see during exams.
 
 A single purchase grants 90 days of access to the full set of Study Labs for every microcertification.
 
 <a class="p-button--positive js-study-button u-hide"></a>
+
 <div class="p-notification--negative js-study-notification u-hide">
-  <p class="p-notification__response" role="status">
-    <span class="p-notification__status">Error:</span>We could not verify if you have access to the study labs.
-  </p>
+  <div class="p-notification__content" role="status">
+    <span class="p-notification__title">Error:</span>
+    <p class="p-notification__message">We could not verify if you have access to the study labs.</p>
+  </div>
 </div>
 
 <script>

--- a/templates/download/iot/installation-media.html
+++ b/templates/download/iot/installation-media.html
@@ -10,9 +10,10 @@
       <h1>Create installation media for Ubuntu</h1>
       <p>These steps will walk you through creating a bootable Ubuntu image SD Card or USB flash drive.</p>
       <div class="p-notification--caution">
-        <p class="p-notification__response">
-          <span class="p-notification__status">WARNING:</span>This will erase any existing content on the removable drive!
-        </p>
+        <div class="p-notification__content">
+          <span class="p-notification__title">WARNING:</span>
+          <p class="p-notification__message">This will erase any existing content on the removable drive!</p>
+        </div>
       </div>
       <p>View instructions for: <a href="#ubuntu">Ubuntu</a>, <a href="#windows">Windows</a>, or <a href="#macos">macOS</a>.</p>
     </div>

--- a/templates/kubernetes/docs/1.17/release-notes.md
+++ b/templates/kubernetes/docs/1.17/release-notes.md
@@ -105,14 +105,15 @@ A list of bug fixes and other minor feature updates in this release can be found
 ## Notes / Known Issues
 
 - The `registry` action for the `kubernetes-worker` charm has been deprecated and will be removed
-in a future release. To enable a custom container registry, please see the
-[registry](/kubernetes/docs/docker-registry) documentation.
+  in a future release. To enable a custom container registry, please see the
+  [registry](/kubernetes/docs/docker-registry) documentation.
 
 ## Previous releases
 
 Please see [this page][historic] for release notes of earlier versions.
 
 <!--LINKS-->
+
 [upgrade-notes]: /kubernetes/docs/upgrade-notes
 [bundle]: https://api.jujucharms.com/charmstore/v5/canonical-kubernetes-471/archive/bundle.yaml
 [historic]: /kubernetes/docs/release-notes-historic
@@ -129,10 +130,10 @@ Please see [this page][historic] for release notes of earlier versions.
 
 <!-- FEEDBACK -->
 <div class="p-notification--information">
-  <p class="p-notification__response">
-    We appreciate your feedback on the documentation. You can
+  <div class="p-notification__content">
+    <p class="p-notification__message">We appreciate your feedback on the documentation. You can
     <a href="https://github.com/charmed-kubernetes/kubernetes-docs/edit/main/pages/k8s/release-notes.md" >edit this page</a>
     or
-    <a href="https://github.com/charmed-kubernetes/kubernetes-docs/issues/new" >file a bug here</a>.
-  </p>
+    <a href="https://github.com/charmed-kubernetes/kubernetes-docs/issues/new" >file a bug here</a>.</p>
+  </div>
 </div>

--- a/templates/kubernetes/docs/1.18/release-notes.md
+++ b/templates/kubernetes/docs/1.18/release-notes.md
@@ -22,7 +22,6 @@ toc: False
 Bug fixes included in this release can be found at
 [https://launchpad.net/charmed-kubernetes/+milestone/1.18+ck2](https://launchpad.net/charmed-kubernetes/+milestone/1.18+ck2).
 
-
 # 1.18+ck1 Bugfix release
 
 ### June 11, 2020 - [charmed-kubernetes-464](https://api.jujucharms.com/charmstore/v5/charmed-kubernetes-464/archive/bundle.yaml)
@@ -71,7 +70,6 @@ where containers would fail to start in a LXD environment.
 Bug fixes included in this release can be found at
 [https://launchpad.net/charmed-kubernetes/+milestone/1.18+ck1](https://launchpad.net/charmed-kubernetes/+milestone/1.18+ck1).
 
-
 # 1.18
 
 ### April 13th, 2020 - [charmed-kubernetes-430](https://api.jujucharms.com/charmstore/v5/charmed-kubernetes-430/archive/bundle.yaml)
@@ -105,13 +103,13 @@ running this action on Charmed Kubernetes components.
 
 - Containerd version hold
 
-The version of [containerd](https://containerd.io/) will now be held.  This means that the version of [containerd](https://containerd.io/) will not be upgraded along with the charm.  To update [containerd](https://containerd.io/) to the latest stable, currently 1.3.3, you can call the `upgrade-containerd` action.  For example:
+The version of [containerd](https://containerd.io/) will now be held. This means that the version of [containerd](https://containerd.io/) will not be upgraded along with the charm. To update [containerd](https://containerd.io/) to the latest stable, currently 1.3.3, you can call the `upgrade-containerd` action. For example:
 
 ```bash
 juju run-action --wait containerd/0 upgrade-containerd
 ```
 
-After completion, the results of the upgrade will be returned.  Run this for each instance of the `containerd` charm.  The upgrades can be staggered to avoid downtime.
+After completion, the results of the upgrade will be returned. Run this for each instance of the `containerd` charm. The upgrades can be staggered to avoid downtime.
 
 ## Component Upgrades
 
@@ -165,6 +163,7 @@ PVCs using those storage classes will hang until the storage class is updated.
 Please see [this page][historic] for release notes of earlier versions.
 
 <!--LINKS-->
+
 [upgrade-notes]: /kubernetes/docs/upgrade-notes
 [bundle]: https://api.jujucharms.com/charmstore/v5/canonical-kubernetes-471/archive/bundle.yaml
 [historic]: /kubernetes/docs/release-notes-historic
@@ -181,10 +180,10 @@ Please see [this page][historic] for release notes of earlier versions.
 
 <!-- FEEDBACK -->
 <div class="p-notification--information">
-  <p class="p-notification__response">
-    We appreciate your feedback on the documentation. You can
+  <div class="p-notification__content">
+    <p class="p-notification__message">We appreciate your feedback on the documentation. You can
     <a href="https://github.com/charmed-kubernetes/kubernetes-docs/edit/main/pages/k8s/release-notes.md" >edit this page</a>
     or
-    <a href="https://github.com/charmed-kubernetes/kubernetes-docs/issues/new" >file a bug here</a>.
-  </p>
+    <a href="https://github.com/charmed-kubernetes/kubernetes-docs/issues/new" >file a bug here</a>.</p>
+  </div>
 </div>

--- a/templates/kubernetes/docs/1.19/release-notes.md
+++ b/templates/kubernetes/docs/1.19/release-notes.md
@@ -18,6 +18,7 @@ toc: False
 ### November 27th, 2020 - [charmed-kubernetes-545](https://api.jujucharms.com/charmstore/v5/charmed-kubernetes-545/archive/bundle.yaml)
 
 ## Fixes
+
 A list of bug fixes and other minor feature updates in this release can be found at
 [https://launchpad.net/charmed-kubernetes/+milestone/1.19+ck2](https://launchpad.net/charmed-kubernetes/+milestone/1.19+ck2).
 
@@ -26,9 +27,9 @@ A list of bug fixes and other minor feature updates in this release can be found
 ### November 20th, 2020 - [charmed-kubernetes-541](https://api.jujucharms.com/charmstore/v5/charmed-kubernetes-541/archive/bundle.yaml)
 
 ## Fixes
+
 A list of bug fixes and other minor feature updates in this release can be found at
 [https://launchpad.net/charmed-kubernetes/+milestone/1.19+ck1](https://launchpad.net/charmed-kubernetes/+milestone/1.19+ck1).
-
 
 # 1.19
 
@@ -122,17 +123,17 @@ A list of bug fixes and other minor feature updates in this release can be found
 ## Notes / Known Issues
 
 - The `insecure-bind-address` and `insecure-port` options to `kube-apiserver` have
-been removed in this release. Using `juju run` with `kubectl` to interact with the
-cluster now requires an explicit `--kubeconfig <file>` option:
+  been removed in this release. Using `juju run` with `kubectl` to interact with the
+  cluster now requires an explicit `--kubeconfig <file>` option:
 
-    ```bash
-    juju run --unit kubernetes-master/0 'kubectl --kubeconfig /root/.kube/config get nodes'
-    NAME              STATUS   ROLES    AGE   VERSION
-    ip-172-31-10-19   Ready    <none>   71m   v1.19.0
-    ```
+      ```bash
+      juju run --unit kubernetes-master/0 'kubectl --kubeconfig /root/.kube/config get nodes'
+      NAME              STATUS   ROLES    AGE   VERSION
+      ip-172-31-10-19   Ready    <none>   71m   v1.19.0
+      ```
 
 - The webhook authentication service included in this release runs on port 5000 of each
-kubernetes-master unit. Ensure this port is available prior to upgrading.
+  kubernetes-master unit. Ensure this port is available prior to upgrading.
 
 - Additional known issues scheduled for the first 1.19 bugfix release can be found at [https://launchpad.net/charmed-kubernetes/+milestone/1.19+ck1](https://launchpad.net/charmed-kubernetes/+milestone/1.19+ck1)
 
@@ -146,6 +147,7 @@ relevant sections of the [upstream release notes](https://github.com/kubernetes/
 Please see [this page][historic] for release notes of earlier versions.
 
 <!--LINKS-->
+
 [upgrade-notes]: /kubernetes/docs/upgrade-notes
 [bundle]: https://api.jujucharms.com/charmstore/v5/canonical-kubernetes-471/archive/bundle.yaml
 [cis-benchmark]: /kubernetes/docs/cis-compliance
@@ -159,10 +161,10 @@ Please see [this page][historic] for release notes of earlier versions.
 
 <!-- FEEDBACK -->
 <div class="p-notification--information">
-  <p class="p-notification__response">
-    We appreciate your feedback on the documentation. You can
+  <div class="p-notification__content">
+    <p class="p-notification__message">We appreciate your feedback on the documentation. You can
     <a href="https://github.com/charmed-kubernetes/kubernetes-docs/edit/main/pages/k8s/release-notes.md" >edit this page</a>
     or
-    <a href="https://github.com/charmed-kubernetes/kubernetes-docs/issues/new" >file a bug here</a>.
-  </p>
+    <a href="https://github.com/charmed-kubernetes/kubernetes-docs/issues/new" >file a bug here</a>.</p>
+  </div>
 </div>

--- a/templates/kubernetes/docs/audit-logging.md
+++ b/templates/kubernetes/docs/audit-logging.md
@@ -21,7 +21,6 @@ documentation covers the configuration and usage of these audit logs in
 methodology behind audit logging in Kubernetes, see the
 [Kubernetes Auditing documentation][k8s-audit].
 
-
 ## Viewing the log
 
 By default, **Charmed Kubernetes** enables audit logging to files on the
@@ -38,7 +37,7 @@ Note that this log is replicated on all kubernetes-master units.
 ## Audit policy configuration
 
 Audit policy defines rules about what events should be recorded and what data
-they should include.  For **Charmed Kubernetes** this is configurable on the kubernetes-master charm
+they should include. For **Charmed Kubernetes** this is configurable on the kubernetes-master charm
 using the `audit-policy` setting.
 
 To view the current policy:
@@ -55,7 +54,7 @@ named `audit-policy.yaml` with the following contents:
 apiVersion: audit.k8s.io/v1beta1
 kind: Policy
 rules:
-- level: Metadata
+  - level: Metadata
 ```
 
 You can set the new audit policy like so:
@@ -70,17 +69,17 @@ upstream [Kubernetes Audit Policy documentation][k8s-audit-policy].
 ## Audit log backend configuration
 
 The audit log backend writes audit events to a file in JSON format. It is
-configurable in **Charmed Kubernetes**  through the use of the `api-extra-args`
+configurable in **Charmed Kubernetes** through the use of the `api-extra-args`
 config on kubernetes-master.
 
 By default, the log backend is enabled in Charmed Kubernetes with the following
 configuration:
 
-| kube-apiserver config | value |
-| --------------------------------- | ----- |
-| audit-log-path                | /root/cdk/audit/audit.log |
-| audit-log-maxsize          | 100 |
-| audit-log-maxbackup   | 9 |
+| kube-apiserver config | value                     |
+| --------------------- | ------------------------- |
+| audit-log-path        | /root/cdk/audit/audit.log |
+| audit-log-maxsize     | 100                       |
+| audit-log-maxbackup   | 9                         |
 
 You can override the defaults by using `api-extra-args`. For example:
 
@@ -88,16 +87,12 @@ You can override the defaults by using `api-extra-args`. For example:
 juju config kubernetes-master api-extra-args="audit-log-path=/root/cdk/my-audit-location audit-log-maxage=30 audit-log-maxsize=200 audit-log-maxbackup=5"
 ```
 
-<div class="p-notification--caution">
-  <p markdown="1" class="p-notification__response">
-    <span class="p-notification__status">Note:</span>
-    The <code>audit-log-path</code> must be a directory that is writeable by the
-     kube-apiserver snap.
-     Any non-hidden folders in <code>/root</code>, <code>/var/snap/kube-apiserver/current</code>, or
-     <code>/var/snap/kube-apiserver/common</code> should work.
-  </p>
+<div class="p-notification--caution is-inline">
+  <div markdown="1" class="p-notification__content">
+    <span class="p-notification__title">Note:</span>
+    <p class="p-notification__message"The <code>audit-log-path</code> must be a directory that is writeable by the kube-apiserver snap. Any non-hidden folders in <code>/root</code>, <code>/var/snap/kube-apiserver/current</code>, or <code>/var/snap/kube-apiserver/common</code> should work.</p>
+  </div>
 </div>
-
 
 Please refer to the upstream
 [Kubernetes Audit Log Backend documentation][k8s-audit-log]
@@ -125,19 +120,19 @@ apiVersion: v1
 kind: Config
 preferences: {}
 clusters:
-- name: example-cluster
-  cluster:
-    server: http://10.1.35.4
+  - name: example-cluster
+    cluster:
+      server: http://10.1.35.4
 users:
-- name: example-user
-  user:
-    username: some-user
-    password: some-password
+  - name: example-user
+    user:
+      username: some-user
+      password: some-password
 contexts:
-- name: example-context
-  context:
-    cluster: example-cluster
-    user: example-user
+  - name: example-context
+    context:
+      cluster: example-cluster
+      user: example-user
 current-context: example-context
 ```
 
@@ -159,6 +154,7 @@ Please refer to the upstream
 information about the audit webhook config format and related options.
 
 <!-- LINKS -->
+
 [k8s-audit]: https://kubernetes.io/docs/tasks/debug-application-cluster/audit/
 [k8s-audit-policy]: https://kubernetes.io/docs/tasks/debug-application-cluster/audit/#policy
 [k8s-audit-log]: https://kubernetes.io/docs/tasks/debug-application-cluster/audit/#log-backend
@@ -166,10 +162,11 @@ information about the audit webhook config format and related options.
 
 <!-- FEEDBACK -->
 <div class="p-notification--information">
-  <p class="p-notification__response">
-    We appreciate your feedback on the documentation. You can
+  <div class="p-notification__content">
+    <p class="p-notification__message">We appreciate your feedback on the documentation. You can
     <a href="https://github.com/charmed-kubernetes/kubernetes-docs/edit/main/pages/k8s/audit-logging.md" >edit this page</a>
     or
     <a href="https://github.com/charmed-kubernetes/kubernetes-docs/issues/new" >file a bug here</a>.
-  </p>
+    </p>
+  </div>
 </div>

--- a/templates/kubernetes/docs/auth.md
+++ b/templates/kubernetes/docs/auth.md
@@ -17,39 +17,38 @@ toc: False
 
 **Charmed Kubernetes** implements access
 control based on the Kubernetes model. A complete overview of the Kubernetes
-authorisation  system is given in the [Kubernetes Documentation][upstream-auth].
+authorisation system is given in the [Kubernetes Documentation][upstream-auth].
 This page provides summary information on the available modes and how to configure
 **Charmed Kubernetes** to use them.
 
-<div class="p-notification--information">
-  <p markdown="1" class="p-notification__response">
-    <span class="p-notification__status">Note:</span>
-The default authorisation mode in <strong>Charmed Kubernetes</strong> 1.19 has changed from
-"AlwaysAllow" to "Node,RBAC".
-  </p>
+<div class="p-notification--information is-inline">
+  <div markdown="1" class="p-notification__content">
+    <span class="p-notification__title">Note:</span>
+    <p class="p-notification__message">The default authorisation mode in <strong>Charmed Kubernetes</strong> 1.19 has changed from "AlwaysAllow" to "Node,RBAC".</p>
+  </div>
 </div>
 
 The following modes are supported:
 
- - **Node** (default): Grants permissions to kubelets based on the pods they are scheduled to run.
-    When using this mode, **Charmed Kubernetes** will enable `NodeRestriction` and will issue (and
-    decommission) tokens for kubernetes-workers as you scale your infrastructure.
-    More detailed information can be found in the [Kubernetes documentation][node].
- - **RBAC** (default):  Using role-based access control, access is granted to users based on the
-   roles assigned to them. This mode expects respective roles and bindings to be available
-   for any running services. **Charmed Kubernetes** already has roles and bindings ready for use
-   ([see below][roles]).
- - **AlwaysAllow**: All calls to the API server are allowed.
- - **AlwaysDeny**: This mode denies all API requests - it is only really useful for testing.
- - **ABAC**: Using attribute-based access control, access rights are granted to users
-    through the use of policies which combine attributes together. The policies can use any
-    type of attributes (user attributes, resource attributes, object attributes, environment
-    attributes, etc). For more information on ABAC mode, see the
-    [Kubernetes ABAC documentation][abac].
- - **Webhook**:  With this mode set, Kubernetes will query an outside REST service
-   when determining user privileges. This mode requires additional configuration to
-   specify the service being queried. A full explanation of this can be found in the
-   [Kubernetes Webhook mode documentation][webhook].
+- **Node** (default): Grants permissions to kubelets based on the pods they are scheduled to run.
+  When using this mode, **Charmed Kubernetes** will enable `NodeRestriction` and will issue (and
+  decommission) tokens for kubernetes-workers as you scale your infrastructure.
+  More detailed information can be found in the [Kubernetes documentation][node].
+- **RBAC** (default): Using role-based access control, access is granted to users based on the
+  roles assigned to them. This mode expects respective roles and bindings to be available
+  for any running services. **Charmed Kubernetes** already has roles and bindings ready for use
+  ([see below][roles]).
+- **AlwaysAllow**: All calls to the API server are allowed.
+- **AlwaysDeny**: This mode denies all API requests - it is only really useful for testing.
+- **ABAC**: Using attribute-based access control, access rights are granted to users
+  through the use of policies which combine attributes together. The policies can use any
+  type of attributes (user attributes, resource attributes, object attributes, environment
+  attributes, etc). For more information on ABAC mode, see the
+  [Kubernetes ABAC documentation][abac].
+- **Webhook**: With this mode set, Kubernetes will query an outside REST service
+  when determining user privileges. This mode requires additional configuration to
+  specify the service being queried. A full explanation of this can be found in the
+  [Kubernetes Webhook mode documentation][webhook].
 
 ### Determining the current configuration
 
@@ -60,6 +59,7 @@ juju config kubernetes-master authorization-mode
 ```
 
 The default value is:
+
 ```bash
 Node,RBAC
 ```
@@ -91,10 +91,12 @@ It is possible to set more than one mode using a comma-separated list:
 juju config kubernetes-master authorization-mode="Node,RBAC"
 ```
 
-<div class="p-notification--positive"><p markdown="1" class="p-notification__response">
-<span class="p-notification__status">Note:</span>
-Using "Node,RBAC" for authorisation is the recommended configuration.
-</p></div>
+<div class="p-notification--positive is-inline">
+  <div markdown="1" class="p-notification__content">
+    <span class="p-notification__title">Note:</span>
+    <p class="p-notification__message">Using "Node,RBAC" for authorisation is the recommended configuration.</p>
+  </div>
+</div>
 
 The order matters. Kubernetes will process each API request with each module in
 sequence. If the current authorising module either allows or denies the
@@ -102,7 +104,6 @@ request, that decision is made and no further modules are consulted. If the
 current module has no opinion on the request, then the decision is passed to
 the next module in the list. If no decision has been returned by the last
 module in the list, then the request is denied.
-
 
 <a id='rbac'> </a>
 
@@ -125,17 +126,15 @@ kubectl get clusterrolebindings --all-namespaces
 For more detail on roles and bindings, please see the
 [Kubernetes RBAC documentation][rbac].
 
-
 <a id='authn'> </a>
 
 ## Authentication
 
-<div class="p-notification--information">
-  <p markdown="1" class="p-notification__response">
-    <span class="p-notification__status">Note:</span>
-The default authentication mechanism in <strong>Charmed Kubernetes</strong> 1.19 has changed
-from file-based authentication to a webhook token service.
-  </p>
+<div class="p-notification--information is-inline">
+  <div markdown="1" class="p-notification__content">
+    <span class="p-notification__title">Note:</span>
+    <p class="p-notification__message">The default authentication mechanism in <strong>Charmed Kubernetes</strong> 1.19 has changed from file-based authentication to a webhook token service.</p>
+  </div>
 </div>
 
 **Charmed Kubernetes** manages a webhook authentication service that compares API
@@ -148,13 +147,11 @@ on port `5000` of each master unit. Source code for the [application][auth-webho
 as well as the associated [systemd service][auth-webhook-svc] can be found in the
 `kubernetes-master` source repository.
 
-<div class="p-notification--information">
-  <p markdown="1" class="p-notification__response">
-    <span class="p-notification__status">Note:</span>
-Only one webhook authenticator can be configured on the Kubernetes apiserver. To use
-a custom webhook, see the <strong>Managing users with an external service</strong>
-section below.
-  </p>
+<div class="p-notification--information is-inline">
+  <div markdown="1" class="p-notification__content">
+    <span class="p-notification__title">Note:</span>
+    <p class="p-notification__message">Only one webhook authenticator can be configured on the Kubernetes apiserver. To use a custom webhook, see the <strong>Managing users with an external service</strong> section below.</p>
+  </div>
 </div>
 
 Read about the Kubernetes approach to authentication in this page of the
@@ -176,6 +173,7 @@ juju run-action --wait kubernetes-master/0 user-create name='alice'
 ```
 
 Example output:
+
 ```bash
 unit-kubernetes-master-0:
   UnitId: kubernetes-master/0
@@ -197,6 +195,7 @@ juju run-action --wait kubernetes-master/0 user-create name='bob' groups='system
 ```
 
 Example output:
+
 ```bash
 unit-kubernetes-master-0:
   UnitId: kubernetes-master/0
@@ -219,6 +218,7 @@ juju run-action --wait kubernetes-master/0 user-list
 ```
 
 Example output:
+
 ```bash
 unit-kubernetes-master-0:
   UnitId: kubernetes-master/0
@@ -239,6 +239,7 @@ juju run-action --wait kubernetes-master/0 user-delete name=bob
 ```
 
 Example output:
+
 ```bash
 unit-kubernetes-master-0:
   UnitId: kubernetes-master/0
@@ -258,11 +259,11 @@ by Kubernetes secrets to authenticate a request. When present, the following ext
 services may also be used to process requests:
 
 - **AWS IAM**: IAM credentials can be used for authentication and authorisation
-on your Charmed Kubernetes cluster, even if the cluster is not hosted on AWS.
-For further details, see the documentation on
-[AWS IAM with Charmed Kubernetes][aws-iam].
+  on your Charmed Kubernetes cluster, even if the cluster is not hosted on AWS.
+  For further details, see the documentation on
+  [AWS IAM with Charmed Kubernetes][aws-iam].
 - **LDAP**: See the documentation on using
-[LDAP and Keystone with Charmed Kubernetes][docs-ldap].
+  [LDAP and Keystone with Charmed Kubernetes][docs-ldap].
 
 Additionally, a custom endpoint can be configured to authenticate requests. This
 must be an https url accessible by the `kubernetes-master` units. When a
@@ -275,7 +276,6 @@ juju config kubernetes-master authn-webhook-endpoint='https://your.server:8443/a
 
 More information about webhook authentication service requirements can be found
 in the [upstream documentation][upstream-webhook].
-
 
  <!-- LINKS -->
 
@@ -294,10 +294,12 @@ in the [upstream documentation][upstream-webhook].
 
 <!-- FEEDBACK -->
 <div class="p-notification--information">
-  <p class="p-notification__response">
-    We appreciate your feedback on the documentation. You can
-    <a href="https://github.com/charmed-kubernetes/kubernetes-docs/edit/main/pages/k8s/auth.md" >edit this page</a>
-    or
-    <a href="https://github.com/charmed-kubernetes/kubernetes-docs/issues/new" >file a bug here</a>.
-  </p>
+  <div class="p-notification__content">
+    <p class="p-notification__message">
+      We appreciate your feedback on the documentation. You can
+      <a href="https://github.com/charmed-kubernetes/kubernetes-docs/edit/main/pages/k8s/auth.md" >edit this page</a>
+      or
+      <a href="https://github.com/charmed-kubernetes/kubernetes-docs/issues/new" >file a bug here</a>.
+    </p>
+  </div>
 </div>

--- a/templates/kubernetes/docs/aws-iam-auth.md
+++ b/templates/kubernetes/docs/aws-iam-auth.md
@@ -21,7 +21,6 @@ regard to where it is hosted. The only requirement is that both the client
 machine running `kubectl` and the nodes running the webhook pod(s) are able to
 reach AWS in order to get and validate tokens.
 
-
 ### Installing
 
 The [aws-iam][aws-iam-charm] subordinate charm
@@ -33,8 +32,8 @@ applications:
   aws-iam:
     charm: cs:~containers/aws-iam
 relations:
-  - ['aws-iam', 'kubernetes-master']
-  - ['aws-iam', 'vault']
+  - ["aws-iam", "kubernetes-master"]
+  - ["aws-iam", "vault"]
 ```
 
 or if using easyrsa:
@@ -44,8 +43,8 @@ applications:
   aws-iam:
     charm: cs:~containers/aws-iam
 relations:
-  - ['aws-iam', 'kubernetes-master']
-  - ['aws-iam', 'easyrsa']
+  - ["aws-iam", "kubernetes-master"]
+  - ["aws-iam", "easyrsa"]
 ```
 
 To use this overlay with the **Charmed Kubernetes** bundle, it is specified
@@ -78,7 +77,7 @@ spec:
   # Groups to be attached to your users/roles. For example `system:masters` to
   # create cluster admin, or `view` for view only,
   groups:
-  - view
+    - view
 ```
 
 ### Using AWS-IAM with kubectl
@@ -95,11 +94,12 @@ on the [aws-iam-authenticator releases page][aws-iam-authenticator-releases].
 The aws-iam-authenticator is able to use any ARN for authentication. The easiest
 way to get started is to use an empty role as described in the
 [aws-iam documentation][aws-iam-role-creation].
- * Log into AWS console and navigate to [the IAM page][aws-iam-page].
- * Click "create new role".
- * Choose the "Role for cross-account access" / "Provide access between AWS accounts you own" option.
- * Paste in your AWS account ID number (available in the top right in the console).
- * Your role does not need any additional policies attached.
+
+- Log into AWS console and navigate to [the IAM page][aws-iam-page].
+- Click "create new role".
+- Choose the "Role for cross-account access" / "Provide access between AWS accounts you own" option.
+- Paste in your AWS account ID number (available in the top right in the console).
+- Your role does not need any additional policies attached.
 
 #### Updating kubectl config
 
@@ -159,6 +159,7 @@ account.
 ```bash
 kubectl get po -A
 ```
+
 ... will result in an error:
 
 ```
@@ -182,8 +183,9 @@ spec:
   # create cluster admin, or `system:nodes`, `system:bootstrappers` for nodes to
   # access the API server.
   groups:
-  - view
+    - view
 ```
+
 Logging in with the k8s-view-role matched against the RBAC user 'knobby', but this user has
 no permissions so the command failed. Create an RBAC Role and RoleBinding to grant permissions:
 
@@ -193,13 +195,13 @@ kind: Role
 metadata:
   name: pod-reader
 rules:
-- apiGroups: [""]
-  resources:
-  - pods
-  verbs:
-  - get
-  - list
-  - watch
+  - apiGroups: [""]
+    resources:
+      - pods
+    verbs:
+      - get
+      - list
+      - watch
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -209,9 +211,9 @@ metadata:
   name: read-pods
   namespace: default
 subjects:
-- kind: User
-  name: knobby
-  apiGroup: rbac.authorization.k8s.io
+  - kind: User
+    name: knobby
+    apiGroup: rbac.authorization.k8s.io
 roleRef:
   kind: Role
   name: pod-reader
@@ -233,6 +235,7 @@ Note that the permissions in this example are limited to the 'default' namespace
 ```bash
 kubectl get po --all-namespaces
 ```
+
 ...will result in an error:
 
 ```no-highlight
@@ -259,9 +262,10 @@ perform actions, activity logs can be obtained from
 [Amazon's CloudTrail][cloudtrail].
 
 The flow of operations that occur when using kubectl with aws-iam is as follows:
+
 1. kubectl execs `aws-iam-authenticator` to get a token.
 2. `aws-iam-authenticator` contacts AWS from the user's machine
-to get the token.
+   to get the token.
 3. kubectl passes token to the Kubernetes API server.
 4. The API server passes the token to the webhook pod for verification.
 5. The webhook pod contacts AWS to verify the token.
@@ -269,14 +273,15 @@ to get the token.
 7. The API server uses RBAC rules to authorise the user.
 
 One can troubleshoot these steps to figure out where things are going wrong.
- * Run `aws-iam-authenticator token -i <cluster id> -r <aws arn>` to see if a
-token is returned. Note that `aws-iam-authenticator` will cache credentials
-between calls.
- * Check verbose output of `kubectl` command by adding `--v=9` such as
-`kubectl get po --v=9`
- * Check the logs of the `aws-iam-authenticator` deployment with
-`juju run --unit kubernetes-master/0 -- /snap/bin/kubectl --kubeconfig /root/.kube/config -n kube-system logs deploy/aws-iam-authenticator`
- * Check the logs of the API server with `juju run --unit kubernetes-master/0 -- journalctl -u snap.kube-apiserver.daemon.service`
+
+- Run `aws-iam-authenticator token -i <cluster id> -r <aws arn>` to see if a
+  token is returned. Note that `aws-iam-authenticator` will cache credentials
+  between calls.
+- Check verbose output of `kubectl` command by adding `--v=9` such as
+  `kubectl get po --v=9`
+- Check the logs of the `aws-iam-authenticator` deployment with
+  `juju run --unit kubernetes-master/0 -- /snap/bin/kubectl --kubeconfig /root/.kube/config -n kube-system logs deploy/aws-iam-authenticator`
+- Check the logs of the API server with `juju run --unit kubernetes-master/0 -- journalctl -u snap.kube-apiserver.daemon.service`
 
 <!-- LINKS -->
 
@@ -296,10 +301,12 @@ between calls.
 
 <!-- FEEDBACK -->
 <div class="p-notification--information">
-  <p class="p-notification__response">
-    We appreciate your feedback on the documentation. You can
-    <a href="https://github.com/charmed-kubernetes/kubernetes-docs/edit/main/pages/k8s/aws-iam-auth.md" >edit this page</a>
-    or
-    <a href="https://github.com/charmed-kubernetes/kubernetes-docs/issues/new" >file a bug here</a>.
-  </p>
+  <div class="p-notification__content">
+    <p class="p-notification__message">
+      We appreciate your feedback on the documentation. You can
+      <a href="https://github.com/charmed-kubernetes/kubernetes-docs/edit/main/pages/k8s/aws-iam-auth.md" >edit this page</a>
+      or
+      <a href="https://github.com/charmed-kubernetes/kubernetes-docs/issues/new" >file a bug here</a>.
+    </p>
+  </div>
 </div>

--- a/templates/kubernetes/docs/aws-integration.md
+++ b/templates/kubernetes/docs/aws-integration.md
@@ -13,10 +13,9 @@ layout: [base, ubuntu-com]
 toc: False
 ---
 
-**Charmed Kubernetes** will run seamlessly on AWS.  With the addition of the
+**Charmed Kubernetes** will run seamlessly on AWS. With the addition of the
 `aws-integrator`, your cluster will also be able to directly use AWS native
 features.
-
 
 ## AWS integrator
 
@@ -42,9 +41,9 @@ applications:
     num_units: 1
     trust: true
 relations:
-  - ['aws-integrator', 'kubernetes-master']
-  - ['aws-integrator', 'kubernetes-worker']
-  ```
+  - ["aws-integrator", "kubernetes-master"]
+  - ["aws-integrator", "kubernetes-worker"]
+```
 
 To use this overlay with the **Charmed Kubernetes** bundle, it is specified during deploy like this:
 
@@ -63,7 +62,7 @@ please see the [charm readme][aws-integrator-readme].
 
 ### Using EBS volumes
 
-Many  pods you may wish to deploy will require storage. Although you can use
+Many pods you may wish to deploy will require storage. Although you can use
 any type of storage supported by Kubernetes (see the
 [storage documentation][storage]), you also have the option to use the native
 AWS storage, Elastic Block Store (EBS).
@@ -91,6 +90,7 @@ kubectl get sc
 ```
 
 which should return:
+
 ```bash
 NAME      PROVISIONER             AGE
 ebs-gp2   kubernetes.io/aws-ebs   39s
@@ -161,18 +161,17 @@ spec:
 EOY
 ```
 
-<div class="p-notification--caution">
-  <p markdown="1" class="p-notification__response">
-    <span class="p-notification__status">Note:</span>
-If you create EBS volumes and subsequently tear down the cluster, check
-with the AWS console to make sure all the associated resources have also been released.
-  </p>
+<div class="p-notification--caution is-inline">
+  <div markdown="1" class="p-notification__content">
+    <span class="p-notification__title">Note:</span>
+    <p class="p-notification__message">If you create EBS volumes and subsequently tear down the cluster, check with the AWS console to make sure all the associated resources have also been released.</p>
+  </div>
 </div>
 
 ### Using ELB Loadbalancers
 
 With the aws-integrator charm in place, actions which invoke a loadbalancer in
-Kubernetes  will automatically generate an AWS Elastic Load Balancer.  This can
+Kubernetes will automatically generate an AWS Elastic Load Balancer. This can
 be demonstrated with a simple application. Here we will create a simple
 application and scale it to five pods:
 
@@ -209,40 +208,40 @@ kubectl describe service hello
 ...which should return output similar to:
 
 ```yaml
-Name:                     hello
-Namespace:                default
-Labels:                   run=load-balancer-example
-Annotations:              <none>
-Selector:                 run=load-balancer-example
-Type:                     LoadBalancer
-IP:                       10.152.183.134
-LoadBalancer Ingress:     ad5fc7750350611e99768068a686bb67-239702253.eu-west-1.elb.amazonaws.com
-Port:                     <unset>  8080/TCP
-TargetPort:               8080/TCP
-NodePort:                 <unset>  31203/TCP
-Endpoints:                10.1.13.4:8080,10.1.13.5:8080,10.1.35.8:8080 + 2 more...
-Session Affinity:         None
-External Traffic Policy:  Cluster
-Events:                   <none>
+Name: hello
+Namespace: default
+Labels: run=load-balancer-example
+Annotations: <none>
+Selector: run=load-balancer-example
+Type: LoadBalancer
+IP: 10.152.183.134
+LoadBalancer Ingress: ad5fc7750350611e99768068a686bb67-239702253.eu-west-1.elb.amazonaws.com
+Port: <unset>  8080/TCP
+TargetPort: 8080/TCP
+NodePort: <unset>  31203/TCP
+Endpoints: 10.1.13.4:8080,10.1.13.5:8080,10.1.35.8:8080 + 2 more...
+Session Affinity: None
+External Traffic Policy: Cluster
+Events: <none>
 ```
 
 You can see that the LoadBalancer Ingress is now associated with an ELB address in front
-of the five endpoints of the  example deployment. Leaving a while for DNS propagation, you
+of the five endpoints of the example deployment. Leaving a while for DNS propagation, you
 can test the ingress address:
 
 ```bash
 curl  http://ad5fc7750350611e99768068a686bb67-239702253.eu-west-1.elb.amazonaws.com:8080
 ```
+
 ```
 Hello Kubernetes!
 ```
 
-<div class="p-notification--caution">
-  <p markdown="1" class="p-notification__response">
-    <span class="p-notification__status">Note:</span>
-If you create ELBs and subsequently tear down the cluster, check with the AWS console
-to make sure all the associated resources have also been released.
-  </p>
+<div class="p-notification--caution is-inline">
+  <siv markdown="1" class="p-notification__content">
+    <span class="p-notification__title">Note:</span>
+    <p class="p-notification__message">If you create ELBs and subsequently tear down the cluster, check with the AWS console to make sure all the associated resources have also been released.</p>
+  </div>
 </div>
 
 ### Upgrading the integrator-charm
@@ -289,10 +288,11 @@ If you are an AWS user, you may also be interested in how to
 
 <!-- FEEDBACK -->
 <div class="p-notification--information">
-  <p class="p-notification__response">
-    We appreciate your feedback on the documentation. You can
-    <a href="https://github.com/charmed-kubernetes/kubernetes-docs/edit/main/pages/k8s/aws-integration.md" >edit this page</a>
-    or
-    <a href="https://github.com/charmed-kubernetes/kubernetes-docs/issues/new" >file a bug here</a>.
-  </p>
+  <div class="p-notification__content">
+    <p class="p-notification__message">We appreciate your feedback on the documentation. You can
+      <a href="https://github.com/charmed-kubernetes/kubernetes-docs/edit/main/pages/k8s/aws-integration.md" >edit this page</a>
+      or
+      <a href="https://github.com/charmed-kubernetes/kubernetes-docs/issues/new" >file a bug here</a>.
+    </p>
+  </div>
 </div>

--- a/templates/kubernetes/docs/azure-integration.md
+++ b/templates/kubernetes/docs/azure-integration.md
@@ -14,9 +14,8 @@ toc: False
 ---
 
 **Charmed Kubernetes** will run seamlessly on Microsoft Azure <sup>&reg;</sup>.
-With the  addition of the `azure-integrator`, your cluster will also be able
-to directly  use Azure native features.
-
+With the addition of the `azure-integrator`, your cluster will also be able
+to directly use Azure native features.
 
 ## Azure integrator
 
@@ -42,9 +41,9 @@ applications:
     num_units: 1
     trust: true
 relations:
-  - ['azure-integrator', 'kubernetes-master:azure']
-  - ['azure-integrator', 'kubernetes-worker:azure']
-  ```
+  - ["azure-integrator", "kubernetes-master:azure"]
+  - ["azure-integrator", "kubernetes-worker:azure"]
+```
 
 To use this overlay with the **Charmed Kubernetes** bundle, it is specified
 during deploy like this:
@@ -65,12 +64,10 @@ juju scp kubernetes-master/0:config ~/.kube/config
     current quotas allocated to a new Azure account. If you see error messages
     saying allocating machines would exceed your quota, you will need to log a
 
-    <a href="https://docs.microsoft.com/en-us/azure/azure-portal/supportability/regional-quota-requests" class="p-notification__action">support request with Azure</a> to increase the quota accordingly.
+    <a href="https://docs.microsoft.com/en-us/azure/azure-portal/supportability/regional-quota-requests">support request with Azure</a> to increase the quota accordingly.
 
   </p>
 </div>
-
-
 
 <div class="p-notification--caution">
   <p class="p-notification__response">
@@ -92,7 +89,6 @@ backed by
 Azure's Disk Storage.
 
 ### 1. Create a storage class using the `kubernetes.io/azure-disk` provisioner:
-
 
 ```bash
 kubectl create -f - <<EOY
@@ -199,10 +195,8 @@ external clients.
 <!-- LINKS -->
 
 [asset-azure-overlay]: https://raw.githubusercontent.com/charmed-kubernetes/bundle/master/overlays/azure-overlay.yaml
-
 [storage]: /kubernetes/docs/storage
 [azure-integrator]: /kubernetes/docs/charm-azure-integrator
-
 [install]: /kubernetes/docs/install-manual
 
 <!-- FEEDBACK -->

--- a/templates/kubernetes/docs/azure-integration.md
+++ b/templates/kubernetes/docs/azure-integration.md
@@ -59,27 +59,22 @@ juju scp kubernetes-master/0:config ~/.kube/config
 ```
 
 <div class="p-notification--information">
-  <p class="p-notification__response">
-    A standard install of Charmed Kubernetes will use more resources than the
-    current quotas allocated to a new Azure account. If you see error messages
-    saying allocating machines would exceed your quota, you will need to log a
-
-    <a href="https://docs.microsoft.com/en-us/azure/azure-portal/supportability/regional-quota-requests">support request with Azure</a> to increase the quota accordingly.
-
-  </p>
+  <div class="p-notification__content">
+    <p class="p-notification__message">A standard install of Charmed Kubernetes will use more resources than the current quotas allocated to a new Azure account. If you see error messages saying allocating machines would exceed your quota, you will need to log a <a href="https://docs.microsoft.com/en-us/azure/azure-portal/supportability/regional-quota-requests">support request with Azure</a> to increase the quota accordingly.</p>
+  </div>
 </div>
 
-<div class="p-notification--caution">
-  <p class="p-notification__response">
-    <span class="p-notification__status">Resource usage:</span>
-    By relating to this charm, other charms can directly allocate resources, such
+<div class="p-notification--caution is-inline">
+  <div class="p-notification__content">
+    <span class="p-notification__title">Resource usage:</span>
+    <p class="p-notification__message">By relating to this charm, other charms can directly allocate resources, such
     as managed disks and load balancers, which could lead to cloud charges and
     count against quotas. Because these resources are not managed by Juju, they
     will not be automatically deleted when the models or applications are
     destroyed, nor will they show up in Juju's status or GUI. It is therefore up
     to the operator to manually delete these resources when they are no longer
-    needed, using the Azure management website or API.
-  </p>
+    needed, using the Azure management website or API.</p>
+  </div>
 </div>
 
 ## Storage
@@ -201,10 +196,10 @@ external clients.
 
 <!-- FEEDBACK -->
 <div class="p-notification--information">
-  <p class="p-notification__response">
-    We appreciate your feedback on the documentation. You can
+  <div class="p-notification__content">
+    <p class="p-notification__message">We appreciate your feedback on the documentation. You can
     <a href="https://github.com/charmed-kubernetes/kubernetes-docs/edit/main/pages/k8s/azure-integration.md" >edit this page</a>
     or
-    <a href="https://github.com/charmed-kubernetes/kubernetes-docs/issues/new" >file a bug here</a>.
-  </p>
+    <a href="https://github.com/charmed-kubernetes/kubernetes-docs/issues/new" >file a bug here</a>.</p>
+  </div>
 </div>

--- a/templates/kubernetes/docs/backups.md
+++ b/templates/kubernetes/docs/backups.md
@@ -22,10 +22,12 @@ please refer to their own documentation for details.
 
 ## Creating an **etcd** snapshot
 
- <div class="p-notification--warning"><p markdown="1" class="p-notification__response">
- <span class="p-notification__status">Warning:</span>
- Snapshots can only be restored on the **same version of etcd**.
-  </p></div>
+ <div class="p-notification--warning is-inline">
+  <div markdown="1" class="p-notification__content">
+    <span class="p-notification__title">Warning:</span>
+    <p class="p-notification__message">Snapshots can only be restored on the **same version of etcd**.</p>
+  </div>
+</div>
 
 **etcd** is a distributed key/value store. To create a snapshot, all that is required is to run the `snapshot` action on one of the units running **etcd**:
 
@@ -37,24 +39,25 @@ By specifying `--wait`, the console will wait to return the result of running th
 
 ```yaml
 unit-etcd-0:
- id: 3d6a505e-07d7-4697-8471-60156f87b1b4
- results:
-   copy:
-     cmd: juju scp etcd/0:/home/ubuntu/etcd-snapshots/etcd-snapshot-2018-09-26-18.04.02.tar.gz
-       .
-   snapshot:
-     path: /home/ubuntu/etcd-snapshots/etcd-snapshot-2018-09-26-18.04.02.tar.gz
-     sha256: e85ae4d49b6a889de2063031379ab320cc8f09b6e328cdff2fb9179fc641eee9
-     size: 68K
-     version: |-
-       etcdctl version: 3.2.10
-       API version: 2
- status: completed
- timing:
-   completed: 2018-09-26 18:04:04 +0000 UTC
-   enqueued: 2018-09-26 18:04:04 +0000 UTC
-   started: 2018-09-26 18:04:03 +0000 UTC
- unit: etcd/0
+  id: 3d6a505e-07d7-4697-8471-60156f87b1b4
+  results:
+    copy:
+      cmd:
+        juju scp etcd/0:/home/ubuntu/etcd-snapshots/etcd-snapshot-2018-09-26-18.04.02.tar.gz
+        .
+    snapshot:
+      path: /home/ubuntu/etcd-snapshots/etcd-snapshot-2018-09-26-18.04.02.tar.gz
+      sha256: e85ae4d49b6a889de2063031379ab320cc8f09b6e328cdff2fb9179fc641eee9
+      size: 68K
+      version: |-
+        etcdctl version: 3.2.10
+        API version: 2
+  status: completed
+  timing:
+    completed: 2018-09-26 18:04:04 +0000 UTC
+    enqueued: 2018-09-26 18:04:04 +0000 UTC
+    started: 2018-09-26 18:04:03 +0000 UTC
+  unit: etcd/0
 ```
 
 This path/filename relates to the unit where the action was run. As we will likely want to use the snapshot on a different unit, we should fetch the snapshot to the local machine. The command to perform this is also helpfully supplied in the `copy` section of the output (see above):
@@ -72,10 +75,13 @@ sha256sum etcd-snapshot-2018-09-26-18.04.02.tar.gz
 
 ## Restoring a snapshot
 
-<div class="p-notification--warning"><p markdown="1" class="p-notification__response">
-<span class="p-notification__status">Warning:</span>
-Restoring a snapshot should not be performed when there is more than one unit of **etcd** running.
- </p></div>
+<div class="p-notification--warning is-inline">
+  <div markdown="1" class="p-notification__content">
+    <span class="p-notification__title">Warning:</span>
+    <p class="p-notification__message">Restoring a snapshot should not be performed when there is more than one unit of **etcd** running.
+  </p>
+ </div>
+</div>
 
 As restoring only works when there is a single unit of **etcd**, it is usual to deploy a new instance of the application first.
 
@@ -142,10 +148,10 @@ unit-new-etcd-0:
 
 <!-- FEEDBACK -->
 <div class="p-notification--information">
-  <p class="p-notification__response">
-    We appreciate your feedback on the documentation. You can
+  <div class="p-notification__content">
+    <p class="p-notification__message">We appreciate your feedback on the documentation. You can
     <a href="https://github.com/charmed-kubernetes/kubernetes-docs/edit/main/pages/k8s/backups.md" >edit this page</a>
     or
-    <a href="https://github.com/charmed-kubernetes/kubernetes-docs/issues/new" >file a bug here</a>.
-  </p>
+    <a href="https://github.com/charmed-kubernetes/kubernetes-docs/issues/new" >file a bug here</a>.</p>
+  </div>
 </div>

--- a/templates/kubernetes/docs/ceph.md
+++ b/templates/kubernetes/docs/ceph.md
@@ -51,12 +51,12 @@ default storage class is for the cloud (e.g., on AWS this will be EBS volumes).
 juju add-relation ceph-osd ceph-mon
 ```
 
-<div class="p-notification--information">
-  <p markdown="1" class="p-notification__response">
-    <span class="p-notification__status">Note:</span>
-For more on how Juju makes use of storage, please see the relevant
-<a href="https://juju.is/docs/olm/defining-and-using-persistent-storage"> Juju documentation</a>
-  </p>
+<div class="p-notification--information is-inline">
+  <div markdown="1" class="p-notification__content">
+    <span class="p-notification__title">Note:</span>
+    <p class="p-notification__message">For more on how Juju makes use of storage, please see the relevant
+<a href="https://juju.is/docs/olm/defining-and-using-persistent-storage"> Juju documentation</a></p>
+  </div>
 </div>
 
 ### Relating to Charmed Kubernetes
@@ -152,10 +152,10 @@ here you can install any of the things that require storage out of the box.
 
 <!-- FEEDBACK -->
 <div class="p-notification--information">
-  <p class="p-notification__response">
-    We appreciate your feedback on the documentation. You can
+  <div class="p-notification__content">
+    <p class="p-notification__message">We appreciate your feedback on the documentation. You can
     <a href="https://github.com/charmed-kubernetes/kubernetes-docs/edit/main/pages/k8s/ceph.md" >edit this page</a>
     or
-    <a href="https://github.com/charmed-kubernetes/kubernetes-docs/issues/new" >file a bug here</a>.
-  </p>
+    <a href="https://github.com/charmed-kubernetes/kubernetes-docs/issues/new" >file a bug here</a>.</p>
+  </div>
 </div>

--- a/templates/kubernetes/docs/certs-and-trust.md
+++ b/templates/kubernetes/docs/certs-and-trust.md
@@ -15,8 +15,8 @@ toc: False
 
 The components of **Charmed Kubernetes**
 need to be able to communicate securely over the network. This is accomplished
-using [TLS][] and [public-key encryption][PKI] with a [chain of trust][] up
-to a shared root [Certificate Authority (CA)][CA]. However, when the cluster
+using [TLS][] and [public-key encryption][pki] with a [chain of trust][] up
+to a shared root [Certificate Authority (CA)][ca]. However, when the cluster
 is being brought up or a new unit is being added, the chain of trust and
 certificates required must be bootstrapped into the machines somehow.
 
@@ -43,7 +43,7 @@ generating or distributing additional certificates to be used by the
 applications on the machines, so they must be managed by the charms via the
 secure relation data channel. This is done using the [tls-certificates][]
 [interface protocol][interface] and a relation to an application providing a
-Certificate Authority.  (This CA could be either a root CA, or an intermediary
+Certificate Authority. (This CA could be either a root CA, or an intermediary
 CA authorised by some other root CA to issue certificates.)
 
 When the relation is established, the root CA's certificate is sent via the
@@ -69,11 +69,11 @@ Each service that will be connected to will need a [server certificate][]
 identifying and validating it to any clients that wish to connect.
 
 The primary address at which the service can be reached will be its [common
-name][CN]; ideally, this will be a fully-qualified domain name (FQDN) which
+name][cn]; ideally, this will be a fully-qualified domain name (FQDN) which
 will not change, but for internal service communication, it is often just the
 [ingress address][network primitives] for the unit. Any additional names or
 addresses by which the service can be reached will be its [subject alternative
-names (SANs)][SANs].
+names (SANs)][sans].
 
 **Charmed Kubernetes** will manage the server certificates automatically, including
 generating the certificate with the proper CN and SANs. However, the
@@ -116,14 +116,12 @@ be accessed.
 
 See the [operations documentation][vault-cdk] for details on how to deploy Vault as a CA.
 
-
-
-[TLS]: https://www.networkworld.com/article/2303073/lan-wan/lan-wan-what-is-transport-layer-security-protocol.html
-[PKI]: https://github.com/OpenVPN/easy-rsa/blob/master/doc/Intro-To-PKI.md
+[tls]: https://www.networkworld.com/article/2303073/lan-wan/lan-wan-what-is-transport-layer-security-protocol.html
+[pki]: https://github.com/OpenVPN/easy-rsa/blob/master/doc/Intro-To-PKI.md
 [chain of trust]: https://en.wikipedia.org/wiki/Chain_of_trust
-[CA]: https://en.wikipedia.org/wiki/Certificate_authority
-[Juju units]: https://juju.is/docs/olm/quick-reference
-[Juju controller]: https://juju.is/docs/olm/quick-reference
+[ca]: https://en.wikipedia.org/wiki/Certificate_authority
+[juju units]: https://juju.is/docs/olm/quick-reference
+[juju controller]: https://juju.is/docs/olm/quick-reference
 [tls-certificates]: https://github.com/juju-solutions/interface-tls-certificates
 [interface]: https://juju.is/docs/olm/quick-reference
 [websockets]: https://en.wikipedia.org/wiki/WebSocket
@@ -134,25 +132,25 @@ See the [operations documentation][vault-cdk] for details on how to deploy Vault
 [easyrsa-charm]: https://charmhub.io/containers-easyrsa
 [easy-rsa]: https://github.com/OpenVPN/easy-rsa
 [install_ca_cert]: https://charm-helpers.readthedocs.io/en/latest/api/charmhelpers.core.host.html#charmhelpers.core.host.install_ca_cert
-[Comodo]: https://en.wikipedia.org/wiki/Comodo_Group
-[DigiCert]: https://en.wikipedia.org/wiki/DigiCert
+[comodo]: https://en.wikipedia.org/wiki/Comodo_Group
+[digicert]: https://en.wikipedia.org/wiki/DigiCert
 [kubelet]: https://kubernetes.io/docs/reference/command-line-tools-reference/kubelet/
 [server certificate]: https://en.wikipedia.org/wiki/Public_key_certificate#TLS/SSL_server_certificate
 [client certificate]: https://en.wikipedia.org/wiki/Public_key_certificate#TLS/SSL_client_certificate
-[CN]: https://knowledge.digicert.com/solution/SO7239.html
-[SANs]: https://en.wikipedia.org/wiki/Subject_Alternative_Name
+[cn]: https://knowledge.digicert.com/solution/SO7239.html
+[sans]: https://en.wikipedia.org/wiki/Subject_Alternative_Name
 [network primitives]: https://juju.is/docs/olm/quick-reference
 [kubernetes-master]: /kubernetes/docs/charm-kubernetes-master
-[`extra_sans`]:  /kubernetes/docs/charm-kubernetes-master#extra_sans
-[HA]: https://en.wikipedia.org/wiki/High_availability
+[`extra_sans`]: /kubernetes/docs/charm-kubernetes-master#extra_sans
+[ha]: https://en.wikipedia.org/wiki/High_availability
 [vault-cdk]: /kubernetes/docs/using-vault
 
 <!-- FEEDBACK -->
 <div class="p-notification--information">
-  <p class="p-notification__response">
-    We appreciate your feedback on the documentation. You can
+  <div class="p-notification__content">
+    <p class="p-notification__message">We appreciate your feedback on the documentation. You can
     <a href="https://github.com/charmed-kubernetes/kubernetes-docs/edit/main/pages/k8s/certs-and-trust.md" >edit this page</a>
     or
-    <a href="https://github.com/charmed-kubernetes/kubernetes-docs/issues/new" >file a bug here</a>.
-  </p>
+    <a href="https://github.com/charmed-kubernetes/kubernetes-docs/issues/new" >file a bug here</a>.</p>
+  </div>
 </div>

--- a/templates/kubernetes/docs/cis-compliance.md
+++ b/templates/kubernetes/docs/cis-compliance.md
@@ -229,10 +229,10 @@ status: completed
 
 <!-- FEEDBACK -->
 <div class="p-notification--information">
-  <p class="p-notification__response">
-    We appreciate your feedback on the documentation. You can
+  <div class="p-notification__content">
+    <p class="p-notification__message">We appreciate your feedback on the documentation. You can
     <a href="https://github.com/charmed-kubernetes/kubernetes-docs/edit/main/pages/k8s/cis-compliance.md" >edit this page</a>
     or
-    <a href="https://github.com/charmed-kubernetes/kubernetes-docs/issues/new" >file a bug here</a>.
-  </p>
+    <a href="https://github.com/charmed-kubernetes/kubernetes-docs/issues/new" >file a bug here</a>.</p>
+  </div>
 </div>

--- a/templates/kubernetes/docs/cni-canal.md
+++ b/templates/kubernetes/docs/cni-canal.md
@@ -20,7 +20,6 @@ while utilizing Flannel's UDP-based network traffic to provide for an easier set
 experience that works in a wider variety of host network environments without
 special configuration.
 
-
 ## Deploying Charmed Kubernetes with Canal
 
 To deploy a cluster with Canal, deploy the kubernetes-canal bundle:
@@ -35,15 +34,15 @@ that would apply to `charmed-kubernetes` to this bundle also.
 
 ## Canal configuration options
 
-|Name                  | Type    | Default   | Description                      |
-|----------------------|---------|-----------|----------------------------------|
-| calico-node-image    | string  | docker.io/calico/node:v3.6.1|The image id to use for calico/node. |
-| calico-policy-image  | string  | docker.io/calico/kube-controllers:v3.6.1|The image id to use for calico/kube-controllers. |
-| cidr                 | string  | 10.1.0.0/16|Network CIDR to assign to Flannel |
-| iface                | string  |           |The interface to bind flannel overlay networking. The default value is the interface bound to the cni endpoint. |
-| nagios_context       | string  | juju      |Used by the nrpe subordinate charms. A string that will be prepended to instance name to set the host name in nagios. So for instance the hostname would be something like:     juju-myservice-0 If you're running multiple environments with the same services in them this allows you to differentiate between them. |
-| nagios_servicegroups | string  |           |A comma-separated list of nagios servicegroups. If left empty, the nagios_context will be used as the servicegroup |
-                                |
+| Name                 | Type   | Default                                  | Description                                                                                                                                                                                                                                                                                                        |
+| -------------------- | ------ | ---------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| calico-node-image    | string | docker.io/calico/node:v3.6.1             | The image id to use for calico/node.                                                                                                                                                                                                                                                                               |
+| calico-policy-image  | string | docker.io/calico/kube-controllers:v3.6.1 | The image id to use for calico/kube-controllers.                                                                                                                                                                                                                                                                   |
+| cidr                 | string | 10.1.0.0/16                              | Network CIDR to assign to Flannel                                                                                                                                                                                                                                                                                  |
+| iface                | string |                                          | The interface to bind flannel overlay networking. The default value is the interface bound to the cni endpoint.                                                                                                                                                                                                    |
+| nagios_context       | string | juju                                     | Used by the nrpe subordinate charms. A string that will be prepended to instance name to set the host name in nagios. So for instance the hostname would be something like: juju-myservice-0 If you're running multiple environments with the same services in them this allows you to differentiate between them. |
+| nagios_servicegroups | string |                                          | A comma-separated list of nagios servicegroups. If left empty, the nagios_context will be used as the servicegroup                                                                                                                                                                                                 |
+|                      |
 
 ### Checking the current configuration
 
@@ -80,10 +79,10 @@ For additional troubleshooting pointers, please see the
 
 <!-- FEEDBACK -->
 <div class="p-notification--information">
-  <p class="p-notification__response">
-    We appreciate your feedback on the documentation. You can
+  <div class="p-notification__content">
+    <p class="p-notification__message">We appreciate your feedback on the documentation. You can
     <a href="https://github.com/charmed-kubernetes/kubernetes-docs/edit/main/pages/k8s/cni-canal.md" >edit this page</a>
     or
-    <a href="https://github.com/charmed-kubernetes/kubernetes-docs/issues/new" >file a bug here</a>.
-  </p>
+    <a href="https://github.com/charmed-kubernetes/kubernetes-docs/issues/new" >file a bug here</a>.</p>
+  </div>
 </div>

--- a/templates/kubernetes/docs/cni-flannel.md
+++ b/templates/kubernetes/docs/cni-flannel.md
@@ -13,12 +13,10 @@ layout: [base, ubuntu-com]
 toc: False
 ---
 
-
 [Flannel][] is a simple, lightweight layer 3 fabric for Kubernetes. Flannel manages an
 IPv4 network between multiple nodes in a cluster. It does not control how containers
 are networked to the host, only how the traffic is transported between hosts. For
 more complicated scenarios, see also [Calico][] and [Canal][]
-
 
 ## Deploying **Charmed Kubernetes** with flannel
 
@@ -28,13 +26,12 @@ flannel will be used for CNI.
 
 ## Flannel options
 
-
-| Name                  |  Type     |  Default value | Description  |
-|-----------------------|-----------|----------------|--------------|
-| cidr                       | string     | 10.1.0.0/16      | Network CIDR to assign to Flannel  |
-| iface                      | string     | see description>  |  The interface to bind flannel overlay networking. The default value is the interface bound to the CNI endpoint. |
-|  nagios_context |  string |  juju  |  A string that will be prepended to instance name to set the host name in nagios. If you're running multiple environments with the same services in them this allows you to differentiate between them. Used by the nrpe subordinate charm. |
-| nagios_servicegroups | string  | (empty)  | A comma-separated list of nagios servicegroups. If left empty, the `nagios_context` will be used as the servicegroup  |
+| Name                 | Type   | Default value    | Description                                                                                                                                                                                                                                |
+| -------------------- | ------ | ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| cidr                 | string | 10.1.0.0/16      | Network CIDR to assign to Flannel                                                                                                                                                                                                          |
+| iface                | string | see description> | The interface to bind flannel overlay networking. The default value is the interface bound to the CNI endpoint.                                                                                                                            |
+| nagios_context       | string | juju             | A string that will be prepended to instance name to set the host name in nagios. If you're running multiple environments with the same services in them this allows you to differentiate between them. Used by the nrpe subordinate charm. |
+| nagios_servicegroups | string | (empty)          | A comma-separated list of nagios servicegroups. If left empty, the `nagios_context` will be used as the servicegroup                                                                                                                       |
 
 ### Checking the current configuration
 
@@ -63,23 +60,21 @@ juju debug-log --replay --include=flannel
 
 For additional troubleshooting pointers, please see the [dedicated troubleshooting page][troubleshooting].
 
-
-
 <!-- LINKS -->
 
-[Flannel]: https://github.com/coreos/flannel
+[flannel]: https://github.com/coreos/flannel
 [troubleshooting]: /kubernetes/docs/troubleshooting
-[quickstart]:  /kubernetes/docs/quickstart
-[install-manual]:  /kubernetes/docs/install-manual
-[Calico]: /kubernetes/docs/cni-calico
-[Canal]: /kubernetes/docs/cni-canal
+[quickstart]: /kubernetes/docs/quickstart
+[install-manual]: /kubernetes/docs/install-manual
+[calico]: /kubernetes/docs/cni-calico
+[canal]: /kubernetes/docs/cni-canal
 
 <!-- FEEDBACK -->
 <div class="p-notification--information">
-  <p class="p-notification__response">
-    We appreciate your feedback on the documentation. You can
+  <div class="p-notification__content">
+    <p class="p-notification__message">We appreciate your feedback on the documentation. You can
     <a href="https://github.com/charmed-kubernetes/kubernetes-docs/edit/main/pages/k8s/cni-flannel.md" >edit this page</a>
     or
-    <a href="https://github.com/charmed-kubernetes/kubernetes-docs/issues/new" >file a bug here</a>.
-  </p>
+    <a href="https://github.com/charmed-kubernetes/kubernetes-docs/issues/new" >file a bug here</a>.</p>
+  </div>
 </div>

--- a/templates/kubernetes/docs/cni-multus.md
+++ b/templates/kubernetes/docs/cni-multus.md
@@ -91,6 +91,7 @@ network interfaces to your pods. In this example, we'll create an Ubuntu pod
 with 2 extra Flannel interfaces, in addition to the default one.
 
 Create a NetworkAttachmentDefinition for Flannel:
+
 ```
 apiVersion: "k8s.cni.cncf.io/v1"
 kind: NetworkAttachmentDefinition
@@ -118,6 +119,7 @@ spec:
 ```
 
 Create a Pod with the `k8s.v1.cni.cncf.io/networks` annotation:
+
 ```
 apiVersion: v1
 kind: Pod
@@ -206,10 +208,10 @@ For additional troubleshooting pointers, please see the [dedicated troubleshooti
 
 <!-- FEEDBACK -->
 <div class="p-notification--information">
-  <p class="p-notification__response">
-    We appreciate your feedback on the documentation. You can
+  <div class="p-notification__content">
+    <p class="p-notification__message">We appreciate your feedback on the documentation. You can
     <a href="https://github.com/charmed-kubernetes/kubernetes-docs/edit/main/pages/k8s/cni-multus.md" >edit this page</a>
     or
-    <a href="https://github.com/charmed-kubernetes/kubernetes-docs/issues/new" >file a bug here</a>.
-  </p>
+    <a href="https://github.com/charmed-kubernetes/kubernetes-docs/issues/new" >file a bug here</a>.</p>
+  </div>
 </div>

--- a/templates/kubernetes/docs/cni-overview.md
+++ b/templates/kubernetes/docs/cni-overview.md
@@ -20,7 +20,7 @@ simple specification makes it easy for Kubernetes to interact with a wide range
 of CNI-based software solutions.
 
 With **Charmed Kubernetes**, these networking 'plug-ins' are deployed as
-subordinate charms with each  node running as a `kubernetes-master` or
+subordinate charms with each node running as a `kubernetes-master` or
 `kubernetes-worker`, and ensure the smooth running of the cluster. It is
 possible to choose one of several different CNI providers for **Charmed
 Kubernetes**, which are listed below:
@@ -29,16 +29,17 @@ Kubernetes**, which are listed below:
 
 The currently supported base CNI solutions for **Charmed Kubernetes** are:
 
- -   [Flannel][flannel]
- -   [Calico][calico]
- -   [Canal][canal]
- -   [Tigera Secure EE][tigera]
+- [Flannel][flannel]
+- [Calico][calico]
+- [Canal][canal]
+- [Tigera Secure EE][tigera]
 
 By default, **Charmed Kubernetes** will deploy the cluster using flannel. To chose a different CNI provider, see the individual links above.
 
 The following CNI addons are also available:
- -   [Multus][multus]
- -   [SR-IOV][sr-iov]
+
+- [Multus][multus]
+- [SR-IOV][sr-iov]
 
 ## Migrating to a different CNI solution
 
@@ -60,10 +61,10 @@ Kubernetes, such a migration should be manageable with no downtime.
 
 <!-- FEEDBACK -->
 <div class="p-notification--information">
-  <p class="p-notification__response">
-    We appreciate your feedback on the documentation. You can
+  <div class="p-notification__content">
+    <p class="p-notification__message">We appreciate your feedback on the documentation. You can
     <a href="https://github.com/charmed-kubernetes/kubernetes-docs/edit/main/pages/k8s/cni-overview.md" >edit this page</a>
     or
-    <a href="https://github.com/charmed-kubernetes/kubernetes-docs/issues/new" >file a bug here</a>.
-  </p>
+    <a href="https://github.com/charmed-kubernetes/kubernetes-docs/issues/new" >file a bug here</a>.</p>
+  </div>
 </div>

--- a/templates/kubernetes/docs/container-runtime.md
+++ b/templates/kubernetes/docs/container-runtime.md
@@ -21,27 +21,25 @@ runtimes on a case-by case basis.
 However, it is also possible to use Docker for running containers as in previous versions
 of **Charmed Kubernetes**.
 
-
 ## Configuring containerd
 
 Settings which require additional explanation are described below.
 
-| name | type   | Default      | Description                               |
-|------|--------|--------------|-------------------------------------------|
-| <a id="table-custom_registries"> </a> custom_registries | string | [] | [See notes](#custom_registries-description)  |
-| <a id="table-disable-juju-proxy"> </a> disable-juju-proxy | boolean | False | Ignore juju-http(s) proxy settings on this charm. If set to true, all juju https proxy settings will be ignored  |
-| <a id="table-enable-cgroups"> </a> enable-cgroups | boolean | False | Enable GRUB cgroup overrides cgroup_enable=memory swapaccount=1. WARNING changing this option will reboot the host - use with caution on production services.  |
-| <a id="table-gpu_driver"> </a> gpu_driver | string | auto | Override GPU driver installation.  Options are "auto", "nvidia", "none".  |
-| <a id="table-http_proxy"> </a> http_proxy | string |  | URL to use for HTTP_PROXY to be used by Containerd. Useful in egress-filtered environments where a proxy is the only option for accessing the registry to pull images.  |
-| <a id="table-https_proxy"> </a> https_proxy | string |  | URL to use for HTTPS_PROXY to be used by Containerd. Useful in egress-filtered environments where a proxy is the only option for accessing the registry to pull images.  |
-| <a id="table-no_proxy"> </a> no_proxy | string |  | [See notes](#no_proxy-description)  |
-| <a id="table-runtime"> </a> runtime | string | auto | Set a custom containerd runtime.  Set "auto" to select based on hardware.  |
-| <a id="table-shim"> </a> shim | string | containerd-shim | Set a custom containerd shim.  |
+| name                                                      | type    | Default         | Description                                                                                                                                                             |
+| --------------------------------------------------------- | ------- | --------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| <a id="table-custom_registries"> </a> custom_registries   | string  | []              | [See notes](#custom_registries-description)                                                                                                                             |
+| <a id="table-disable-juju-proxy"> </a> disable-juju-proxy | boolean | False           | Ignore juju-http(s) proxy settings on this charm. If set to true, all juju https proxy settings will be ignored                                                         |
+| <a id="table-enable-cgroups"> </a> enable-cgroups         | boolean | False           | Enable GRUB cgroup overrides cgroup_enable=memory swapaccount=1. WARNING changing this option will reboot the host - use with caution on production services.           |
+| <a id="table-gpu_driver"> </a> gpu_driver                 | string  | auto            | Override GPU driver installation. Options are "auto", "nvidia", "none".                                                                                                 |
+| <a id="table-http_proxy"> </a> http_proxy                 | string  |                 | URL to use for HTTP_PROXY to be used by Containerd. Useful in egress-filtered environments where a proxy is the only option for accessing the registry to pull images.  |
+| <a id="table-https_proxy"> </a> https_proxy               | string  |                 | URL to use for HTTPS_PROXY to be used by Containerd. Useful in egress-filtered environments where a proxy is the only option for accessing the registry to pull images. |
+| <a id="table-no_proxy"> </a> no_proxy                     | string  |                 | [See notes](#no_proxy-description)                                                                                                                                      |
+| <a id="table-runtime"> </a> runtime                       | string  | auto            | Set a custom containerd runtime. Set "auto" to select based on hardware.                                                                                                |
+| <a id="table-shim"> </a> shim                             | string  | containerd-shim | Set a custom containerd shim.                                                                                                                                           |
 
 ---
 
 ### custom_registries
-
 
 <a id="custom_registries-description"> </a>
 **Description:**
@@ -50,13 +48,11 @@ Registry credentials. Setting this config allows Kubelet to pull images from
 registries where auth is required.
 
 The value for this config must be a JSON array of credential objects, like this:
-  `[{"url": "https://my.registry:port", "username": "user", "password": "pass"}]`
+`[{"url": "https://my.registry:port", "username": "user", "password": "pass"}]`
 
 [Back to table](#table-custom_registries)
 
-
 ### no_proxy
-
 
 <a id="no_proxy-description"> </a>
 **Description:**
@@ -67,8 +63,6 @@ the proxy defined in http_proxy or https_proxy. Must be less than
 2023 characters long.
 
 [Back to table](#table-no_proxy)
-
-
 
 ### Checking the current configuration
 
@@ -88,7 +82,7 @@ juju config containerd gpu_driver=none
 
 ## Migrating to containerd
 
-If you have upgraded to  **Charmed Kubernetes** version 1.15, you can transition to using containerd by following the steps outlined in
+If you have upgraded to **Charmed Kubernetes** version 1.15, you can transition to using containerd by following the steps outlined in
 [this section of the upgrade notes][docker2containerd].
 
 ## Using Docker
@@ -103,17 +97,16 @@ juju deploy cs:~containers/docker
 juju relate docker kubernetes-worker-docker
 ```
 
-
 <!-- LINKS -->
 
 [docker2containerd]: /kubernetes/docs/upgrade-notes#1.15
 
 <!-- FEEDBACK -->
 <div class="p-notification--information">
-  <p class="p-notification__response">
-    We appreciate your feedback on the documentation. You can
+  <div class="p-notification__content">
+    <p class="p-notification__message">We appreciate your feedback on the documentation. You can
     <a href="https://github.com/charmed-kubernetes/kubernetes-docs/edit/main/pages/k8s/container-runtime.md" >edit this page</a>
     or
-    <a href="https://github.com/charmed-kubernetes/kubernetes-docs/issues/new" >file a bug here</a>.
-  </p>
+    <a href="https://github.com/charmed-kubernetes/kubernetes-docs/issues/new" >file a bug here</a>.</p>
+  </div>
 </div>

--- a/templates/kubernetes/docs/custom-loadbalancer.md
+++ b/templates/kubernetes/docs/custom-loadbalancer.md
@@ -14,18 +14,18 @@ toc: False
 ---
 
 **Charmed Kubernetes** supports setting a
-custom IP address for the control plane.  There are two ways of achieving this, depending
+custom IP address for the control plane. There are two ways of achieving this, depending
 on which type of load balancing solution you wish to configure:
 
- -  If you have a virtual IP to place in front of machines, configure the settings on the
-    `kubeapi-load-balancer` charm.
+- If you have a virtual IP to place in front of machines, configure the settings on the
+  `kubeapi-load-balancer` charm.
 
- -  If a full load balancing solution is in place such as an F5 appliance, remove the
-     `kubeapi-load-balancer` and use the settings on the `kubernetes-master` charm to
-      configure the load balancer. This is also the appropriate step if you want to use
-      a load balancer integrated with a particular cloud (e.g **OctaviaLB** for
-      OpenStack). See the relevant entry in the "Cloud Integration" section of the
-      documentation for more on native load balancers.
+- If a full load balancing solution is in place such as an F5 appliance, remove the
+  `kubeapi-load-balancer` and use the settings on the `kubernetes-master` charm to
+  configure the load balancer. This is also the appropriate step if you want to use
+  a load balancer integrated with a particular cloud (e.g **OctaviaLB** for
+  OpenStack). See the relevant entry in the "Cloud Integration" section of the
+  documentation for more on native load balancers.
 
 Both solutions are described in the sections below.
 
@@ -41,12 +41,11 @@ juju config kubeapi-load-balancer loadbalancer-ips="10.0.0.1 10.0.0.2"
 
 Multiple IP addresses should be given as a space-separated list.
 
-
 # Custom load balancer in front of kubernetes-master charm
 
 If you have a full load balancer such as an F5 appliance or OpenStack's Neutron,
 use the configuration options on the `kubernetes-master` charm and forgo
-`kubeapi-load-balancer`  entirely.
+`kubeapi-load-balancer` entirely.
 
 Remove the `kubeapi-load-balancer` application if it exists:
 
@@ -65,10 +64,10 @@ Multiple IP addresses should be given as a space-separated list.
 
 <!-- FEEDBACK -->
 <div class="p-notification--information">
-  <p class="p-notification__response">
-    We appreciate your feedback on the documentation. You can
+  <div class="p-notification__content">
+    <p class="p-notification__message">We appreciate your feedback on the documentation. You can
     <a href="https://github.com/charmed-kubernetes/kubernetes-docs/edit/main/pages/k8s/custom-loadbalancer.md" >edit this page</a>
     or
-    <a href="https://github.com/charmed-kubernetes/kubernetes-docs/issues/new" >file a bug here</a>.
-  </p>
+    <a href="https://github.com/charmed-kubernetes/kubernetes-docs/issues/new" >file a bug here</a>.</p>
+  </div>
 </div>

--- a/templates/kubernetes/docs/decommissioning.md
+++ b/templates/kubernetes/docs/decommissioning.md
@@ -128,10 +128,10 @@ users:
 
 <!-- FEEDBACK -->
 <div class="p-notification--information">
-  <p class="p-notification__response">
-    We appreciate your feedback on the documentation. You can
+  <div class="p-notification__content">
+    <p class="p-notification__message">We appreciate your feedback on the documentation. You can
     <a href="https://github.com/charmed-kubernetes/kubernetes-docs/edit/main/pages/k8s/decommissioning.md" >edit this page</a>
     or
-    <a href="https://github.com/charmed-kubernetes/kubernetes-docs/issues/new" >file a bug here</a>.
-  </p>
+    <a href="https://github.com/charmed-kubernetes/kubernetes-docs/issues/new" >file a bug here</a>.</p>
+  </div>
 </div>

--- a/templates/kubernetes/docs/encryption-at-rest.md
+++ b/templates/kubernetes/docs/encryption-at-rest.md
@@ -29,7 +29,7 @@ configure the encryption key used by **Kubernetes**.
 
 To enable encryption-at-rest for **Charmed Kubernetes**, simply deploy the [Vault charm][] (as
 well as a database backend for it), and relate it to `kubernetes-master` via
-the `vault-kv` relation endpoint.  The easiest way to do this is to deploy **Charmed Kubernetes**
+the `vault-kv` relation endpoint. The easiest way to do this is to deploy **Charmed Kubernetes**
 with the following overlay:
 
 ```yaml
@@ -41,8 +41,8 @@ applications:
     charm: cs:percona-cluster
     num_units: 1
 relations:
-  - ['vault', 'percona-cluster']
-  - ['vault:secrets', 'kubernetes-master:vault-kv']
+  - ["vault", "percona-cluster"]
+  - ["vault:secrets", "kubernetes-master:vault-kv"]
 ```
 
 To deploy **Charmed Kubernetes** with this overlay - [download it][cdk-vault-overlay]), save it as, e.g.,
@@ -62,25 +62,25 @@ Charmed Kubernetes will then automatically enable encryption for the secrets dat
 
 This does not work on **LXD** at this time, due to security limitations
 preventing charms from acquiring and managing the block devices and file
-systems needed to implement this.  In the future, support for KMS, or
-encryption-as-a-service, will remove this restriction.  In the meantime,
+systems needed to implement this. In the future, support for KMS, or
+encryption-as-a-service, will remove this restriction. In the meantime,
 **LXD** deployments can make use of encryption at the level of the **LXD**
 storage pool, or even full-disk-encryption on the host machine.
 
 [cdk-vault-overlay]: https://raw.githubusercontent.com/juju-solutions/kubernetes-docs/master/assets/cdk-vault-overlay.yaml
 [secrets]: https://kubernetes.io/docs/tasks/inject-data-application/distribute-credentials-secure/
 [encryption at rest]: https://kubernetes.io/docs/tasks/administer-cluster/encrypt-data/
-[HashiCorp's Vault]: https://www.vaultproject.io/
-[VaultLocker]: https://github.com/openstack-charmers/vaultlocker
-[Vault charm]: https://charmhub.io/vault
+[hashicorp's vault]: https://www.vaultproject.io/
+[vaultlocker]: https://github.com/openstack-charmers/vaultlocker
+[vault charm]: https://charmhub.io/vault
 [unseal]: https://docs.openstack.org/project-deploy-guide/charm-deployment-guide/victoria/app-vault.html#initialize-and-unseal-vault
 
 <!-- FEEDBACK -->
 <div class="p-notification--information">
-  <p class="p-notification__response">
-    We appreciate your feedback on the documentation. You can
+  <div class="p-notification__content">
+    <p class="p-notification__message">We appreciate your feedback on the documentation. You can
     <a href="https://github.com/charmed-kubernetes/kubernetes-docs/edit/main/pages/k8s/encryption-at-rest.md" >edit this page</a>
     or
-    <a href="https://github.com/charmed-kubernetes/kubernetes-docs/issues/new" >file a bug here</a>.
-  </p>
+    <a href="https://github.com/charmed-kubernetes/kubernetes-docs/issues/new" >file a bug here</a>.</p>
+  </div>
 </div>

--- a/templates/kubernetes/docs/equinix.md
+++ b/templates/kubernetes/docs/equinix.md
@@ -14,10 +14,9 @@ toc: False
 ---
 
 As with any cloud supported by Juju, **Charmed Kubernetes** can be deployed and used on
-[Equinix Metal][]. This document provides some extra information and an overlay to 
+[Equinix Metal][]. This document provides some extra information and an overlay to
 help get the most out of this cloud. For instructions on installing Juju itself, please
 see the latest [Juju documentation][].
-
 
 ## Before installing
 
@@ -28,7 +27,7 @@ run the command:
 juju list-clouds --all
 ```
 
-If `equinix` does not appear in the list, your local Juju install probably just needs to 
+If `equinix` does not appear in the list, your local Juju install probably just needs to
 refresh its list of clouds. Run:
 
 ```bash
@@ -41,10 +40,8 @@ You should also add your credentials for this cloud. Use the interactive command
 juju add-credential equinix
 ```
 
-...and follow the prompts to enter the information required (including the project id, and 
+...and follow the prompts to enter the information required (including the project id, and
 your auth token).
-
-
 
 ## Installing
 
@@ -61,7 +58,7 @@ juju deploy ./equinix-bundle.yaml
 ```
 
 <!-- COMMENTED OUT UNTIL OVERLAYS WORK
-It adjusts the default bundle to use Calico networking, deploys Ceph for storage and 
+It adjusts the default bundle to use Calico networking, deploys Ceph for storage and
 co-locates some services to make more efficient use of the available instances.
 
 You can copy this example or ([download it here][asset-equinix-overlay]):
@@ -175,7 +172,7 @@ applications:
     to:
     - 0
     - 1
-    - 2  
+    - 2
   kubeapi-load-balancer:
     num_units: 3
     expose: true
@@ -210,10 +207,9 @@ relations:
 To use this overlay with the **Charmed Kubernetes** bundle, it is specified during deploy like this:
 
 ```bash
-juju deploy charmed-kubernetes  --overlay ./equinix-overlay.yaml 
+juju deploy charmed-kubernetes  --overlay ./equinix-overlay.yaml
 ```
 -->
-
 
 When the deployment has settled, remember to fetch the configuration file!
 
@@ -234,8 +230,8 @@ the Cloud Controller Manager has been run.
 
 To use Kubernetes on Equinix Metal, you should now set up the [Equinix Cloud Controller Manager][].
 
-While the deployment is in progress no pods will be able to spun up on the Kubernetes due to 
-taints being set on each node. The taints will be removed once the Cloud Controller Manager (CCM) 
+While the deployment is in progress no pods will be able to spun up on the Kubernetes due to
+taints being set on each node. The taints will be removed once the Cloud Controller Manager (CCM)
 is enabled and the nodes are registered with the cloud control plane.
 
 First, a Kubernetes secret has to be created, defining the variables for the CCM:
@@ -359,12 +355,13 @@ simple application. Here we will create a simple application and scale it to fiv
 kubectl create deployment hello-world --image=gcr.io/google-samples/node-hello:1.0
 kubectl scale deployment hello-world --replicas=5
 ```
- 
+
 You can verify that the application and replicas have been created with:
 
 ```bash
 kubectl get deployments hello-world
 ```
+
 Which should return output similar to:
 
 ```text
@@ -396,7 +393,8 @@ You can see that the External IP is now in front of the five endpoints of the ex
 ```bash
 curl  http://202.49.242.3:8080
 ```
-```text 
+
+```text
 Hello Kubernetes!
 ```
 
@@ -408,16 +406,16 @@ Hello Kubernetes!
 [storage]: /kubernetes/docs/storage
 [bugs]: https://bugs.launchpad.net/charmed-kubernetes
 [install]: /kubernetes/docs/install-manual
-[Equinix Cloud Controller Manager]: https://github.com/equinix/cloud-provider-equinix-metal/
-[Juju documentation]: https://juju.is/docs/olm/installing-juju
-[Equinix Metal]: https://metal.equinix.com/
+[equinix cloud controller manager]: https://github.com/equinix/cloud-provider-equinix-metal/
+[juju documentation]: https://juju.is/docs/olm/installing-juju
+[equinix metal]: https://metal.equinix.com/
 
 <!-- FEEDBACK -->
 <div class="p-notification--information">
-  <p class="p-notification__response">
-    We appreciate your feedback on the documentation. You can
+  <div class="p-notification__content">
+    <p class="p-notification__message">We appreciate your feedback on the documentation. You can
     <a href="https://github.com/charmed-kubernetes/kubernetes-docs/edit/main/pages/k8s/equinix.md" >edit this page</a>
     or
-    <a href="https://github.com/charmed-kubernetes/kubernetes-docs/issues/new" >file a bug here</a>.
-  </p>
+    <a href="https://github.com/charmed-kubernetes/kubernetes-docs/issues/new" >file a bug here</a>.</p>
+  </div>
 </div>

--- a/templates/kubernetes/docs/get-in-touch.md
+++ b/templates/kubernetes/docs/get-in-touch.md
@@ -27,7 +27,7 @@ Find us in **#cdk** on the [Kubernetes slack][slack].
 
 ## Bugs
 
-**Charmed Kubernetes** bugs  are tracked in [launchpad][lp].
+**Charmed Kubernetes** bugs are tracked in [launchpad][lp].
 
 ## Documentation
 
@@ -38,7 +38,6 @@ Visit the [documentation repository][docs] for issues or comments about this doc
 The source for the bundles and all the core charms for Charmed Kubernetes is
 [available on GitHub][source].
 
-
 ## Professional support
 
 If you are looking for additional support, find out about [Ubuntu Advantage][support].
@@ -47,7 +46,7 @@ Canonical can also provide [managed solutions][managed] for Kubernetes.
 
 <!-- LINKS -->
 
-[docs]:  https://github.com/juju-solutions/kubernetes-docs
+[docs]: https://github.com/juju-solutions/kubernetes-docs
 [lp]: https://bugs.launchpad.net/charmed-kubernetes
 [support]: /support
 [managed]: /kubernetes/managed
@@ -56,10 +55,10 @@ Canonical can also provide [managed solutions][managed] for Kubernetes.
 
 <!-- FEEDBACK -->
 <div class="p-notification--information">
-  <p class="p-notification__response">
-    We appreciate your feedback on the documentation. You can
+  <div class="p-notification__content">
+    <p class="p-notification__message">We appreciate your feedback on the documentation. You can
     <a href="https://github.com/charmed-kubernetes/kubernetes-docs/edit/main/pages/k8s/get-in-touch.md" >edit this page</a>
     or
-    <a href="https://github.com/charmed-kubernetes/kubernetes-docs/issues/new" >file a bug here</a>.
-  </p>
+    <a href="https://github.com/charmed-kubernetes/kubernetes-docs/issues/new" >file a bug here</a>.</p>
+  </div>
 </div>

--- a/templates/kubernetes/docs/gpu-workers.md
+++ b/templates/kubernetes/docs/gpu-workers.md
@@ -117,28 +117,27 @@ spec:
     spec:
       restartPolicy: Never
       containers:
-      - image: nvidia/cuda
-        name: nvidia-smi
-        args:
-          - nvidia-smi
-        resources:
-          limits:
-            nvidia.com/gpu: 1
-          requests:
-            nvidia.com/gpu: 1
-        volumeMounts:
-        - mountPath: /usr/bin/
-          name: binaries
-        - mountPath: /usr/lib/x86_64-linux-gnu
-          name: libraries
+        - image: nvidia/cuda
+          name: nvidia-smi
+          args:
+            - nvidia-smi
+          resources:
+            limits:
+              nvidia.com/gpu: 1
+            requests:
+              nvidia.com/gpu: 1
+          volumeMounts:
+            - mountPath: /usr/bin/
+              name: binaries
+            - mountPath: /usr/lib/x86_64-linux-gnu
+              name: libraries
       volumes:
-      - name: binaries
-        hostPath:
-          path: /usr/bin/
-      - name: libraries
-        hostPath:
-          path: /usr/lib/x86_64-linux-gnu
-
+        - name: binaries
+          hostPath:
+            path: /usr/bin/
+        - name: libraries
+          hostPath:
+            path: /usr/lib/x86_64-linux-gnu
 ```
 
 Download the file and run it with:
@@ -152,13 +151,12 @@ find the hardware report.
 
 ![dashboard image][img-log]
 
-
 <!-- IMAGES -->
 
 [img-log]: https://assets.ubuntu.com/v1/2ba88cee-nvidia.png
 
-
 <!-- LINKS -->
+
 [asset-nvidia]: https://raw.githubusercontent.com/juju-solutions/kubernetes-docs/master/assets/nvidia-test.yaml
 [quickstart]: /kubernetes/docs/quickstart
 [aws-instance]: https://aws.amazon.com/ec2/instance-types/
@@ -166,10 +164,10 @@ find the hardware report.
 
 <!-- FEEDBACK -->
 <div class="p-notification--information">
-  <p class="p-notification__response">
-    We appreciate your feedback on the documentation. You can
+  <div class="p-notification__content">
+    <p class="p-notification__message">We appreciate your feedback on the documentation. You can
     <a href="https://github.com/charmed-kubernetes/kubernetes-docs/edit/main/pages/k8s/gpu-workers.md" >edit this page</a>
     or
-    <a href="https://github.com/charmed-kubernetes/kubernetes-docs/issues/new" >file a bug here</a>.
-  </p>
+    <a href="https://github.com/charmed-kubernetes/kubernetes-docs/issues/new" >file a bug here</a>.</p>
+  </div>
 </div>

--- a/templates/kubernetes/docs/hacluster.md
+++ b/templates/kubernetes/docs/hacluster.md
@@ -70,10 +70,10 @@ juju scp kubernetes-master/0:config ~/.kube/config
 
 <!-- FEEDBACK -->
 <div class="p-notification--information">
-  <p class="p-notification__response">
-    We appreciate your feedback on the documentation. You can
+  <div class="p-notification__content">
+    <p class="p-notification__message">We appreciate your feedback on the documentation. You can
     <a href="https://github.com/charmed-kubernetes/kubernetes-docs/edit/main/pages/k8s/hacluster.md" >edit this page</a>
     or
-    <a href="https://github.com/charmed-kubernetes/kubernetes-docs/issues/new" >file a bug here</a>.
-  </p>
+    <a href="https://github.com/charmed-kubernetes/kubernetes-docs/issues/new" >file a bug here</a>.</p>
+  </div>
 </div>

--- a/templates/kubernetes/docs/high-availability.md
+++ b/templates/kubernetes/docs/high-availability.md
@@ -24,15 +24,15 @@ This documentation will present the strategies and methodology for software
 solutions only - if you have a hardware load-balancer, that would obviously be
 a better option.
 
- We start with the two basic components of a **Charmed Kubernetes** cluster:
+We start with the two basic components of a **Charmed Kubernetes** cluster:
 
- - your control plane, the `kubernetes-master` charm
- - the worker units, the `kubernetes-worker` charm
+- your control plane, the `kubernetes-master` charm
+- the worker units, the `kubernetes-worker` charm
 
 ## Control Plane
 
 An initial plan to make the control plane more resilient might be to simply add more
-master nodes with  `juju add-unit kubernetes-master`:
+master nodes with `juju add-unit kubernetes-master`:
 
 ![multi-master worker image][img-multi-master]
 
@@ -101,10 +101,10 @@ development with projects that are Kubernetes-aware such as MetalLB.
 The pages linked below give practical details on how to use the currently supported
 software to enable HA
 
-  - [Keepalived][keepalived]
-  - [HAcluster][hacluster]
-  - [MetalLB][metallb]
-  - [Custom Load Balancer/Virtual IP][customlb]
+- [Keepalived][keepalived]
+- [HAcluster][hacluster]
+- [MetalLB][metallb]
+- [Custom Load Balancer/Virtual IP][customlb]
 
 <!-- IMAGES -->
 
@@ -121,10 +121,10 @@ software to enable HA
 
 <!-- FEEDBACK -->
 <div class="p-notification--information">
-  <p class="p-notification__response">
-    We appreciate your feedback on the documentation. You can
+  <div class="p-notification__content">
+    <p class="p-notification__message">We appreciate your feedback on the documentation. You can
     <a href="https://github.com/charmed-kubernetes/kubernetes-docs/edit/main/pages/k8s/high-availability.md" >edit this page</a>
     or
-    <a href="https://github.com/charmed-kubernetes/kubernetes-docs/issues/new" >file a bug here</a>.
-  </p>
+    <a href="https://github.com/charmed-kubernetes/kubernetes-docs/issues/new" >file a bug here</a>.</p>
+  </div>
 </div>

--- a/templates/kubernetes/docs/kata.md
+++ b/templates/kubernetes/docs/kata.md
@@ -50,13 +50,12 @@ applications:
   kata:
     charm: cs:~containers/kata
 relations:
-- - kata:untrusted
-  - containerd:untrusted
-- - kata
-  - kubernetes-master
-- - kata
-  - kubernetes-worker
-
+  - - kata:untrusted
+    - containerd:untrusted
+  - - kata
+    - kubernetes-master
+  - - kata
+    - kubernetes-worker
 ```
 
 Save this YAML and then deploy:
@@ -91,12 +90,12 @@ applications:
   kata:
     charm: cs:~containers/kata
 relations:
-- - kata:untrusted
-  - containerd:untrusted
-- - kata
-  - kubernetes-master
-- - kata
-  - kubernetes-worker
+  - - kata:untrusted
+    - containerd:untrusted
+  - - kata
+    - kubernetes-master
+  - - kata
+    - kubernetes-worker
 ```
 
 Once written, deploy it with:
@@ -114,7 +113,7 @@ workers later with the `juju add-unit kubernetes-worker` command.
 ### Untrusted annotation
 
 The simplest way to run your pods with Kata is to annotate them with
-`io.kubernetes.cri.untrusted-workload: "true"`.  For example:
+`io.kubernetes.cri.untrusted-workload: "true"`. For example:
 
 ```yaml
 apiVersion: v1
@@ -125,8 +124,8 @@ metadata:
     io.kubernetes.cri.untrusted-workload: "true"
 spec:
   containers:
-  - name: nginx
-    image: nginx
+    - name: nginx
+      image: nginx
 ```
 
 ### RuntimeClass
@@ -153,8 +152,8 @@ metadata:
 spec:
   runtimeClassName: kata
   containers:
-  - name: nginx
-    image: nginx
+    - name: nginx
+      image: nginx
 ```
 
 <!-- LINKS -->
@@ -165,11 +164,10 @@ spec:
 
 <!-- FEEDBACK -->
 <div class="p-notification--information">
-  <p class="p-notification__response">
-    We appreciate your feedback on the documentation. You can
+  <div class="p-notification__content">
+    <p class="p-notification__message">We appreciate your feedback on the documentation. You can
     <a href="https://github.com/charmed-kubernetes/kubernetes-docs/edit/main/pages/k8s/kata.md" >edit this page</a>
     or
-    <a href="https://github.com/charmed-kubernetes/kubernetes-docs/issues/new" >file a bug here</a>.
-  </p>
+    <a href="https://github.com/charmed-kubernetes/kubernetes-docs/issues/new" >file a bug here</a>.</p>
+  </div>
 </div>
-

--- a/templates/kubernetes/docs/keepalived.md
+++ b/templates/kubernetes/docs/keepalived.md
@@ -24,68 +24,78 @@ metal or MAAS is by using [keepalived][keepalived-home]. This is available as a
 configured as follows:
 
 1. Deploy the `keepalived` charm:
-    ```bash
-    juju deploy cs:~containers/keepalived
-    ```
+
+   ```bash
+   juju deploy cs:~containers/keepalived
+   ```
 
 1. Add the required relations:
-    ```bash
-    juju add-relation keepalived:juju-info kubeapi-load-balancer:juju-info
-    juju add-relation keepalived:lb-sink kubeapi-load-balancer:website
-    juju add-relation keepalived:loadbalancer kubernetes-master:loadbalancer
-    juju add-relation keepalived:website kubernetes-worker:kube-api-endpoint
-    ```
-    This redirects both the Kubernetes master and worker units to point at the keepalived
-    service rather than the api-endpoint directly.
+
+   ```bash
+   juju add-relation keepalived:juju-info kubeapi-load-balancer:juju-info
+   juju add-relation keepalived:lb-sink kubeapi-load-balancer:website
+   juju add-relation keepalived:loadbalancer kubernetes-master:loadbalancer
+   juju add-relation keepalived:website kubernetes-worker:kube-api-endpoint
+   ```
+
+   This redirects both the Kubernetes master and worker units to point at the keepalived
+   service rather than the api-endpoint directly.
 
 1. Configure the keepalived application. You should substitute a suitable IP address and
-     FQDN in the example below:
-    ```bash
-    export VIP=10.10.74.250
-    export VIP_HOSTNAME=test.example.com
-    juju config keepalived virtual_ip=$VIP
-    juju config keepalived vip_hostname=$VIP_HOSTNAME
-    ```
-    Allocating a VIP and ensuring that it can route to all of the instances is a manual
-    process which depends on your infrastructure.  It does require that the VIP be able
-    to route to each instance, and that the VRRP protocol is allowed on the network.
-    While this should be the case on bare metal and MAAS, and can be made to
-    work on [OpenStack][openstack-vip], it will generally not be possible on
-    public clouds. Thus, it is generally better to in those cases to replace
-    kubeapi-load-balancer with a cloud-provided load balancer with health
-    checks, such as Octavia or ELB.
+   FQDN in the example below:
 
-1.  Add both the new hostname and VIP to the API server certificate. This is done by specifying
-    additional [SANs][]:
-    ```bash
-    juju config kubeapi-load-balancer extra_sans="$VIP $VIP_HOSTNAME"
-    juju config kubernetes-master extra_sans="$VIP $VIP_HOSTNAME"
-    ```
+   ```bash
+   export VIP=10.10.74.250
+   export VIP_HOSTNAME=test.example.com
+   juju config keepalived virtual_ip=$VIP
+   juju config keepalived vip_hostname=$VIP_HOSTNAME
+   ```
+
+   Allocating a VIP and ensuring that it can route to all of the instances is a manual
+   process which depends on your infrastructure. It does require that the VIP be able
+   to route to each instance, and that the VRRP protocol is allowed on the network.
+   While this should be the case on bare metal and MAAS, and can be made to
+   work on [OpenStack][openstack-vip], it will generally not be possible on
+   public clouds. Thus, it is generally better to in those cases to replace
+   kubeapi-load-balancer with a cloud-provided load balancer with health
+   checks, such as Octavia or ELB.
+
+1. Add both the new hostname and VIP to the API server certificate. This is done by specifying
+   additional [SANs][]:
+
+   ```bash
+   juju config kubeapi-load-balancer extra_sans="$VIP $VIP_HOSTNAME"
+   juju config kubernetes-master extra_sans="$VIP $VIP_HOSTNAME"
+   ```
 
 1. Wait for the new service to settle. You can check the status of the `keepalived`
-    application by running:
-    ```bash
-    juju status keepalived
-    ```
-    Once the application reports a 'ready' status, continue to the next step.
+   application by running:
+
+   ```bash
+   juju status keepalived
+   ```
+
+   Once the application reports a 'ready' status, continue to the next step.
 
 1. Remove unneeded relations:
-    ```bash
-    juju remove-relation kubernetes-worker:kube-api-endpoint kubeapi-load-balancer:website
-    juju remove-relation kubernetes-master:loadbalancer kubeapi-load-balancer:loadbalancer
-    ```
+
+   ```bash
+   juju remove-relation kubernetes-worker:kube-api-endpoint kubeapi-load-balancer:website
+   juju remove-relation kubernetes-master:loadbalancer kubeapi-load-balancer:loadbalancer
+   ```
 
 1. Scale up the `kubeapi-load-balancer`. You can specify as many units as your situation requires.
-    In this example, we add two additional units for a total of three:
-    ```bash
-    juju add-unit kubeapi-load-balancer -n 2
-    ```
+   In this example, we add two additional units for a total of three:
+
+   ```bash
+   juju add-unit kubeapi-load-balancer -n 2
+   ```
 
 1. Check for correct functionality by using kubectl and verifying it returns results. You can also check the SANs listed in the certificate returned by the VIP.
-    ```bash
-    kubectl get pods --all-namespaces
-    openssl s_client -connect $VIP:443 | openssl x509 -noout -text
-    ```
+   ```bash
+   kubectl get pods --all-namespaces
+   openssl s_client -connect $VIP:443 | openssl x509 -noout -text
+   ```
 
 Note that the `keepalived` application is a
 [_subordinate charm_][subordinate-charm] - it does not require a machine of its
@@ -95,18 +105,19 @@ application, it will be found co-located on the machines running the load
 balancer.
 
 <!--LINKS-->
+
 [keepalived-home]: http://www.keepalived.org/
-[SANs]: https://www.openssl.org/docs/manmaster/man5/x509v3_config.html#Subject-Alternative-Name
+[sans]: https://www.openssl.org/docs/manmaster/man5/x509v3_config.html#Subject-Alternative-Name
 [logging-doc]: /kubernetes/docs/logging
 [subordinate-charm]: https://juju.is/docs/sdk#heading--subordinate-charms
 [openstack-vip]: https://medium.com/jexia/virtual-ip-with-openstack-neutron-dd9378a48bdf
 
 <!-- FEEDBACK -->
 <div class="p-notification--information">
-  <p class="p-notification__response">
-    We appreciate your feedback on the documentation. You can
+  <div class="p-notification__content">
+    <p class="p-notification__message">We appreciate your feedback on the documentation. You can
     <a href="https://github.com/charmed-kubernetes/kubernetes-docs/edit/main/pages/k8s/keepalived.md" >edit this page</a>
     or
-    <a href="https://github.com/charmed-kubernetes/kubernetes-docs/issues/new" >file a bug here</a>.
-  </p>
+    <a href="https://github.com/charmed-kubernetes/kubernetes-docs/issues/new" >file a bug here</a>.</p>
+  </div>
 </div>

--- a/templates/kubernetes/docs/ldap.md
+++ b/templates/kubernetes/docs/ldap.md
@@ -15,22 +15,21 @@ toc: False
 
 There is a distinction between authentication and authorisation:
 
-  * Authentication verifies who a user is.
-  * Authorisation deals with what a user is allowed to do.
+- Authentication verifies who a user is.
+- Authorisation deals with what a user is allowed to do.
 
 **Charmed Kubernetes** can be configured to use Keystone and LDAP for authentication only
 or both authentication and authorisation.
 
-
 ## Requirements
 
-* This document assumes you have already [installed][install] **Charmed Kubernetes**.
-* For LDAP authentication, this documentation assumes you already have a suitable LDAP
-   server running.
-* You will need to install the Keystone client. This can be done by running:
-   ```bash
-   sudo snap install client-keystone-auth --edge
-   ```
+- This document assumes you have already [installed][install] **Charmed Kubernetes**.
+- For LDAP authentication, this documentation assumes you already have a suitable LDAP
+  server running.
+- You will need to install the Keystone client. This can be done by running:
+  ```bash
+  sudo snap install client-keystone-auth --edge
+  ```
 
 ## Install Keystone
 
@@ -103,7 +102,7 @@ juju add-relation kubernetes-master:keystone-credentials openstack-integrator:cr
 ## Fetch the Keystone script
 
 When related to Keystone directly (or to the `openstack-integrator:keystone-credentials` interface),
-the Kubernetes master application will generate a utility script. 
+the Kubernetes master application will generate a utility script.
 This should be copied to the local client with:
 
 ```bash
@@ -146,6 +145,7 @@ juju run --unit keystone/0 leader-get admin_passwd
 ```
 
 ### Create the domain for Kubernetes
+
 You should now create a new domain for Kubernetes.
 
 ![dashboard image](https://assets.ubuntu.com/v1/00468cda-ldap1.png)
@@ -206,15 +206,20 @@ variables in order to retrieve a token from Keystone.
 ```bash
 source ~/bin/kube-keystone.sh
 ```
+
 ```
 Function get_keystone_token created. Type get_keystone_token in order to
 generate a login token for the Kubernetes dashboard.
 ```
+
 Enter the command...
+
 ```bash
 get_keystone_token
 ```
+
 ...and a token will be generated:
+
 ```
 ccf9b218845f4d67835f8c6a7c2d1cd4
 ```
@@ -227,7 +232,7 @@ This token can then be used to log in to the Kubernetes dashboard.
 
 Keystone has the ability to use LDAP for authentication.
 The Keystone charm is related to the Keystone-LDAP subordinate charm in order to
-support LDAP.  
+support LDAP.
 
 ```bash
 juju deploy keystone-ldap
@@ -272,32 +277,32 @@ of the charm and switch to **RBAC** authorization mode as follows:
 juju config kubernetes-master authorization-mode="Node,RBAC"
 ```
 
-**Charmed Kubernetes** can  also use Keystone for authorisation as follows:
+**Charmed Kubernetes** can also use Keystone for authorisation as follows:
 
 ```bash
 juju config kubernetes-master enable-keystone-authorization=true
 ```
 
- When authorisation is enabled, the [default policy defined in the configuration][policy] will be used.
- Optionally, A custom policy can be applied by running:
+When authorisation is enabled, the [default policy defined in the configuration][policy] will be used.
+Optionally, A custom policy can be applied by running:
 
 ```bash
 juju config kubernetes-master keystone-policy="$(cat policy.yaml)"
 ```
-
 
 ## Custom Certificate Authority
 
 When using a custom certificate authority attached to Keystone, some additional configuration is
 required.
 
- * Add CA to client machines that will run `kubectl`.
+- Add CA to client machines that will run `kubectl`.
 
 ```
 sudo cp custom_ca.crt /usr/local/share/ca-certificates
 sudo update-ca-certificates
 ```
- * Add CA to the kubernetes-master configuration
+
+- Add CA to the kubernetes-master configuration
 
 ```bash
 juju config kubernetes-master keystone-ssl-ca="$(base64 custom_ca.crt)"
@@ -310,8 +315,8 @@ different values or editing config files. If you are having problems, please
 [read the troubleshooting guide][trouble] for specific tips and information on
 configuring Keystone/LDAP.
 
-
 <!--LINKS-->
+
 [install]: /kubernetes/docs/quickstart
 [policy]: https://raw.githubusercontent.com/juju-solutions/kubernetes-docs/master/assets/policy.yaml
 [keystone-bundle]: https://raw.githubusercontent.com/juju-solutions/kubernetes-docs/master/assets/keystone.yaml
@@ -319,13 +324,12 @@ configuring Keystone/LDAP.
 [trouble]: /kubernetes/docs/troubleshooting/#troubleshooting-keystoneldap-issues
 [openstack-integrator]: /kubernetes/docs/openstack-integration
 
-
 <!-- FEEDBACK -->
 <div class="p-notification--information">
-  <p class="p-notification__response">
-    We appreciate your feedback on the documentation. You can 
-    <a href="https://github.com/charmed-kubernetes/kubernetes-docs/edit/main/pages/k8s/ldap.md" >edit this page</a> 
-    or 
-    <a href="https://github.com/charmed-kubernetes/kubernetes-docs/issues/new" >file a bug here</a>.
-  </p>
+  <div class="p-notification__content">
+    <p class="p-notification__message">We appreciate your feedback on the documentation. You can
+    <a href="https://github.com/charmed-kubernetes/kubernetes-docs/edit/main/pages/k8s/ldap.md" >edit this page</a>
+    or
+    <a href="https://github.com/charmed-kubernetes/kubernetes-docs/issues/new" >file a bug here</a>.</p>
+  </div>
 </div>

--- a/templates/kubernetes/docs/monitoring.md
+++ b/templates/kubernetes/docs/monitoring.md
@@ -123,8 +123,8 @@ endpoint for scraping, and then setting up Grafana to use this data.
 
 Starting with Charmed Kubernetes 1.17,
 [kube-state-metrics](https://github.com/kubernetes/kube-state-metrics)
-are added, automatically, when `enable-metrics` is set to  `true ` on the
-`kubernetes-master` charm.  This is enabled by default.  Enable
+are added, automatically, when `enable-metrics` is set to `true ` on the
+`kubernetes-master` charm. This is enabled by default. Enable
 with the following command.
 
 ```bash
@@ -137,7 +137,7 @@ To view metrics scraped from
 [kube-state-metrics](https://github.com/kubernetes/kube-state-metrics),
 refer to
 [Monitoring with Prometheus, Grafana, and Telegraf](#monitoring-with-prometheus-grafana-and-telegraf)
-and enable Grafana.  You can then open the **Charmed Kubernetes Dashboard**.
+and enable Grafana. You can then open the **Charmed Kubernetes Dashboard**.
 
 ## Monitoring with Nagios
 
@@ -207,10 +207,10 @@ See the [External Nagios][external-nagios] section of the NRPE charm readme for 
 
 <!-- FEEDBACK -->
 <div class="p-notification--information">
-  <p class="p-notification__response">
-    We appreciate your feedback on the documentation. You can
+  <div class="p-notification__content">
+    <p class="p-notification__message">We appreciate your feedback on the documentation. You can
     <a href="https://github.com/charmed-kubernetes/kubernetes-docs/edit/main/pages/k8s/monitoring.md" >edit this page</a>
     or
-    <a href="https://github.com/charmed-kubernetes/kubernetes-docs/issues/new" >file a bug here</a>.
-  </p>
+    <a href="https://github.com/charmed-kubernetes/kubernetes-docs/issues/new" >file a bug here</a>.</p>
+  </div>
 </div>

--- a/templates/kubernetes/docs/multiple-networks.md
+++ b/templates/kubernetes/docs/multiple-networks.md
@@ -32,9 +32,9 @@ Juju. If you're not, you can familiarise yourself with them by reading the
 
 Preconditions:
 
--   You have MAAS nodes that are attached to multiple logical networks (separate
-physical networks or VLANs).
--   You have commissioned the nodes in MAAS.
+- You have MAAS nodes that are attached to multiple logical networks (separate
+  physical networks or VLANs).
+- You have commissioned the nodes in MAAS.
 
 ### Create spaces in MAAS
 
@@ -105,28 +105,27 @@ juju deploy charmed-kubernetes --overlay my-overlay.yaml
 
 The following endpoints are available for use in bindings:
 
-| Charm | Endpoint | Description of traffic |
-| ----- | -------- | ----------- |
-| etcd  | cluster  | ETCD internal (peer) |
-| etcd  | db       | ETCD external (client) |
-| flannel | cni | Flannel traffic (pod to pod communication) |
-| canal | cni | Flannel traffic (pod to pod communication) |
-| calico | cni | Calico traffic (pod to pod communication) |
-| kubernetes-master | kube-api-endpoint | Main traffic to kube-apiserver, from kubeapi-load-balancer |
-| kubernetes-master | kube-control | Secondary traffic to kube-apiserver, from pods |
-| kubeapi-load-balancer | website | Traffic to kubeapi-load-balancer, from kubectl, kubelet and kube-proxy |
-| kubernetes-worker | kube-control | Traffic to kubelet, from kube-apiserver (health checks) |
+| Charm                 | Endpoint          | Description of traffic                                                 |
+| --------------------- | ----------------- | ---------------------------------------------------------------------- |
+| etcd                  | cluster           | ETCD internal (peer)                                                   |
+| etcd                  | db                | ETCD external (client)                                                 |
+| flannel               | cni               | Flannel traffic (pod to pod communication)                             |
+| canal                 | cni               | Flannel traffic (pod to pod communication)                             |
+| calico                | cni               | Calico traffic (pod to pod communication)                              |
+| kubernetes-master     | kube-api-endpoint | Main traffic to kube-apiserver, from kubeapi-load-balancer             |
+| kubernetes-master     | kube-control      | Secondary traffic to kube-apiserver, from pods                         |
+| kubeapi-load-balancer | website           | Traffic to kubeapi-load-balancer, from kubectl, kubelet and kube-proxy |
+| kubernetes-worker     | kube-control      | Traffic to kubelet, from kube-apiserver (health checks)                |
 
 You can read more about bindings in the Juju documentation here:
 [Binding endpoints within a bundle](https://juju.is/docs/sdk/bundles)
 
-
 <!-- FEEDBACK -->
 <div class="p-notification--information">
-  <p class="p-notification__response">
-    We appreciate your feedback on the documentation. You can
+  <div class="p-notification__content">
+    <p class="p-notification__message">We appreciate your feedback on the documentation. You can
     <a href="https://github.com/charmed-kubernetes/kubernetes-docs/edit/main/pages/k8s/multiple-networks.md" >edit this page</a>
     or
-    <a href="https://github.com/charmed-kubernetes/kubernetes-docs/issues/new" >file a bug here</a>.
-  </p>
+    <a href="https://github.com/charmed-kubernetes/kubernetes-docs/issues/new" >file a bug here</a>.</p>
+  </div>
 </div>

--- a/templates/kubernetes/docs/overview.md
+++ b/templates/kubernetes/docs/overview.md
@@ -65,10 +65,10 @@ additional configuration or hassle.
 
 <!-- FEEDBACK -->
 <div class="p-notification--information">
-  <p class="p-notification__response">
-    We appreciate your feedback on the documentation. You can
+  <div class="p-notification__content">
+    <p class="p-notification__message">We appreciate your feedback on the documentation. You can
     <a href="https://github.com/charmed-kubernetes/kubernetes-docs/edit/main/pages/k8s/overview.md" >edit this page</a>
     or
-    <a href="https://github.com/charmed-kubernetes/kubernetes-docs/issues/new" >file a bug here</a>.
-  </p>
+    <a href="https://github.com/charmed-kubernetes/kubernetes-docs/issues/new" >file a bug here</a>.</p>
+  </div>
 </div>

--- a/templates/kubernetes/docs/proxies.md
+++ b/templates/kubernetes/docs/proxies.md
@@ -13,7 +13,7 @@ layout: [base, ubuntu-com]
 toc: False
 ---
 
-There are many occasions, particularly in production environments, when 
+There are many occasions, particularly in production environments, when
 your Kubernetes cluster does not have direct, unfettered access to the internet.
 This can cause complications when installing, updating or modifying your cluster.
 
@@ -27,7 +27,7 @@ A Juju model can define proxies for the resources Charmed Kubernetes will need:
 - A snap proxy, for installing software from snap packages ([see below](#snap-store-proxy))
 - An apt proxy, for software installed via apt packages.
 - A Juju proxy, which exposes proxy settings to Juju itself, and to deployed
-   charms.
+  charms.
 
 Note that Juju can also set other proxy types, but these are not relevant to
 Charmed Kubernetes.
@@ -50,8 +50,8 @@ otherwise accessible source for packages:
 juju model-config apt-no-proxy=localhost,127.0.0.1,ppa.local,10.24.2.0/24
 ```
 
-As demonstrated here, it is possible to indicate several resources by 
-supplying a comma-delimited list. It is also possible to select a range of 
+As demonstrated here, it is possible to indicate several resources by
+supplying a comma-delimited list. It is also possible to select a range of
 network addresses using a CIDR.
 
 You can see the configuration settings for the current model by running:
@@ -81,28 +81,28 @@ The majority of charms, including all the core Charmed Kubernetes charms, rely o
 IoT that are easy to install, secure, cross‐platform and dependency‐free.
 
 The list of snaps required by Charmed Kubernetes is detailed in the "components"
-page for each release. For example, for 1.22, the 
+page for each release. For example, for 1.22, the
 [snaps are listed here][1.22-components].
 
 If your installation needs to proxy the connection to the Snap Store for any reason,
-the recommended solution is to use the [Snap Store Proxyy][] software. This can 
-also be configured for offline use (see the 
+the recommended solution is to use the [Snap Store Proxyy][] software. This can
+also be configured for offline use (see the
 [Charmed Kubernetes offline documentation][offline]).
 
 <!-- LINKS -->
 
-[Juju proxy documentation]: https://juju.is/docs/t/offline-mode-strategies/1071
+[juju proxy documentation]: https://juju.is/docs/t/offline-mode-strategies/1071
 [1.22-components]: 1.22/components
 [offline]: install-offline
 [snap]: https://snapcraft.io
-[Snap Store Proxy]: https://docs.ubuntu.com/snap-store-proxy/en/
+[snap store proxy]: https://docs.ubuntu.com/snap-store-proxy/en/
 
 <!-- FEEDBACK -->
 <div class="p-notification--information">
-  <p class="p-notification__response">
-    We appreciate your feedback on the documentation. You can
+  <div class="p-notification__content">
+    <p class="p-notification__message">We appreciate your feedback on the documentation. You can
     <a href="https://github.com/charmed-kubernetes/kubernetes-docs/edit/main/pages/k8s/proxies.md" >edit this page</a>
     or
-    <a href="https://github.com/charmed-kubernetes/kubernetes-docs/issues/new" >file a bug here</a>.
-  </p>
+    <a href="https://github.com/charmed-kubernetes/kubernetes-docs/issues/new" >file a bug here</a>.</p>
+  </div>
 </div>

--- a/templates/kubernetes/docs/release-notes-historic.md
+++ b/templates/kubernetes/docs/release-notes-historic.md
@@ -12,6 +12,7 @@ permalink: release-notes-historic.html
 layout: [base, ubuntu-com]
 toc: False
 ---
+
 # 1.18+ck2 Bugfix release
 
 ### August 12, 2020 - [charmed-kubernetes-485](https://api.jujucharms.com/charmstore/v5/charmed-kubernetes-485/archive/bundle.yaml)
@@ -20,7 +21,6 @@ toc: False
 
 Bug fixes included in this release can be found at
 [https://launchpad.net/charmed-kubernetes/+milestone/1.18+ck2](https://launchpad.net/charmed-kubernetes/+milestone/1.18+ck2).
-
 
 # 1.18+ck1 Bugfix release
 
@@ -115,7 +115,7 @@ juju run-action --wait containerd/0 upgrade-containerd
 ```
 
 This will perform the upgrade and return any output. If you have more than
-one unit of containerd,  you should run this on each unit. The upgrades can be
+one unit of containerd, you should run this on each unit. The upgrades can be
 staggered to avoid downtime.
 
 ## Component Upgrades
@@ -257,8 +257,8 @@ A list of bug fixes and other minor feature updates in this release can be found
 ## Notes / Known Issues
 
 - The `registry` action for the `kubernetes-worker` charm has been deprecated and will be removed
-in a future release. To enable a custom container registry, please see the
-[registry](/kubernetes/docs/docker-registry) documentation.
+  in a future release. To enable a custom container registry, please see the
+  [registry](/kubernetes/docs/docker-registry) documentation.
 
 # 1.16+ck2 Bugfix release
 
@@ -280,7 +280,7 @@ A list of bug fixes and other minor feature updates in this release can be found
 
 # 1.16
 
-### September 27, 2019 -  [charmed-kubernetes-252](https://api.jujucharms.com/charmstore/v5/charmed-kubernetes-252/archive/bundle.yaml)
+### September 27, 2019 - [charmed-kubernetes-252](https://api.jujucharms.com/charmstore/v5/charmed-kubernetes-252/archive/bundle.yaml)
 
 Before upgrading, please read the [upgrade notes](/kubernetes/docs/upgrade-notes).
 
@@ -360,10 +360,9 @@ The Kubernetes Dashboard shipped with Charmed Kubernetes 1.16 is version 2.0.0-b
 A list of bug fixes and other minor feature updates in this release can be found at
 [https://launchpad.net/charmed-kubernetes/+milestone/1.15+ck1](https://launchpad.net/charmed-kubernetes/+milestone/1.15+ck1).
 
-
 # 1.15
 
-### June 28, 2019 -  [charmed-kubernetes-142](https://api.jujucharms.com/charmstore/v5/charmed-kubernetes-142/archive/bundle.yaml)
+### June 28, 2019 - [charmed-kubernetes-142](https://api.jujucharms.com/charmstore/v5/charmed-kubernetes-142/archive/bundle.yaml)
 
 ## What's new
 
@@ -395,7 +394,7 @@ string to allow for the addition of a new mode. This change is illustrated in
 the table below:
 
 | New value     | Old value         | Description                                           |
-|---------------|-------------------|-------------------------------------------------------|
+| ------------- | ----------------- | ----------------------------------------------------- |
 | "Never"       | false             | Never use IPIP encapsulation. (The default)           |
 | "Always"      | true              | Always use IPIP encapsulation.                        |
 | "CrossSubnet" | \<Not supported\> | Only use IPIP encapsulation for cross-subnet traffic. |
@@ -465,15 +464,13 @@ field changed to `csi-cinderplugin`. Existing volumes will be unaffected, but
 new PVCs using those storage classes will hang until the storage class is
 updated.
 
-
 # 1.14 Bugfix release
 
 ### June 19th, 2019 - [charmed-kubernetes-124](https://api.jujucharms.com/charmstore/v5/charmed-kubernetes-124/archive/bundle.yaml)
 
 ## Fixes
 
- - Fixed leader_set being called by kubernetes-master followers ([Issue](https://bugs.launchpad.net/charm-kubernetes-master/+bug/1833089))
-
+- Fixed leader_set being called by kubernetes-master followers ([Issue](https://bugs.launchpad.net/charm-kubernetes-master/+bug/1833089))
 
 # 1.14 Bugfix release
 
@@ -481,10 +478,9 @@ updated.
 
 ## Fixes
 
- - Fixed leader_get import error in .reactive/kubernetes_master_worker_base.py ([Issue](https://bugs.launchpad.net/charm-kubernetes-worker/+bug/1831550))
- - Fixed kernel network tunables need better defaults and to be configurable ([Issue](https://bugs.launchpad.net/charm-kubernetes-worker/+bug/1825436))
- - Fixed proxy-extra-args config missing from kubernetes-master ([Issue](https://github.com/charmed-kubernetes/layer-kubernetes-master-worker-base/pull/3))
-
+- Fixed leader_get import error in .reactive/kubernetes_master_worker_base.py ([Issue](https://bugs.launchpad.net/charm-kubernetes-worker/+bug/1831550))
+- Fixed kernel network tunables need better defaults and to be configurable ([Issue](https://bugs.launchpad.net/charm-kubernetes-worker/+bug/1825436))
+- Fixed proxy-extra-args config missing from kubernetes-master ([Issue](https://github.com/charmed-kubernetes/layer-kubernetes-master-worker-base/pull/3))
 
 # 1.14 Bugfix release
 
@@ -492,13 +488,12 @@ updated.
 
 ## Fixes
 
- - Fixed missing core snap resource for etcd, kubernetes-master, kubernetes-worker, and kubernetes-e2e charms ([Issue](https://bugs.launchpad.net/charm-kubernetes-worker/+bug/1828063))
- - Fixed kubernetes-master charm resetting user changes to basic_auth.csv ([Issue](https://bugs.launchpad.net/charm-kubernetes-master/+bug/1826260))
- - Fixed charm upgrades removing /srv/kubernetes directory ([Issue](https://bugs.launchpad.net/charm-kubeapi-load-balancer/+bug/1825288))
- - Fixed docker-opts charm config being ignored on kubernetes-worker ([Issue](https://bugs.launchpad.net/charm-kubernetes-worker/+bug/1826463))
- - Fixed master services constantly restarting due to cert change ([Issue](https://bugs.launchpad.net/charm-easyrsa/+bug/1826625))
- - Fixed kubernetes-worker tag error on GCP ([Issue](https://bugs.launchpad.net/charm-kubernetes-worker/+bug/1827528))
-
+- Fixed missing core snap resource for etcd, kubernetes-master, kubernetes-worker, and kubernetes-e2e charms ([Issue](https://bugs.launchpad.net/charm-kubernetes-worker/+bug/1828063))
+- Fixed kubernetes-master charm resetting user changes to basic_auth.csv ([Issue](https://bugs.launchpad.net/charm-kubernetes-master/+bug/1826260))
+- Fixed charm upgrades removing /srv/kubernetes directory ([Issue](https://bugs.launchpad.net/charm-kubeapi-load-balancer/+bug/1825288))
+- Fixed docker-opts charm config being ignored on kubernetes-worker ([Issue](https://bugs.launchpad.net/charm-kubernetes-worker/+bug/1826463))
+- Fixed master services constantly restarting due to cert change ([Issue](https://bugs.launchpad.net/charm-easyrsa/+bug/1826625))
+- Fixed kubernetes-worker tag error on GCP ([Issue](https://bugs.launchpad.net/charm-kubernetes-worker/+bug/1827528))
 
 # 1.14 Bugfix release
 
@@ -506,23 +501,22 @@ updated.
 
 ## Fixes
 
- - Added automatic and manual cleanup for subnet tags (
- - Added action apply-manifest ([Issue](https://github.com/charmed-kubernetes/charm-kubernetes-master/pull/3))
- - Added label to inform Juju of cloud ([Issue](https://github.com/charmed-kubernetes/charm-kubernetes-worker/pull/3))
- - Added support for loadbalancer-ips ([Issue](https://github.com/charmed-kubernetes/charm-kubeapi-load-balancer/pull/1))
- - Fixed handling "not found" error message 
- - Fixed snapd_refresh smashed by subordinate charm ([Issue](https://github.com/charmed-kubernetes/layer-etcd/pull/148))
- - Fixed making sure cert has proper IP as well as DNS ([Issue](https://github.com/charmed-kubernetes/layer-etcd/pull/149))
- - Fixed etcd charm stuck on "Requesting tls certificates" ([Issue](https://github.com/charmed-kubernetes/layer-etcd/pull/150))
- - Fixed cert relation thrashing due to random SAN order ([Issue](https://github.com/charmed-kubernetes/layer-etcd/pull/151))
- - Fixed contact point for keystone to be public address ([Issue](https://github.com/charmed-kubernetes/charm-kubernetes-master/pull/2))
- - Fixed cluster tag not being sent to new worker applications ([Issue](https://github.com/charmed-kubernetes/charm-kubernetes-master/pull/4))
- - Fixed removal of ceph relations causing trouble ([Issue](https://github.com/charmed-kubernetes/charm-kubernetes-master/pull/6))
- - Fixed pause/resume actions ([Issue](https://github.com/charmed-kubernetes/charm-kubernetes-worker/pull/2))
- - Fixed ingress address selection to avoid fan IPs ([Issue](https://github.com/charmed-kubernetes/layer-kubernetes-common/pull/1))
- - Fixed snapd_refresh handler ([Issue](https://github.com/charmed-kubernetes/layer-kubernetes-master-worker-base/pull/2))
- - Fixed credentials fields to allow for fallback and override 
-
+- Added automatic and manual cleanup for subnet tags (
+- Added action apply-manifest ([Issue](https://github.com/charmed-kubernetes/charm-kubernetes-master/pull/3))
+- Added label to inform Juju of cloud ([Issue](https://github.com/charmed-kubernetes/charm-kubernetes-worker/pull/3))
+- Added support for loadbalancer-ips ([Issue](https://github.com/charmed-kubernetes/charm-kubeapi-load-balancer/pull/1))
+- Fixed handling "not found" error message
+- Fixed snapd_refresh smashed by subordinate charm ([Issue](https://github.com/charmed-kubernetes/layer-etcd/pull/148))
+- Fixed making sure cert has proper IP as well as DNS ([Issue](https://github.com/charmed-kubernetes/layer-etcd/pull/149))
+- Fixed etcd charm stuck on "Requesting tls certificates" ([Issue](https://github.com/charmed-kubernetes/layer-etcd/pull/150))
+- Fixed cert relation thrashing due to random SAN order ([Issue](https://github.com/charmed-kubernetes/layer-etcd/pull/151))
+- Fixed contact point for keystone to be public address ([Issue](https://github.com/charmed-kubernetes/charm-kubernetes-master/pull/2))
+- Fixed cluster tag not being sent to new worker applications ([Issue](https://github.com/charmed-kubernetes/charm-kubernetes-master/pull/4))
+- Fixed removal of ceph relations causing trouble ([Issue](https://github.com/charmed-kubernetes/charm-kubernetes-master/pull/6))
+- Fixed pause/resume actions ([Issue](https://github.com/charmed-kubernetes/charm-kubernetes-worker/pull/2))
+- Fixed ingress address selection to avoid fan IPs ([Issue](https://github.com/charmed-kubernetes/layer-kubernetes-common/pull/1))
+- Fixed snapd_refresh handler ([Issue](https://github.com/charmed-kubernetes/layer-kubernetes-master-worker-base/pull/2))
+- Fixed credentials fields to allow for fallback and override
 
 # 1.14 Bugfix release
 
@@ -532,10 +526,9 @@ updated.
 
 - Fixed Ceph PV fails to mount in pod ([Issue](https://bugs.launchpad.net/cdk-addons/+bug/1820908))
 - Fixed Problems switching from kube-dns to CoreDNS ([Issue](https://bugs.launchpad.net/charm-kubernetes-master/+bug/1822001))
-- Fixed defaultbackend-s390x image 
-- Fixed `keystone-ssl-ca` config description 
+- Fixed defaultbackend-s390x image
+- Fixed `keystone-ssl-ca` config description
 - Partial fix for using custom CA with Keystone
-
 
 # 1.14
 
@@ -567,58 +560,57 @@ Existing deployments that are upgraded to **CDK 1.14** will
 continue to use **KubeDNS** until the operator chooses to upgrade to
 **CoreDNS**. See the [upgrade notes][upgrade-notes] for details.
 
- - Docker upgrades: Docker 18.09.2 is the new default in Ubuntu. CDK now includes a charm action to simplify [upgrading Docker across a set of worker nodes][upgrading-docker].
+- Docker upgrades: Docker 18.09.2 is the new default in Ubuntu. CDK now includes a charm action to simplify [upgrading Docker across a set of worker nodes][upgrading-docker].
 
 - Registry enhancements: Read-only mode, frontend support, and additional TLS configuration options have been added to the [Docker registry charm](https://charmhub.io/containers-docker-registry).
 
 - Cloud integrations: New configuration options have been added to the
-[vSphere](https://charmhub.io/containers-vsphere-integrator/) (`folder` and `respool_path`) and
-[OpenStack]( https://charmhub.io/containers-openstack-integrator/) (`ignore-volume-az`, `bs-version`, `trust-device-path`) integrator charms.
-
+  [vSphere](https://charmhub.io/containers-vsphere-integrator/) (`folder` and `respool_path`) and
+  [OpenStack](https://charmhub.io/containers-openstack-integrator/) (`ignore-volume-az`, `bs-version`, `trust-device-path`) integrator charms.
 
 ## Fixes
 
- - Added an action to upgrade Docker 
- - Added better multi-client support to EasyRSA 
- - Added block storage options for OpenStack 
- - Added dashboard-auth config option to master 
- - Added docker registry handling to master
- - Added more TLS options to Docker registry ([Issue](https://github.com/CanonicalLtd/docker-registry-charm/pull/20))
- - Added new folder/respool_path config for vSphere 
- - Added proxy support to Docker registry ([Issue](https://github.com/CanonicalLtd/docker-registry-charm/pull/21))
- - Added read-only mode for Docker registry ([Issue](https://github.com/CanonicalLtd/docker-registry-charm/pull/22))
- - Fixed `allow-privileged` not enabled when Ceph relation joins 
- - Fixed apt install source for VaultLocker 
- - Fixed Ceph relation join not creating necessary pools 
- - Fixed Ceph volume provisioning fails with "No such file or directory" 
- - Fixed detecting of changed AppKV values 
- - Fixed docker-ce-version config not working for non-NVIDIA configuration 
- - Fixed Docker registry behavior with multiple frontends ([Issue](https://github.com/CanonicalLtd/docker-registry-charm/pull/26))
- - Fixed Docker registry not cleaning up old relation data ([Issue](https://github.com/CanonicalLtd/docker-registry-charm/pull/28))
- - Fixed Docker registry to correctly handle frontend removal ([Issue](https://github.com/CanonicalLtd/docker-registry-charm/pull/29))
- - Fixed Docker registry to work behind a TLS-terminating frontend ([Issue](https://github.com/CanonicalLtd/docker-registry-charm/pull/25))
- - Fixed error: snap "etcd" is not compatible with --classic
- - Fixed file descriptor limit on api server 
- - Fixed GCP NetworkUnavailable hack when only some pods pending 
- - Fixed handle_requests being called when no clients are related 
- - Fixed handling of nameless and SANless server certificates 
- - Fixed inconsistent cert flags 
- - Fixed ingress=false not allowing custom ingress to be used
- - Fixed installing from outdated docker APT respository
- - Fixed IPv6 disabled on kubeapi-loadbalancer machines leads to error during installation 
- - Fixed Keystone not working with multiple masters
- - Fixed kubeconfig should contain the VIP when keepalived used with kubeapi-load-balancer 
- - Fixed metrics server for k8s 1.11 
- - Fixed proxy var to apply when adding an apt-key 
- - Fixed RBAC enabled results in error: unable to upgrade connection 
- - Fixed registry action creating configmap in the wrong namespace 
- - Fixed rules for metrics-server
- - Fixed status when writing kubeconfig file 
- - Fixed "subnet not found" to be non-fatal
- - Fixed vSphere integrator charm not updating cloud-config when setting new charm defaults 
- - Removed deprecated allow-privileged config from worker
- - Removed use of global / shared client certificate 
- - Updated default nginx-ingress controller to 0.22.0 for amd64 and arm64
+- Added an action to upgrade Docker
+- Added better multi-client support to EasyRSA
+- Added block storage options for OpenStack
+- Added dashboard-auth config option to master
+- Added docker registry handling to master
+- Added more TLS options to Docker registry ([Issue](https://github.com/CanonicalLtd/docker-registry-charm/pull/20))
+- Added new folder/respool_path config for vSphere
+- Added proxy support to Docker registry ([Issue](https://github.com/CanonicalLtd/docker-registry-charm/pull/21))
+- Added read-only mode for Docker registry ([Issue](https://github.com/CanonicalLtd/docker-registry-charm/pull/22))
+- Fixed `allow-privileged` not enabled when Ceph relation joins
+- Fixed apt install source for VaultLocker
+- Fixed Ceph relation join not creating necessary pools
+- Fixed Ceph volume provisioning fails with "No such file or directory"
+- Fixed detecting of changed AppKV values
+- Fixed docker-ce-version config not working for non-NVIDIA configuration
+- Fixed Docker registry behavior with multiple frontends ([Issue](https://github.com/CanonicalLtd/docker-registry-charm/pull/26))
+- Fixed Docker registry not cleaning up old relation data ([Issue](https://github.com/CanonicalLtd/docker-registry-charm/pull/28))
+- Fixed Docker registry to correctly handle frontend removal ([Issue](https://github.com/CanonicalLtd/docker-registry-charm/pull/29))
+- Fixed Docker registry to work behind a TLS-terminating frontend ([Issue](https://github.com/CanonicalLtd/docker-registry-charm/pull/25))
+- Fixed error: snap "etcd" is not compatible with --classic
+- Fixed file descriptor limit on api server
+- Fixed GCP NetworkUnavailable hack when only some pods pending
+- Fixed handle_requests being called when no clients are related
+- Fixed handling of nameless and SANless server certificates
+- Fixed inconsistent cert flags
+- Fixed ingress=false not allowing custom ingress to be used
+- Fixed installing from outdated docker APT respository
+- Fixed IPv6 disabled on kubeapi-loadbalancer machines leads to error during installation
+- Fixed Keystone not working with multiple masters
+- Fixed kubeconfig should contain the VIP when keepalived used with kubeapi-load-balancer
+- Fixed metrics server for k8s 1.11
+- Fixed proxy var to apply when adding an apt-key
+- Fixed RBAC enabled results in error: unable to upgrade connection
+- Fixed registry action creating configmap in the wrong namespace
+- Fixed rules for metrics-server
+- Fixed status when writing kubeconfig file
+- Fixed "subnet not found" to be non-fatal
+- Fixed vSphere integrator charm not updating cloud-config when setting new charm defaults
+- Removed deprecated allow-privileged config from worker
+- Removed use of global / shared client certificate
+- Updated default nginx-ingress controller to 0.22.0 for amd64 and arm64
 
 # 1.13 Bugfix Release
 
@@ -626,8 +618,8 @@ continue to use **KubeDNS** until the operator chooses to upgrade to
 
 ## Fixes
 
-- Fixed docker does not start when docker_runtime is set to nvidia 
-- Fixed snapd_refresh charm option conflict 
+- Fixed docker does not start when docker_runtime is set to nvidia
+- Fixed snapd_refresh charm option conflict
 
 # CVE-2018-18264
 
@@ -636,7 +628,7 @@ continue to use **KubeDNS** until the operator chooses to upgrade to
 ## What happened
 
 - A security vulnerability was found in the Kubernetes dashboard that affected all
-versions of the dashboard.
+  versions of the dashboard.
 
 A new dashboard version, v1.10.1, was released to address this vulnerability. This
 includes an important change to logging in to the dashboard. The Skip button is now
@@ -692,47 +684,46 @@ reside in the same namespace as the nginx deployment.
 
 ## Fixes
 
- - Added post deployment script for jaas/jujushell 
- - Added support for load-balancer failover 
- - Added always restart for etcd 
- - Added Xenial support to Azure integrator 
- - Added Bionic support to OpenStack integrator 
- - Added support for ELB service-linked role 
- - Added ability to configure Docker install source 
- - Fixed EasyRSA does not run as an LXD container on 18.04 
- - Fixed ceph volumes cannot be attached to the pods after 1.12 
- - Fixed ceph volumes fail to attach with "node has no NodeID annotation" 
- - Fixed ceph-xfs volumes failing to format due to "executable file not found in $PATH" 
- - Fixed ceph volumes not detaching properly 
- - Fixed ceph-csi addons not getting cleaned up properly 
- - Fixed Calico/Canal not working with kube-proxy on master 
- - Fixed issue with Canal charm not populating the kubeconfig option in 10-canal.conflist 
- - Fixed cannot access logs after enabling RBAC 
- - Fixed RBAC breaking prometheus/grafana metric collection
- - Fixed upstream Docker charm config option using wrong package source 
- - Fixed a timing issue where ceph can appear broken when it's not 
- - Fixed status when cni is not ready 
- - Fixed an issue with calico-node service failures not surfacing 
- - Fixed empty configuration due to timing issue with cni. 
- - Fixed an issue where the calico-node service failed to start 
- - Fixed updating policy definitions during upgrade-charm on AWS integrator
- - Fixed parsing credentials config value 
- - Fixed pvc stuck in pending (azure-integrator)
- - Fixed updating properties of the openstack integrator charm do not propagate automatically (openstack-integrator)
- - Fixed flannel error during install hook due to incorrect resource (flannel)
- - Updated master and worker to handle upstream changes from OpenStack Integrator 
- - Updated to CNI 0.7.4 
- - Updated to Flannel v0.10.0 
- - Updated Calico and Canal charms to Calico v2.6.12 
- - Updated to latest CUDA and removed version pins of nvidia-docker stack 
- - Updated to nginx-ingress-controller v0.21.0 
- - Removed portmap from Calico resource 
- - Removed CNI bins from flannel resource 
+- Added post deployment script for jaas/jujushell
+- Added support for load-balancer failover
+- Added always restart for etcd
+- Added Xenial support to Azure integrator
+- Added Bionic support to OpenStack integrator
+- Added support for ELB service-linked role
+- Added ability to configure Docker install source
+- Fixed EasyRSA does not run as an LXD container on 18.04
+- Fixed ceph volumes cannot be attached to the pods after 1.12
+- Fixed ceph volumes fail to attach with "node has no NodeID annotation"
+- Fixed ceph-xfs volumes failing to format due to "executable file not found in $PATH"
+- Fixed ceph volumes not detaching properly
+- Fixed ceph-csi addons not getting cleaned up properly
+- Fixed Calico/Canal not working with kube-proxy on master
+- Fixed issue with Canal charm not populating the kubeconfig option in 10-canal.conflist
+- Fixed cannot access logs after enabling RBAC
+- Fixed RBAC breaking prometheus/grafana metric collection
+- Fixed upstream Docker charm config option using wrong package source
+- Fixed a timing issue where ceph can appear broken when it's not
+- Fixed status when cni is not ready
+- Fixed an issue with calico-node service failures not surfacing
+- Fixed empty configuration due to timing issue with cni.
+- Fixed an issue where the calico-node service failed to start
+- Fixed updating policy definitions during upgrade-charm on AWS integrator
+- Fixed parsing credentials config value
+- Fixed pvc stuck in pending (azure-integrator)
+- Fixed updating properties of the openstack integrator charm do not propagate automatically (openstack-integrator)
+- Fixed flannel error during install hook due to incorrect resource (flannel)
+- Updated master and worker to handle upstream changes from OpenStack Integrator
+- Updated to CNI 0.7.4
+- Updated to Flannel v0.10.0
+- Updated Calico and Canal charms to Calico v2.6.12
+- Updated to latest CUDA and removed version pins of nvidia-docker stack
+- Updated to nginx-ingress-controller v0.21.0
+- Removed portmap from Calico resource
+- Removed CNI bins from flannel resource
 
 ## Known issues
 
- - A [current bug](https://github.com/kubernetes/kubernetes/issues/70044) in Kubernetes could prevent the upgrade from properly deleting old pods. `kubectl delete pod <pod_name> --force --grace-period=0` can be used to clean them up.
-
+- A [current bug](https://github.com/kubernetes/kubernetes/issues/70044) in Kubernetes could prevent the upgrade from properly deleting old pods. `kubectl delete pod <pod_name> --force --grace-period=0` can be used to clean them up.
 
 ## 1.12 Release Notes
 
@@ -779,10 +770,10 @@ For operators who currently use the `http-proxy`, `https-proxy` and `no-proxy` J
 ## Fixes
 
 - Fixed kube-dns constantly restarting on 18.04
-- Fixed LXD machines not working on 18.04 
-- Fixed kubernetes-worker unable to restart services after kubernetes-master leader is removed 
-- Fixed kubeapi-load-balancer default timeout might be too low 
-- Fixed unable to deploy on NVidia hardware 
+- Fixed LXD machines not working on 18.04
+- Fixed kubernetes-worker unable to restart services after kubernetes-master leader is removed
+- Fixed kubeapi-load-balancer default timeout might be too low
+- Fixed unable to deploy on NVidia hardware
 <!--LINKS-->
 
 [docs-ldap]: /kubernetes/docs/ldap
@@ -793,10 +784,10 @@ For operators who currently use the `http-proxy`, `https-proxy` and `no-proxy` J
 
 <!-- FEEDBACK -->
 <div class="p-notification--information">
-  <p class="p-notification__response">
-    We appreciate your feedback on the documentation. You can
+  <div class="p-notification__content">
+    <p class="p-notification__message">We appreciate your feedback on the documentation. You can
     <a href="https://github.com/charmed-kubernetes/kubernetes-docs/edit/main/pages/k8s/release-notes-historic.md" >edit this page</a>
     or
-    <a href="https://github.com/charmed-kubernetes/kubernetes-docs/issues/new" >file a bug here</a>.
-  </p>
+    <a href="https://github.com/charmed-kubernetes/kubernetes-docs/issues/new" >file a bug here</a>.</p>
+  </div>
 </div>

--- a/templates/kubernetes/docs/release-notes.md
+++ b/templates/kubernetes/docs/release-notes.md
@@ -54,15 +54,15 @@ in LXD containers.
 - [LP 1936816](https://bugs.launchpad.net/bugs/1936816) and [LP 1913228](https://bugs.launchpad.net/bugs/1913228) Filesystem Hierachy Standards
 
   Applications running inside a kubernetes-master should set pid files and log files in
-appropriate operational locations like `/run/` and `/var/log/kubernetes/`. Care was taken to restart
-services using these new locations and migrate some existing files out of `/root/cdk/`.
+  appropriate operational locations like `/run/` and `/var/log/kubernetes/`. Care was taken to restart
+  services using these new locations and migrate some existing files out of `/root/cdk/`.
 
   For the service `cdk.master.auth-webhook` the new pid file and log files are named
-`/run/cdk.master.auth-webhook.pid` and `/var/log/kubernetes/cdk.master.auth-webhook.log`
-to match the systemctl service name.
+  `/run/cdk.master.auth-webhook.pid` and `/var/log/kubernetes/cdk.master.auth-webhook.log`
+  to match the systemctl service name.
 
   If the [`filebeat`](https://charmhub.io/filebeat) charm is related to kubernetes-master,
-ensure that its logpath include this new path ( e.g. `juju config filebeat logpath='/var/log/kubernetes/*.log'` )
+  ensure that its logpath include this new path ( e.g. `juju config filebeat logpath='/var/log/kubernetes/*.log'` )
 
 ## Deprecations and API changes
 
@@ -70,7 +70,6 @@ ensure that its logpath include this new path ( e.g. `juju config filebeat logpa
 
 For details of other deprecation notices and API changes for Kubernetes 1.23, please see the
 relevant sections of the [upstream release notes][upstream-changelog-1.23].
-
 
 # 1.22+ck2 Bugfix release
 
@@ -80,7 +79,6 @@ relevant sections of the [upstream release notes][upstream-changelog-1.23].
 
 A list of bug fixes and other minor feature updates in this release can be found at
 [the launchpad milestone page for 1.22+ck2](https://launchpad.net/charmed-kubernetes/+milestone/1.22+ck2).
-
 
 # 1.22+ck1 Bugfix release
 
@@ -114,7 +112,6 @@ action to force a recheck immediately.
 
 A list of bug fixes and other minor feature updates in this release can be found at
 [the launchpad milestone page for 1.22+ck1](https://launchpad.net/charmed-kubernetes/+milestone/1.22+ck1).
-
 
 # 1.22
 
@@ -153,7 +150,7 @@ A list of bug fixes and other feature updates in this release can be found at
 - [LP 1935992](https://bugs.launchpad.net/charm-kubernetes-worker/+bug/1935992) Code cleanup
 
   Previously deprecated features have been removed in this release. This includes
-the following `kubernetes-master` features:
+  the following `kubernetes-master` features:
 
   - `addons-registry` config
   - `create-rbd-pv` action and related templates
@@ -171,16 +168,16 @@ the following `kubernetes-master` features:
 - [LP 1907153](https://bugs.launchpad.net/snapd/+bug/1907153) Snap install failure in LXD
 
   Snaps may fail to install when the `kubernetes-master` charm is deployed to a LXD container.
-This happens when the version of `snapd` on the host does not match the version inside the
-container. As a workaround, ensure the same version of `snapd` is installed on the host and
-in LXD containers.
+  This happens when the version of `snapd` on the host does not match the version inside the
+  container. As a workaround, ensure the same version of `snapd` is installed on the host and
+  in LXD containers.
 
 ## Deprecations and API changes
 
 - Upstream
 
   For details of other deprecation notices and API changes for Kubernetes 1.22, please see the
-relevant sections of the [upstream release notes][upstream-changelog].
+  relevant sections of the [upstream release notes][upstream-changelog].
 
 ## Previous releases
 
@@ -195,7 +192,6 @@ Please see [this page][rel] for release notes of earlier versions.
 A list of bug fixes and other minor feature updates in this release can be found at
 [the launchpad milestone page](https://launchpad.net/charmed-kubernetes/+milestone/1.21+ck3).
 
-
 # 1.21+ck2 Bugfix release
 
 ### May 28, 2021 - [charmed-kubernetes-679](https://api.jujucharms.com/charmstore/v5/charmed-kubernetes-679/archive/bundle.yaml)
@@ -205,7 +201,6 @@ A list of bug fixes and other minor feature updates in this release can be found
 A list of bug fixes and other minor feature updates in this release can be found at
 [the launchpad milestone page](https://launchpad.net/charmed-kubernetes/+milestone/1.21+ck2).
 
-
 # 1.21+ck1 Bugfix release
 
 ### May 04, 2021 - [charmed-kubernetes-655](https://api.jujucharms.com/charmstore/v5/charmed-kubernetes-655/archive/bundle.yaml)
@@ -214,7 +209,6 @@ A list of bug fixes and other minor feature updates in this release can be found
 
 A list of bug fixes and other minor feature updates in this release can be found at
 [the launchpad milestone page](https://launchpad.net/charmed-kubernetes/+milestone/1.21+ck1).
-
 
 # 1.21
 
@@ -253,7 +247,7 @@ A list of bug fixes and other minor feature updates in this release can be found
 ## Notes and Known Issues
 
 - [LP 1920216](https://bugs.launchpad.net/operator-metallb/+bug/1920216) MetalLB
-speaker pod logs error with "selfLink was empty, can't make reference".
+  speaker pod logs error with "selfLink was empty, can't make reference".
 
 ## Deprecations and API changes
 
@@ -274,11 +268,11 @@ relevant sections of the [upstream release notes](https://github.com/kubernetes/
 Please see [this page][rel] for release notes of earlier versions.
 
 <!--LINKS-->
+
 [upgrade-notes]: /kubernetes/docs/upgrade-notes
 [rel]: /kubernetes/docs/release-notes
 [images-per-release]: https://github.com/charmed-kubernetes/bundle/tree/master/container-images
 [arc-docs]: https://github.com/Azure/azure-arc-validation/blob/main/README.md
-
 
 # 1.20+ck1 Bugfix release
 
@@ -306,8 +300,6 @@ with Juju and Google cloud where deployments may fail due to FAN networking.
 Workaround this by disabling FAN configuration for Google cloud models:
 
 `juju model-config -m <model_name> fan-config="" container-networking-method=""`
-
-
 
 # 1.20
 
@@ -348,7 +340,6 @@ Details on how to set this up can be found in the [Kubernetes Dashboard section 
 A list of bug fixes and other minor feature updates in this release can be found at
 [https://launchpad.net/charmed-kubernetes/+milestone/1.20](https://launchpad.net/charmed-kubernetes/+milestone/1.20).
 
-
 ## Notes / Known Issues
 
 ## Deprecations and API changes
@@ -356,12 +347,12 @@ A list of bug fixes and other minor feature updates in this release can be found
 For details of deprecation notices and API changes for Kubernetes 1.20, please see the
 relevant sections of the [upstream release notes](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.20.md#deprecation)
 
-
 # 1.19+ck2 Bugfix release
 
 ### November 27th, 2020 - [charmed-kubernetes-545](https://api.jujucharms.com/charmstore/v5/charmed-kubernetes-545/archive/bundle.yaml)
 
 ## Fixes
+
 A list of bug fixes and other minor feature updates in this release can be found at
 [https://launchpad.net/charmed-kubernetes/+milestone/1.19+ck2](https://launchpad.net/charmed-kubernetes/+milestone/1.19+ck2).
 
@@ -370,6 +361,7 @@ A list of bug fixes and other minor feature updates in this release can be found
 ### November 20th, 2020 - [charmed-kubernetes-541](https://api.jujucharms.com/charmstore/v5/charmed-kubernetes-541/archive/bundle.yaml)
 
 ## Fixes
+
 A list of bug fixes and other minor feature updates in this release can be found at
 [https://launchpad.net/charmed-kubernetes/+milestone/1.19+ck1](https://launchpad.net/charmed-kubernetes/+milestone/1.19+ck1).
 
@@ -465,17 +457,17 @@ A list of bug fixes and other minor feature updates in this release can be found
 ## Notes / Known Issues
 
 - The `insecure-bind-address` and `insecure-port` options to `kube-apiserver` have
-been removed in this release. Using `juju run` with `kubectl` to interact with the
-cluster now requires an explicit `--kubeconfig <file>` option:
+  been removed in this release. Using `juju run` with `kubectl` to interact with the
+  cluster now requires an explicit `--kubeconfig <file>` option:
 
-    ```bash
-    juju run --unit kubernetes-master/0 'kubectl --kubeconfig /root/.kube/config get nodes'
-    NAME              STATUS   ROLES    AGE   VERSION
-    ip-172-31-10-19   Ready    <none>   71m   v1.19.0
-    ```
+      ```bash
+      juju run --unit kubernetes-master/0 'kubectl --kubeconfig /root/.kube/config get nodes'
+      NAME              STATUS   ROLES    AGE   VERSION
+      ip-172-31-10-19   Ready    <none>   71m   v1.19.0
+      ```
 
 - The webhook authentication service included in this release runs on port 5000 of each
-kubernetes-master unit. Ensure this port is available prior to upgrading.
+  kubernetes-master unit. Ensure this port is available prior to upgrading.
 
 - Additional known issues scheduled for the first 1.19 bugfix release can be found at [https://launchpad.net/charmed-kubernetes/+milestone/1.19+ck1](https://launchpad.net/charmed-kubernetes/+milestone/1.19+ck1)
 
@@ -489,6 +481,7 @@ relevant sections of the [upstream release notes](https://github.com/kubernetes/
 Please see [this page][historic] for release notes of earlier versions.
 
 <!--LINKS-->
+
 [upgrade-notes]: /kubernetes/docs/upgrade-notes
 [bundle]: https://api.jujucharms.com/charmstore/v5/canonical-kubernetes-471/archive/bundle.yaml
 [cis-benchmark]: /kubernetes/docs/cis-compliance
@@ -500,13 +493,12 @@ Please see [this page][historic] for release notes of earlier versions.
 [veth-mtu]: https://docs.projectcalico.org/networking/mtu
 [1.19-calico]: /kubernetes/docs/1.19/charm-calico
 
-
-
 ## Previous releases
 
 Please see [this page][historic] for release notes of earlier versions.
 
 <!--LINKS-->
+
 [upgrade-notes]: /kubernetes/docs/upgrade-notes
 [bundle]: https://api.jujucharms.com/charmstore/v5/canonical-kubernetes-471/archive/bundle.yaml
 [historic]: /kubernetes/docs/release-notes-historic
@@ -529,10 +521,10 @@ Please see [this page][historic] for release notes of earlier versions.
 
 <!-- FEEDBACK -->
 <div class="p-notification--information">
-  <p class="p-notification__response">
-    We appreciate your feedback on the documentation. You can
+  <div class="p-notification__content">
+    <p class="p-notification__message">We appreciate your feedback on the documentation. You can
     <a href="https://github.com/charmed-kubernetes/kubernetes-docs/edit/main/pages/k8s/release-notes.md" >edit this page</a>
     or
-    <a href="https://github.com/charmed-kubernetes/kubernetes-docs/issues/new" >file a bug here</a>.
-  </p>
+    <a href="https://github.com/charmed-kubernetes/kubernetes-docs/issues/new" >file a bug here</a>.</p>
+  </div>
 </div>

--- a/templates/kubernetes/docs/snap-coherence.md
+++ b/templates/kubernetes/docs/snap-coherence.md
@@ -114,10 +114,10 @@ across all `kubernetes-master` units. If the update is successful, the
 
 <!-- FEEDBACK -->
 <div class="p-notification--information">
-  <p class="p-notification__response">
-    We appreciate your feedback on the documentation. You can
-    <a href="https://github.com/charmed-kubernetes/kubernetes-docs/edit/main/pages/k8s/snap-refresh.md" >edit this page</a>
+  <div class="p-notification__content">
+    <p class="p-notification__message">We appreciate your feedback on the documentation. You can
+    <a href="https://github.com/charmed-kubernetes/kubernetes-docs/edit/main/pages/k8s/snap-coherence.md" >edit this page</a>
     or
-    <a href="https://github.com/charmed-kubernetes/kubernetes-docs/issues/new" >file a bug here</a>.
-  </p>
+    <a href="https://github.com/charmed-kubernetes/kubernetes-docs/issues/new" >file a bug here</a>.</p>
+  </div>
 </div>

--- a/templates/kubernetes/docs/snap-refresh.md
+++ b/templates/kubernetes/docs/snap-refresh.md
@@ -38,27 +38,27 @@ juju config <charm> snapd_refresh=<value>
 ```
 
 The value returned or set above should be an explicit timer, an empty string,
-or the special keyword *max*.
+or the special keyword _max_.
 
 - Explicit timer
 
-    An explicit timer may be a simple `mon` (scan every Monday) or a more
-    complex `mon3,23:00` (scan on the third Monday of the month at 23:00). See
-    possible values for explicit timers in the the *refresh.timer* section of
-    the [system options][system-snap-opts] documentation.
+  An explicit timer may be a simple `mon` (scan every Monday) or a more
+  complex `mon3,23:00` (scan on the third Monday of the month at 23:00). See
+  possible values for explicit timers in the the _refresh.timer_ section of
+  the [system options][system-snap-opts] documentation.
 
 - Empty string
 
-    An empty string instructs `snapd` to refresh snap packages according to the
-    default system policy. This is currently 4 times per day.
+  An empty string instructs `snapd` to refresh snap packages according to the
+  default system policy. This is currently 4 times per day.
 
-- *max*
+- _max_
 
-    When set to `max`, refresh scans will be delayed for the maximum amount of
-    time allowed by `snapd`. This is currently once per month based on the
-    date this option was set.
+  When set to `max`, refresh scans will be delayed for the maximum amount of
+  time allowed by `snapd`. This is currently once per month based on the
+  date this option was set.
 
-### Determine the actual *max* value
+### Determine the actual _max_ value
 
 Use `snap get` on a deployed system to determine the value that `snapd` uses
 when a charm is configured with `snapd_refresh=max`. An example with `etcd`
@@ -105,10 +105,10 @@ juju run --unit kubernetes-master/0 'snap refresh cdk-addons'
 
 <!-- FEEDBACK -->
 <div class="p-notification--information">
-  <p class="p-notification__response">
-    We appreciate your feedback on the documentation. You can
+  <div class="p-notification__content">
+    <p class="p-notification__message">We appreciate your feedback on the documentation. You can
     <a href="https://github.com/charmed-kubernetes/kubernetes-docs/edit/main/pages/k8s/snap-refresh.md" >edit this page</a>
     or
-    <a href="https://github.com/charmed-kubernetes/kubernetes-docs/issues/new" >file a bug here</a>.
-  </p>
+    <a href="https://github.com/charmed-kubernetes/kubernetes-docs/issues/new" >file a bug here</a>.</p>
+  </div>
 </div>

--- a/templates/kubernetes/docs/troubleshooting.md
+++ b/templates/kubernetes/docs/troubleshooting.md
@@ -117,7 +117,7 @@ Running the `juju-crashdump` script will generate a tarball of debug information
 
 ### Charms deployed to LXD containers fail after upgrade/reboot
 
-For deployments using Juju's `localhost` cloud, which deploys charms to LXD/LXC containers, or other 
+For deployments using Juju's `localhost` cloud, which deploys charms to LXD/LXC containers, or other
 cases where applications are deployed to LXD, there is a known issue
 ([https://bugs.launchpad.net/juju/+bug/1904619](https://bugs.launchpad.net/juju/+bug/1904619))
 with the profiles applied by Juju. The LXD profile used by Juju is named after the charm, including
@@ -130,6 +130,7 @@ To check what the profiles should contain, the YAML output from `juju status` or
 ```bash
 juju machines --format=yaml
 ```
+
 ... will detail the profiles in the output, e.g.:
 
 ```
@@ -166,6 +167,7 @@ To check this matches with the actually applied profile, you can run `lxc` (this
 ```bash
 lxc profile show juju-default-kubernetes-worker-718
 ```
+
 This should give the appropriate corresponding output:
 
 ```yaml
@@ -186,7 +188,7 @@ devices:
     type: unix-char
 name: juju-default-kubernetes-worker-718
 used_by:
-- /1.0/instances/juju-4ac678-1
+  - /1.0/instances/juju-4ac678-1
 ```
 
 If this differs from what is expected, the profile can be manually edited. E.g., for the above profile:
@@ -194,7 +196,6 @@ If this differs from what is expected, the profile can be manually edited. E.g.,
 ```bash
 lxc profile edit juju-default-kubernetes-worker-718
 ```
-
 
 ### Load Balancer interfering with Helm
 
@@ -322,6 +323,7 @@ Kubernetes for the policy. Check to make sure they are running:
 ```bash
 kubectl -n kube-system get po
 ```
+
 ```bash
 NAME                                              READY   STATUS    RESTARTS   AGE
 k8s-keystone-auth-5c6b7f9b7c-mvvkx                1/1     Running   0          21m
@@ -333,6 +335,7 @@ Check the logs of the pods for errors:
 ```bash
 kubectl -n kube-system logs k8s-keystone-auth-5c6b7f9b7c-mvvkx
 ```
+
 ```bash
 W1121 05:02:02.878988       1 config.go:73] Argument --sync-config-file or --sync-configmap-name missing. Data synchronization between Keystone and Kubernetes is disabled.
 I1121 05:02:02.879139       1 keystone.go:527] Creating kubernetes API client.
@@ -352,6 +355,7 @@ isn't valid, but make sure it matches what you expect.
 ```bash
 kubectl -n kube-system get configmap k8s-auth-policy -o=yaml
 ```
+
 ```yaml
 apiVersion: v1
 data:
@@ -394,6 +398,7 @@ Verify the service exists and has endpoints
 ```bash
 kubectl get svc -n kube-system
 ```
+
 ```bash
 NAME                        TYPE        CLUSTER-IP       EXTERNAL-IP   PORT(S)             AGE
 heapster                    ClusterIP   10.152.183.49    <none>        80/TCP              136m
@@ -487,10 +492,10 @@ juju run --unit kubernetes-master/0 -- journalctl -u snap.kube-apiserver.daemon.
 
 <!-- FEEDBACK -->
 <div class="p-notification--information">
-  <p class="p-notification__response">
-    We appreciate your feedback on the documentation. You can
+  <div class="p-notification__content">
+    <p class="p-notification__message">We appreciate your feedback on the documentation. You can
     <a href="https://github.com/charmed-kubernetes/kubernetes-docs/edit/main/pages/k8s/troubleshooting.md" >edit this page</a>
     or
-    <a href="https://github.com/charmed-kubernetes/kubernetes-docs/issues/new" >file a bug here</a>.
-  </p>
+    <a href="https://github.com/charmed-kubernetes/kubernetes-docs/issues/new" >file a bug here</a>.</p>
+  </div>
 </div>

--- a/templates/openstack/install.html
+++ b/templates/openstack/install.html
@@ -120,7 +120,7 @@
   <div class="u-fixed-width">
     <h2>Single-node OpenStack deployment</h2>
     <p class="u-sv3">These instructions use <a href="https://snapcraft.io/microstack" class="p-link--external">MicroStack</a> &dash; OpenStack in a snap, MicroStack is a pure upstream OpenStack distribution designed for small scale and edge deployments, that can be installed and maintained with a minimal effort.</p>
-    <div class="p-notification">
+    <div class="p-notification is-inline">
       <div class="p-notification__content">
         <span class="p-notification__title">NOTE:</span>
         <p class="p-notification__message">MicroStack is in a beta state. We encourage you to test it, give us your <a class="p-link--external" href="https://bugs.launchpad.net/microstack">feedback</a> and <a class="p-link--external" href="https://discourse.juju.is/search?q=microstack">ask questions</a>.</p>

--- a/templates/openstack/install.html
+++ b/templates/openstack/install.html
@@ -121,9 +121,10 @@
     <h2>Single-node OpenStack deployment</h2>
     <p class="u-sv3">These instructions use <a href="https://snapcraft.io/microstack" class="p-link--external">MicroStack</a> &dash; OpenStack in a snap, MicroStack is a pure upstream OpenStack distribution designed for small scale and edge deployments, that can be installed and maintained with a minimal effort.</p>
     <div class="p-notification">
-      <p class="p-notification__response">
-        <span class="p-notification__status">NOTE:</span> MicroStack is in a beta state. We encourage you to test it, give us your <a class="p-link--external" href="https://bugs.launchpad.net/microstack">feedback</a> and <a class="p-link--external" href="https://discourse.juju.is/search?q=microstack">ask questions</a>.
-      </p>
+      <div class="p-notification__content">
+        <span class="p-notification__title">NOTE:</span>
+        <p class="p-notification__message">MicroStack is in a beta state. We encourage you to test it, give us your <a class="p-link--external" href="https://bugs.launchpad.net/microstack">feedback</a> and <a class="p-link--external" href="https://discourse.juju.is/search?q=microstack">ask questions</a>.</p>
+      </div>
     </div>
       
       {{single_node | safe}}
@@ -136,10 +137,11 @@
   <div class="u-fixed-width">
     <h2>Multi-node OpenStack deployment</h2>
     <p>These instructions use <a href="https://snapcraft.io/microstack" class="p-link--external">MicroStack</a> &dash; in a snap. MicroStack is a pure upstream OpenStack distribution, designed for small scale and edge deployments, that can be installed and maintained with a minimal effort.</p>
-    <div class="p-notification">
-      <p class="p-notification__response">
-        <span class="p-notification__status">NOTE:</span> MicroStack is in a beta state. We encourage you to test it, give us your <a class="p-link--external" href="https://bugs.launchpad.net/microstack">feedback</a> and <a class="p-link--external" href="https://discourse.juju.is/search?q=microstack">ask questions</a>.
-      </p>
+    <div class="p-notification is-inline">
+      <div class="p-notification__content">
+        <span class="p-notification__title">NOTE:</span>
+        <p class="p-notification__message">MicroStack is in a beta state. We encourage you to test it, give us your <a class="p-link--external" href="https://bugs.launchpad.net/microstack">feedback</a> and <a class="p-link--external" href="https://discourse.juju.is/search?q=microstack">ask questions</a>.</p>
+      </div>
     </div>
     
     {{multi_node | safe}}
@@ -155,10 +157,11 @@
         These instructions use <a href="https://docs.openstack.org/charm-guide/latest/">OpenStack Charms</a>. OpenStack Charms are the foundation of Canonical’s <a href="https://ubuntu.com/openstack">Charmed OpenStack</a> distribution which is an enterprise private cloud, designed to run mission-critical workloads.
       </p>
       <p class="u-sv3">Find the documentation for "Installation" of <a href="https://docs.openstack.org/project-deploy-guide/charm-deployment-guide/latest/" class="p-link--external">OpenStack Charms Deployment Guide here</a>.</p>
-      <div class="p-notification">
-        <p class="p-notification__response">
-          <span class="p-notification__status">NOTE:</span> In order to qualify for the <a href="https://assets.ubuntu.com/v1/d4766546-Private-Cloud-Build_Datasheet.pdf" class="p-link--external">Private Cloud Build (PCB)</a> service, <a href="https://assets.ubuntu.com/v1/1a8fb1b3-UA-I_datasheet_2019-Oct.pdf" class="p-link--external">Ubuntu Advantage for Infrastructure (UA-I)</a> support subscription and <a href="https://assets.ubuntu.com/v1/a797f6f9-Datasheet_Openstack_05.10.20+%281%29.pdf" class="p-link--external">Managed OpenStack</a>, at least 12 nodes are required for Charmed OpenStack. Please contact your Canonical sales representative for detailed information on minimum hardware requirements
-        </p>
+      <div class="p-notification is-inline">
+        <div class="p-notification__content">
+          <span class="p-notification__title">NOTE:</span>
+          <p class="p-notification__message">In order to qualify for the <a href="https://assets.ubuntu.com/v1/d4766546-Private-Cloud-Build_Datasheet.pdf" class="p-link--external">Private Cloud Build (PCB)</a> service, <a href="https://assets.ubuntu.com/v1/1a8fb1b3-UA-I_datasheet_2019-Oct.pdf" class="p-link--external">Ubuntu Advantage for Infrastructure (UA-I)</a> support subscription and <a href="https://assets.ubuntu.com/v1/a797f6f9-Datasheet_Openstack_05.10.20+%281%29.pdf" class="p-link--external">Managed OpenStack</a>, at least 12 nodes are required for Charmed OpenStack. Please contact your Canonical sales representative for detailed information on minimum hardware requirements</p>
+        </div>
       </div>
       <p>To learn more about OpenStack Charms, visit <a class="p-link--external" href="https://docs.openstack.org/project-deploy-guide/charm-deployment-guide/latest/">OpenStack Charms Deployment Guide</a>.</p>
     </div>

--- a/templates/openstack/pricing-calculator.html
+++ b/templates/openstack/pricing-calculator.html
@@ -48,9 +48,11 @@
   </div>
 
   <div class="u-fixed-width">
-    <div class="p-notification--information">
-      <p class="p-notification__response" role="status">
-        <span class="p-notification__status">NOTE: The private cloud pricing calculator is for informational purposes only. Exact prices may vary depending on your detailed requirements, cloud configuration and local cost conditions. The hourly cost per instance contains all CapEx and OpEx costs over a three-year period, including reference hardware, typical hosting charges, average operations staff salary costs, cloud delivery and support subscriptions. The total savings are calculated compared to the reference AWS EC2 pricing for on-demand t3a type instances. In case of any questions, get in touch with our experts.</span>
+    <div class="p-notification--information is-inline">
+      <div class="p-notification__content" role="status">
+        <span class="p-notification__title">NOTE:</span> 
+        <p class="p-notification__message">The private cloud pricing calculator is for informational purposes only. Exact prices may vary depending on your detailed requirements, cloud configuration and local cost conditions. The hourly cost per instance contains all CapEx and OpEx costs over a three-year period, including reference hardware, typical hosting charges, average operations staff salary costs, cloud delivery and support subscriptions. The total savings are calculated compared to the reference AWS EC2 pricing for on-demand t3a type instances. In case of any questions, get in touch with our experts.</p>
+      </div>
     </div>
   </div>
 </section>

--- a/templates/resources/index.html
+++ b/templates/resources/index.html
@@ -74,7 +74,10 @@
   {% if posts == false %}
   <div class="u-fixed-width">
     <div class="p-notification--negative">
-      <p class="p-notification__response"><span class="p-notification__status">Error:</span>The live news feed failed to load. Please <a href="https://github.com/canonical-websites/www.ubuntu.com/issues/new" class="p-link--external">report this bug</a> and our team will fix the problem as soon as&nbsp;possible.</p>
+      <div class="p-notification__content">
+        <span class="p-notification__title">Error:</span>
+        <p class="p-notification__message">The live news feed failed to load. Please <a href="https://github.com/canonical-websites/www.ubuntu.com/issues/new" class="p-link--external">report this bug</a> and our team will fix the problem as soon as&nbsp;possible.</p>
+      </div>
     </div>
   </div>
   {% endif %}
@@ -127,10 +130,11 @@
 
   {% if posts_length == 0 %}
     <div class="u-fixed-width">
-      <div class="p-notification--information">
-        <p class="p-notification__response">
-          <span class="p-notification__status">Information:</span> There were no results found for this category
-        </p>
+      <div class="p-notification--information is-inline">
+        <div class="p-notification__content">
+          <span class="p-notification__title">Information:</span>
+          <p class="p-notification__message">There were no results found for this category</p>
+        </div>
       </div>
     </div>
   {% endif %}

--- a/templates/shared/_partner-logos.html
+++ b/templates/shared/_partner-logos.html
@@ -1,8 +1,11 @@
 {% set partners=get_json_feed(json_feed_url, limit=feed_item_limit) %}
 
 {% if partners == false %}
-  <div class="p-notification--negative">
-    <p class="p-notification__response"><span class="p-notification__status">Error:</span>Our partner logos failed to load. Please <a href="https://github.com/canonical-websites/www.ubuntu.com/issues/new" class="p-link--external">report this bug</a> and our team will fix the problem as soon as possible.</p>
+  <div class="p-notification--negative is-inline">
+    <div class="p-notification__content">
+      <span class="p-notification__title">Error:</span>
+      <p class="p-notification__message"></p>Our partner logos failed to load. Please <a href="https://github.com/canonical-websites/www.ubuntu.com/issues/new" class="p-link--external">report this bug</a> and our team will fix the problem as soon as possible.</p>
+    </div>
   </div>
 {% else %}
   {% if title %}<h2 class="p-muted-heading u-align--center">{{title}}</h2>{% endif %}

--- a/templates/templates/base.html
+++ b/templates/templates/base.html
@@ -81,9 +81,9 @@
   <div class="wrapper u-no-margin--top">
     <div id="success">
         <div class="p-notification--positive u-no-margin--bottom">
-            <p class="p-notification__response">
-              Your submission was sent successfully! <a href="#" onclick="location.href = document.referrer; return false;"><i class="p-icon--close">Close</i></a>
-            </p>
+            <div class="p-notification__content">
+              <p class="p-notification__message">Your submission was sent successfully! <a href="#" onclick="location.href = document.referrer; return false;"><i class="p-notification__close">Close</i></a></p>
+            </div>
         </div>
     </div>
     <div id="main-content" class="inner-wrapper">

--- a/templates/templates/docs/shared/_docs.html
+++ b/templates/templates/docs/shared/_docs.html
@@ -79,9 +79,9 @@
 
 			<div class="p-strip is-shallow">
 				<div class="p-notification--information">
-					<p class="p-notification__response">
-						Last updated {{ document.updated }}. <a href="{{ forum_url }}{{ document.topic_path }}">Help improve this document in the forum</a>.
-					</p>
+					<div class="p-notification__content">
+            <p class="p-notification__message">Last updated {{ document.updated }}. <a href="{{ forum_url }}{{ document.topic_path }}">Help improve this document in the forum</a>.</p>
+          </div>
 				</div>
 			</div>
     </main>

--- a/templates/training/index.html
+++ b/templates/training/index.html
@@ -34,10 +34,11 @@
     </div>
   </div>
   <div class="row">
-    <div class="p-notification--caution col-6" style="position: relative;">
-      <p class="p-notification__response" role="status">
-        <span class="p-notification__status">PLEASE NOTE:</span> Due to current circumstances linked to the COVID-19 pandemic, all training programmes mentioned in this page are performed remotely. All training content and labs will remain the same. We aim to return to an on-site delivery model as soon as the circumstances permit.
-      </p>
+    <div class="p-notification--caution is-inline col-6" style="position: relative;">
+      <div class="p-notification__content" role="status">
+        <span class="p-notification__title">PLEASE NOTE:</span>
+        <p class="p-notification__message">Due to current circumstances linked to the COVID-19 pandemic, all training programmes mentioned in this page are performed remotely. All training content and labs will remain the same. We aim to return to an on-site delivery model as soon as the circumstances permit.</p>
+      </div>
     </div>
   </div>
 </section>

--- a/templates/tutorials/tutorial.html
+++ b/templates/tutorials/tutorial.html
@@ -139,7 +139,9 @@
       </div>
 
       <div class="l-tutorial__feedback-result p-notification--positive u-hide">
-        <p class="p-notification__response">Thank you for your feedback.</p>
+        <div class="p-notification__content">
+          <p class="p-notification__message">Thank you for your feedback.</p>
+        </div>
       </div>
       {% endif %}
 


### PR DESCRIPTION
## Done

- The notification pattern was updated, and support for the old version of the pattern is removed in Vanilla 3.x, this PR updates many instances across the project to the new structure - see the upgrade guide: https://vanillaframework.io/docs/migration-guide-to-v3#notifications
- There are notifications on 100+ pages/templates, so there'll be at least one more follow up PR to make it slightly easier to review

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Check the files that were changed, and find the pages on the demo, see that the notifications on them are not broken

## Issue / Card

(partially) fixes https://github.com/canonical-web-and-design/web-squad/issues/4854

