### PR TITLE
Remove uses of p-inline-images for vanilla3.0 wip

### DIFF
--- a/static/js/src/chart-data.js
+++ b/static/js/src/chart-data.js
@@ -1374,7 +1374,7 @@ export var kernelReleaseNames = [
 ];
 
 export var kernelVersionNames = [
-  "22.04 kernel",
+  "5.15 kernel",
   "",
   "5.13 kernel",
   "",

--- a/templates/ai/index.html
+++ b/templates/ai/index.html
@@ -26,7 +26,7 @@
         width="304",
         height="263",
         hi_def=True,
-        loading="auto|lazy"
+        loading="lazy"
         ) | safe
       }}
     </div>
@@ -34,201 +34,215 @@
 </section>
 
 <section class="p-strip is-bordered">
-  <p class="p-muted-heading u-align--center">LEADERS IN ARTIFICIAL INTELLIGENCE CHOOSE UBUNTU</p>
-  <div class="row">
-    <ul class="p-inline-images--small u-no-margin--bottom">
-      <li class="p-inline-images__item">
-        {{ image(
-          url="https://assets.ubuntu.com/v1/ae0456eb-Netflix_logo.svg",
-          alt="Netflix",
-          width="130",
-          height="36",
-          hi_def=True,
-          loading="lazy",
-          attrs={"class": "p-inline-images__logo"},
-          ) | safe
-        }}
-      </li>
-      <li class="p-inline-images__item">
-        {{ image (
-          url="https://assets.ubuntu.com/v1/1095d3bc-Tesla_logo_silver.png",
-          alt="Tesla",
-          width="130",
-          height="17",
-          hi_def=True,
-          loading="auto|lazy"
-          ) | safe
-          }}
-      </li>
-      <li class="p-inline-images__item">
-        {{ image (
-          url="https://assets.ubuntu.com/v1/52d4cc16-Nvidia_Logo_Horizontal.svg",
-          alt="Nvidia",
-          width="130",
-          height="25",
-          hi_def=True,
-          loading="auto|lazy"
-          ) | safe
-        }}
-      </li>
-      <li class="p-inline-images__item">
-        {{ image (
-          url="https://assets.ubuntu.com/v1/26eb00dd-fb.png",
-          alt="Facebook",
-          width="130",
-          height="25",
-          hi_def=True,
-          loading="auto|lazy"
-          ) | safe
-        }}
-      </li>
-      <li class="p-inline-images__item">
-          {{ image (
-            url="https://assets.ubuntu.com/v1/c346c103-openai.png",
-            alt="OpenAI",
+  <div class="u-fixed-width">
+    <div class="p-logo-section">
+      <p class="p-logo-section__title p-muted-heading u-align--center">Leaders in artificial intelligence choose Ubuntu</p>
+      <div class="p-logo-section__items u-no-margin--bottom">
+        <div class="p-logo-section__item">
+          {{ image(
+            url="https://assets.ubuntu.com/v1/ae0456eb-Netflix_logo.svg",
+            alt="Netflix",
             width="130",
-            height="90",
+            height="36",
             hi_def=True,
-            loading="auto|lazy"
+            loading="lazy",
+            attrs={"class": "p-logo-section__logo"},
             ) | safe
           }}
-      </li>
-    </ul>
+        </div>
+        <div class="p-logo-section__item">
+          {{ image (
+            url="https://assets.ubuntu.com/v1/1095d3bc-Tesla_logo_silver.png",
+            alt="Tesla",
+            width="130",
+            height="17",
+            hi_def=True,
+            loading="lazy",
+            attrs={"class": "p-logo-section__logo"}
+            ) | safe
+            }}
+        </div>
+        <div class="p-logo-section__item">
+          {{ image (
+            url="https://assets.ubuntu.com/v1/52d4cc16-Nvidia_Logo_Horizontal.svg",
+            alt="Nvidia",
+            width="130",
+            height="25",
+            hi_def=True,
+            loading="lazy",
+            attrs={"class": "p-logo-section__logo"}
+            ) | safe
+          }}
+        </div>
+        <div class="p-logo-section__item">
+          {{ image (
+            url="https://assets.ubuntu.com/v1/26eb00dd-fb.png",
+            alt="Facebook",
+            width="130",
+            height="25",
+            hi_def=True,
+            loading="lazy",
+            attrs={"class": "p-logo-section__logo"}
+            ) | safe
+          }}
+        </div>
+        <div class="p-logo-section__item">
+            {{ image (
+              url="https://assets.ubuntu.com/v1/c346c103-openai.png",
+              alt="OpenAI",
+              width="130",
+              height="90",
+              hi_def=True,
+              loading="lazy",
+              attrs={"class": "p-logo-section__logo"}
+              ) | safe
+            }}
+        </div>
+      </div>
+    </div>
   </div>
 </section>
 
 <section class="p-strip is-bordered">
   <div class="row u-equal-height">
     <div class="col-6">
-      <h2>Develop</h2>
-      <h4>Best of breed data science tools.</h4>
+      <h3>Best of breed data science tools.</h3>
       <p>The most productive tools for AI / ML development, with guides and resources available.</p>
-      <ul class="p-inline-images--small u-no-margin--bottom u-align-text--left">
-        <li class="p-inline-images__item u-no-margin--left u-no-margin--bottom">
-          {{ image (
-            url="https://assets.ubuntu.com/v1/8ee86883-jupyter-logo.png",
+      <div class="p-logo-section">
+        <div class="p-logo-section__items u-no-margin--bottom u-align-text--left">
+          <div class="p-logo-section__item u-no-margin--left u-no-margin--bottom">
+            {{ image (
+              url="https://assets.ubuntu.com/v1/8ee86883-jupyter-logo.png",
             alt="Jupyter",
             width="55",
             height="64",
             hi_def=True,
-            loading="auto|lazy"
+            loading="lazy",
+            attrs={"class": "p-logo-section__logo"}
             ) | safe
           }}
-        </li>
-        <li class="p-inline-images__item u-no-margin--left u-no-margin--bottom">
-          {{ image (
-            url="https://assets.ubuntu.com/v1/d6a20f43-keras.png",
-            alt="Keras",
-            width="110",
-            height="32",
-            hi_def=True,
-            loading="auto|lazy"
-            ) | safe
-          }}
-        </li>
-        <li class="p-inline-images__item u-no-margin--left u-no-margin--bottom">
-          {{ image (
-            url="https://assets.ubuntu.com/v1/f4ffa06e-scikit-learn-logo.png",
-            alt="Scikit Learn",
-            width="98",
-            height="48",
-            hi_def=True,
-            loading="auto|lazy"
-            ) | safe
-          }}
-        </li>
-      </ul>
-      <ul class="p-inline-images--small u-no-margin--bottom u-align-text--left">
-        <li class="p-inline-images__item u-no-margin--left u-no-margin--bottom">
-          {{ image (
-            url="https://assets.ubuntu.com/v1/8b1f29ef-tensor_2.png",
-            alt="TensorFlow",
-            width="177",
-            height="32",
-            hi_def=True,
-            loading="auto|lazy"
-            ) | safe
-          }}
-        </li>
-        <li class="p-inline-images__item u-no-margin--left u-no-margin--bottom">
-          {{ image (
-            url="https://assets.ubuntu.com/v1/f3dd556d-Pytorch_logo.png",
-            alt="PyTorch",
-            width="122",
-            height="30",
-            hi_def=True,
-            loading="auto|lazy"
-            ) | safe
-          }}
-        </li>
-      </ul>
+          </div>
+          <div class="p-logo-section__item u-no-margin--left u-no-margin--bottom">
+            {{ image (
+              url="https://assets.ubuntu.com/v1/d6a20f43-keras.png",
+              alt="Keras",
+              width="110",
+              height="32",
+              hi_def=True,
+              loading="lazy",
+              attrs={"class": "p-logo-section__logo"}
+              ) | safe
+            }}
+          </div>
+          <div class="p-logo-section__item u-no-margin--left u-no-margin--bottom">
+            {{ image (
+              url="https://assets.ubuntu.com/v1/f4ffa06e-scikit-learn-logo.png",
+              alt="Scikit Learn",
+              width="98",
+              height="48",
+              hi_def=True,
+              loading="lazy",
+              attrs={"class": "p-logo-section__logo"}
+              ) | safe
+            }}
+          </div>
+          <div class="p-logo-section__item u-no-margin--left u-no-margin--bottom">
+            {{ image (
+              url="https://assets.ubuntu.com/v1/8b1f29ef-tensor_2.png",
+              alt="TensorFlow",
+              width="177",
+              height="32",
+              hi_def=True,
+              loading="lazy",
+              attrs={"class": "p-logo-section__logo"}
+              ) | safe
+            }}
+          </div>
+          <div class="p-logo-section__item u-no-margin--left u-no-margin--bottom">
+            {{ image (
+              url="https://assets.ubuntu.com/v1/f3dd556d-Pytorch_logo.png",
+              alt="PyTorch",
+              width="122",
+              height="30",
+              hi_def=True,
+              loading="lazy",
+              attrs={"class": "p-logo-section__logo"}
+              ) | safe
+            }}
+          </div>
+        </div>
+      </div>
     </div>
     <div class="col-6">
-      <div class="u-fixed-width u-show--small u-hide--large u-hide--medium">
+      <div class="u-show--small u-hide--large u-hide--medium">
         <hr class="p-separator">
       </div>
-      <h2>Deploy</h2>
+      <h3>Deploy</h3>
       <h4>Multi-framework model serving.</h4>
       <p>Effective model deployment across devices mesh. Low-latency inference serving.</p>
-      <ul class="p-inline-images--small u-no-margin--bottom u-align-text--left">
-        <li class="p-inline-images__item u-no-margin--left u-no-margin--bottom">
-          {{ image (
-            url="https://assets.ubuntu.com/v1/3224ee3e-seldon.png",
-            alt="Seldon",
-            width="139",
-            height="35",
-            hi_def=True,
-            loading="auto|lazy"
+      <div class="p-logo-section">
+        <div class="p-logo-section__items u-no-margin--bottom u-align-text--left">
+          <div class="p-logo-section__item u-no-margin--left u-no-margin--bottom">
+            {{ image (
+              url="https://assets.ubuntu.com/v1/3224ee3e-seldon.png",
+              alt="Seldon",
+              width="139",
+              height="35",
+              hi_def=True,
+              loading="lazy",
+              attrs={"class": "p-logo-section__logo"}
+              ) | safe
+            }}
+          </div>
+          <div class="p-logo-section__item u-no-margin--left u-no-margin--bottom">
+            {{ image (
+              url="https://assets.ubuntu.com/v1/5e6a97ad-kfserving.png",
+              alt="KFServing",
+              width="141",
+              height="28",
+              hi_def=True,
+              loading="lazy",
+            attrs={"class": "p-logo-section__logo"}
             ) | safe
           }}
-        </li>
-        <li class="p-inline-images__item u-no-margin--left u-no-margin--bottom">
-          {{ image (
-            url="https://assets.ubuntu.com/v1/5e6a97ad-kfserving.png",
-            alt="KFServing",
-            width="141",
-            height="28",
-            hi_def=True,
-            loading="auto|lazy"
-            ) | safe
-          }}
-        </li>
-      </ul>
-      <ul class="p-inline-images--small u-no-margin--bottom u-align-text--left">
-        <li class="p-inline-images__item u-no-margin--left u-no-margin--bottom">
+        </div>
+        <div class="p-logo-section__item u-no-margin--left u-no-margin--bottom">
           {{ image (
             url="https://assets.ubuntu.com/v1/653daa8b-onnx-logo.png",
             alt="Onnx",
             width="117",
             height="30",
             hi_def=True,
-            loading="auto|lazy"
+            loading="lazy",
+            attrs={"class": "p-logo-section__logo"}
             ) | safe
           }}
-        </li>
-        <li class="p-inline-images__item u-no-margin--left u-no-margin--bottom">
+        </div>
+        <div class="p-logo-section__item u-no-margin--left u-no-margin--bottom">
           {{ image (
             url="https://assets.ubuntu.com/v1/8f97d534-tensor_rt.png",
             alt="TensorRt",
             width="106",
             height="48",
             hi_def=True,
-            loading="auto|lazy"
+            loading="lazy",
+            attrs={"class": "p-logo-section__logo"}
             ) | safe
           }}
-        </li>
-        <li class="p-inline-images__item u-no-margin--left u-no-margin--bottom">
+        </div>
+        <div class="p-logo-section__item u-no-margin--left u-no-margin--bottom">
           {{ image (
             url="https://assets.ubuntu.com/v1/2af7ca99-xgboost-logo.png",
             alt="XGBoost",
             width="69",
             height="20",
             hi_def=True,
-            loading="auto|lazy"
+            loading="lazy",
+            attrs={"class": "p-logo-section__logo"}
             ) | safe
           }}
-        </li>
-      </ul>
+        </div>
+      </div>
     </div>
   </div>
   <div class="row u-equal-height">
@@ -239,54 +253,58 @@
       <h2>ML operations</h2>
       <h4>Infrastructure for production data science.</h4>
       <p>Centralised or multi-cloud training infrastructure for better resource allocation and data governance.</p>
-      <ul class="p-inline-images--small u-no-margin--bottom u-align-text--left">
-        <li class="p-inline-images__item u-no-margin--left u-no-margin--bottom">
+      <div class="p-logo-section__items u-no-margin--bottom u-align-text--left">
+        <div class="p-logo-section__item u-no-margin--left u-no-margin--bottom">
           {{ image (
             url="https://assets.ubuntu.com/v1/b1f04506-Kubeflow-Logo-RGB.svg",
             alt="Kubeflow",
             width="138",
             height="32",
             hi_def=True,
-            loading="auto|lazy"
+            loading="lazy",
+            attrs={"class": "p-logo-section__logo"}
             ) | safe
           }}
-        </li>
-        <li class="p-inline-images__item u-no-margin--left u-no-margin--bottom">
+        </div>
+        <div class="p-logo-section__item u-no-margin--left u-no-margin--bottom">
           {{ image (
             url="https://assets.ubuntu.com/v1/da0946e1-mlflow.png",
             alt="ML-Flow",
             width="104",
             height="40",
             hi_def=True,
-            loading="auto|lazy"
+            loading="lazy",
+            attrs={"class": "p-logo-section__logo"}
             ) | safe
           }}
-        </li>
-      </ul>
-      <ul class="p-inline-images--small u-no-margin--bottom u-align-text--left">
-        <li class="p-inline-images__item u-no-margin--left u-no-margin--bottom">
+        </div>
+      </div>
+      <div class="p-logo-section__items u-no-margin--bottom u-align-text--left">
+        <div class="p-logo-section__item u-no-margin--left u-no-margin--bottom">
           {{ image (
             url="https://assets.ubuntu.com/v1/6577232a-pachyderm-logo.svg",
             alt="Pachyderm",
             width="177",
             height="38",
             hi_def=True,
-            loading="auto|lazy"
+            loading="lazy",
+            attrs={"class": "p-logo-section__logo"}
             ) | safe
           }}
-        </li>
-        <li class="p-inline-images__item u-no-margin--left u-no-margin--bottom">
+        </div>
+        <div class="p-logo-section__item u-no-margin--left u-no-margin--bottom">
           {{ image (
             url="https://assets.ubuntu.com/v1/3d65e5fe-juju_black-orange_hex.svg",
             alt="Juju",
             width="89",
             height="32",
             hi_def=True,
-            loading="auto|lazy"
+            loading="lazy",
+            attrs={"class": "p-logo-section__logo"}
             ) | safe
           }}
-        </li>
-      </ul>
+        </div>
+      </div>
     </div>
     <div class="col-6">
       <div class="u-fixed-width">
@@ -295,65 +313,70 @@
       <h2>Data lake</h2>
       <h4>Analyse epic amounts of data, wherever it is.</h4>
       <p>Build large-scale data lakes optimised for machine learning on bare metal, virtual or cloud infrastructure with open source.</p>
-      <ul class="p-inline-images--small u-no-margin--bottom u-align-text--left">
-        <li class="p-inline-images__item u-no-margin--left u-no-margin--bottom">
+      <div class="p-logo-section__items u-no-margin--bottom u-align-text--left">
+        <div class="p-logo-section__item u-no-margin--left u-no-margin--bottom">
           {{ image (
             url="https://assets.ubuntu.com/v1/34b3ddce-Apache_Spark.png",
             alt="",
             width="61",
             height="32",
             hi_def=True,
-            loading="auto|lazy"
+            loading="lazy",
+            attrs={"class": "p-logo-section__logo"}
             ) | safe
           }}
-        </li>
-        <li class="p-inline-images__item u-no-margin--left u-no-margin--bottom">
+        </div>
+        <div class="p-logo-section__item u-no-margin--left u-no-margin--bottom">
           {{ image (
             url="https://assets.ubuntu.com/v1/c2a4ebd4-Kafka.svg",
             alt="Kafka",
             width="78",
             height="36",
             hi_def=True,
-            loading="auto|lazy"
+            loading="lazy",
+            attrs={"class": "p-logo-section__logo"}
             ) | safe
           }}
-        </li>
-        <li class="p-inline-images__item u-no-margin--left u-no-margin--bottom">
+        </div>
+        <div class="p-logo-section__item u-no-margin--left u-no-margin--bottom">
           {{ image (
             url="https://assets.ubuntu.com/v1/853e440f-Cassandra.svg",
             alt="Cassandra",
             width="96",
             height="64",
             hi_def=True,
-            loading="auto|lazy"
+            loading="lazy",
+            attrs={"class": "p-logo-section__logo"}
             ) | safe
           }}
-        </li>
-      </ul>
-      <ul class="p-inline-images--small u-no-margin--bottom u-align-text--left">
-        <li class="p-inline-images__item u-no-margin--left u-no-margin--bottom">
+        </div>
+      </div>
+      <div class="p-logo-section__items u-no-margin--bottom u-align-text--left">
+        <div class="p-logo-section__item u-no-margin--left u-no-margin--bottom">
           {{ image (
             url="https://assets.ubuntu.com/v1/93da3292-Elastic_logo.png",
             alt="Elastic",
             width="117",
             height="40",
             hi_def=True,
-            loading="auto|lazy"
+            loading="lazy",
+            attrs={"class": "p-logo-section__logo"}
             ) | safe
           }}
-        </li>
-        <li class="p-inline-images__item u-no-margin--left u-no-margin--bottom">
+        </div>
+        <div class="p-logo-section__item u-no-margin--left u-no-margin--bottom">
           {{ image (
             url="https://assets.ubuntu.com/v1/2aae3674-Hadoop.svg",
             alt="Hadoop",
             width="165",
             height="40",
             hi_def=True,
-            loading="auto|lazy"
+            loading="lazy",
+            attrs={"class": "p-logo-section__logo"}
             ) | safe
           }}
-        </li>
-      </ul>
+        </div>
+      </div>
     </div>
   </div>
   <div class="row u-equal-height">
@@ -364,54 +387,58 @@
       <h2>Hardware control</h2>
       <h4>Drivers, storage, networking, CPU, GPU, DPU.</h4>
       <p>Enjoy full control over your firmware, in a safe environment, tested by millions.</p>
-      <ul class="p-inline-images--small u-no-margin--bottom u-align-text--left">
-        <li class="p-inline-images__item u-no-margin--left u-no-margin--bottom">
+      <div class="p-logo-section__items u-no-margin--bottom u-align-text--left">
+        <div class="p-logo-section__item u-no-margin--left u-no-margin--bottom">
           {{ image (
             url="https://assets.ubuntu.com/v1/52d4cc16-Nvidia_Logo_Horizontal.svg",
             alt="Nvidia",
             width="167",
             height="32",
             hi_def=True,
-            loading="auto|lazy"
+            loading="lazy",
+            attrs={"class": "p-logo-section__logo"}
             ) | safe
           }}
-        </li>
-        <li class="p-inline-images__item u-no-margin--left u-no-margin--bottom">
+        </div>
+        <div class="p-logo-section__item u-no-margin--left u-no-margin--bottom">
           {{ image (
             url="https://assets.ubuntu.com/v1/7b141b13-partner-logo-amd.svg",
             alt="AMD",
             width="123",
             height="30",
             hi_def=True,
-            loading="auto|lazy"
+            loading="lazy",
+            attrs={"class": "p-logo-section__logo"}
             ) | safe
           }}
-        </li>
-      </ul>
-      <ul class="p-inline-images--small u-no-margin--bottom u-align-text--left">
-        <li class="p-inline-images__item u-no-margin--left u-no-margin--bottom">
+        </div>
+      </div>
+      <div class="p-logo-section__items u-no-margin--bottom u-align-text--left">
+        <div class="p-logo-section__item u-no-margin--left u-no-margin--bottom">
           {{ image (
             url="https://assets.ubuntu.com/v1/e0ef0377-intel-logo-2-1.png",
             alt="Intel",
             width="72",
             height="28",
             hi_def=True,
-            loading="auto|lazy"
+            loading="lazy",
+            attrs={"class": "p-logo-section__logo"}
             ) | safe
           }}
-        </li>
-        <li class="p-inline-images__item u-no-margin--left u-no-margin--bottom">
+        </div>
+        <div class="p-logo-section__item u-no-margin--left u-no-margin--bottom">
           {{ image (
             url="https://assets.ubuntu.com/v1/4efbd291-Arm_logo_blue_cropped.svg",
             alt="ARM",
             width="78",
             height="24",
             hi_def=True,
-            loading="auto|lazy"
+            loading="lazy",
+            attrs={"class": "p-logo-section__logo"}
             ) | safe
           }}
-        </li>
-      </ul>
+        </div>
+      </div>
     </div>
     <div class="col-6">
       <div class="u-fixed-width">
@@ -420,65 +447,70 @@
       <h2>Portable to scale</h2>
       <h4>Give your workloads consistency everywhere.</h4>
       <p>Portable from desktop to vast multi-clouds. Fast-deploy on every major public cloud with GPU acceleration.</p>
-      <ul class="p-inline-images--small u-no-margin--bottom u-align-text--left">
-        <li class="p-inline-images__item u-no-margin--left u-no-margin--bottom">
+      <div class="p-logo-section__items u-no-margin--bottom u-align-text--left">
+        <div class="p-logo-section__item u-no-margin--left u-no-margin--bottom">
           {{ image (
             url="https://assets.ubuntu.com/v1/38697bf3-server_brand-dark-grey.svg",
             alt="Server brand",
             width="45",
             height="48",
             hi_def=True,
-            loading="auto|lazy"
+            loading="lazy",
+            attrs={"class": "p-logo-section__logo"}
             ) | safe
           }}
-        </li>
-        <li class="p-inline-images__item u-no-margin--left u-no-margin--bottom">
+        </div>
+        <div class="p-logo-section__item u-no-margin--left u-no-margin--bottom">
           {{ image (
             url="https://assets.ubuntu.com/v1/7ecbaf72-OpenStack_openstack-logo.svg",
             alt="Openstack",
             width="49",
             height="48",
             hi_def=True,
-            loading="auto|lazy"
+            loading="lazy",
+            attrs={"class": "p-logo-section__logo"}
             ) | safe
           }}
-        </li>
-        <li class="p-inline-images__item u-no-margin--left u-no-margin--bottom">
+        </div>
+        <div class="p-logo-section__item u-no-margin--left u-no-margin--bottom">
           {{ image (
             url="https://assets.ubuntu.com/v1/a82add58-profile-aws.svg",
             alt="AWS",
             width="67",
             height="40",
             hi_def=True,
-            loading="auto|lazy"
+            loading="lazy",
+            attrs={"class": "p-logo-section__logo"}
             ) | safe
           }}
-        </li>
-      </ul>
-      <ul class="p-inline-images--small u-no-margin--bottom u-align-text--left">
-        <li class="p-inline-images__item u-no-margin--left u-no-margin--bottom">
+        </div>
+      </div>
+      <div class="p-logo-section__items u-no-margin--bottom u-align-text--left">
+        <div class="p-logo-section__item u-no-margin--left u-no-margin--bottom">
           {{ image (
             url="https://assets.ubuntu.com/v1/e5f6bd10-Google_Cloud_Platform-Logo.png",
             alt="Google Cloud",
             width="179",
             height="28",
             hi_def=True,
-            loading="auto|lazy"
+            loading="lazy",
+            attrs={"class": "p-logo-section__logo"}
             ) | safe
           }}
-        </li>
-        <li class="p-inline-images__item u-no-margin--left u-no-margin--bottom">
+        </div>
+        <div class="p-logo-section__item u-no-margin--left u-no-margin--bottom">
           {{ image (
             url="https://assets.ubuntu.com/v1/da9a1344-Microsoft-Azure-logo_stacked_transparent.png",
             alt="Microsoft Azure",
             width="112",
             height="32",
             hi_def=True,
-            loading="auto|lazy"
+            loading="lazy",
+            attrs={"class": "p-logo-section__logo"}
             ) | safe
           }}
-        </li>
-      </ul>
+        </div>
+      </div>
     </div>
   </div>
 </section>
@@ -506,7 +538,7 @@
         width="400",
         height="353",
         hi_def=True,
-        loading="auto|lazy"
+        loading="lazy"
         ) | safe
       }}
     </div>
@@ -522,7 +554,7 @@
         width="300",
         height="324",
         hi_def=True,
-        loading="auto|lazy"
+        loading="lazy"
         ) | safe
       }}
     </div>
@@ -565,7 +597,7 @@
         width="300",
         height="293",
         hi_def=True,
-        loading="auto|lazy"
+        loading="lazy"
         ) | safe
       }}
     </div>
