### PR TITLE
Add tracking at different steps before checkout

### DIFF
--- a/static/js/src/advantage/ecom-events.js
+++ b/static/js/src/advantage/ecom-events.js
@@ -24,6 +24,36 @@ export function removeFromCartEvent(product) {
   }
 }
 
+export function logSelectOptionEvent(option, value) {
+  if (dataLayer) {
+    dataLayer.push({
+      event: "selectOption",
+      ecommerce: {
+        select: {
+          option: option,
+          value: value,
+        },
+      },
+    });
+  }
+}
+
+export function logOpenModalEvent() {
+  if (dataLayer) {
+    dataLayer.push({
+      event: "openModal",
+    });
+  }
+}
+
+export function logCloseModalEvent() {
+  if (dataLayer) {
+    dataLayer.push({
+      event: "closeModal",
+    });
+  }
+}
+
 /**
  *
  * @param {Array} cartItems

--- a/static/js/src/advantage/react/components/Subscriptions/SubscriptionDetails/DetailsContent/DetailsContent.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/SubscriptionDetails/DetailsContent/DetailsContent.tsx
@@ -19,6 +19,7 @@ import {
   isFreeSubscription,
   isBlenderSubscription,
 } from "advantage/react/utils";
+import { sendAnalyticsEvent } from "advantage/react/utils/sendAnalyticsEvent";
 import React, { ReactNode } from "react";
 
 import DetailsTabs from "../DetailsTabs";
@@ -108,6 +109,13 @@ const DetailsContent = ({ selectedId }: Props) => {
         },
       ]}
       className="u-sv4 u-no-margin--bottom"
+      onClick={() => {
+        sendAnalyticsEvent({
+          eventCategory: "Advantage",
+          eventAction: "subscription-token-click",
+          eventLabel: "Token copied",
+        });
+      }}
     />
   ) : null;
 

--- a/static/js/src/advantage/subscribe/listeners/form-event-listeners.js
+++ b/static/js/src/advantage/subscribe/listeners/form-event-listeners.js
@@ -1,3 +1,4 @@
+import { logSelectOptionEvent } from "advantage/ecom-events";
 import {
   changeFeature,
   changeQuantity,
@@ -38,6 +39,7 @@ export default function initFormInputs(store) {
     inputs.forEach((input) => {
       input.addEventListener("input", (e) => {
         store.dispatch(action(e.target.value));
+        logSelectOptionEvent(name, e.target.value);
       });
     });
   }

--- a/static/js/src/advantage/subscribe/listeners/ui-event-listeners.js
+++ b/static/js/src/advantage/subscribe/listeners/ui-event-listeners.js
@@ -1,3 +1,4 @@
+import { logCloseModalEvent, logOpenModalEvent } from "advantage/ecom-events";
 import {
   toggleOtherVersionsModal,
   togglePurchaseModal,
@@ -19,6 +20,7 @@ export default function initUIControls(store) {
   // Add close modal function to window object so the React modal can use it
   window.handleTogglePurchaseModal = () => {
     store.dispatch(togglePurchaseModal());
+    logCloseModalEvent();
   };
 
   const buyButton = document.querySelector("#buy-now-button");
@@ -26,5 +28,6 @@ export default function initUIControls(store) {
   buyButton.addEventListener("click", (e) => {
     e.preventDefault();
     store.dispatch(togglePurchaseModal());
+    logOpenModalEvent();
   });
 }


### PR DESCRIPTION

## Done

- Added tracking for product selection and modal interaction

## QA

- Go to https://ubuntu-com-11325.demos.haus/advantage/subscribe?test_backend=true
- click on different options
- open and close the modal
- it should log those actions

## Issue / Card

Fixes canonical-web-and-design/commercial-squad#507

