### PR TITLE
Add subsystem id to hardware details

### DIFF
--- a/templates/certified/hardware-details.html
+++ b/templates/certified/hardware-details.html
@@ -75,7 +75,7 @@
                 <ul class="p-list u-no-margin--bottom">
                 {% for device in devices %}
                 <li class="p-list__item u-no-padding--top">
-                  {{ device.name }} {% if device.bus in ["usb", "pci"] %}({{ device.identifier }}){% endif %}
+                  {{ device.name }} {% if device.bus in ["usb", "pci"] %}({{ device.identifier }}{% if device.subsystem != '' %} {{ device.subsystem }}{% endif %}){% endif %}
                 </li>
                 {% endfor %}
                 </ul>

--- a/templates/certified/model-details.html
+++ b/templates/certified/model-details.html
@@ -121,7 +121,7 @@
                   <tr>
                     <th colspan="2" class="u-text--muted">{{ hardware_subtitle }}</th>
                     <td colspan="8">{% for value in values %} 
-                      <p style="margin-bottom: 0.5rem;">{{ value.name }}{% if value.bus in ["usb", "pci"] %} {{ value.bus }} ({{ value.identifier }}){% endif %}</p>
+                      <p style="margin-bottom: 0.5rem;">{{ value.name }}{% if value.bus in ["usb", "pci"] %} {{ value.bus }} ({{ value.identifier }}{% if value.subsystem != '' %} {{ value.subsystem }}{% endif %}){% endif %}</p>
                       {% endfor %}
                     </td>
                   </tr>

--- a/webapp/certified/views.py
+++ b/webapp/certified/views.py
@@ -88,6 +88,7 @@ def certified_hardware_details(canonical_id, release):
             ),
             "bus": device["bus"],
             "identifier": device["identifier"],
+            "subsystem": device["subsystem"],
         }
 
         category = device["category"]
@@ -171,6 +172,7 @@ def certified_model_details(canonical_id):
                                 ),
                                 "bus": device["bus"],
                                 "identifier": device["identifier"],
+                                "subsystem": device["subsystem"],
                             }
                         )
         release_details["releases"].append(release_info)


### PR DESCRIPTION
## Done

Add subsystem id to hardware details page

## QA

- Check https://ubuntu-com-11336.demos.haus/certified/202108-29379/20.04%20LTS
- Compare with current https://ubuntu.com/certified/202108-29379/20.04%20LTS

I did this using my common sense. Feel free to suggest any ammendments, changing the format, orthography...

## Issue / Card

Fixes https://github.com/canonical-web-and-design/ubuntu.com/issues/11311

## Screenshots

![subsystem-id](https://user-images.githubusercontent.com/14939793/157480385-1e41675e-deb3-4681-a68f-679d4d3a5203.png)



## Help

[QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html) - [Commit guidelines](https://canonical-web-and-design.github.io/practices/workflow/commit-messages.html)