@@ -585,7 +617,7 @@
               width="32",
               height="28",
               hi_def=True,
-              loading="auto|lazy",
+              loading="lazy",
               attrs={"class": "p-heading-icon__img p-heading-icon__img--small"},
               ) | safe
             }}
@@ -608,7 +640,7 @@
               width="32",
               height="28",
               hi_def=True,
-              loading="auto|lazy",
+              loading="lazy",
               attrs={"class": "p-heading-icon__img p-heading-icon__img--small"},
               ) | safe
             }}
@@ -628,7 +660,7 @@
               width="32",
               height="28",
               hi_def=True,
-              loading="auto|lazy",
+              loading="lazy",
               attrs={"class": "p-heading-icon__img p-heading-icon__img--small"},
               ) | safe
             }}
@@ -677,7 +709,7 @@
       width="281",
       height="200",
       hi_def=True,
-      loading="auto|lazy"
+      loading="lazy"
       ) | safe
       }}
     </div>

--- a/templates/ai/what-is-kubeflow.html
+++ b/templates/ai/what-is-kubeflow.html
@@ -40,7 +40,7 @@
   <div>
     <h2 class="p-muted-heading u-align--center">Contributors to Kubeflow</h2>
     <ul class="p-inline-images">
-      <li class="p-inline-images__item">
+      <li class="p-logo-section__item">
         {{
           image(
             url="https://assets.ubuntu.com/v1/bc4d28f8-Google_2015_logo.svg",
@@ -48,12 +48,12 @@
             height="42",
             width="128",
             hi_def=True,
-            attrs={"class": "p-inline-images__logos"},
+            attrs={"class": "p-logo-section__logos"},
             loading="lazy",
           ) | safe
         }}
       </li>
-      <li class="p-inline-images__item">
+      <li class="p-logo-section__item">
         {{
           image(
             url="https://assets.ubuntu.com/v1/b179abab-microsoft-logo+copy.svg",
@@ -61,12 +61,12 @@
             height="33",
             width="145",
             hi_def=True,
-            attrs={"class": "p-inline-images__logos"},
+            attrs={"class": "p-logo-section__logos"},
             loading="lazy",
           ) | safe
         }}
       </li>
-      <li class="p-inline-images__item">
+      <li class="p-logo-section__item">
         {{
           image(
             url="https://assets.ubuntu.com/v1/5d6da5c4-logo-canonical-aubergine.svg",
@@ -74,12 +74,12 @@
             height="20",
             width="140",
             hi_def=True,
-            attrs={"class": "p-inline-images__logos"},
+            attrs={"class": "p-logo-section__logos"},
             loading="lazy",
           ) | safe
         }}
       </li>
-      <li class="p-inline-images__item">
+      <li class="p-logo-section__item">
         {{
           image(
             url="https://assets.ubuntu.com/v1/16aec8e3-cisco-logo-transparent.png",
@@ -87,12 +87,12 @@
             height="53",
             width="110",
             hi_def=True,
-            attrs={"class": "p-inline-images__logos"},
+            attrs={"class": "p-logo-section__logos"},
             loading="lazy",
           ) | safe
         }}
       </li>
-      <li class="p-inline-images__item">
+      <li class="p-logo-section__item">
         {{
           image(
             url="https://assets.ubuntu.com/v1/67db21e0-logo-ibm.png",
@@ -100,12 +100,12 @@
             height="40",
             width="90",
             hi_def=True,
-            attrs={"class": "p-inline-images__logos"},
+            attrs={"class": "p-logo-section__logos"},
             loading="lazy",
           ) | safe
         }}
       </li>
-      <li class="p-inline-images__item">
+      <li class="p-logo-section__item">
         {{
           image(
             url="https://assets.ubuntu.com/v1/e0ef0377-intel-logo-2-1.png",
@@ -113,7 +113,7 @@
             height="35",
             width="90",
             hi_def=True,
-            attrs={"class": "p-inline-images__logos"},
+            attrs={"class": "p-logo-section__logos"},
             loading="lazy",
           ) | safe
         }}
@@ -158,7 +158,7 @@
     </div>
     <div class="col-5 u-hide--small u-hide--medium">
       <ul class="p-inline-images">
-        <li class="p-inline-images__item">
+        <li class="p-logo-section__item">
         {{
           image(
             url="https://assets.ubuntu.com/v1/8ee86883-jupyter-logo.png",
@@ -166,12 +166,12 @@
             height="90",
             width="80",
             hi_def=True,
-            attrs={"class": "p-inline-images__logos"},
+            attrs={"class": "p-logo-section__logos"},
             loading="lazy",
           ) | safe
         }}
         </li>
-        <li class="p-inline-images__item ">
+        <li class="p-logo-section__item ">
         {{
           image(
             url="https://assets.ubuntu.com/v1/c4da5b86-Tensor-flow-logo.png",
@@ -179,12 +179,12 @@
             height="90",
             width="90",
             hi_def=True,
-            attrs={"class": "p-inline-images__logos"},
+            attrs={"class": "p-logo-section__logos"},
             loading="lazy",
           ) | safe
         }}
         </li>
-        <li class="p-inline-images__item">
+        <li class="p-logo-section__item">
         {{
           image(
             url="https://assets.ubuntu.com/v1/6d6b4148-seldon-logo.png",
@@ -192,12 +192,12 @@
             height="90",
             width="100",
             hi_def=True,
-            attrs={"class": "p-inline-images__logos"},
+            attrs={"class": "p-logo-section__logos"},
             loading="lazy",
           ) | safe
         }}
         </li>
-        <li class="p-inline-images__item">
+        <li class="p-logo-section__item">
         {{
           image(
             url="https://assets.ubuntu.com/v1/a774cbbb-py-torch-logo.png",
@@ -205,12 +205,12 @@
             height="90",
             width="100",
             hi_def=True,
-            attrs={"class": "p-inline-images__logos"},
+            attrs={"class": "p-logo-section__logos"},
             loading="lazy",
           ) | safe
         }}
         </li>
-        <li class="p-inline-images__item">
+        <li class="p-logo-section__item">
         {{
           image(
             url="https://assets.ubuntu.com/v1/5d796b1c-itsio-logo.png",
@@ -218,12 +218,12 @@
             height="60",
             width="100",
             hi_def=True,
-            attrs={"class": "p-inline-images__logos"},
+            attrs={"class": "p-logo-section__logos"},
             loading="lazy",
           ) | safe
         }}
         </li>
-        <li class="p-inline-images__item">
+        <li class="p-logo-section__item">
         {{
           image(
             url="https://assets.ubuntu.com/v1/6b57da22-mxnet-logo.png",
@@ -231,12 +231,12 @@
             height="40",
             width="110",
             hi_def=True,
-            attrs={"class": "p-inline-images__logos"},
+            attrs={"class": "p-logo-section__logos"},
             loading="lazy",
           ) | safe
         }}
         </li>
-        <li class="p-inline-images__item">
+        <li class="p-logo-section__item">
         {{
           image(
             url="https://assets.ubuntu.com/v1/41913ead-katib-logo.png",
@@ -244,12 +244,12 @@
             height="90",
             width="75",
             hi_def=True,
-            attrs={"class": "p-inline-images__logos"},
+            attrs={"class": "p-logo-section__logos"},
             loading="lazy",
           ) | safe
         }}
         </li>
-        <li class="p-inline-images__item">
+        <li class="p-logo-section__item">
         {{
           image(
             url="https://assets.ubuntu.com/v1/826d5be3-1200px-Prometheus_software_logo.svg.png",
@@ -257,12 +257,12 @@
             height="80",
             width="80",
             hi_def=True,
-            attrs={"class": "p-inline-images__logos"},
+            attrs={"class": "p-logo-section__logos"},
             loading="lazy",
           ) | safe
         }}
         </li>
-        <li class="p-inline-images__item">
+        <li class="p-logo-section__item">
         {{
           image(
             url="https://assets.ubuntu.com/v1/3d0a8131-ambassador-logo.png",
@@ -270,12 +270,12 @@
             height="100",
             width="80",
             hi_def=True,
-            attrs={"class": "p-inline-images__logos"},
+            attrs={"class": "p-logo-section__logos"},
             loading="lazy",
           ) | safe
         }}
         </li>
-        <li class="p-inline-images__item">
+        <li class="p-logo-section__item">
         {{
           image(
             url="https://assets.ubuntu.com/v1/653daa8b-onnx-logo.png",
@@ -283,12 +283,12 @@
             height="30",
             width="110",
             hi_def=True,
-            attrs={"class": "p-inline-images__logos"},
+            attrs={"class": "p-logo-section__logos"},
             loading="lazy",
           ) | safe
         }}
         </li>
-        <li class="p-inline-images__item">
+        <li class="p-logo-section__item">
         {{
           image(
             url="https://assets.ubuntu.com/v1/2af7ca99-xgboost-logo.png",
@@ -296,12 +296,12 @@
             height="37",
             width="110",
             hi_def=True,
-            attrs={"class": "p-inline-images__logos"},
+            attrs={"class": "p-logo-section__logos"},
             loading="lazy",
           ) | safe
         }}
         </li>
-        <li class="p-inline-images__item">
+        <li class="p-logo-section__item">
         {{
           image(
             url="https://assets.ubuntu.com/v1/f4ffa06e-scikit-learn-logo.png",
@@ -309,12 +309,12 @@
             height="60",
             width="110",
             hi_def=True,
-            attrs={"class": "p-inline-images__logos"},
+            attrs={"class": "p-logo-section__logos"},
             loading="lazy",
           ) | safe
         }}
         </li>
-        <li class="p-inline-images__item ">
+        <li class="p-logo-section__item ">
         {{
           image(
             url="https://assets.ubuntu.com/v1/7c4d800a-pachyderm-logo.png",
@@ -322,7 +322,7 @@
             height="100",
             width="110",
             hi_def=True,
-            attrs={"class": "p-inline-images__logos"},
+            attrs={"class": "p-logo-section__logos"},
             loading="lazy",
           ) | safe
         }}
@@ -399,7 +399,7 @@
     </div>
  <div class="col-6 u-vertically-center">
       <ul class="p-inline-images">
-        <li class="p-inline-images__item">
+        <li class="p-logo-section__item">
           {{
             image(
               url="https://assets.ubuntu.com/v1/0c18b0ae-paypal_logo.svg",
@@ -407,12 +407,12 @@
               height="22",
               width="85",
               hi_def=True,
-              attrs={"class": "p-inline-images__logos"},
+              attrs={"class": "p-logo-section__logos"},
               loading="lazy",
             ) | safe
           }}
         </li>
-        <li class="p-inline-images__item">
+        <li class="p-logo-section__item">
           {{
             image(
               url="https://assets.ubuntu.com/v1/4a1c3691-lyft.svg",
@@ -420,12 +420,12 @@
               height="30",
               width="45",
               hi_def=True,
-              attrs={"class": "p-inline-images__logos"},
+              attrs={"class": "p-logo-section__logos"},
               loading="lazy",
             ) | safe
           }}
         </li>
-        <li class="p-inline-images__item">
+        <li class="p-logo-section__item">
           {{
             image(
               url="https://assets.ubuntu.com/v1/9131d1b3-CERN_logo.svg",
@@ -433,12 +433,12 @@
               height="50",
               width="50",
               hi_def=True,
-              attrs={"class": "p-inline-images__logos"},
+              attrs={"class": "p-logo-section__logos"},
               loading="lazy",
             ) | safe
           }}
         </li>
-        <li class="p-inline-images__item">
+        <li class="p-logo-section__item">
           {{
             image(
               url="https://assets.ubuntu.com/v1/547ef405-uber.svg",
@@ -446,12 +446,12 @@
               height="20",
               width="60",
               hi_def=True,
-              attrs={"class": "p-inline-images__logos"},
+              attrs={"class": "p-logo-section__logos"},
               loading="lazy",
             ) | safe
           }}
         </li>
-        <li class="p-inline-images__item">
+        <li class="p-logo-section__item">
           {{
             image(
               url="https://assets.ubuntu.com/v1/2400d5a7-Spotify_logo_with_text.svg",
@@ -459,12 +459,12 @@
               height="30",
               width="95",
               hi_def=True,
-              attrs={"class": "p-inline-images__logos"},
+              attrs={"class": "p-logo-section__logos"},
               loading="lazy",
             ) | safe
           }}
         </li>
