### PR TITLE
Expand columns for engage pages without forms

### DIFF
--- a/templates/engage/base.html
+++ b/templates/engage/base.html
@@ -83,9 +83,9 @@
 
 <section class="p-strip is-shallow is-bordered">
   <div class="row">
-    <div class="{% if document['metadata']['form_id'] != '' %}col-7{% else %}col-8{% endif %}">
+    <div class="{% if 'form_id' in document['metadata'] and document['metadata']['form_id'] != '' %}col-7{% else %}col-12{% endif %}">
       {% for text in document["body_html"] %}
-      {{ text | safe }}
+        {{ text | safe }}
       {% endfor %}
     </div>
     {% if "form_id" in document["metadata"] and document["metadata"]["form_id"] != "" %}


### PR DESCRIPTION
## Done

Expand columns when there is no form

## QA

- Check some engage pages without form such as https://ubuntu-com-11335.demos.haus/engage/custom-ubuntu-pro-image-on-azure
- See that the column expands to take up more space and the content centers.
- Compare with current https://ubuntu.com/engage/custom-ubuntu-pro-image-on-azure
- Check the engage pages with form are undisturbed https://ubuntu-com-11335.demos.haus/engage/gsi-managed-it-service
## Issue / Card
Fixes https://github.com/canonical-web-and-design/ubuntu.com/issues/11268
originally requested by @malina-i 

## Help

[QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html) - [Commit guidelines](https://canonical-web-and-design.github.io/practices/workflow/commit-messages.html)
