### PR TITLE
Update accordion to vanilla-3.0 patterns

### DIFF
--- a/templates/certified/model-details.html
+++ b/templates/certified/model-details.html
@@ -70,7 +70,7 @@
           {% for release in release_details["releases"] %}
           <li class="{% if release_details['releases']|length > 1 %}p-accordion__group{% endif %}">
             {% if release_details['releases']|length > 1%}
-            <h3 role="heading" aria-level="3" class="p-accordion__heading u-no-margin--bottom">
+            <h3 class="p-accordion__heading u-no-margin--bottom">
               <button type="button" class="p-accordion__tab" style="background-position: top 1.25rem left 1rem;"id="tab{{ loop.index }}" aria-controls="tab{{ loop.index }}-section" aria-expanded="false">{{ release.name }}</button>
             </h3>
             {% else %}

--- a/templates/certified/model-details.html
+++ b/templates/certified/model-details.html
@@ -70,9 +70,9 @@
           {% for release in release_details["releases"] %}
           <li class="{% if release_details['releases']|length > 1 %}p-accordion__group{% endif %}">
             {% if release_details['releases']|length > 1%}
-            <div role="heading" aria-level="3" class="p-accordion__heading">
-              <button type="button" class="p-accordion__tab" style="background-position: top 1.25rem left 1rem;"id="tab{{ loop.index }}" aria-controls="tab{{ loop.index }}-section" aria-expanded="false"><h3 class="u-no-margin--bottom">{{ release.name }}</h3></button>
-            </div>
+            <h3 role="heading" aria-level="3" class="p-accordion__heading u-no-margin--bottom">
+              <button type="button" class="p-accordion__tab" style="background-position: top 1.25rem left 1rem;"id="tab{{ loop.index }}" aria-controls="tab{{ loop.index }}-section" aria-expanded="false">{{ release.name }}</button>
+            </h3>
             {% else %}
             <h3>{{ release.name }}</h3>
             {% endif %}


### PR DESCRIPTION
## Done

Updates one style to match the examples that use heading elements. You can check an example of it at https://ubuntu-com-11319.demos.haus/certified/201901-26804

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/certified/201901-26804
    - Be sure to test on mobile, tablet and desktop screen sizes

## Issue / Card

Fixes https://github.com/canonical-web-and-design/web-squad/issues/4857