-        <li class="p-inline-images__item">
+        <li class="p-logo-section__item">
           {{
             image(
               url="https://assets.ubuntu.com/v1/015ae0cc-Bloomberg.svg",
@@ -472,12 +472,12 @@
               height="110",
               width="110",
               hi_def=True,
-              attrs={"class": "p-inline-images__logos"},
+              attrs={"class": "p-logo-section__logos"},
               loading="lazy",
             ) | safe
           }}
         </li>
-        <li class="p-inline-images__item">
+        <li class="p-logo-section__item">
           {{
             image(
               url="https://assets.ubuntu.com/v1/4f597a36-Shopify.svg",
@@ -485,7 +485,7 @@
               height="110",
               width="110",
               hi_def=True,
-              attrs={"class": "p-inline-images__logos"},
+              attrs={"class": "p-logo-section__logos"},
               loading="lazy",
             ) | safe
           }}

--- a/templates/appliance/hardware.html
+++ b/templates/appliance/hardware.html
@@ -581,17 +581,17 @@
   <div class="row">
     <div class="col-12">
       <ul class="p-inline-images">
-        <li class="p-inline-images__item">
-          <img class="p-inline-images__logo" src="https://assets.ubuntu.com/v1/6077ee45-Dell.svg" alt="Dell">
+        <li class="p-logo-section__item">
+          <img class="p-logo-section__logo" src="https://assets.ubuntu.com/v1/6077ee45-Dell.svg" alt="Dell">
         </li>
-        <li class="p-inline-images__item">
-          <img class="p-inline-images__logo" src="https://assets.ubuntu.com/v1/1ca57ae1-Lenovo.svg" alt="Lenovo">
+        <li class="p-logo-section__item">
+          <img class="p-logo-section__logo" src="https://assets.ubuntu.com/v1/1ca57ae1-Lenovo.svg" alt="Lenovo">
         </li>
-        <li class="p-inline-images__item">
-          <img class="p-inline-images__logo" src="https://assets.ubuntu.com/v1/ffda2d20-HP.svg" alt="HP">
+        <li class="p-logo-section__item">
+          <img class="p-logo-section__logo" src="https://assets.ubuntu.com/v1/ffda2d20-HP.svg" alt="HP">
         </li>
-        <li class="p-inline-images__item">
-          <img class="p-inline-images__logo" src="https://assets.ubuntu.com/v1/185a14f4-Avnet.png" alt="Avnet">
+        <li class="p-logo-section__item">
+          <img class="p-logo-section__logo" src="https://assets.ubuntu.com/v1/185a14f4-Avnet.png" alt="Avnet">
         </li>
       </ul>
     </div>

--- a/templates/azure/ebook/index.html
+++ b/templates/azure/ebook/index.html
@@ -1,0 +1,99 @@
+{% extends "azure/base_azure.html" %}
+
+{% block title %}Why do Cloud innovators migrate to Pro? Get the e-book.{% endblock %}
+{% block meta_description %}Learn about the security compliance and support features of the Linux based Ubuntu Pro image on Azure.{% endblock %}
+{% block meta_copydoc %}https://docs.google.com/document/d/1JL_TeFBg1tSqiYIiXU0IwJTKWRDKJEXWtEgLRWFnToI/edit#{% endblock meta_copydoc %}
+
+{% block head_extra %}
+  <style>
+    h2,
+    .p-heading--2 {
+      font-weight: 300;
+    }
+  </style>
+{% endblock %}
+
+{% block content %}
+
+<section class="p-strip--suru-bottomed">
+  <div class="row">
+    <div class="col-7 u-vertically-center">
+      <div>
+        <h1>Why do cloud innovators migrate to Ubuntu Pro?</h1>
+
+        <p class="u-no-padding--top p-heading--4">Get our e-book to find out</p>
+
+        <p>
+          <a href="#ubuntu-pro-ebook" class="p-button--positive">Download<span class="u-off-screen"> the Why do Cloud innovators migrate to Pro? e-book by completing this form</span></a>
+        </p>
+      </div>
+    </div>
+    <div class="col-5 u-hide--small u-vertically-center u-align--center">
+      {{ image (
+        url="https://assets.ubuntu.com/v1/0959ce33-NEW_Ubuntu_ebook_1.png",
+        alt="",
+        width="214",
+        height="300",
+        hi_def=True,
+        loading="auto",
+        attrs={ "class": "p-image--bordered"}
+        ) | safe
+      }}
+    </div>
+  </div>
+</section>
+
+{% include "azure/shared/_azure-logo-strip.html" %}
+
+<div class="p-strip--light">
+  <div class="row">
+    <div class="col-7">
+      <h2 class="p-heading--4">Ubuntu Pro for Azure is a premium image delivering the most comprehensive open source security and compliance</h2>
+
+      <hr class="p-separator u-no-margin--top" />
+
+      <p class="p-heading--4"><strong>70% of Azure virtual machines are running on Ubuntu due to reliability and ease of use</strong></p>
+
+      <p>As the publishers of Ubuntu, we went one step further and developed a premium Ubuntu Pro image in partnership with public cloud providers, to deliver a preferred open-source solution for cloud innovators.</p>
+
+      <p>Here is our latest e-book, where we share the details of how Ubuntu Pro on Azure delivers extended open-source security, enterprise compliance, 10 years of extended maintenance and more.</p>
+    </div>
+
+    <div class="col-5" id="ubuntu-pro-ebook">
+      {% with id="4393", returnURL="/azure/ebook/thank-you", cta="Get the e-book", cta_class="p-button--positive" %}
+        {% include "engage/shared/_en_engage_form.html" %}
+      {% endwith %}
+    </div>
+  </div>
+</div>
+
+<div class="p-strip">
+  {% include "azure/shared/_how-ubuntu-pro-helps-you.html" %}
+</div>
+
+<div class="p-strip--light">
+  <div class="row">
+    <div class="col-7">
+      <h2>Level up your Ubuntu journey by activating this private Azure Marketplace offer</h2>
+
+      <p>Already running Ubuntu on Microsoft Azure, or planning a migration to the public cloud?</p>
+
+      <p>Leverage Canonical's expert service and all the features of Ubuntu Pro with this exclusive private offer.</p>
+
+      <a href="/azure/private-offer" class="p-button--positive">Learn more</a>
+    </div>
+    
+    <div class="col-5 u-align--center">
+      {{ image (
+        url="https://assets.ubuntu.com/v1/71fe6a11-private-offer-shield.svg",
+        alt="",
+        width="206",
+        height="234",
+        hi_def=True,
+        loading="lazy"
+        ) | safe
+      }}
+    </div>
+  </div>
+</div>
+{% endblock %}

--- a/templates/azure/ebook/thank-you.html
+++ b/templates/azure/ebook/thank-you.html
@@ -1,0 +1,40 @@
+{% extends "engage/base_engage.html" %}
+
+{% block title %}Download {{ resource_name }} {% endblock %}
+
+{% block head_extra%}<meta name="robots" content="noindex" />{% endblock %}
+
+{% block content %}
+<section class="p-strip p-engage-banner--grad">
+  <div class="u-fixed-width navigation-logo-engage">
+    <a href="/">
+      {{
+        image(
+            url="https://assets.ubuntu.com/v1/f263d9c4-logo-ubuntu-white.svg",
+            alt="Ubuntu",
+            width="143",
+            height="32",
+            hi_def=True,
+            loading="auto",
+        ) | safe
+      }}
+    </a>
+  </div>
+  <div class="row">
+    <div class="col-8">
+      <h1>Thank you</h1>
+    </div>
+  </div>
+</section>
+
+<section class="p-strip">
+  <div class="row">
+    <div class="col-8">
+      <p>The ebook is now ready to download.</p>
+      <p>
+        <a class="p-button--positive" href="https://pages.ubuntu.com/rs/066-EOV-335/images/ubuntu_pro_ebook.pdf">Download</a>
+      </p>
+    </div>
+  </div>
+</section>
+{% endblock content %}

--- a/templates/azure/private-offer.html
+++ b/templates/azure/private-offer.html
@@ -2,7 +2,7 @@
 
 {% block title %}Azure Private Offer{% endblock %}
 {% block meta_description %}Ubuntu on Azure Private Offer - Get exclusive services and support for your large scale Linux operation{% endblock %}
-{% block meta_copydoc %}https://docs.google.com/document/d/1ZgV1ZiyHJe3UNQkj0I-OCpZ4MIAWLHheig2Q2rclcuk/edit{% endblock meta_copydoc %}
+{% block meta_copydoc %}https://docs.google.com/document/d/1P4sqhsi6jqWwbqjrBDuAOABGIcbJDM6Efy59ztaroVk/edit{% endblock meta_copydoc %}
 
 {% block head_extra %}
   <style>
@@ -17,17 +17,17 @@
 <section class="p-strip--suru-blog-header">
   <div class="row">
     <div class="col-7 u-vertically-center">
-      <h1>Join cloud innovators today</h1>
+      <h1>Get 24/7 SLA support and enhanced security with our private offer</h1>
 
-      <p class="u-no-padding--top p-heading--4">Free your mind so you can focus on what matters</p>
+      <p class="u-no-padding--top p-heading--4">Choose the broadest open-source security coverage in the cloud</p>
 
       <p>
