### PR TITLE
Allow registration for embedded brighttalk videos

### DIFF
--- a/templates/security/certifications.html
+++ b/templates/security/certifications.html
@@ -61,7 +61,7 @@
     <div class="col-6 u-hide--small u-align--center">
       <div class="jsBrightTALKEmbedWrapper" style="width:100%; height:100%; position:relative;background: #ffffff;">
         <script class="jsBrightTALKEmbedConfig" type="application/json">
-          { "channelId" : 6793, "language": "en-US", "commId" : 524647, "displayMode" : "standalone", "height" : "280" }
+          { "channelId" : 6793, "language": "en-US", "commId" : 524647, "displayMode" : "standalone", "height" : "auto" }
         </script>
         <script src="https://www.brighttalk.com/clients/js/player-embed/player-embed.js" class="jsBrightTALKEmbed"></script>
       </div>

--- a/templates/security/certifications.html
+++ b/templates/security/certifications.html
@@ -61,9 +61,15 @@
     <div class="col-6 u-hide--small u-align--center">
       <div class="jsBrightTALKEmbedWrapper" style="width:100%; height:100%; position:relative;background: #ffffff;">
         <script class="jsBrightTALKEmbedConfig" type="application/json">
-          { "channelId" : 6793, "language": "en-US", "commId" : 524647, "displayMode" : "standalone", "height" : "auto" }
+          { "channelId" : 6793, "language": "en-US", "commId" : 524647, "displayMode" : "standalone", "height" : "280" }
         </script>
         <script src="https://www.brighttalk.com/clients/js/player-embed/player-embed.js" class="jsBrightTALKEmbed"></script>
+        <script>
+          const iframe = document.querySelector('.jsBrightTALKEmbedWrapper iframe');
+          iframe.addEventListener('load', () => {
+            iframe.scrolling = "yes";
+          });
+        </script>        
       </div>
     </div>
   </div>

--- a/templates/security/disa-stig.html
+++ b/templates/security/disa-stig.html
@@ -44,7 +44,7 @@
     <div class="col-5 u-hide--small u-align--center">
       <div class="jsBrightTALKEmbedWrapper u-vertically-center" style="width:100%; height:100%; position:relative;background: #ffffff;">
         <script class="jsBrightTALKEmbedConfig" type="application/json">
-          { "channelId" : 6793, "language": "en-US", "commId" : 524647, "displayMode" : "standalone", "height" : "280" }
+          { "channelId" : 6793, "language": "en-US", "commId" : 524647, "displayMode" : "standalone", "height" : "auto" }
         </script>
         <script src="https://www.brighttalk.com/clients/js/player-embed/player-embed.js" class="jsBrightTALKEmbed"></script>
       </div>

--- a/templates/security/disa-stig.html
+++ b/templates/security/disa-stig.html
@@ -44,9 +44,15 @@
     <div class="col-5 u-hide--small u-align--center">
       <div class="jsBrightTALKEmbedWrapper u-vertically-center" style="width:100%; height:100%; position:relative;background: #ffffff;">
         <script class="jsBrightTALKEmbedConfig" type="application/json">
-          { "channelId" : 6793, "language": "en-US", "commId" : 524647, "displayMode" : "standalone", "height" : "auto" }
+          { "channelId" : 6793, "language": "en-US", "commId" : 524647, "displayMode" : "standalone", "height" : "280" }
         </script>
         <script src="https://www.brighttalk.com/clients/js/player-embed/player-embed.js" class="jsBrightTALKEmbed"></script>
+        <script>
+          const iframe = document.querySelector('.jsBrightTALKEmbedWrapper iframe');
+          iframe.addEventListener('load', () => {
+            iframe.scrolling = "yes";
+          });
+        </script>        
       </div>
     </div>
   </div>

--- a/templates/security/fips.html
+++ b/templates/security/fips.html
@@ -82,9 +82,15 @@
     <div class="col-6 u-hide--small u-align--center">
       <div class="jsBrightTALKEmbedWrapper u-vertically-center" style="width:100%; height:100%; position:relative;background: #ffffff;">
         <script class="jsBrightTALKEmbedConfig" type="application/json">
