### PR TITLE
Add dismissible notification

### DIFF
--- a/static/js/src/advantage/react/components/Subscriptions/Notifications/Notifications.test.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/Notifications/Notifications.test.tsx
@@ -76,3 +76,56 @@ describe("Offers Notifications", () => {
     expect(wrapper.find("[data-test='offers']").exists()).toBe(false);
   });
 });
+
+describe("Account users Notification", () => {
+  let queryClient: QueryClient;
+
+  beforeEach(() => {
+    queryClient = new QueryClient();
+  });
+
+  jest.spyOn(window.localStorage.__proto__, "setItem");
+  window.localStorage.__proto__.setItem = jest.fn();
+
+  it("displays an onboarding notification if there is only one account user", () => {
+    queryClient.setQueryData("accountUsers", {
+      users: [{ name: "blip" }],
+    });
+    const wrapper = mount(
+      <QueryClientProvider client={queryClient}>
+        <Notifications />
+      </QueryClientProvider>
+    );
+    expect(wrapper.find("[data-test='onboarding']").exists()).toBe(true);
+  });
+  it("does not display an onboarding notification if there are multiple account users", () => {
+    queryClient.setQueryData("accountUsers", {
+      users: [{ name: "blip" }, { name: "blop" }],
+    });
+    const wrapper = mount(
+      <QueryClientProvider client={queryClient}>
+        <Notifications />
+      </QueryClientProvider>
+    );
+    expect(wrapper.find("[data-test='onboarding']").exists()).toBe(false);
+  });
+
+  it("dismisses the notification when clicking the close button", () => {
+    queryClient.setQueryData("accountUsers", {
+      users: [{ name: "blip" }],
+    });
+    const wrapper = mount(
+      <QueryClientProvider client={queryClient}>
+        <Notifications />
+      </QueryClientProvider>
+    );
+    wrapper
+      .find("[data-test='onboarding']")
+      .find("[data-testid='notification-close-button']")
+      .simulate("click");
+    expect(localStorage.setItem).toHaveBeenCalledWith(
+      "dismissedOnboardingNotification",
+      "true"
+    );
+  });
+});

