### PR TITLE
Update UC20 thank-you page to point toward appropriate tutorial

### DIFF
--- a/templates/download/raspberry-pi/thank-you.html
+++ b/templates/download/raspberry-pi/thank-you.html
@@ -58,6 +58,24 @@
       </div>
     </div>
     <div class="row p-divider">
+      {% if version==releases.latest.core_version %}
+      <div class="col-4 blog-p-card--post">
+        <header class="blog-p-card__header--tutorial">
+          <h5 class="p-muted-heading u-no-margin--bottom">
+            core, UC20
+          </h5>
+        </header>
+        <div class="blog-p-card__content">
+          <h3 class="p-heading--3 u-no-margin--top u-no-margin--bottom">
+            <a class="p-link--soft" href="/core/docs/uc20/install-raspberry-pi">Installing Ubuntu Core 20 on a Raspberry Pi</a>
+          </h3>
+          <p class="u-sv3">A complete guide to installing Ubuntu Core on a Raspberry Pi 4 (4GB or 8GB).</p>
+        </div>
+        <footer class="blog-p-card__footer">
+          Difficulty: <span class="l-tutorials-meter l-tutorials-meter--2">2 out of 5</span>
+        </footer>
+      </div>
+      {% else %}
       <div class="col-4 blog-p-card--post">
         <header class="blog-p-card__header--tutorial">
           <h5 class="p-muted-heading u-no-margin--bottom">
@@ -74,6 +92,7 @@
           Difficulty: <span class="l-tutorials-meter l-tutorials-meter--1">1 out of 5</span>
         </footer>
       </div>
+      {% endif %}
       <div class="col-4 blog-p-card--post p-divider__block">
         <header class="blog-p-card__header--tutorial">
           <h5 class="p-muted-heading u-no-margin--bottom">


### PR DESCRIPTION
## Done

- The tutorials the thank-page pointed toward were not relevant to Ubuntu core 20. I have added a condition to check if the download for core and if it is render an appropriate tutorial card.

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- Go to the download thank-you page for Ubuntu Core and check that a tutorial card appears for the appropriate tutorial. Also go to a download for Ubuntu server and check the card does not appear.

## Issue / Card

Fixes https://github.com/canonical-web-and-design/ubuntu.com/issues/11320