-          { "channelId" : 6793, "language": "en-US", "commId" : 524647, "displayMode" : "standalone", "height" : "auto" }
+          { "channelId" : 6793, "language": "en-US", "commId" : 524647, "displayMode" : "standalone", "height" : "280" }
         </script>
         <script src="https://www.brighttalk.com/clients/js/player-embed/player-embed.js" class="jsBrightTALKEmbed"></script>
+        <script>
+          const iframe = document.querySelector('.jsBrightTALKEmbedWrapper iframe');
+          iframe.addEventListener('load', () => {
+            iframe.scrolling = "yes";
+          });
+        </script>
       </div>
     </div>
   </div>

--- a/templates/security/fips.html
+++ b/templates/security/fips.html
@@ -82,7 +82,7 @@
     <div class="col-6 u-hide--small u-align--center">
       <div class="jsBrightTALKEmbedWrapper u-vertically-center" style="width:100%; height:100%; position:relative;background: #ffffff;">
         <script class="jsBrightTALKEmbedConfig" type="application/json">
-          { "channelId" : 6793, "language": "en-US", "commId" : 524647, "displayMode" : "standalone", "height" : "250" }
+          { "channelId" : 6793, "language": "en-US", "commId" : 524647, "displayMode" : "standalone", "height" : "auto" }
         </script>
         <script src="https://www.brighttalk.com/clients/js/player-embed/player-embed.js" class="jsBrightTALKEmbed"></script>
       </div>

--- a/templates/security/index.html
+++ b/templates/security/index.html
@@ -64,9 +64,15 @@
     <div class="col-6 u-hide--small u-align--center">
       <div class="jsBrightTALKEmbedWrapper" style="width:100%; height:100%; position:relative; background:#ffffff;">
         <script class="jsBrightTALKEmbedConfig" type="application/json">
-          { "channelId" : 6793, "language": "en-US", "commId" : 516333, "displayMode" : "standalone", "height" : "auto"}
+          { "channelId" : 6793, "language": "en-US", "commId" : 516333, "displayMode" : "standalone", "height" : "280"}
         </script>
         <script src="https://www.brighttalk.com/clients/js/player-embed/player-embed.js" class="jsBrightTALKEmbed"></script>
+        <script>
+          const iframe = document.querySelector('.jsBrightTALKEmbedWrapper iframe');
+          iframe.addEventListener('load', () => {
+            iframe.scrolling = "yes";
+          });
+        </script>
       </div>
     </div>
   </div>

--- a/templates/security/index.html
+++ b/templates/security/index.html
@@ -62,9 +62,9 @@
       </p>
     </div>
     <div class="col-6 u-hide--small u-align--center">
-      <div class="jsBrightTALKEmbedWrapper" style="width:100%; height:100%; position:relative;background: #ffffff;">
+      <div class="jsBrightTALKEmbedWrapper" style="width:100%; height:100%; position:relative; background:#ffffff;">
         <script class="jsBrightTALKEmbedConfig" type="application/json">
-          { "channelId" : 6793, "language": "en-US", "commId" : 516333, "displayMode" : "standalone", "height" : "250" }
+          { "channelId" : 6793, "language": "en-US", "commId" : 516333, "displayMode" : "standalone", "height" : "auto"}
         </script>
         <script src="https://www.brighttalk.com/clients/js/player-embed/player-embed.js" class="jsBrightTALKEmbed"></script>
       </div>


### PR DESCRIPTION
## Done

- The videos were embedded at a fixed size meaning half the registration form was cut off. I have added a script to allow scrolling.

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: https://ubuntu-com-11332.demos.haus
    - Be sure to test on mobile, tablet and desktop screen sizes
- Check each page with embedded bright talk videos to see if the registration form is accessible. 

## Issue / Card

Fixes https://github.com/canonical-web-and-design/ubuntu.com/issues/11192