-        <a href="#private-offer-form" class="p-button--positive">Get the exclusive private offer</a>
+        <a href="#private-offer-form" class="p-button--positive">Get private offer</a>
       </p>
     </div>
     <div class="col-5 u-hide--small u-vertically-center u-align--center">
       {{ image (
-        url="https://assets.ubuntu.com/v1/ee1049ee-Ubuntu+Pro+-+Private+offer+shield2.svg",
+        url="https://assets.ubuntu.com/v1/71fe6a11-private-offer-shield.svg",
         alt="",
         width="206",
         height="232",
@@ -44,18 +44,18 @@
 <section class="p-strip--light">
   <div class="row">
     <div class="col-7">
-      <h2 class="p-heading--4">Canonical has the expertise to assist you in your project</h2>
+      <h2 class="p-heading--4">Ubuntu Pro for Azure is a premium image delivering the most comprehensive open source security and complianc</h2>
 
       <hr class="p-separator u-no-margin--top" />
       
-      <h2>Get Azure integrated support with SLA from Canonical to gain 24/7 open-source expertise at your disposal with the private offer</h2>
+      <h2 class="p-heading--4"><strong>Get Azure integrated support with SLA from Canonical to gain 24/7 open-source expertise at your disposal with the private offer</strong></h2>
 
       <p>OS level support from Canonical enhances Microsoft support and utilises the existing workflows for Ubuntu-based operational or break-fix support issues.</p>
 
-      <p>Private offer also supports an ability to work from a set of images that have been hardened and optimised for security and operations for the whole organisation. This simplifies IT governance and allows all your internal users to seamlessly follow your strategy.</p>
+      <p>The private offer also supports an ability to work from a set of images that have been hardened and optimised for security and operations for the whole organisation. This simplifies IT governance and allows all your internal users to seamlessly follow your strategy.</p>
     </div>
     <div class="col-5" id="private-offer-form">
-      {% with id="4394", returnURL="/azure/thank-you", cta="Get the exclusive private offer" %}
+      {% with id="4394", returnURL="/azure/thank-you", cta="Get the exclusive private offer", cta_class="p-button--positive" %}
         {% include "engage/shared/_en_engage_form.html" %}
       {% endwith %}
     </div>
@@ -99,7 +99,7 @@
       }}
     </div>
     <div class="col-6">
-      <h2>Uplevel Ubuntu journey by activating this private Azure Marketplace offer</h2>
+      <h2>Level up your Ubuntu journey by activating this private Azure Marketplace offer</h2>
 
       <p>Already running Ubuntu on Microsoft Azure, or planning a migration to the public cloud?</p>
 

--- a/templates/ceph/what-is-ceph.html
+++ b/templates/ceph/what-is-ceph.html
@@ -171,7 +171,7 @@
         NOTABLE CEPH USERS
       </h2>
       <ul class="p-inline-images">
-        <li class="p-inline-images__item">
+        <li class="p-logo-section__item">
           {{
             image(
               url="https://assets.ubuntu.com/v1/202457a2-CERN_logo2.svg",
@@ -179,12 +179,12 @@
               height="138",
               width="140",
               hi_def=True,
-              attrs={"class": "p-inline-images__logo"},
+              attrs={"class": "p-logo-section__logo"},
               loading="lazy",
             ) | safe
           }}
         </li>
-        <li class="p-inline-images__item">
+        <li class="p-logo-section__item">
           {{
             image(
               url="https://assets.ubuntu.com/v1/d199354d-2018-logo-deutsche-telekom.svg",
@@ -192,12 +192,12 @@
               height="145",
               width="145",
               hi_def=True,
-              attrs={"class": "p-inline-images__logo"},
+              attrs={"class": "p-logo-section__logo"},
               loading="lazy",
             ) | safe
           }}
         </li>
-        <li class="p-inline-images__item">
+        <li class="p-logo-section__item">
           {{
             image(
               url="https://assets.ubuntu.com/v1/9ae8ff55-2018-logo-bloomberg.svg",
@@ -205,12 +205,12 @@
               height="145",
               width="145",
               hi_def=True,
-              attrs={"class": "p-inline-images__logo"},
+              attrs={"class": "p-logo-section__logo"},
               loading="lazy",
             ) | safe
           }}
         </li>
-        <li class="p-inline-images__item">
+        <li class="p-logo-section__item">
           {{
             image(
               url="https://assets.ubuntu.com/v1/80ab9b3c-2018-logo-cisco.svg",
@@ -218,12 +218,12 @@
               height="145",
               width="145",
               hi_def=True,
-              attrs={"class": "p-inline-images__logo"},
+              attrs={"class": "p-logo-section__logo"},
               loading="lazy",
             ) | safe
           }}
         </li>
-        <li class="p-inline-images__item">
+        <li class="p-logo-section__item">
           {{
             image(
               url="https://assets.ubuntu.com/v1/5029f949-Dream-Host-logo.png",
@@ -231,12 +231,12 @@
               height="46",
               width="145",
               hi_def=True,
-              attrs={"class": "p-inline-images__logo"},
+              attrs={"class": "p-logo-section__logo"},
               loading="lazy",
             ) | safe
           }}
         </li>
-        <li class="p-inline-images__item">
+        <li class="p-logo-section__item">
           {{
             image(
               url="https://assets.ubuntu.com/v1/53b8a9c1-DigitalOcean_logo.svg",
@@ -244,7 +244,7 @@
               height="145",
               width="145",
               hi_def=True,
-              attrs={"class": "p-inline-images__logo"},
+              attrs={"class": "p-logo-section__logo"},
               loading="lazy",
             ) | safe
           }}
@@ -275,7 +275,7 @@
         INFLUENTIAL CONTRIBUTORS TO CEPH
       </h2>
       <ul class="p-inline-images">
-        <li class="p-inline-images__item">
+        <li class="p-logo-section__item">
           {{
             image(
               url="https://assets.ubuntu.com/v1/5d6da5c4-logo-canonical-aubergine.svg",
@@ -283,12 +283,12 @@
               height="47",
               width="144",
               hi_def=True,
-              attrs={"class": "p-inline-images__logo"},
+              attrs={"class": "p-logo-section__logo"},
               loading="lazy",
             ) | safe
           }}
         </li>
-        <li class="p-inline-images__item">
+        <li class="p-logo-section__item">
           {{
             image(
               url="https://assets.ubuntu.com/v1/202457a2-CERN_logo2.svg",
@@ -296,12 +296,12 @@
               height="138",
               width="140",
               hi_def=True,
-              attrs={"class": "p-inline-images__logo"},
+              attrs={"class": "p-logo-section__logo"},
               loading="lazy",
             ) | safe
           }}
         </li>
-        <li class="p-inline-images__item">
+        <li class="p-logo-section__item">
           {{
             image(
               url="https://assets.ubuntu.com/v1/80ab9b3c-2018-logo-cisco.svg",
@@ -309,12 +309,12 @@
               height="145",
               width="145",
               hi_def=True,
-              attrs={"class": "p-inline-images__logo"},
+              attrs={"class": "p-logo-section__logo"},
               loading="lazy",
             ) | safe
           }}
         </li>
-        <li class="p-inline-images__item">
+        <li class="p-logo-section__item">
           {{
             image(
               url="https://assets.ubuntu.com/v1/8d9986ed-2018-logo-Fujitsu.svg",
@@ -322,12 +322,12 @@
               height="145",
               width="145",
               hi_def=True,
-              attrs={"class": "p-inline-images__logo"},
+              attrs={"class": "p-logo-section__logo"},
               loading="lazy",
             ) | safe
           }}
         </li>
-        <li class="p-inline-images__item">
+        <li class="p-logo-section__item">
           {{
             image(
               url="https://assets.ubuntu.com/v1/94ea495b-2018-logo-Intel.svg",
@@ -335,12 +335,12 @@
               height="145",
               width="145",
               hi_def=True,
-              attrs={"class": "p-inline-images__logo"},
+              attrs={"class": "p-logo-section__logo"},
               loading="lazy",
             ) | safe
           }}
         </li>
-        <li class="p-inline-images__item">
+        <li class="p-logo-section__item">
           {{
             image(
               url="https://assets.ubuntu.com/v1/be89e41a-red-hat-2019-primary-stacked.svg",
@@ -348,12 +348,12 @@
               height="128",
               width="120",
               hi_def=True,
-              attrs={"class": "p-inline-images__logo"},
+              attrs={"class": "p-logo-section__logo"},
               loading="lazy",
             ) | safe
           }}
         </li>
-        <li class="p-inline-images__item">
+        <li class="p-logo-section__item">
           {{
             image(
               url="https://assets.ubuntu.com/v1/9a1f50f7-partner-logo-sandisk.svg",
@@ -361,7 +361,7 @@
               height="30",
               width="144",
               hi_def=True,
-              attrs={"class": "p-inline-images__logo"},
+              attrs={"class": "p-logo-section__logo"},
               loading="lazy",
             ) | safe
           }}

--- a/templates/cloud/public-cloud.html
+++ b/templates/cloud/public-cloud.html
@@ -106,7 +106,7 @@
     </div>
     <div class="col-6 u-vertically-center">
       <ul class="p-inline-images">
-        <li class="p-inline-images__item">
+        <li class="p-logo-section__item">
           {{
             image(
               url="https://assets.ubuntu.com/v1/a82add58-profile-aws.svg",
@@ -118,7 +118,7 @@
             ) | safe
           }}
         </li>
-        <li class="p-inline-images__item">
+        <li class="p-logo-section__item">
           {{
             image(
               url="https://assets.ubuntu.com/v1/da9a1344-Microsoft-Azure-logo_stacked_transparent.png",
@@ -130,7 +130,7 @@
             ) | safe
           }}
         </li>
-        <li class="p-inline-images__item">
+        <li class="p-logo-section__item">
           {{ image (
             url="https://assets.ubuntu.com/v1/8c1c38b0-google-cloud-3.svg",
             alt="Google Cloud",

--- a/templates/containers/what-are-containers.html
+++ b/templates/containers/what-are-containers.html
@@ -251,7 +251,7 @@
         height="171",
         hi_def=True,
         loading="lazy",
-        attrs={"class": "p-inline-images__logos"},
+        attrs={"class": "p-logo-section__logos"},
         ) | safe
       }}
     </div>

--- a/templates/core/index.html
+++ b/templates/core/index.html
@@ -29,7 +29,7 @@
   <div class="row u-vertically-center u-align--center" style="position: relative; top: -2rem;">
     <p class="p-muted-heading u-no-max-width p-heading--5">Get to market fast with our device partners</p>
     <ul class="p-inline-images">
-      <li class="p-inline-images__item">
+      <li class="p-logo-section__item">
         {{
         image(
         url="https://assets.ubuntu.com/v1/c24cb4b9-logo-intel.svg",
@@ -41,7 +41,7 @@
         ) | safe
         }}
       </li>
-      <li class="p-inline-images__item">
+      <li class="p-logo-section__item">
         {{
         image(
         url="https://assets.ubuntu.com/v1/016b770d-raspberry+pi+horizontal.svg",
@@ -53,7 +53,7 @@
         ) | safe
         }}
       </li>
-      <li class="p-inline-images__item">
+      <li class="p-logo-section__item">
         {{ image (
         url="https://assets.ubuntu.com/v1/731aab6c-logo-amd.svg",
         alt="AMD",
@@ -64,7 +64,7 @@
         ) | safe
         }}
       </li>
-      <li class="p-inline-images__item">
+      <li class="p-logo-section__item">
         {{ image (
         url="https://assets.ubuntu.com/v1/1ac0e434-Nvidia_Logo_Horizontal.svg",
         alt="NVIDIA",
@@ -75,7 +75,7 @@
         ) | safe
         }}
       </li>
-      <li class="p-inline-images__item">
+      <li class="p-logo-section__item">
         {{ image (
         url="https://assets.ubuntu.com/v1/3cf238fd-Qualcomm-Logo.svg",
         alt="QUALCOMM",
@@ -86,7 +86,7 @@
         ) | safe
         }}
       </li>
-      <li class="p-inline-images__item">
+      <li class="p-logo-section__item">
         {{ image (
         url="https://assets.ubuntu.com/v1/c95e6028-rigado-logo.png",
         alt="RIGADO",
@@ -97,7 +97,7 @@
         ) | safe
         }}
       </li>
-      <li class="p-inline-images__item">
+      <li class="p-logo-section__item">
         {{ image (
         url="https://assets.ubuntu.com/v1/e9dabb1f-adlink+logo.png",
         alt="ADLINK",
@@ -108,7 +108,7 @@
         ) | safe
         }}
       </li>
-      <li class="p-inline-images__item">
+      <li class="p-logo-section__item">
         {{ image (
         url="https://assets.ubuntu.com/v1/582bee22-avantech-logo.png",
         alt="Avantech",
@@ -119,7 +119,7 @@
         ) | safe
         }}
       </li>
-      <li class="p-inline-images__item">
+      <li class="p-logo-section__item">
         {{ image (
         url="https://assets.ubuntu.com/v1/185a14f4-Avnet.png",
         alt="Avnet",
@@ -130,7 +130,7 @@
         ) | safe
         }}
       </li>
-      <li class="p-inline-images__item">
+      <li class="p-logo-section__item">
         {{
         image(
         url="https://assets.ubuntu.com/v1/97e29c13-Dell.svg",
@@ -142,7 +142,7 @@
         ) | safe
         }}
       </li>
-      <li class="p-inline-images__item">
+      <li class="p-logo-section__item">
         {{ image (
         url="https://assets.ubuntu.com/v1/53de61ea-honeywell-logo.png",
         alt="Honeywell",
@@ -153,7 +153,7 @@
         ) | safe
         }}
       </li>
-      <li class="p-inline-images__item">
+      <li class="p-logo-section__item">
         {{ image (
         url="https://assets.ubuntu.com/v1/156ddbf8-rexroth_logo.svg",
         alt="rexroth",
@@ -164,7 +164,7 @@
         ) | safe
         }}
       </li>
-      <li class="p-inline-images__item">
+      <li class="p-logo-section__item">
         {{ image (
         url="https://assets.ubuntu.com/v1/255a3171-abb-logo.svg",
         alt="ABB",
@@ -175,7 +175,7 @@
         ) | safe
         }}
       </li>
-      <li class="p-inline-images__item">
+      <li class="p-logo-section__item">
         {{ image (
         url="https://assets.ubuntu.com/v1/2234031b-Siemens-logo.svg.png",
         alt="Siemens",
@@ -186,7 +186,7 @@
         ) | safe
         }}
       </li>
-      <li class="p-inline-images__item">
+      <li class="p-logo-section__item">
         {{ image (
         url="https://assets.ubuntu.com/v1/3ba27c02-osram-logo.svg",
         alt="osram",
@@ -197,7 +197,7 @@
         ) | safe
         }}
       </li>
-      <li class="p-inline-images__item">
+      <li class="p-logo-section__item">
         {{ image (
         url="https://assets.ubuntu.com/v1/24bd5aaf-dfi-logo.png",
         alt="DFI",
@@ -208,7 +208,7 @@
         ) | safe
         }}
       </li>
-      <li class="p-inline-images__item">
+      <li class="p-logo-section__item">
         {{ image (
         url="https://assets.ubuntu.com/v1/f6a59799-partner-logo-arm.svg",
         alt="ARM",
@@ -219,7 +219,7 @@
         ) | safe
         }}
       </li>
-      <li class="p-inline-images__item">
+      <li class="p-logo-section__item">
         {{ image (
         url="https://assets.ubuntu.com/v1/75502e5c-NXP-Logo.svg",
         alt="NXP",
@@ -230,7 +230,7 @@
         ) | safe
         }}
       </li>
-      <li class="p-inline-images__item">
+      <li class="p-logo-section__item">
         {{ image (
           url="https://assets.ubuntu.com/v1/e4ac6657-xilinx-inc-logo-vector.svg",
           alt="Xilink",
@@ -241,7 +241,7 @@
           ) | safe
         }}
       </li>
-      <li class="p-inline-images__item">
+      <li class="p-logo-section__item">
         {{ image (
         url="https://assets.ubuntu.com/v1/0ebb345c-MediaTek_logo.svg",
         alt="MediaTek",

--- a/templates/desktop/features.html
+++ b/templates/desktop/features.html
@@ -309,7 +309,7 @@
       <h2>Edit and illustrate</h2>
       <p>Edit your photos or create professional illustrations and designs with tools like Gimp and Krita, available in the Ubuntu Software centre.</p>
       <ul class="p-inline-images">
-        <li class="p-inline-images__item">
+        <li class="p-logo-section__item">
           {{
             image(
               url="https://assets.ubuntu.com/v1/b38df947-krita.png",
@@ -317,12 +317,12 @@
               height="60",
               width="60",
               hi_def=True,
-              attrs={"class": "p-inline-images__logo"},
+              attrs={"class": "p-logo-section__logo"},
               loading="lazy"
             ) | safe
           }}
         </li>
-        <li class="p-inline-images__item">
+        <li class="p-logo-section__item">
           {{
             image(
               url="https://assets.ubuntu.com/v1/4d47a674-gimp-60x43.svg",
@@ -331,11 +331,11 @@
               width="60",
               hi_def=True,
               loading="lazy",
-              attrs={"class": "p-inline-images__logo"},
+              attrs={"class": "p-logo-section__logo"},
             ) | safe
           }}
         </li>
-        <li class="p-inline-images__item">
+        <li class="p-logo-section__item">
           {{
             image(
               url="https://assets.ubuntu.com/v1/786ed546-blender.svg",
@@ -343,7 +343,7 @@
               height="60",
               width="60",
               hi_def=True,
-              attrs={"class": "p-inline-images__logo"},
+              attrs={"class": "p-logo-section__logo"},
               loading="lazy"
             ) | safe
           }}

--- a/templates/desktop/partners.html
+++ b/templates/desktop/partners.html
@@ -14,7 +14,7 @@
     </div>
     <div class="col-6 u-hide--small u-align--center u-vertically-center">
       <ul class="p-inline-images">
-        <li class="p-inline-images__item u-no-margin--right">
+        <li class="p-logo-section__item u-no-margin--right">
           {{
             image(
               url="https://assets.ubuntu.com/v1/d258d23b-2018-logo-dell.svg",
@@ -22,12 +22,12 @@
               height="100",
               width="100",
               hi_def=True,
-              attrs={"class": "p-inline-images__logo"},
+              attrs={"class": "p-logo-section__logo"},
               loading="auto",
             ) | safe
           }}
         </li>
-        <li class="p-inline-images__item u-no-margin--right">
+        <li class="p-logo-section__item u-no-margin--right">
           {{
             image(
               url="https://assets.ubuntu.com/v1/f627fbfb-hp.svg",
@@ -35,12 +35,12 @@
               height="100",
               width="100",
               hi_def=True,
-              attrs={"class": "p-inline-images__logo"},
+              attrs={"class": "p-logo-section__logo"},
               loading="auto",
             ) | safe
           }}
         </li>
-        <li class="p-inline-images__item u-no-margin--right">
+        <li class="p-logo-section__item u-no-margin--right">
           {{
             image(
               url="https://assets.ubuntu.com/v1/cb3fcdfb-lenovo.svg",
@@ -48,7 +48,7 @@
               height="100",
               width="144",
               hi_def=True,
-              attrs={"class": "p-inline-images__logo"},
+              attrs={"class": "p-logo-section__logo"},
               loading="auto",
             ) | safe
           }}

--- a/templates/engage/shared/_en_engage_form.html
+++ b/templates/engage/shared/_en_engage_form.html
@@ -60,7 +60,7 @@
         <input name="Consent_to_Processing__c" aria-label="Consent" value="Yes" type="hidden">
       </li>
       <li>
-        <button type="submit" class="u-no-margin--bottom" >{% if cta %}{{ cta }}{% else %}Download the whitepaper{% endif %}</button>
+        <button type="submit" class="u-no-margin--bottom {% if cta_class %}{{ cta_class }}{% endif %}" >{% if cta %}{{ cta }}{% else %}Download the whitepaper{% endif %}</button>
         <input name="formid" aria-label="formid" value="{{ id }}" type="hidden">
         <input type="hidden" name="returnURL" aria-label="returnURL" value="{{ returnURL }}" />
         <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" id="utm_campaign" value="" />

--- a/templates/gov/index.html
+++ b/templates/gov/index.html
@@ -172,7 +172,7 @@
   <div class="u-fixed-width">
     <h2 class="p-muted-heading u-align--center">Public cloud</h2>
     <ul class="p-inline-images u-no-margin--bottom">
-      <li class="p-inline-images__item">
+      <li class="p-logo-section__item">
         {{
           image(
           url="https://assets.ubuntu.com/v1/79a533b8-google-cloud.png?w=144",
@@ -181,11 +181,11 @@
           height="88",
           hi_def=True,
           loading="lazy",
-          attrs={"class": "p-inline-images__logos"},
+          attrs={"class": "p-logo-section__logos"},
           ) | safe
         }}
       </li>
-      <li class="p-inline-images__item">
+      <li class="p-logo-section__item">
         {{
           image(
           url="https://assets.ubuntu.com/v1/208cd3a7-azure-logo-blue-on-white.svg",
@@ -194,11 +194,11 @@
           height="41",
           hi_def=True,
           loading="lazy",
-          attrs={"class": "p-inline-images__logo"},
+          attrs={"class": "p-logo-section__logo"},
           ) | safe
         }}
       </li>
-      <li class="p-inline-images__item">
+      <li class="p-logo-section__item">
         {{
           image(
           url="https://assets.ubuntu.com/v1/39002345-AmazonWebservices_Logo.svg",
@@ -207,13 +207,13 @@
           height="54",
           hi_def=True,
           loading="lazy",
-          attrs={"class": "p-inline-images__logo"},
+          attrs={"class": "p-logo-section__logo"},
           ) | safe
         }}
       </li>
     </ul>
     <ul class="p-inline-images">
-      <li class="p-inline-images__item">
+      <li class="p-logo-section__item">
         {{
           image(
           url="https://assets.ubuntu.com/v1/f1d885ce-Oracle-cloud.png?w=144",
@@ -222,7 +222,7 @@
           height="44",
           hi_def=True,
           loading="lazy",
-          attrs={"class": "p-inline-images__logo"},
+          attrs={"class": "p-logo-section__logo"},
           ) | safe
         }}
       </li>
@@ -234,7 +234,7 @@
   <div class="u-fixed-width">
     <h2 class="p-muted-heading u-align--center">Hardware partners</h2>
     <ul class="p-inline-images u-no-margin--bottom">
-      <li class="p-inline-images__item">
+      <li class="p-logo-section__item">
         {{
           image(
             url="https://assets.ubuntu.com/v1/225ab637-logo-asus.svg",
@@ -242,12 +242,12 @@
             height="88",
             width="400",
             hi_def=True,
-            attrs={"class": "p-inline-images__logo"},
+            attrs={"class": "p-logo-section__logo"},
             loading="lazy",
           ) | safe
         }}
       </li>
-      <li class="p-inline-images__item">
+      <li class="p-logo-section__item">
         {{
           image(
           url="https://assets.ubuntu.com/v1/4d6054f9-logo-cisco.svg",
@@ -256,11 +256,11 @@
           height="76",
           hi_def=True,
           loading="lazy",
-          attrs={"class": "p-inline-images__logo"},
+          attrs={"class": "p-logo-section__logo"},
           ) | safe
         }}
       </li>
-      <li class="p-inline-images__item">
+      <li class="p-logo-section__item">
         {{
           image(
               url="https://assets.ubuntu.com/v1/5ddba83a-logo-dell.svg",
@@ -269,11 +269,11 @@
               height="88",
               hi_def=True,
               loading="lazy",
-              attrs={"class": "p-inline-images__logo"},
+              attrs={"class": "p-logo-section__logo"},
           ) | safe
         }}
       </li>
-      <li class="last-item p-inline-images__item">
+      <li class="last-item p-logo-section__item">
         {{
           image(
               url="https://assets.ubuntu.com/v1/c24cb4b9-logo-intel.svg",
@@ -282,13 +282,13 @@
               height="88",
               hi_def=True,
               loading="lazy",
-              attrs={"class": "p-inline-images__logo"},
+              attrs={"class": "p-logo-section__logo"},
           ) | safe
         }}
       </li>
     </ul>
     <ul class="p-inline-images">
-      <li class="p-inline-images__item">
+      <li class="p-logo-section__item">
         {{
           image(
               url="https://assets.ubuntu.com/v1/a298e7ec-logo-hp.svg",
@@ -297,11 +297,11 @@
               height="88",
               hi_def=True,
               loading="lazy",
-              attrs={"class": "p-inline-images__logo"},
+              attrs={"class": "p-logo-section__logo"},
           ) | safe
         }}
       </li>
-      <li class="p-inline-images__item">
+      <li class="p-logo-section__item">
           {{ image (
             url="https://assets.ubuntu.com/v1/118404f2-partner-logo-hp.svg",
             alt="HP Enterprise",
@@ -309,11 +309,11 @@
             height="54",
             hi_def=True,
             loading="auto|lazy",
-            attrs={"class": "p-inline-images__logo"},
+            attrs={"class": "p-logo-section__logo"},
             ) | safe
           }}
       </li>
-      <li class="p-inline-images__item">
+      <li class="p-logo-section__item">
         {{
           image(
               url="https://assets.ubuntu.com/v1/68713fd5-logo-lenovo.svg",
@@ -322,11 +322,11 @@
               height="24",
               hi_def=True,
               loading="lazy",
-              attrs={"class": "p-inline-images__logo"},
+              attrs={"class": "p-logo-section__logo"},
           ) | safe
         }}
       </li>
-      <li class="p-inline-images__item">
+      <li class="p-logo-section__item">
         {{
           image(
             url="https://assets.ubuntu.com/v1/3528a12f-logo-microsoft-160.png",
@@ -334,7 +334,7 @@
             height="72",
             width="144",
             hi_def=True,
-            attrs={"class": "p-inline-images__logos"},
+            attrs={"class": "p-logo-section__logos"},
             loading="lazy",
           ) | safe
         }}

--- a/templates/industrial/index.html
+++ b/templates/industrial/index.html
@@ -45,7 +45,7 @@
     <div class="row">
       <div class="col-10 col-start-large-2">
         <ul class="p-inline-images--small u-no-margin--bottom">
-          <li class="p-inline-images__item">
+          <li class="p-logo-section__item">
               {{
                 image(
                   url="https://assets.ubuntu.com/v1/156ddbf8-rexroth_logo.svg",
@@ -54,11 +54,11 @@
                   width="215",
                   hi_def=True,
                   loading="lazy",
-                  attrs={"class": "p-inline-images__logo"},
+                  attrs={"class": "p-logo-section__logo"},
                 ) | safe
               }}
           </li>
-          <li class="p-inline-images__item">
+          <li class="p-logo-section__item">
               {{
                 image(
                   url="https://assets.ubuntu.com/v1/1f876369-advantech.svg",
@@ -67,11 +67,11 @@
                   width="431",
                   hi_def=True,
                   loading="lazy",
-                  attrs={"class": "p-inline-images__logo is-wide"},
+                  attrs={"class": "p-logo-section__logo is-wide"},
                 ) | safe
               }}
           </li>
-          <li class="p-inline-images__item">
+          <li class="p-logo-section__item">
               {{
                 image(
                   url="https://assets.ubuntu.com/v1/59280c0e-abb-logo.svg",
@@ -80,11 +80,11 @@
                   width="230",
                   hi_def=True,
                   loading="lazy",
-                  attrs={"class": "p-inline-images__logo"},
+                  attrs={"class": "p-logo-section__logo"},
                 ) | safe
               }}
           </li>
-          <li class="p-inline-images__item">
+          <li class="p-logo-section__item">
               {{
                 image(
                   url="https://assets.ubuntu.com/v1/97e29c13-Dell.svg",
@@ -93,11 +93,11 @@
                   width="88",
                   hi_def=True,
                   loading="lazy",
-                  attrs={"class": "p-inline-images__logo"},
+                  attrs={"class": "p-logo-section__logo"},
                 ) | safe
               }}
           </li>
-          <li class="p-inline-images__item">
+          <li class="p-logo-section__item">
               {{
                 image(
                   url="https://assets.ubuntu.com/v1/185a14f4-Avnet.png",
@@ -106,11 +106,11 @@
                   width="463",
                   hi_def=True,
                   loading="lazy",
-                  attrs={"class": "p-inline-images__logo is-wide"},
+                  attrs={"class": "p-logo-section__logo is-wide"},
                 ) | safe
               }}
           </li>
-          <li class="p-inline-images__item">
+          <li class="p-logo-section__item">
               {{
                 image(
                   url="https://assets.ubuntu.com/v1/85f935b9-Eurotech_logo.svg",
@@ -119,7 +119,7 @@
                   width="277",
                   hi_def=True,
                   loading="lazy",
-                  attrs={"class": "p-inline-images__logo is-wide"},
+                  attrs={"class": "p-logo-section__logo is-wide"},
                 ) | safe
               }}
           </li>
@@ -206,7 +206,7 @@
         <li>App stores including OPC-UA, Modbus, MQTT clients and more</li>
       </ul>
       <ul class="p-inline-images u-no-margin--bottom u-align--left">    
-        <li class="p-inline-images__item u-no-margin--left">
+        <li class="p-logo-section__item u-no-margin--left">
           <a href="https://snapcraft.io/edgexfoundry">
             {{
               image(
@@ -216,12 +216,12 @@
                 width="64",
                 hi_def=True,
                 loading="lazy",
-                attrs={"class": "p-inline-images__logo"},
+                attrs={"class": "p-logo-section__logo"},
               ) | safe
             }}
           </a>
         </li>
-        <li class="p-inline-images__item u-no-margin--left">
+        <li class="p-logo-section__item u-no-margin--left">
           <a href="https://snapcraft.io/kura">
             {{
               image(
@@ -231,12 +231,12 @@
                 width="52",
                 hi_def=True,
                 loading="lazy",
-                attrs={"class": "p-inline-images__logo"},
+                attrs={"class": "p-logo-section__logo"},
               ) | safe
             }}
           </a>
         </li>
-        <li class="p-inline-images__item u-no-margin--left">
+        <li class="p-logo-section__item u-no-margin--left">
           <a href="https://snapcraft.io/aws-iot-greengrass">
             {{
               image(
@@ -246,12 +246,12 @@
                 width="64",
                 hi_def=True,
                 loading="lazy",
-                attrs={"class": "p-inline-images__logo"},
+                attrs={"class": "p-logo-section__logo"},
               ) | safe
             }}
           </a>
         </li>
-        <li class="p-inline-images__item u-no-margin--left">
+        <li class="p-logo-section__item u-no-margin--left">
           <a href="https://snapcraft.io/azure-iot-edge">
             {{
               image(
@@ -261,7 +261,7 @@
                 width="64",
                 hi_def=True,
                 loading="lazy",
-                attrs={"class": "p-inline-images__logo"},
+                attrs={"class": "p-logo-section__logo"},
               ) | safe
             }}
           </a>
@@ -314,7 +314,7 @@
       </ul>
       <ul class="p-inline-images u-no-margin--bottom u-align--left">
       
-        <li class="p-inline-images__item u-no-margin--left">
+        <li class="p-logo-section__item u-no-margin--left">
           <a href="https://microstack.run/">
             {{
               image(
@@ -324,12 +324,12 @@
                 width="75",
                 hi_def=True,
                 loading="lazy",
-                attrs={"class": "p-inline-images__logo"},
+                attrs={"class": "p-logo-section__logo"},
               ) | safe
             }}
           </a>
         </li>
-        <li class="p-inline-images__item u-no-margin--left">
+        <li class="p-logo-section__item u-no-margin--left">
           <a href="https://microk8s.io/">
             {{
               image(
@@ -339,12 +339,12 @@
                 width="64",
                 hi_def=True,
                 loading="lazy",
-                attrs={"class": "p-inline-images__logo"},
+                attrs={"class": "p-logo-section__logo"},
               ) | safe
             }}
           </a>
         </li>
-        <li class="p-inline-images__item u-no-margin--left">
+        <li class="p-logo-section__item u-no-margin--left">
           <a href="https://linuxcontainers.org/lxd/introduction/">
             {{
               image(
@@ -354,7 +354,7 @@
                 width="69",
                 hi_def=True,
                 loading="lazy",
-                attrs={"class": "p-inline-images__logo"},
+                attrs={"class": "p-logo-section__logo"},
               ) | safe
             }}
           </a>
@@ -385,7 +385,7 @@
       </ul>
       <ul class="p-inline-images u-no-margin--bottom u-align--left">
       
-        <li class="p-inline-images__item u-no-margin--left">
+        <li class="p-logo-section__item u-no-margin--left">
           {{
             image(
               url="https://assets.ubuntu.com/v1/c8749268-logo-ros.svg",
@@ -394,11 +394,11 @@
               width="242",
               hi_def=True,
               loading="lazy",
-              attrs={"class": "p-inline-images__logo"},
+              attrs={"class": "p-logo-section__logo"},
             ) | safe
           }}
         </li>
-        <li class="p-inline-images__item u-no-margin--left">
+        <li class="p-logo-section__item u-no-margin--left">
           {{
             image(
               url="https://assets.ubuntu.com/v1/8da00274-open-robotics.png",
@@ -407,11 +407,11 @@
               width="224",
               hi_def=True,
               loading="lazy",
-              attrs={"class": "p-inline-images__logo"},
+              attrs={"class": "p-logo-section__logo"},
             ) | safe
           }}
         </li>
-        <li class="p-inline-images__item u-no-margin">
+        <li class="p-logo-section__item u-no-margin">
           {{
             image(
               url="https://assets.ubuntu.com/v1/1ac0e434-Nvidia_Logo_Horizontal.svg",
@@ -420,7 +420,7 @@
               width="335",
               hi_def=True,
               loading="lazy",
-              attrs={"class": "p-inline-images__logo"},
+              attrs={"class": "p-logo-section__logo"},
             ) | safe
           }}
         </li>
@@ -471,7 +471,7 @@
       </ul>
       <ul class="p-inline-images u-no-margin--bottom u-align--left">
       
-        <li class="p-inline-images__item u-no-margin--left">
+        <li class="p-logo-section__item u-no-margin--left">
           <a href="https://snapcraft.io/flutter">
             {{
               image(
@@ -481,12 +481,12 @@
                 width="64",
                 hi_def=True,
                 loading="lazy",
-                attrs={"class": "p-inline-images__logo"},
+                attrs={"class": "p-logo-section__logo"},
               ) | safe
             }}
           </a>
         </li>
-        <li class="p-inline-images__item u-no-margin--left">
+        <li class="p-logo-section__item u-no-margin--left">
           {{
             image(
               url="https://assets.ubuntu.com/v1/4076f787-QT-software.png",
@@ -495,11 +495,11 @@
               width="87",
               hi_def=True,
               loading="lazy",
-              attrs={"class": "p-inline-images__logo"},
+              attrs={"class": "p-logo-section__logo"},
             ) | safe
           }}
         </li>
-        <li class="p-inline-images__item u-no-margin--left">
+        <li class="p-logo-section__item u-no-margin--left">
           {{
             image(
               url="https://assets.ubuntu.com/v1/24a4d66d-HTML5_logo_and_wordmark.svg",
@@ -508,7 +508,7 @@
               width="45",
               hi_def=True,
               loading="lazy",
-              attrs={"class": "p-inline-images__logo"},
+              attrs={"class": "p-logo-section__logo"},
             ) | safe
           }}
         </li>

--- a/templates/internet-of-things/appstore.html
+++ b/templates/internet-of-things/appstore.html
@@ -68,7 +68,7 @@ With the IoT App Store for Linux, create, publish and distribute software on one
     <div class="p-logo-section">
       <h2 class="p-logo-section__header p-muted-heading u-align--center">READ ABOUT THE COMPANIES USING APP STORES FOR IOT</h2>
       <div class="p-logo-section__items">
-        <div class="p-logo-section__item" class="p-inline-images__item">
+        <div class="p-logo-section__item" class="p-logo-section__item">
           <a href="/engage/case-study-rigado">
             {{
               image(
@@ -77,13 +77,13 @@ With the IoT App Store for Linux, create, publish and distribute software on one
                 height="71",
                 width="113",
                 hi_def=True,
-                attrs={"class": "p-inline-images__logo"},
+                attrs={"class": "p-logo-section__logo"},
                 loading="lazy",
               ) | safe
             }}
           </a>
         </div>
-        <div class="p-logo-section__item" class="p-inline-images__item">
+        <div class="p-logo-section__item" class="p-logo-section__item">
           <a href="/dell">
             {{
               image(
@@ -92,13 +92,13 @@ With the IoT App Store for Linux, create, publish and distribute software on one
                 height="29",
                 width="162",
                 hi_def=True,
-                attrs={"class": "p-inline-images__logo"},
+                attrs={"class": "p-logo-section__logo"},
                 loading="lazy",
               ) | safe
             }}
           </a>
         </div>
-        <div class="p-logo-section__item" class="p-inline-images__item">
+        <div class="p-logo-section__item" class="p-logo-section__item">
           <a href="/blog/bosch-rexroth-adopts-ubuntu-core-and-snaps-for-app-based-ctrlx-automation-platform">
             {{
               image (
@@ -112,7 +112,7 @@ With the IoT App Store for Linux, create, publish and distribute software on one
             }}
           </a>
         </div>
-        <div class="p-logo-section__item" class="p-inline-images__item">
+        <div class="p-logo-section__item" class="p-logo-section__item">
           <a href="/engage/cyberdyne">
             {{
               image(
@@ -121,13 +121,13 @@ With the IoT App Store for Linux, create, publish and distribute software on one
                 height="99",
                 width="158",
                 hi_def=True,
-                attrs={"class": "p-inline-images__logo"},
+                attrs={"class": "p-logo-section__logo"},
                 loading="lazy",
               ) | safe
             }}
           </a>
         </div>
-        <div class="p-logo-section__item" class="p-inline-images__item">
+        <div class="p-logo-section__item" class="p-logo-section__item">
           <a href="/blog/lime-microsystems-and-canonical-announce-limenet-crowdfunding">
             {{
               image(
@@ -136,13 +136,13 @@ With the IoT App Store for Linux, create, publish and distribute software on one
                 height="69",
                 width="162",
                 hi_def=True,
-                attrs={"class": "p-inline-images__logo"},
+                attrs={"class": "p-logo-section__logo"},
                 loading="lazy",
               ) | safe
             }}
           </a>
         </div>
-        <div class="p-logo-section__item" class="p-inline-images__item">
+        <div class="p-logo-section__item" class="p-logo-section__item">
           <a href="/engage/domotz-case-study">
             {{
               image(
@@ -151,7 +151,7 @@ With the IoT App Store for Linux, create, publish and distribute software on one
                 height="36",
                 width="162",
                 hi_def=True,
-                attrs={"class": "p-inline-images__logo"},
+                attrs={"class": "p-logo-section__logo"},
                 loading="lazy",
               ) | safe
             }}

--- a/templates/internet-of-things/index.html
+++ b/templates/internet-of-things/index.html
@@ -201,7 +201,7 @@
     <p>For industrial and enterprise solutions, just add your apps and they'll handle the rest.</p>
   </div>
   <ul class="p-inline-images u-no-margin--bottom">
-    <li class="p-inline-images__item">
+    <li class="p-logo-section__item">
       {{
       image(
         url="https://assets.ubuntu.com/v1/5ddba83a-logo-dell.svg",
@@ -209,11 +209,11 @@
         width="88",
         height="88",
         hi_def=True,
-        attrs={"class": "p-inline-images__logo"},
+        attrs={"class": "p-logo-section__logo"},
       ) | safe
       }}
     </li>
-    <li class="p-inline-images__item">
+    <li class="p-logo-section__item">
       {{
         image(
           url="https://assets.ubuntu.com/v1/c95e6028-rigado-logo.png",
@@ -221,11 +221,11 @@
           width="130",
           height="80",
           hi_def=True,
-          attrs={"class": "p-inline-images__logo", "style": "max-width: 140px; max-height: 140px;"},
+          attrs={"class": "p-logo-section__logo", "style": "max-width: 140px; max-height: 140px;"},
         ) | safe
       }}
     </li>
-    <li class="p-inline-images__item">
+    <li class="p-logo-section__item">
       {{
         image(
           url="https://assets.ubuntu.com/v1/582bee22-avantech-logo.png",
@@ -233,7 +233,7 @@
           width="170",
           height="48",
           hi_def=True,
-          attrs={"class": "p-inline-images__logo"},
+          attrs={"class": "p-logo-section__logo"},
         ) | safe
       }}
     </li>

--- a/templates/kubernetes/index.html
+++ b/templates/kubernetes/index.html
@@ -42,7 +42,7 @@
         <li class="p-list__item is-ticked">Full control over kernel security patching with Canonical Livepatch</li>
       </ul>
       <ul class="p-inline-images">
-        <li class="p-inline-images__item">
+        <li class="p-logo-section__item">
           {{
             image(
             url="https://assets.ubuntu.com/v1/22fd6473-MicrosoftAzure_logo.svg",
@@ -51,11 +51,11 @@
             height="42",
             hi_def=True,
             loading="lazy",
-            attrs={"class": "p-inline-images__logos"},
+            attrs={"class": "p-logo-section__logos"},
             ) | safe
           }}
         </li>
-        <li class="p-inline-images__item">
+        <li class="p-logo-section__item">
             {{
               image(
               url="https://assets.ubuntu.com/v1/a82add58-profile-aws.svg",
@@ -64,11 +64,11 @@
               height="52",
               hi_def=True,
               loading="lazy",
-              attrs={"class": "p-inline-images__logos"},
+              attrs={"class": "p-logo-section__logos"},
               ) | safe
             }}
           </li>
-          <li class="p-inline-images__item">
+          <li class="p-logo-section__item">
             {{
               image(
               url="https://assets.ubuntu.com/v1/6e176d9a-Google+Cloud+stacked.svg",
@@ -77,11 +77,11 @@
               height="86",
               hi_def=True,
               loading="lazy",
-              attrs={"class": "p-inline-images__logos"},
+              attrs={"class": "p-logo-section__logos"},
               ) | safe
             }}
           </li>
-          <li class="p-inline-images__item">
+          <li class="p-logo-section__item">
             {{
               image(
               url="https://assets.ubuntu.com/v1/8207d0a9-IBM-cloud.svg",
@@ -90,11 +90,11 @@
               height="44",
               hi_def=True,
               loading="lazy",
-              attrs={"class": "p-inline-images__logos"},
+              attrs={"class": "p-logo-section__logos"},
               ) | safe
             }}
           </li>
-          <li class="p-inline-images__item">
+          <li class="p-logo-section__item">
             {{
               image(
               url="https://assets.ubuntu.com/v1/f3be98eb-oracle-cloud-logo.png",
@@ -103,7 +103,7 @@
               height="86",
               hi_def=True,
               loading="lazy",
-              attrs={"class": "p-inline-images__logos"},
+              attrs={"class": "p-logo-section__logos"},
               ) | safe
             }}
           </li>
@@ -223,7 +223,7 @@
   <div class="row">
     <h2 class="p-muted-heading u-align--center">FULLY-SUPPORTED KUBERNETES CLOUDS</h2>
     <ul class="p-inline-images">
-      <li class="p-inline-images__item">
+      <li class="p-logo-section__item">
         <a href="https://maas.io/">
           {{
             image(
@@ -232,12 +232,12 @@
             width="158",
             hi_def=True,
             loading="lazy",
-            attrs={"class": "p-inline-images__logos"},
+            attrs={"class": "p-logo-section__logos"},
             ) | safe
           }}
         </a>
       </li>
-      <li class="p-inline-images__item">
+      <li class="p-logo-section__item">
         <a href="https://linuxcontainers.org/">
           {{
             image(
@@ -246,12 +246,12 @@
             width="122",
             hi_def=True,
             loading="lazy",
-            attrs={"class": "p-inline-images__logos"},
+            attrs={"class": "p-logo-section__logos"},
             ) | safe
           }}
         </a>
         </li>
-        <li class="p-inline-images__item">
+        <li class="p-logo-section__item">
           {{
             image(
             url="https://assets.ubuntu.com/v1/f7f8709c-logo-joyent.svg",
@@ -259,11 +259,11 @@
             width="146",
             hi_def=True,
             loading="lazy",
-            attrs={"class": "p-inline-images__logos"},
+            attrs={"class": "p-logo-section__logos"},
             ) | safe
           }}
         </li>
-        <li class="p-inline-images__item">
+        <li class="p-logo-section__item">
           {{
             image(
             url="https://assets.ubuntu.com/v1/ff936628-rackspace.svg",
@@ -271,11 +271,11 @@
             width="136",
             hi_def=True,
             loading="lazy",
-            attrs={"class": "p-inline-images__logos"},
+            attrs={"class": "p-logo-section__logos"},
             ) | safe
           }}
         </li>
-        <li class="p-inline-images__item">
+        <li class="p-logo-section__item">
           <a href="/kubernetes/docs/equinix">
             {{ 
             image (
@@ -289,7 +289,7 @@
             }}
           </a>
         </li>
-        <li class="p-inline-images__item">
+        <li class="p-logo-section__item">
           {{
             image(
             url="https://assets.ubuntu.com/v1/760109ef-CloudSigma_Logo_Full.png",
@@ -297,11 +297,11 @@
             width="130",
             hi_def=True,
             loading="lazy",
-            attrs={"class": "p-inline-images__logos"},
+            attrs={"class": "p-logo-section__logos"},
             ) | safe
           }}
         </li>
-        <li class="p-inline-images__item">
+        <li class="p-logo-section__item">
           <a href="/kubernetes/docs/openstack-integration">
             {{
               image(
@@ -310,12 +310,12 @@
               width="156",
               hi_def=True,
               loading="lazy",
-              attrs={"class": "p-inline-images__logos"},
+              attrs={"class": "p-logo-section__logos"},
               ) | safe
             }}
           </a>
         </li>
-        <li class="p-inline-images__item">
+        <li class="p-logo-section__item">
           <a href="/kubernetes/docs/vsphere-integration">
             {{
               image(
@@ -324,7 +324,7 @@
               width="170",
               hi_def=True,
               loading="lazy",
-              attrs={"class": "p-inline-images__logos"},
+              attrs={"class": "p-logo-section__logos"},
               ) | safe
             }}
           </a>
@@ -449,7 +449,7 @@
         <li class="p-list__item is-ticked">Flexibility across environments from <a href="public-cloud">public cloud</a> to edge</li>
       </ul>
       <ul class="p-inline-images u-hide--small">
-        <li class="p-inline-images__item u-no-margin--left">
+        <li class="p-logo-section__item u-no-margin--left">
           <a href="/kubernetes/features">
             {{
               image(
@@ -459,12 +459,12 @@
               height="24",
               hi_def=True,
               loading="lazy",
-              attrs={"class": "p-inline-images__logos"},
+              attrs={"class": "p-logo-section__logos"},
               ) | safe
             }}
           </a>
           </li>
-          <li class="p-inline-images__item">
+          <li class="p-logo-section__item">
             {{
               image(
               url="https://assets.ubuntu.com/v1/c767b383-Portainer+Logo.svg",
@@ -473,11 +473,11 @@
               height="40",
               hi_def=True,
               loading="lazy",
-              attrs={"class": "p-inline-images__logos"},
+              attrs={"class": "p-logo-section__logos"},
               ) | safe
             }}
           </li>
-          <li class="p-inline-images__item u-no-margin--right">
+          <li class="p-logo-section__item u-no-margin--right">
             <a href="/kubernetes/features">
               {{
                 image(
@@ -487,7 +487,7 @@
                 height="50",
                 hi_def=True,
                 loading="lazy",
-                attrs={"class": "p-inline-images__logos"},
+                attrs={"class": "p-logo-section__logos"},
                 ) | safe
               }}
             </a>

--- a/templates/kubernetes/what-is-kubernetes.html
+++ b/templates/kubernetes/what-is-kubernetes.html
@@ -175,7 +175,7 @@
       KEY CONTRIBUTORS TO KUBERNETES
     </h2>
     <ul class="p-inline-images">
-      <li class="p-inline-images__item">
+      <li class="p-logo-section__item">
         {{
           image(
           url="https://assets.ubuntu.com/v1/5d6da5c4-logo-canonical-aubergine.svg",
@@ -187,7 +187,7 @@
           ) | safe
         }}
       </li>
-      <li class="p-inline-images__item">
+      <li class="p-logo-section__item">
         {{
           image(
           url="https://assets.ubuntu.com/v1/80fe0ebe-Huawei-logo.svg",
@@ -199,7 +199,7 @@
           ) | safe
         }}
       </li>
-      <li class="p-inline-images__item">
+      <li class="p-logo-section__item">
         {{
           image(
           url="https://assets.ubuntu.com/v1/5bd692e3-partner-logo-fujitsu.svg",
@@ -207,12 +207,12 @@
           height="57",
           width="122",
           hi_def=True,
-          attrs={"class": "p-inline-images__logo"},
+          attrs={"class": "p-logo-section__logo"},
           loading="lazy",
           ) | safe
         }}
       </li>
-      <li class="p-inline-images__item">
+      <li class="p-logo-section__item">
         {{
           image(
           url="https://assets.ubuntu.com/v1/e4c220b3-logo-microsoft.svg",
@@ -220,12 +220,12 @@
           height="73",
           width="145",
           hi_def=True,
-          attrs={"class": "p-inline-images__logo"},
+          attrs={"class": "p-logo-section__logo"},
           loading="lazy",
           ) | safe
         }}
       </li>
-      <li class="p-inline-images__item">
+      <li class="p-logo-section__item">
         {{
           image(
             url="https://assets.ubuntu.com/v1/bac02008-Amazon.com-Logo.svg",
@@ -233,12 +233,12 @@
             height="29",
             width="144",
             hi_def=True,
-            attrs={"class": "p-inline-images__logos"},
+            attrs={"class": "p-logo-section__logos"},
             loading="lazy",
           ) | safe
         }}
       </li>
-      <li class="p-inline-images__item">
+      <li class="p-logo-section__item">
         {{
           image(
           url="https://assets.ubuntu.com/v1/3abbe38f-zte_logo_en.png?w=65",
@@ -246,12 +246,12 @@
           height="30",
           width="65",
           hi_def=True,
-          attrs={"class": "p-inline-images__logo"},
+          attrs={"class": "p-logo-section__logo"},
           loading="lazy",
           ) | safe
         }}
       </li>
-      <li class="p-inline-images__item">
+      <li class="p-logo-section__item">
         {{
           image(
           url="https://assets.ubuntu.com/v1/82c62241-red-hat-2019-primary.svg",
@@ -259,12 +259,12 @@
           height="40",
           width="169",
           hi_def=True,
-          attrs={"class": "p-inline-images__logo", "style": "width:169px;"},
+          attrs={"class": "p-logo-section__logo", "style": "width:169px;"},
           loading="lazy",
           ) | safe
         }}
       </li>
-      <li class="p-inline-images__item">
+      <li class="p-logo-section__item">
         {{
           image(
           url="https://assets.ubuntu.com/v1/9c276e79-mirantis-logo-horizontal.svg",
@@ -272,12 +272,12 @@
           height="30",
           width="270",
           hi_def=True,
-          attrs={"class": "p-inline-images__logo", "style": "width:270px;"},
+          attrs={"class": "p-logo-section__logo", "style": "width:270px;"},
           loading="lazy",
           ) | safe
         }}
       </li>
-      <li class="p-inline-images__item">
+      <li class="p-logo-section__item">
         {{
           image(
           url="https://assets.ubuntu.com/v1/bc96d94b-CoreOS-logo.png",
@@ -285,12 +285,12 @@
           height="57",
           width="150",
           hi_def=True,
-          attrs={"class": "p-inline-images__logo"},
+          attrs={"class": "p-logo-section__logo"},
           loading="lazy",
           ) | safe
         }}
       </li>
-      <li class="p-inline-images__item">
+      <li class="p-logo-section__item">
         {{
           image(
           url="https://assets.ubuntu.com/v1/8f442c65-rancher-logo-horiz-color.svg",
@@ -298,7 +298,7 @@
           height="23",
           width="144",
           hi_def=True,
-          attrs={"class": "p-inline-images__logo"},
+          attrs={"class": "p-logo-section__logo"},
           loading="lazy",
           ) | safe
         }}
@@ -813,7 +813,7 @@
           height="171",
           hi_def=True,
           loading="lazy",
-          attrs={"class": "p-inline-images__logos"},
+          attrs={"class": "p-logo-section__logos"},
           ) | safe
         }}
       </div>

--- a/templates/managed/apps/cassandra.html
+++ b/templates/managed/apps/cassandra.html
@@ -43,7 +43,7 @@
     <div class="col-12">
       <h2 class="p-muted-heading u-align--center">Managed on:</h2>
       <ul class="p-inline-images--small">
-        <li class="p-inline-images__item">
+        <li class="p-logo-section__item">
           {{
             image(
               url="https://assets.ubuntu.com/v1/11d594e7-K8s+logo+white+outline.svg",
@@ -51,11 +51,11 @@
               width="266",
               height="259",
               hi_def=True,
-              attrs={"class": "p-inline-images__logo"},
+              attrs={"class": "p-logo-section__logo"},
             ) | safe
           }}
         </li>
-        <li class="p-inline-images__item">
+        <li class="p-logo-section__item">
           {{
             image(
               url="https://assets.ubuntu.com/v1/6e176d9a-Google+Cloud+stacked.svg",
@@ -63,11 +63,11 @@
               width="150",
               height="125",
               hi_def=True,
-              attrs={"class": "p-inline-images__logo"},
+              attrs={"class": "p-logo-section__logo"},
             ) | safe
           }}
         </li>
-        <li class="p-inline-images__item">
+        <li class="p-logo-section__item">
           {{
             image(
               url="https://assets.ubuntu.com/v1/8e5cc412-AWS.svg",
@@ -75,11 +75,11 @@
               width="107",
               height="64",
               hi_def=True,
-              attrs={"class": "p-inline-images__logo"},
+              attrs={"class": "p-logo-section__logo"},
             ) | safe
           }}
         </li>
-        <li class="p-inline-images__item">
+        <li class="p-logo-section__item">
           {{
             image(
               url="https://assets.ubuntu.com/v1/01cfe6d9-profile-azure.svg",
@@ -87,11 +87,11 @@
               width="125",
               height="100",
               hi_def=True,
-              attrs={"class": "p-inline-images__logo is-wide"},
+              attrs={"class": "p-logo-section__logo is-wide"},
             ) | safe
           }}
         </li>
-        <li class="p-inline-images__item">
+        <li class="p-logo-section__item">
           {{
             image(
               url="https://assets.ubuntu.com/v1/623e36f9-OpenStack_Logo_Mark+%281%29.svg",
@@ -99,11 +99,11 @@
               width="60",
               height="50",
               hi_def=True,
-              attrs={"class": "p-inline-images__logo"},
+              attrs={"class": "p-logo-section__logo"},
             ) | safe
           }}
         </li>
-        <li class="p-inline-images__item">
+        <li class="p-logo-section__item">
           {{
             image(
               url="https://assets.ubuntu.com/v1/244981d4-vmware_logo.svg",
@@ -111,7 +111,7 @@
               width="130",
               height="21",
               hi_def=True,
-              attrs={"class": "p-inline-images__logo is-wide"},
+              attrs={"class": "p-logo-section__logo is-wide"},
             ) | safe
           }}
         </li>

--- a/templates/managed/apps/index.html
+++ b/templates/managed/apps/index.html
@@ -304,7 +304,7 @@ coverage.{% endblock meta_description %}
   <div class="u-fixed-width">
     <h2 class="p-muted-heading u-align--center">Run your apps anywhere</h2>
     <ul class="p-inline-images">
-      <li class="p-inline-images__item">
+      <li class="p-logo-section__item">
         {{
           image(
           url="https://assets.ubuntu.com/v1/42299ebc-google-cloud.png",
@@ -313,11 +313,11 @@ coverage.{% endblock meta_description %}
           height="50",
           hi_def=True,
           loading="lazy",
-          attrs={"class": "p-inline-images__logos"},
+          attrs={"class": "p-logo-section__logos"},
           ) | safe
         }}
       </li>
-      <li class="p-inline-images__item">
+      <li class="p-logo-section__item">
         {{
           image(
           url="https://assets.ubuntu.com/v1/dba11aee-kubernetes.svg",
@@ -326,11 +326,11 @@ coverage.{% endblock meta_description %}
           height="60",
           hi_def=True,
           loading="lazy",
-          attrs={"class": "p-inline-images__logo"},
+          attrs={"class": "p-logo-section__logo"},
           ) | safe
         }}
       </li>
-      <li class="p-inline-images__item">
+      <li class="p-logo-section__item">
         {{
           image(
           url="https://assets.ubuntu.com/v1/a82add58-profile-aws.svg",
@@ -339,11 +339,11 @@ coverage.{% endblock meta_description %}
           height="50",
           hi_def=True,
           loading="lazy",
-          attrs={"class": "p-inline-images__logo"},
+          attrs={"class": "p-logo-section__logo"},
           ) | safe
         }}
       </li>
-      <li class="p-inline-images__item">
+      <li class="p-logo-section__item">
         {{
           image(
           url="https://assets.ubuntu.com/v1/01cfe6d9-profile-azure.svg",
@@ -352,11 +352,11 @@ coverage.{% endblock meta_description %}
           height="50",
           hi_def=True,
           loading="lazy",
-          attrs={"class": "p-inline-images__logo"},
+          attrs={"class": "p-logo-section__logo"},
           ) | safe
         }}
       </li>
-      <li class="p-inline-images__item">
+      <li class="p-logo-section__item">
         {{
           image(
           url="https://assets.ubuntu.com/v1/623e36f9-OpenStack_Logo_Mark+%281%29.svg",
@@ -365,11 +365,11 @@ coverage.{% endblock meta_description %}
           height="50",
           hi_def=True,
           loading="lazy",
-          attrs={"class": "p-inline-images__logo", "style": "max-height:90px;"},
+          attrs={"class": "p-logo-section__logo", "style": "max-height:90px;"},
           ) | safe
         }}
       </li>
-      <li class="p-inline-images__item">
+      <li class="p-logo-section__item">
         {{
           image(
           url="https://assets.ubuntu.com/v1/d584bd83-logo-vmware.svg",
@@ -378,11 +378,11 @@ coverage.{% endblock meta_description %}
           height="22",
           hi_def=True,
           loading="lazy",
-          attrs={"class": "p-inline-images__logo"},
+          attrs={"class": "p-logo-section__logo"},
           ) | safe
         }}
       </li>
-      <li class="p-inline-images__item">
+      <li class="p-logo-section__item">
         {{
           image(
           url="https://assets.ubuntu.com/v1/f1d885ce-Oracle-cloud.png?w=144",
@@ -391,11 +391,11 @@ coverage.{% endblock meta_description %}
           height="44",
           hi_def=True,
           loading="lazy",
-          attrs={"class": "p-inline-images__logo"},
+          attrs={"class": "p-logo-section__logo"},
           ) | safe
         }}
       </li>
-      <li class="p-inline-images__item">
+      <li class="p-logo-section__item">
         {{
           image(
           url="https://assets.ubuntu.com/v1/33409c7b-logo-maas.svg",
@@ -404,7 +404,7 @@ coverage.{% endblock meta_description %}
           height="47",
           hi_def=True,
           loading="lazy",
-          attrs={"class": "p-inline-images__logo"},
+          attrs={"class": "p-logo-section__logo"},
           ) | safe
         }}
       </li>

--- a/templates/managed/apps/kafka.html
+++ b/templates/managed/apps/kafka.html
@@ -39,7 +39,7 @@
     <div class="col-12">
       <h2 class="p-muted-heading u-align--center">Managed on:</h2>
       <ul class="p-inline-images--small">
-        <li class="p-inline-images__item">
+        <li class="p-logo-section__item">
           {{
             image(
               url="https://assets.ubuntu.com/v1/11d594e7-K8s+logo+white+outline.svg",
@@ -47,11 +47,11 @@
               width="266",
               height="259",
               hi_def=True,
-              attrs={"class": "p-inline-images__logo"},
+              attrs={"class": "p-logo-section__logo"},
             ) | safe
           }}
         </li>
-        <li class="p-inline-images__item">
+        <li class="p-logo-section__item">
           {{
             image(
               url="https://assets.ubuntu.com/v1/6e176d9a-Google+Cloud+stacked.svg",
@@ -59,11 +59,11 @@
               width="150",
               height="125",
               hi_def=True,
-              attrs={"class": "p-inline-images__logo"},
+              attrs={"class": "p-logo-section__logo"},
             ) | safe
           }}
         </li>
-        <li class="p-inline-images__item">
+        <li class="p-logo-section__item">
           {{
             image(
               url="https://assets.ubuntu.com/v1/8e5cc412-AWS.svg",
@@ -71,11 +71,11 @@
               width="107",
               height="64",
               hi_def=True,
-              attrs={"class": "p-inline-images__logo"},
+              attrs={"class": "p-logo-section__logo"},
             ) | safe
           }}
         </li>
-        <li class="p-inline-images__item">
+        <li class="p-logo-section__item">
           {{
             image(
               url="https://assets.ubuntu.com/v1/01cfe6d9-profile-azure.svg",
@@ -83,11 +83,11 @@
               width="125",
               height="100",
               hi_def=True,
-              attrs={"class": "p-inline-images__logo is-wide"},
+              attrs={"class": "p-logo-section__logo is-wide"},
             ) | safe
           }}
         </li>
-        <li class="p-inline-images__item">
+        <li class="p-logo-section__item">
           {{
             image(
               url="https://assets.ubuntu.com/v1/623e36f9-OpenStack_Logo_Mark+%281%29.svg",
@@ -95,11 +95,11 @@
               width="60",
               height="50",
               hi_def=True,
-              attrs={"class": "p-inline-images__logo"},
+              attrs={"class": "p-logo-section__logo"},
             ) | safe
           }}
         </li>
-        <li class="p-inline-images__item">
+        <li class="p-logo-section__item">
           {{
             image(
               url="https://assets.ubuntu.com/v1/244981d4-vmware_logo.svg",
@@ -107,7 +107,7 @@
               width="130",
               height="21",
               hi_def=True,
-              attrs={"class": "p-inline-images__logo is-wide"},
+              attrs={"class": "p-logo-section__logo is-wide"},
             ) | safe
           }}
         </li>

--- a/templates/openstack/features.html
+++ b/templates/openstack/features.html
@@ -627,55 +627,55 @@
     </div>
     <div class="col-5 u-align--center u-hide--small">
       <ul class="p-inline-images">
-        <li class="p-inline-images__item">
+        <li class="p-logo-section__item">
           {{ image (
             url="https://assets.ubuntu.com/v1/06ff193a-GDPR-cropped.png",
             alt="GDPR logo",
             width="70",
             height="67",
             hi_def=True,
-            attrs={"class": "p-inline-images__logo"},
+            attrs={"class": "p-logo-section__logo"},
             loading="lazy"
             ) | safe
           }}
         </li>
-        <li class="p-inline-images__item">
+        <li class="p-logo-section__item">
           {{ image (
             url="https://assets.ubuntu.com/v1/1dafeb51-Hipaa_Logo_HQ_small-transparent.png",
             alt="HIPAA compliant logo",
             width="144",
             height="84",
             hi_def=True,
-            attrs={"class": "p-inline-images__logo"},
+            attrs={"class": "p-logo-section__logo"},
             loading="lazy"
             ) | safe
           }}
         </li>
-        <li class="p-inline-images__item">
+        <li class="p-logo-section__item">
           {{ image (
             url="https://assets.ubuntu.com/v1/961a1ad1-csec-logo-removebg-preview.png",
             alt="CSEC logo",
             width="210",
             height="240",
             hi_def=True,
-            attrs={"class": "p-inline-images__logo"},
+            attrs={"class": "p-logo-section__logo"},
             loading="lazy"
             ) | safe
           }}
         </li>
-        <li class="p-inline-images__item">
+        <li class="p-logo-section__item">
           {{ image (
             url="https://assets.ubuntu.com/v1/ef01809f-DISA-logo-transparent.png",
             alt="DISA logo",
             width="720",
             height="264",
             hi_def=True,
-            attrs={"class": "p-inline-images__logo"},
+            attrs={"class": "p-logo-section__logo"},
             loading="lazy"
             ) | safe
           }}
         </li>
-        <li class="p-inline-images__item">
+        <li class="p-logo-section__item">
           {{ image (
             url="https://assets.ubuntu.com/v1/df72b154-CIS_Benchmarks-cropped.png",
             alt="CIS Benchmarks",

--- a/templates/openstack/index.html
+++ b/templates/openstack/index.html
@@ -119,103 +119,103 @@
   <div class="u-fixed-width">
     <p class="p-muted-heading u-align--center">Proven record of success</p>
     <ul class="p-inline-images">
-      <li class="p-inline-images__item">
+      <li class="p-logo-section__item">
         {{ image (
           url="https://assets.ubuntu.com/v1/0143bd92-AT%26T_logo_2016.svg",
           alt="AT&T",
           width="1000",
           height="411",
           hi_def=True,
-          attrs={"class": "p-inline-images__logo"},
+          attrs={"class": "p-logo-section__logo"},
           loading="auto"
           ) | safe
         }}
       </li>
-      <li class="p-inline-images__item">
+      <li class="p-logo-section__item">
         {{ image (
           url="https://assets.ubuntu.com/v1/2616b34f-ACI-Universal-Payments.svg",
           alt="ACI universal payments",
           width="118",
           height="54",
           hi_def=True,
-          attrs={"class": "p-inline-images__logo"},
+          attrs={"class": "p-logo-section__logo"},
           loading="auto"
           ) | safe
         }}
       </li>
-      <li class="p-inline-images__item">
+      <li class="p-logo-section__item">
         {{ image (
           url="https://assets.ubuntu.com/v1/06c5609f-logo-cisco.svg",
           alt="Cisco",
           width="125",
           height="65",
           hi_def=True,
-          attrs={"class": "p-inline-images__logo"},
+          attrs={"class": "p-logo-section__logo"},
           loading="auto"
           ) | safe
         }}
       </li>
-      <li class="p-inline-images__item">
+      <li class="p-logo-section__item">
         {{ image (
           url="https://assets.ubuntu.com/v1/8442024b-Gendarmerie_nationale_logo.svg.png",
           alt="Gendarmerie nationale",
           width="894",
           height="768",
           hi_def=True,
-          attrs={"class": "p-inline-images__logo"},
+          attrs={"class": "p-logo-section__logo"},
           loading="auto"
           ) | safe
         }}
       </li>
-      <li class="p-inline-images__item">
+      <li class="p-logo-section__item">
         {{ image (
           url="https://assets.ubuntu.com/v1/7538babd-Bloomberg_logo.svg",
           alt="Bloomberg",
           width="130",
           height="26",
           hi_def=True,
-          attrs={"class": "p-inline-images__logo"},
+          attrs={"class": "p-logo-section__logo"},
           loading="auto"
           ) | safe
         }}
       </li>
-      <li class="p-inline-images__item">
+      <li class="p-logo-section__item">
         {{ image (
           url="https://assets.ubuntu.com/v1/7c97efb0-BT_logo.svg",
           alt="BT",
           width="90",
           height="90",
           hi_def=True,
-          attrs={"class": "p-inline-images__logo"},
+          attrs={"class": "p-logo-section__logo"},
           loading="lazy"
           ) | safe
         }}
       </li>
-      <li class="p-inline-images__item">
+      <li class="p-logo-section__item">
         {{ image (
           url="https://assets.ubuntu.com/v1/40b42dd2-bnp-paribas_logo.svg",
           alt="BNP Paribas",
           width="165",
           height="40",
           hi_def=True,
-          attrs={"class": "p-inline-images__logo"},
+          attrs={"class": "p-logo-section__logo"},
           loading="auto"
           ) | safe
         }}
       </li>
-      <li class="p-inline-images__item">
+      <li class="p-logo-section__item">
         {{ image (
           url="https://assets.ubuntu.com/v1/d3959703-T-SYSTEMS-LOGO2013.svg",
           alt="T-systems",
           width="225",
           height="43",
           hi_def=True,
-          attrs={"class": "p-inline-images__logo"},
+          attrs={"class": "p-logo-section__logo"},
           loading="auto"
           ) | safe
         }}
       </li>
-      <li class="p-inline-images__item">
+      <li class="p-logo-section__item">
         {{ image (
           url="https://assets.ubuntu.com/v1/2d2e1ab2-king-abdullah-university-of-science-kaust-logo.png",
           alt="",
@@ -226,74 +226,74 @@
           ) | safe
         }}
       </li>
-      <li class="p-inline-images__item">
+      <li class="p-logo-section__item">
         {{ image (
           url="https://assets.ubuntu.com/v1/2ee0e692-1200px-DaimlerLogo.svg.png",
           alt="Daimer",
           width="240",
           height="30",
           hi_def=True,
-          attrs={"class": "p-inline-images__logo"},
+          attrs={"class": "p-logo-section__logo"},
           loading="auto"
           ) | safe
         }}
       </li>
-      <li class="p-inline-images__item">
+      <li class="p-logo-section__item">
         {{ image (
           url="https://assets.ubuntu.com/v1/d2bfbb2b-MTS_logo_%282016%29.svg",
           alt="MTS",
           width="266",
           height="98",
           hi_def=True,
-          attrs={"class": "p-inline-images__logo"},
+          attrs={"class": "p-logo-section__logo"},
           loading="auto"
           ) | safe
         }}
       </li>
-      <li class="p-inline-images__item">
+      <li class="p-logo-section__item">
         {{ image (
           url="https://assets.ubuntu.com/v1/ee5d503f-rabobank-4.svg",
           alt="Rabobank",
           width="250",
           height="45",
           hi_def=True,
-          attrs={"class": "p-inline-images__logo"},
+          attrs={"class": "p-logo-section__logo"},
           loading="auto"
           ) | safe
         }}
       </li>
-      <li class="p-inline-images__item">
+      <li class="p-logo-section__item">
         {{ image (
           url="https://assets.ubuntu.com/v1/df4150e2-nec-logo.svg",
           alt="NEC",
           width="132",
           height="36",
           hi_def=True,
-          attrs={"class": "p-inline-images__logo"},
+          attrs={"class": "p-logo-section__logo"},
           loading="auto"
           ) | safe
         }}
       </li>
-      <li class="p-inline-images__item">
+      <li class="p-logo-section__item">
         {{ image (
           url="https://assets.ubuntu.com/v1/1d34393a-best-buy_logo.svg",
           alt="Best Buy",
           width="100",
           height="73",
           hi_def=True,
-          attrs={"class": "p-inline-images__logo"},
+          attrs={"class": "p-logo-section__logo"},
           loading="auto"
           ) | safe
         }}
       </li>
-      <li class="p-inline-images__item">
+      <li class="p-logo-section__item">
         {{ image (
           url="https://assets.ubuntu.com/v1/27819db8-spectrum-health-logo.png",
           alt="Spectrum health",
           width="300",
           height="120",
           hi_def=True,
-          attrs={"class": "p-inline-images__logo"},
+          attrs={"class": "p-logo-section__logo"},
           loading="auto"
           ) | safe
         }}

--- a/templates/openstack/shared/_openstack_clients.html
+++ b/templates/openstack/shared/_openstack_clients.html
@@ -1,7 +1,7 @@
 <div class="u-fixed-width">
   <h2 class="p-muted-heading u-align--center">{{ heading }}</h2>
   <ul class="p-inline-images{% if size == 'smaller' %}--smaller{% endif %}">
-    <li class="p-inline-images__item">
+    <li class="p-logo-section__item">
       {{
         image(
           url="https://assets.ubuntu.com/v1/1ccb6d93-logo-deutschetelekom.svg",
@@ -9,12 +9,12 @@
           height="32",
           width="144",
           hi_def=True,
-          attrs={"class": "p-inline-images__logo"},
+          attrs={"class": "p-logo-section__logo"},
           loading="lazy",
         ) | safe
       }}
     </li>
-    <li class="p-inline-images__item">
+    <li class="p-logo-section__item">
       {{
         image(
           url="https://assets.ubuntu.com/v1/be345c7f-bSkyb_logo.png",
@@ -22,12 +22,12 @@
           height="87",
           width="141",
           hi_def=True,
-          attrs={"class": "p-inline-images__logo"},
+          attrs={"class": "p-logo-section__logo"},
           loading="lazy",
         ) | safe
       }}
     </li>
-    <li class="p-inline-images__item">
+    <li class="p-logo-section__item">
       {{
         image(
           url="https://assets.ubuntu.com/v1/b7693339-logo-bloomberg.svg",
@@ -35,12 +35,12 @@
           height="28",
           width="144",
           hi_def=True,
-          attrs={"class": "p-inline-images__logo"},
+          attrs={"class": "p-logo-section__logo"},
           loading="lazy",
         ) | safe
       }}
     </li>
-    <li class="p-inline-images__item">
+    <li class="p-logo-section__item">
       {{
         image(
           url="https://assets.ubuntu.com/v1/4ef05fb7-bestbuy.jpg",
@@ -48,12 +48,12 @@
           height="81",
           width="144",
           hi_def=True,
-          attrs={"class": "p-inline-images__logo"},
+          attrs={"class": "p-logo-section__logo"},
           loading="lazy",
         ) | safe
       }}
     </li>
-    <li class="p-inline-images__item">
+    <li class="p-logo-section__item">
       {{
         image(
           url="https://assets.ubuntu.com/v1/b3315d88-walmart.svg",
@@ -61,12 +61,12 @@
           height="34",
           width="144",
           hi_def=True,
-          attrs={"class": "p-inline-images__logo"},
+          attrs={"class": "p-logo-section__logo"},
           loading="lazy",
         ) | safe
       }}
     </li>
-    <li class="p-inline-images__item">
+    <li class="p-logo-section__item">
       {{
         image(
           url="https://assets.ubuntu.com/v1/73135672-ntt-logo.svg",
@@ -74,12 +74,12 @@
           height="53",
           width="144",
           hi_def=True,
-          attrs={"class": "p-inline-images__logo"},
+          attrs={"class": "p-logo-section__logo"},
           loading="lazy",
         ) | safe
       }}
     </li>
-    <li class="p-inline-images__item">
+    <li class="p-logo-section__item">
       {{
         image(
           url="https://assets.ubuntu.com/v1/ee5d503f-rabobank-4.svg",
@@ -87,12 +87,12 @@
           height="26",
           width="144",
           hi_def=True,
-          attrs={"class": "p-inline-images__logo"},
+          attrs={"class": "p-logo-section__logo"},
           loading="lazy",
         ) | safe
       }}
     </li>
-    <li class="p-inline-images__item">
+    <li class="p-logo-section__item">
       {{
         image(
           url="https://assets.ubuntu.com/v1/f9832168-AstraZeneca.png",
@@ -100,12 +100,12 @@
           height="36",
           width="144",
           hi_def=True,
-          attrs={"class": "p-inline-images__logo"},
+          attrs={"class": "p-logo-section__logo"},
           loading="lazy",
         ) | safe
       }}
     </li>
-    <li class="p-inline-images__item">
+    <li class="p-logo-section__item">
       {{
         image(
           url="https://assets.ubuntu.com/v1/d424d305-Tesco_Logo.svg",
@@ -113,12 +113,12 @@
           height="38",
           width="144",
           hi_def=True,
-          attrs={"class": "p-inline-images__logo"},
+          attrs={"class": "p-logo-section__logo"},
           loading="lazy",
         ) | safe
       }}
     </li>
-    <li class="p-inline-images__item">
+    <li class="p-logo-section__item">
       {{
         image(
           url="https://assets.ubuntu.com/v1/c26cade5-1024px-BNP_Paribas.svg1_.png",
@@ -126,12 +126,12 @@
           height="32",
           width="144",
           hi_def=True,
-          attrs={"class": "p-inline-images__logo"},
+          attrs={"class": "p-logo-section__logo"},
           loading="lazy",
         ) | safe
       }}
     </li>
-    <li class="p-inline-images__item">
+    <li class="p-logo-section__item">
       {{
         image(
           url="https://assets.ubuntu.com/v1/d8f890fb-logo-at%26t.svg",
@@ -139,12 +139,12 @@
           height="88",
           width="145",
           hi_def=True,
-          attrs={"class": "p-inline-images__logo"},
+          attrs={"class": "p-logo-section__logo"},
           loading="lazy",
         ) | safe
       }}
     </li>
-    <li class="p-inline-images__item">
+    <li class="p-logo-section__item">
       {{
         image(
           url="https://assets.ubuntu.com/v1/5cba4548-logo-ebay.svg",
@@ -152,7 +152,7 @@
           height="88",
           width="88",
           hi_def=True,
-          attrs={"class": "p-inline-images__logo"},
+          attrs={"class": "p-logo-section__logo"},
           loading="lazy",
         ) | safe
       }}

--- a/templates/robotics/index.html
+++ b/templates/robotics/index.html
@@ -39,7 +39,7 @@
       Proven in the field - companies using ROS on Ubuntu
     </h2>
     <ul class="p-inline-images">
-      <li class="p-inline-images__item">
+      <li class="p-logo-section__item">
         {{
           image(
           url="https://assets.ubuntu.com/v1/4044372b-ClearpathRobotics-logo.png",
@@ -48,11 +48,11 @@
           height="52",
           hi_def=True,
           loading="auto",
-          attrs={"class": "p-inline-images__logo"},
+          attrs={"class": "p-logo-section__logo"},
           ) | safe
         }}
       </li>
-      <li class="p-inline-images__item">
+      <li class="p-logo-section__item">
         {{
           image(
           url="https://assets.ubuntu.com/v1/255f733c-robotis_logo.png",
@@ -61,11 +61,11 @@
           height="29",
           hi_def=True,
           loading="lazy",
-          attrs={"class": "p-inline-images__logo"},
+          attrs={"class": "p-logo-section__logo"},
           ) | safe
         }}
       </li>
-      <li class="p-inline-images__item">
+      <li class="p-logo-section__item">
         {{
           image(
           url="https://assets.ubuntu.com/v1/e8609fb4-KUKA-logo.svg",
@@ -74,11 +74,11 @@
           height="25",
           hi_def=True,
           loading="lazy",
-          attrs={"class": "p-inline-images__logo"},
+          attrs={"class": "p-logo-section__logo"},
           ) | safe
         }}
       </li>
-      <li class="p-inline-images__item">
+      <li class="p-logo-section__item">
         {{
           image(
           url="https://assets.ubuntu.com/v1/fb984e2b-ApexAI_logo.png",
@@ -87,11 +87,11 @@
           height="37",
           hi_def=True,
           loading="lazy",
-          attrs={"class": "p-inline-images__logo"},
+          attrs={"class": "p-logo-section__logo"},
           ) | safe
         }}
       </li>
-      <li class="p-inline-images__item">
+      <li class="p-logo-section__item">
         {{
           image(
           url="https://assets.ubuntu.com/v1/723b9e31-pal-logo.png",
@@ -100,11 +100,11 @@
           height="60",
           hi_def=True,
           loading="lazy",
-          attrs={"class": "p-inline-images__logo"},
+          attrs={"class": "p-logo-section__logo"},
           ) | safe
         }}
       </li>
-      <li class="p-inline-images__item">
+      <li class="p-logo-section__item">
         {{
           image(
           url="https://assets.ubuntu.com/v1/a78c754a-locus_logo_horizon-removebg-preview.png",
@@ -113,12 +113,12 @@
           height="44",
           hi_def=True,
           loading="lazy",
-          attrs={"class": "p-inline-images__logo"},
+          attrs={"class": "p-logo-section__logo"},
           ) | safe
         }}
 
       </li>
-      <li class="p-inline-images__item">
+      <li class="p-logo-section__item">
         {{
           image(
           url="https://assets.ubuntu.com/v1/9f8bc8e5-Fetch-2019-Horizontal-331x120.png",
@@ -127,7 +127,7 @@
           height="52",
           hi_def=True,
           loading="lazy",
-          attrs={"class": "p-inline-images__logo"},
+          attrs={"class": "p-logo-section__logo"},
           ) | safe
         }}
       </li>

--- a/templates/robotics/what-is-ros.html
+++ b/templates/robotics/what-is-ros.html
@@ -105,7 +105,7 @@
     </div>
     <div class="col-4 u-vertically-center">
       <ul class="p-inline-images u-align--center">
-        <li class="p-inline-images__item">
+        <li class="p-logo-section__item">
           {{
             image(
               url="https://assets.ubuntu.com/v1/06243b53-otto-logo.svg",
@@ -118,7 +118,7 @@
             ) | safe
           }}
         </li>
-        <li class="p-inline-images__item">
+        <li class="p-logo-section__item">
           {{
             image(
               url="https://assets.ubuntu.com/v1/255a3171-abb-logo.svg",
@@ -131,7 +131,7 @@
             ) | safe
           }}
         </li>
-        <li class="p-inline-images__item">
+        <li class="p-logo-section__item">
           {{
             image(
               url="https://assets.ubuntu.com/v1/0952e178-doosan-logo.svg",
@@ -144,7 +144,7 @@
             ) | safe
           }}
         </li>
-        <li class="p-inline-images__item">
+        <li class="p-logo-section__item">
           {{
             image(
               url="https://assets.ubuntu.com/v1/9f8bc8e5-Fetch-2019-Horizontal-331x120.png",
@@ -157,7 +157,7 @@
             ) | safe
           }}
         </li>
-        <li class="p-inline-images__item">
+        <li class="p-logo-section__item">
           {{
             image(
               url="https://assets.ubuntu.com/v1/59e48f9c-irobot.png",
@@ -170,7 +170,7 @@
             ) | safe
           }}
         </li>
-        <li class="p-inline-images__item">
+        <li class="p-logo-section__item">
           {{
             image(
               url="https://assets.ubuntu.com/v1/255f733c-robotis_logo.png",

--- a/templates/security/certifications.html
+++ b/templates/security/certifications.html
@@ -61,7 +61,7 @@
     <div class="col-6 u-hide--small u-align--center">
       <div class="jsBrightTALKEmbedWrapper" style="width:100%; height:100%; position:relative;background: #ffffff;">
         <script class="jsBrightTALKEmbedConfig" type="application/json">
-          { "channelId" : 6793, "language": "en-US", "commId" : 524647, "displayMode" : "standalone", "height" : "280" }
+          { "channelId" : 6793, "language": "en-US", "commId" : 524647, "displayMode" : "standalone", "height" : "auto" }
         </script>
         <script src="https://www.brighttalk.com/clients/js/player-embed/player-embed.js" class="jsBrightTALKEmbed"></script>
       </div>

--- a/templates/security/disa-stig.html
+++ b/templates/security/disa-stig.html
@@ -44,7 +44,7 @@
     <div class="col-5 u-hide--small u-align--center">
       <div class="jsBrightTALKEmbedWrapper u-vertically-center" style="width:100%; height:100%; position:relative;background: #ffffff;">
         <script class="jsBrightTALKEmbedConfig" type="application/json">
-          { "channelId" : 6793, "language": "en-US", "commId" : 524647, "displayMode" : "standalone", "height" : "280" }
+          { "channelId" : 6793, "language": "en-US", "commId" : 524647, "displayMode" : "standalone", "height" : "auto" }
         </script>
         <script src="https://www.brighttalk.com/clients/js/player-embed/player-embed.js" class="jsBrightTALKEmbed"></script>
       </div>

--- a/templates/security/fips.html
+++ b/templates/security/fips.html
@@ -82,7 +82,7 @@
     <div class="col-6 u-hide--small u-align--center">
       <div class="jsBrightTALKEmbedWrapper u-vertically-center" style="width:100%; height:100%; position:relative;background: #ffffff;">
         <script class="jsBrightTALKEmbedConfig" type="application/json">
-          { "channelId" : 6793, "language": "en-US", "commId" : 524647, "displayMode" : "standalone", "height" : "250" }
+          { "channelId" : 6793, "language": "en-US", "commId" : 524647, "displayMode" : "standalone", "height" : "auto" }
         </script>
         <script src="https://www.brighttalk.com/clients/js/player-embed/player-embed.js" class="jsBrightTALKEmbed"></script>
       </div>

--- a/templates/security/index.html
+++ b/templates/security/index.html
@@ -61,10 +61,10 @@
         <a class="p-button js-invoke-modal" data-testid="interactive-form-link" href="/security/contact-us">Contact us</a>
       </p>
     </div>
-    <div class="col-6 u-hide--small u-align--center">
-      <div class="jsBrightTALKEmbedWrapper" style="width:100%; height:100%; position:relative;background: #ffffff;">
+    <div class="col-6 u-hide--small u-align--center" id="webinar">
+      <div class="jsBrightTALKEmbedWrapper" style="width:100%; height:100%; position:relative; background:#ffffff;">
         <script class="jsBrightTALKEmbedConfig" type="application/json">
-          { "channelId" : 6793, "language": "en-US", "commId" : 516333, "displayMode" : "standalone", "height" : "250" }
+          { "channelId" : 6793, "language": "en-US", "commId" : 516333, "displayMode" : "standalone", "height" : "auto"}
         </script>
         <script src="https://www.brighttalk.com/clients/js/player-embed/player-embed.js" class="jsBrightTALKEmbed"></script>
       </div>
@@ -204,7 +204,7 @@
   <div class="u-fixed-width">
     <h2 class="p-muted-heading u-align--center">Ubuntu is trusted by</h2>
     <ul class="p-inline-images">
-      <li class="p-inline-images__item">
+      <li class="p-logo-section__item">
         {{
           image(
             url="https://assets.ubuntu.com/v1/b7693339-logo-bloomberg.svg",
@@ -213,11 +213,11 @@
             width="144",
             hi_def=True,
             loading="lazy",
-            attrs={"class": "p-inline-images__logo"}
+            attrs={"class": "p-logo-section__logo"}
           ) | safe
         }}
       </li>
-      <li class="p-inline-images__item">
+      <li class="p-logo-section__item">
         {{
           image(
             url="https://assets.ubuntu.com/v1/d8f890fb-logo-at%26t.svg",
@@ -226,11 +226,11 @@
             width="88",
             hi_def=True,
             loading="lazy",
-            attrs={"class": "p-inline-images__logo"}
+            attrs={"class": "p-logo-section__logo"}
           ) | safe
         }}
       </li>
-      <li class="p-inline-images__item">
+      <li class="p-logo-section__item">
         {{
           image(
             url="https://assets.ubuntu.com/v1/b3315d88-walmart.svg",
@@ -239,11 +239,11 @@
             width="144",
             hi_def=True,
             loading="lazy",
-            attrs={"class": "p-inline-images__logo"}
+            attrs={"class": "p-logo-section__logo"}
           ) | safe
         }}
       </li>
-      <li class="p-inline-images__item">
+      <li class="p-logo-section__item">
         {{
           image(
             url="https://assets.ubuntu.com/v1/03a06060-logo-deutschetelekom.svg",
@@ -252,11 +252,11 @@
             width="144",
             hi_def=True,
             loading="lazy",
-            attrs={"class": "p-inline-images__logo"}
+            attrs={"class": "p-logo-section__logo"}
           ) | safe
         }}
       </li>
-      <li class="p-inline-images__item">
+      <li class="p-logo-section__item">
         {{
           image(
             url="https://assets.ubuntu.com/v1/e0f7037f-logo-ebay.svg",
@@ -265,11 +265,11 @@
             width="144",
             hi_def=True,
             loading="lazy",
-            attrs={"class": "p-inline-images__logo"}
+            attrs={"class": "p-logo-section__logo"}
           ) | safe
         }}
       </li>
-      <li class="p-inline-images__item">
+      <li class="p-logo-section__item">
         {{
           image(
             url="https://assets.ubuntu.com/v1/4d6054f9-logo-cisco.svg",
@@ -278,11 +278,11 @@
             width="144",
             hi_def=True,
             loading="lazy",
-            attrs={"class": "p-inline-images__logo"}
+            attrs={"class": "p-logo-section__logo"}
           ) | safe
         }}
       </li>
-      <li class="p-inline-images__item">
+      <li class="p-logo-section__item">
         {{
           image(
             url="https://assets.ubuntu.com/v1/73135672-ntt-logo.svg",
@@ -291,11 +291,11 @@
             width="144",
             hi_def=True,
             loading="lazy",
-            attrs={"class": "p-inline-images__logo"}
+            attrs={"class": "p-logo-section__logo"}
           ) | safe
         }}
       </li>
-      <li class="p-inline-images__item">
+      <li class="p-logo-section__item">
         {{
           image(
             url="https://assets.ubuntu.com/v1/8393d534-logo-bestbuy.svg",
@@ -304,11 +304,11 @@
             width="144",
             hi_def=True,
             loading="lazy",
-            attrs={"class": "p-inline-images__logo"}
+            attrs={"class": "p-logo-section__logo"}
           ) | safe
         }}
       </li>
-      <li class="p-inline-images__item">
+      <li class="p-logo-section__item">
         {{
           image(
             url="https://assets.ubuntu.com/v1/0c18b0ae-paypal_logo.svg",
@@ -317,7 +317,7 @@
             width="144",
             hi_def=True,
             loading="lazy",
-            attrs={"class": "p-inline-images__logo"}
+            attrs={"class": "p-logo-section__logo"}
           ) | safe
         }}
       </li>

--- a/templates/server/index.html
+++ b/templates/server/index.html
@@ -118,7 +118,7 @@
   <div class="u-fixed-width">
     <h3 class="p-muted-heading u-align--center">Works with all your hardware and software</h3>
     <ul class="p-inline-images">
-      <li class="p-inline-images__item">
+      <li class="p-logo-section__item">
         {{
           image(
               url="https://assets.ubuntu.com/v1/68713fd5-logo-lenovo.svg",
@@ -127,12 +127,12 @@
               height="24",
               hi_def=True,
               loading="lazy",
-              attrs={"class": "p-inline-images__logo"},
+              attrs={"class": "p-logo-section__logo"},
           ) | safe
         }}
 
       </li>
-      <li class="p-inline-images__item">
+      <li class="p-logo-section__item">
         {{
           image(
               url="https://assets.ubuntu.com/v1/5ddba83a-logo-dell.svg",
@@ -141,11 +141,11 @@
               height="88",
               hi_def=True,
               loading="lazy",
-              attrs={"class": "p-inline-images__logo"},
+              attrs={"class": "p-logo-section__logo"},
           ) | safe
         }}
       </li>
-      <li class="p-inline-images__item">
+      <li class="p-logo-section__item">
         {{
           image(
               url="https://assets.ubuntu.com/v1/683950fd-logo-ibm.svg",
@@ -154,11 +154,11 @@
               height="58",
               hi_def=True,
               loading="lazy",
-              attrs={"class": "p-inline-images__logo"},
+              attrs={"class": "p-logo-section__logo"},
           ) | safe
         }}
       </li>
-      <li class="p-inline-images__item">
+      <li class="p-logo-section__item">
         {{
           image(
               url="https://assets.ubuntu.com/v1/a298e7ec-logo-hp.svg",
@@ -167,11 +167,11 @@
               height="88",
               hi_def=True,
               loading="lazy",
-              attrs={"class": "p-inline-images__logo"},
+              attrs={"class": "p-logo-section__logo"},
           ) | safe
         }}
       </li>
-      <li class="last-item p-inline-images__item">
+      <li class="last-item p-logo-section__item">
         {{
           image(
               url="https://assets.ubuntu.com/v1/c24cb4b9-logo-intel.svg",
@@ -180,11 +180,11 @@
               height="88",
               hi_def=True,
               loading="lazy",
-              attrs={"class": "p-inline-images__logo"},
+              attrs={"class": "p-logo-section__logo"},
           ) | safe
         }}
       </li>
-      <li class="p-inline-images__item">
+      <li class="p-logo-section__item">
         {{
           image(
               url="https://assets.ubuntu.com/v1/4d6054f9-logo-cisco.svg",
@@ -193,11 +193,11 @@
               height="76",
               hi_def=True,
               loading="lazy",
-              attrs={"class": "p-inline-images__logo"},
+              attrs={"class": "p-logo-section__logo"},
           ) | safe
         }}
       </li>
-      <li class="p-inline-images__item">
+      <li class="p-logo-section__item">
         {{
           image(
               url="https://assets.ubuntu.com/v1/731aab6c-logo-amd.svg",
@@ -206,11 +206,11 @@
               height="44",
               hi_def=True,
               loading="lazy",
-              attrs={"class": "p-inline-images__logo"},
+              attrs={"class": "p-logo-section__logo"},
           ) | safe
         }}
       </li>
-      <li class="last-item p-inline-images__item">
+      <li class="last-item p-logo-section__item">
         {{
           image(
               url="https://assets.ubuntu.com/v1/4efbd291-Arm_logo_blue_cropped.svg",
@@ -219,7 +219,7 @@
               height="44",
               hi_def=True,
               loading="lazy",
-              attrs={"class": "p-inline-images__logo"},
+              attrs={"class": "p-logo-section__logo"},
           ) | safe
         }}
       </li>
@@ -229,7 +229,7 @@
     </a></p>
 
     <ul class="p-inline-images">
-      <li class="p-inline-images__item">
+      <li class="p-logo-section__item">
         {{
           image(
               url="https://assets.ubuntu.com/v1/76999dfc-logo-centrify.png",
@@ -238,11 +238,11 @@
               height="87",
               hi_def=True,
               loading="lazy",
-              attrs={"class": "p-inline-images__logo"},
+              attrs={"class": "p-logo-section__logo"},
           ) | safe
         }}
       </li>
-      <li class="p-inline-images__item">
+      <li class="p-logo-section__item">
         {{
           image(
               url="https://assets.ubuntu.com/v1/eed716e9-logo-openstack.svg",
@@ -251,11 +251,11 @@
               height="88",
               hi_def=True,
               loading="lazy",
-              attrs={"class": "p-inline-images__logo"},
+              attrs={"class": "p-logo-section__logo"},
           ) | safe
         }}
       </li>
-      <li class="p-inline-images__item">
+      <li class="p-logo-section__item">
         {{
           image(
               url="https://assets.ubuntu.com/v1/c228b4e9-logo-likewise.png?w=144",
@@ -264,11 +264,11 @@
               height="79",
               hi_def=True,
               loading="lazy",
-              attrs={"class": "p-inline-images__logo"},
+              attrs={"class": "p-logo-section__logo"},
           ) | safe
         }}
       </li>
-      <li class="last-item p-inline-images__item">
+      <li class="last-item p-logo-section__item">
         {{
           image(
               url="https://assets.ubuntu.com/v1/64493bba-logo-openbravo.png?w=144",
@@ -277,7 +277,7 @@
               height="34",
               hi_def=True,
               loading="lazy",
-              attrs={"class": "p-inline-images__logo"},
+              attrs={"class": "p-logo-section__logo"},
           ) | safe
         }}
       </li>

--- a/templates/shared/_partner-logos.html
+++ b/templates/shared/_partner-logos.html
@@ -11,8 +11,8 @@
   {% if title %}<h2 class="p-muted-heading u-align--center">{{title}}</h2>{% endif %}
   <ul id="cloud-partners" class="p-inline-images">
     {% for partner in partners %}
-      <li class="p-inline-images__item">
-        {% if partner.partner_website %}<a href="{{ partner.partner_website }}">{% endif %}<img class="p-inline-images__logo" src="{{ partner.logo }}" style="max-width: 144px;" width="144" alt="{{ partner.name }}" />{% if partner.partner_website %}</a>{% endif %}
+      <li class="p-logo-section__item">
+        {% if partner.partner_website %}<a href="{{ partner.partner_website }}">{% endif %}<img class="p-logo-section__logo" src="{{ partner.logo }}" style="max-width: 144px;" width="144" alt="{{ partner.name }}" />{% if partner.partner_website %}</a>{% endif %}
       </li>
     {% endfor %}
   </ul>

--- a/templates/support/index.html
+++ b/templates/support/index.html
@@ -37,7 +37,7 @@
 <section class="p-strip">
   <div class="u-fixed-width u-align--center">
     <ul class="p-inline-images">
-      <li class="p-inline-images__item">
+      <li class="p-logo-section__item">
         {{
           image(
               url="https://assets.ubuntu.com/v1/7538babd-Bloomberg_logo.svg",
@@ -46,11 +46,11 @@
               height="35",
               hi_def=True,
               loading="lazy",
-              attrs={"class": "p-inline-images__logo", "id": ""},
+              attrs={"class": "p-logo-section__logo", "id": ""},
           ) | safe
         }}
       </li>
-      <li class="p-inline-images__item">
+      <li class="p-logo-section__item">
         {{
           image(
               url="https://assets.ubuntu.com/v1/0143bd92-AT%26T_logo_2016.svg",
@@ -59,11 +59,11 @@
               height="50",
               hi_def=True,
               loading="lazy",
-              attrs={"class": "p-inline-images__logo", "id": ""},
+              attrs={"class": "p-logo-section__logo", "id": ""},
           ) | safe
         }}
       </li>
-      <li class="p-inline-images__item">
+      <li class="p-logo-section__item">
         {{
           image(
               url="https://assets.ubuntu.com/v1/3161e6ba-logo-walmart.svg",
@@ -72,11 +72,11 @@
               height="60",
               hi_def=True,
               loading="lazy",
-              attrs={"class": "p-inline-images__logo", "id": ""},
+              attrs={"class": "p-logo-section__logo", "id": ""},
           ) | safe
         }}
       </li>
-      <li class="p-inline-images__item">
+      <li class="p-logo-section__item">
         {{
           image(
               url="https://assets.ubuntu.com/v1/03a06060-logo-deutschetelekom.svg",
@@ -85,11 +85,11 @@
               height="50",
               hi_def=True,
               loading="lazy",
-              attrs={"class": "p-inline-images__logo", "id": ""},
+              attrs={"class": "p-logo-section__logo", "id": ""},
           ) | safe
         }}
       </li>
-      <li class="p-inline-images__item">
+      <li class="p-logo-section__item">
         {{
           image(
               url="https://assets.ubuntu.com/v1/e0f7037f-logo-ebay.svg",
@@ -98,11 +98,11 @@
               height="40",
               hi_def=True,
               loading="lazy",
-              attrs={"class": "p-inline-images__logo", "id": ""},
+              attrs={"class": "p-logo-section__logo", "id": ""},
           ) | safe
         }}
       </li>
-      <li class="p-inline-images__item">
+      <li class="p-logo-section__item">
         {{
           image(
               url="https://assets.ubuntu.com/v1/06c5609f-logo-cisco.svg",
@@ -111,11 +111,11 @@
               height="50",
               hi_def=True,
               loading="lazy",
-              attrs={"class": "p-inline-images__logo", "id": ""},
+              attrs={"class": "p-logo-section__logo", "id": ""},
           ) | safe
         }}
       </li>
-      <li class="p-inline-images__item">
+      <li class="p-logo-section__item">
         {{
           image(
               url="https://assets.ubuntu.com/v1/ddb0f9d6-logo-ntt.svg",
@@ -124,11 +124,11 @@
               height="66",
               hi_def=True,
               loading="lazy",
-              attrs={"class": "p-inline-images__logo", "id": ""},
+              attrs={"class": "p-logo-section__logo", "id": ""},
           ) | safe
         }}
       </li>
-      <li class="p-inline-images__item">
+      <li class="p-logo-section__item">
         {{
           image(
               url="https://assets.ubuntu.com/v1/1d34393a-best-buy_logo.svg",
@@ -137,11 +137,11 @@
               height="50",
               hi_def=True,
               loading="lazy",
-              attrs={"class": "p-inline-images__logo", "id": ""},
+              attrs={"class": "p-logo-section__logo", "id": ""},
           ) | safe
         }}
       </li>
-      <li class="p-inline-images__item">
+      <li class="p-logo-section__item">
         {{
           image(
               url="https://assets.ubuntu.com/v1/0c18b0ae-paypal_logo.svg",
@@ -150,7 +150,7 @@
               height="36",
               hi_def=True,
               loading="lazy",
-              attrs={"class": "p-inline-images__logo", "id": ""},
+              attrs={"class": "p-logo-section__logo", "id": ""},
           ) | safe
         }}
       </li>

--- a/templates/telco/osm/index.html
+++ b/templates/telco/osm/index.html
@@ -342,7 +342,7 @@
             height="145",
             hi_def=True,
             loading="lazy",
-            attrs={"class": "p-inline-images__logo"},
+            attrs={"class": "p-logo-section__logo"},
             ) | safe
           }}
         </div>
@@ -355,7 +355,7 @@
             width="83",
             hi_def=True,
             loading="lazy",
-            attrs={"class": "p-inline-images__logo"},
+            attrs={"class": "p-logo-section__logo"},
             ) | safe
           }}
         </div>
@@ -368,7 +368,7 @@
             width="97",
             hi_def=True,
             loading="lazy",
-            attrs={"class": "p-inline-images__logo"},
+            attrs={"class": "p-logo-section__logo"},
             ) | safe
           }}
         </div>