--- a/static/js/src/advantage/react/components/Subscriptions/Notifications/Notifications.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/Notifications/Notifications.tsx
@@ -16,15 +16,15 @@ const Notifications = () => {
   const { data: offers } = useGetOffersList();
 
   const [
-    isShowingOnBoardingNotification,
-    setIsShowingOnBoardingNotification,
+    isShowingOnboardingNotification,
+    setIsShowingOnboardingNotification,
   ] = React.useState(
-    localStorage.getItem("dismissedOnBoardingNotification") !== "true"
+    localStorage.getItem("dismissedOnboardingNotification") !== "true"
   );
 
-  const dismissOnBoardingNotification = () => {
-    localStorage.setItem("dismissedOnBoardingNotification", "true");
-    setIsShowingOnBoardingNotification(false);
+  const dismissOnboardingNotification = () => {
+    localStorage.setItem("dismissedOnboardingNotification", "true");
+    setIsShowingOnboardingNotification(false);
   };
 
   return (
@@ -42,14 +42,14 @@ const Notifications = () => {
           subscriptions
         </Notification>
       ) : null}
-      {isShowingOnBoardingNotification ? (
+      {isShowingOnboardingNotification ? (
         <Notification
-          data-test="offers"
+          data-test="onboarding"
           severity="information"
           actions={[
             {
               label: "Dismiss this message",
-              onClick: dismissOnBoardingNotification,
+              onClick: dismissOnboardingNotification,
             },
             {
               label: "Manage account users",
@@ -58,7 +58,7 @@ const Notifications = () => {
               },
             },
           ]}
-          onDismiss={dismissOnBoardingNotification}
+          onDismiss={dismissOnboardingNotification}
         >
           Tip: You can add additional Technical & Billing contacts in
           &quot;Account users&quot; to ensure service continuity and allow the

--- a/static/js/src/advantage/react/components/Subscriptions/Notifications/Notifications.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/Notifications/Notifications.tsx
@@ -1,5 +1,5 @@
 import { Notification } from "@canonical/react-components";
-import React from "react";
+import React, { useEffect } from "react";
 
 import { useURLs } from "../../../hooks";
 import { useUserSubscriptions } from "advantage/react/hooks";
@@ -7,6 +7,7 @@ import { selectStatusesSummary } from "advantage/react/hooks/useUserSubscription
 import ExpiryNotification from "../ExpiryNotification";
 import { ExpiryNotificationSize } from "../ExpiryNotification/ExpiryNotification";
 import useGetOffersList from "advantage/offers/hooks/useGetOffersList";
+import useRequestAccountUsers from "advantage/users/hooks/useRequestAccountUsers";
 
 const Notifications = () => {
   const urls = useURLs();
@@ -14,6 +15,11 @@ const Notifications = () => {
     select: selectStatusesSummary,
   });
   const { data: offers } = useGetOffersList();
+
+  const {
+    data: accountUsers,
+    isSuccess: isAccountUsersSuccess,
+  } = useRequestAccountUsers();
 
   const [
     isShowingOnboardingNotification,
@@ -26,6 +32,11 @@ const Notifications = () => {
     localStorage.setItem("dismissedOnboardingNotification", "true");
     setIsShowingOnboardingNotification(false);
   };
+  useEffect(() => {
+    if ((accountUsers?.users.length ?? 1) > 1) {
+      dismissOnboardingNotification();
+    }
+  }, [accountUsers]);
 
   return (
     <>
@@ -42,7 +53,7 @@ const Notifications = () => {
           subscriptions
         </Notification>
       ) : null}
-      {isShowingOnboardingNotification ? (
+      {isAccountUsersSuccess && isShowingOnboardingNotification ? (
         <Notification
           data-test="onboarding"
           severity="information"

--- a/static/js/src/advantage/react/components/Subscriptions/Notifications/Notifications.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/Notifications/Notifications.tsx
@@ -15,6 +15,18 @@ const Notifications = () => {
   });
   const { data: offers } = useGetOffersList();
 
+  const [
+    isShowingOnBoardingNotification,
+    setIsShowingOnBoardingNotification,
+  ] = React.useState(
+    localStorage.getItem("dismissedOnBoardingNotification") !== "true"
+  );
+
+  const dismissOnBoardingNotification = () => {
+    localStorage.setItem("dismissedOnBoardingNotification", "true");
+    setIsShowingOnBoardingNotification(false);
+  };
+
   return (
     <>
       {statusesSummary?.has_pending_purchases ? (
@@ -28,6 +40,29 @@ const Notifications = () => {
           <a href={urls.account.paymentMethods}>update your payment methods</a>{" "}
           to ensure there is no interruption to your Ubuntu Advantage
           subscriptions
+        </Notification>
+      ) : null}
+      {isShowingOnBoardingNotification ? (
+        <Notification
+          data-test="offers"
+          severity="information"
+          actions={[
+            {
+              label: "Dismiss this message",
+              onClick: dismissOnBoardingNotification,
+            },
+            {
+              label: "Manage account users",
+              onClick: () => {
+                location.href = urls.advantage.users;
+              },
+            },
+          ]}
+          onDismiss={dismissOnBoardingNotification}
+        >
+          Tip: You can add additional Technical & Billing contacts in
+          &quot;Account users&quot; to ensure service continuity and allow the
+          right people access to your Subscriptions
         </Notification>
       ) : null}
       {offers?.length > 0 ? (

--- a/static/js/src/advantage/react/hooks/useURLs.ts
+++ b/static/js/src/advantage/react/hooks/useURLs.ts
@@ -8,6 +8,7 @@ export const APP_URLS = {
   },
   advantage: {
     offers: "/advantage/offers",
+    users: "/advantage/users",
   },
 };
 

--- a/static/js/src/advantage/users/hooks/useRequestAccountUsers.tsx
+++ b/static/js/src/advantage/users/hooks/useRequestAccountUsers.tsx
@@ -1,0 +1,22 @@
+import { useQuery } from "react-query";
+import { requestAccountUsers } from "../api";
+
+const useRequestAccountUsers = () => {
+  const { isLoading, isError, isSuccess, data, error } = useQuery(
+    "accountUsers",
+    async () => {
+      const res = await requestAccountUsers();
+      return res;
+    }
+  );
+
+  return {
+    isLoading: isLoading,
+    isError: isError,
+    isSuccess: isSuccess,
+    data: data,
+    error: error,
+  };
+};
+
+export default useRequestAccountUsers;


### PR DESCRIPTION
## Done

- Add dismissible onboarding notification

## QA

- go to https://ubuntu-com-11327.demos.haus/advantage?test_backend=true
- log in with an account with only one user
- see that the notification is showing on top of the table
- click "Manage account users"
- it should take you to /users
- go back and dismiss the message
- it should go away
- reload the page
- it should still be gone
- open the console and paste `localStorage.removeItem("dismissedOnBoardingNotification");` then press enter
- reload the page
- the notification should be back
- go to /users and add another user
- go back to /advantage, the notification should not show

## Issue / Card

Fixes canonical-web-and-design/commercial-squad#525

## Screenshots

![image](https://user-images.githubusercontent.com/11927929/157212064-78910cbd-a6cd-4c7e-a4f1-8a5f96d7d703.png)

