### PR TITLE
Update kernel name in release cycle chart

### DIFF
--- a/static/js/src/chart-data.js
+++ b/static/js/src/chart-data.js
@@ -1374,7 +1374,7 @@ export var kernelReleaseNames = [
 ];
 
 export var kernelVersionNames = [
-  "22.04 kernel",
+  "5.15 kernel",
   "",
   "5.13 kernel",
   "",


### PR DESCRIPTION
## Done

- Updates a kernel version name from '20.04.5 kernel' to '5.15 kernel'

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: https://ubuntu-com-11326.demos.haus/about/release-cycle#ubuntu-kernel-release-cycle
    - Be sure to test on mobile, tablet and desktop screen sizes

## Issue / Card

Fixes https://app.zenhub.com/workspaces/-web-tribe-5931746dba512f05402b61f6/issues/canonical-web-and-design/ubuntu.com/11291