@@ -381,7 +381,7 @@
             width="160",
             hi_def=True,
             loading="lazy",
-            attrs={"class": "p-inline-images__logo"},
+            attrs={"class": "p-logo-section__logo"},
             ) | safe
           }}
         </div>
@@ -394,7 +394,7 @@
             width="130",
             hi_def=True,
             loading="lazy",
-            attrs={"class": "p-inline-images__logo"},
+            attrs={"class": "p-logo-section__logo"},
             ) | safe
           }}
         </div>
@@ -407,7 +407,7 @@
             width="64",
             hi_def=True,
             loading="lazy",
-            attrs={"class": "p-inline-images__logo"},
+            attrs={"class": "p-logo-section__logo"},
             ) | safe
           }}
         </div>
@@ -420,7 +420,7 @@
             width="100",
             hi_def=True,
             loading="lazy",
-            attrs={"class": "p-inline-images__logo"},
+            attrs={"class": "p-logo-section__logo"},
             ) | safe
           }}
         </div>
@@ -433,7 +433,7 @@
             width="80",
             hi_def=True,
             loading="lazy",
-            attrs={"class": "p-inline-images__logo"},
+            attrs={"class": "p-logo-section__logo"},
             ) | safe
           }}
         </div>
@@ -446,7 +446,7 @@
             width="100",
             hi_def=True,
             loading="lazy",
