### PR TITLE
Correct spelling of Memcached on /support

### DIFF
--- a/templates/support/index.html
+++ b/templates/support/index.html
@@ -372,17 +372,17 @@
           {{
             image(
             url="https://assets.ubuntu.com/v1/234cdd88-memached-logo.png",
-            alt="Memached",
+            alt="Memcached",
             width="70",
             height="50",
             hi_def=True,
             loading="lazy",
-            attrs={"class": "p-media-object__image", "title": "Memached"},
+            attrs={"class": "p-media-object__image", "title": "Memcached"},
             ) | safe
           }}
         </span>
         <span class="p-media-object__details">
-          <h4 class="p-media-object__title p-heading--5 u-no-margin--bottom">Memached</h4>
+          <h4 class="p-media-object__title p-heading--5 u-no-margin--bottom">Memcached</h4>
         </span>
       </div>
       <div class="col-3 col-medium-3 p-media-object">


### PR DESCRIPTION
## Done

- Correct spelling of Memcached on /support

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/support or https://ubuntu-com-11331.demos.haus/support
    - Be sure to test on mobile, tablet and desktop screen sizes
- Search for spelling 'Memached' and check there are no results

## Issue / Card

Fixes https://github.com/canonical-web-and-design/ubuntu.com/issues/11304