-            attrs={"class": "p-inline-images__logo"},
+            attrs={"class": "p-logo-section__logo"},
             ) | safe
           }}
         </div>
@@ -459,7 +459,7 @@
             width="144",
             hi_def=True,
             loading="lazy",
-            attrs={"class": "p-inline-images__logo"},
+            attrs={"class": "p-logo-section__logo"},
             ) | safe
           }}
         </div>
@@ -472,7 +472,7 @@
             width="100",
             hi_def=True,
             loading="lazy",
-            attrs={"class": "p-inline-images__logo"},
+            attrs={"class": "p-logo-section__logo"},
             ) | safe
           }}
         </div>
@@ -485,7 +485,7 @@
             width="100",
             hi_def=True,
             loading="lazy",
-            attrs={"class": "p-inline-images__logo"},
+            attrs={"class": "p-logo-section__logo"},
             ) | safe
           }}
         </div>
@@ -497,7 +497,7 @@
             height="42",
             hi_def=True,
             loading="lazy",
-            attrs={"class": "p-inline-images__logo"},
+            attrs={"class": "p-logo-section__logo"},
             ) | safe
           }}
         </div>
@@ -509,7 +509,7 @@
             height="70",
             hi_def=True,
             loading="lazy",
-            attrs={"class": "p-inline-images__logo"},
+            attrs={"class": "p-logo-section__logo"},
             ) | safe
           }}
         </div>


### PR DESCRIPTION
## Done

**NOTE** without the correct logos some sections don't look right so paused until we have the correct logos
- Replace the use of p-inline-images with p-logo-section

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes

## Issue / Card

Fixes https://github.com/canonical-web-and-design/web-squad/issues/4853
