### PR TITLE
Fix spacing issue in chart.js

### DIFF
--- a/static/js/src/chart-data.js
+++ b/static/js/src/chart-data.js
@@ -379,43 +379,43 @@ export var kernelReleases2004 = [
   {
     startDate: new Date("2022-02-12T00:00:00"),
     endDate: new Date("2022-08-17T00:00:00"),
-    taskName: "Ubuntu 20.04.4 LTS",
+    taskName: "Ubuntu 20.04.4 LTS (v5.13)",
     status: "LTS",
   },
   {
     startDate: new Date("2021-08-16T00:00:00"),
     endDate: new Date("2022-02-18T00:00:00"),
-    taskName: "Ubuntu 20.04.3 LTS",
+    taskName: "Ubuntu 20.04.3 LTS (v5.11)",
     status: "LTS",
   },
   {
     startDate: new Date("2021-02-17T00:00:00"),
     endDate: new Date("2021-08-22T00:00:00"),
-    taskName: "Ubuntu 20.04.2 LTS",
+    taskName: "Ubuntu 20.04.2 LTS (v5.8)",
     status: "LTS",
   },
   {
     startDate: new Date("2020-07-22T00:00:00"),
     endDate: new Date("2025-04-22T00:00:00"),
-    taskName: "Ubuntu 20.04.1 LTS",
+    taskName: "Ubuntu 20.04.1 LTS (v5.4)",
     status: "LTS",
   },
   {
     startDate: new Date("2025-04-22T00:00:00"),
     endDate: new Date("2030-04-21T00:00:00"),
-    taskName: "Ubuntu 20.04.1 LTS",
+    taskName: "Ubuntu 20.04.1 LTS (v5.4)",
     status: "ESM",
   },
   {
     startDate: new Date("2020-04-23T00:00:00"),
     endDate: new Date("2025-04-22T00:00:00"),
-    taskName: "Ubuntu 20.04.0 LTS",
+    taskName: "Ubuntu 20.04.0 LTS (v5.4)",
     status: "LTS",
   },
   {
     startDate: new Date("2025-04-22T00:00:00"),
     endDate: new Date("2030-04-21T00:00:00"),
-    taskName: "Ubuntu 20.04.0 LTS",
+    taskName: "Ubuntu 20.04.0 LTS (v5.4)",
     status: "ESM",
   },
 ];
@@ -745,25 +745,25 @@ export var kernelReleasesALL = [
   {
     startDate: new Date("2020-01-24T00:00:00"),
     endDate: new Date("2020-04-23T00:00:00"),
-    taskName: "Ubuntu 20.04.0 LTS",
+    taskName: "Ubuntu 20.04.0 LTS (v5.4)",
     status: "EARLY",
   },
   {
     startDate: new Date("2020-04-23T00:00:00"),
     endDate: new Date("2025-04-22T00:00:00"),
-    taskName: "Ubuntu 20.04.0 LTS",
+    taskName: "Ubuntu 20.04.0 LTS (v5.4)",
     status: "LTS",
   },
   {
     startDate: new Date("2020-04-23T00:00:00"),
     endDate: new Date("2020-07-22T00:00:00"),
-    taskName: "Ubuntu 20.04.1 LTS",
+    taskName: "Ubuntu 20.04.1 LTS (v5.4)",
     status: "EARLY",
   },
   {
     startDate: new Date("2020-07-22T00:00:00"),
     endDate: new Date("2025-04-22T00:00:00"),
-    taskName: "Ubuntu 20.04.1 LTS",
+    taskName: "Ubuntu 20.04.1 LTS (v5.4)",
     status: "LTS",
   },
   {
@@ -781,19 +781,19 @@ export var kernelReleasesALL = [
   {
     startDate: new Date("2021-02-17T00:00:00"),
     endDate: new Date("2021-08-22T00:00:00"),
-    taskName: "Ubuntu 20.04.2 LTS",
+    taskName: "Ubuntu 20.04.2 LTS (v5.8)",
     status: "LTS",
   },
   {
     startDate: new Date("2021-08-16T00:00:00"),
     endDate: new Date("2022-02-18T00:00:00"),
-    taskName: "Ubuntu 20.04.3 LTS",
+    taskName: "Ubuntu 20.04.3 LTS (v5.11)",
     status: "LTS",
   },
   {
     startDate: new Date("2022-02-12T00:00:00"),
     endDate: new Date("2022-08-17T00:00:00"),
-    taskName: "Ubuntu 20.04.4 LTS",
+    taskName: "Ubuntu 20.04.4 LTS (v5.13)",
     status: "LTS",
   },
   {
@@ -970,25 +970,25 @@ export var kernelReleasesLTS = [
   {
     startDate: new Date("2020-04-23T00:00:00"),
     endDate: new Date("2022-04-23T00:00:00"),
-    taskName: "Ubuntu 20.04.0 LTS",
+    taskName: "Ubuntu 20.04.0 LTS (v5.4)",
     status: "LTS",
   },
   {
     startDate: new Date("2022-04-23T00:00:00"),
     endDate: new Date("2025-04-22T00:00:00"),
-    taskName: "Ubuntu 20.04.0 LTS",
+    taskName: "Ubuntu 20.04.0 LTS (v5.4)",
     status: "CVE",
   },
   {
     startDate: new Date("2020-07-22T00:00:00"),
     endDate: new Date("2022-04-13T00:00:00"),
-    taskName: "Ubuntu 20.04.1 LTS",
+    taskName: "Ubuntu 20.04.1 LTS (v5.4)",
     status: "LTS",
   },
   {
     startDate: new Date("2022-04-13T00:00:00"),
     endDate: new Date("2025-04-22T00:00:00"),
-    taskName: "Ubuntu 20.04.1 LTS",
+    taskName: "Ubuntu 20.04.1 LTS (v5.4)",
     status: "CVE",
   },
   {
@@ -1006,19 +1006,19 @@ export var kernelReleasesLTS = [
   {
     startDate: new Date("2021-02-17T00:00:00"),
     endDate: new Date("2021-08-22T00:00:00"),
-    taskName: "Ubuntu 20.04.2 LTS",
+    taskName: "Ubuntu 20.04.2 LTS (v5.8)",
     status: "LTS",
   },
   {
     startDate: new Date("2021-08-16T00:00:00"),
     endDate: new Date("2022-02-18T00:00:00"),
-    taskName: "Ubuntu 20.04.3 LTS",
+    taskName: "Ubuntu 20.04.3 LTS (v5.11)",
     status: "LTS",
   },
   {
     startDate: new Date("2022-02-12T00:00:00"),
     endDate: new Date("2022-07-17T00:00:00"),
-    taskName: "Ubuntu 20.04.4 LTS",
+    taskName: "Ubuntu 20.04.4 LTS (v5.13)",
     status: "LTS",
   },
   {

--- a/static/js/src/chart.js
+++ b/static/js/src/chart.js
@@ -239,6 +239,20 @@ function formatKeyLabel(key) {
 
 /**
  *
+ * @param {Array} taskTypes
+ *
+ * Calculate the longest Y-Axis label
+ */
+function calculateYAxisWidth(YAxisLabels) {
+  var YAxisLabelsCopy = YAxisLabels.slice();
+  var longestLabel = YAxisLabelsCopy.sort(function (a, b) {
+    return b.length - a.length;
+  })[0];
+  return longestLabel.length * 7;
+}
+
+/**
+ *
  * @param {String} chartSelector
  * @param {Array} taskTypes
  * @param {Object} taskStatus
@@ -259,8 +273,8 @@ export function createChart(
     top: 0,
     right: 40,
     bottom: 20,
-    left: 150,
   };
+  margin.left = calculateYAxisWidth(taskTypes);
   var rowHeight = 32;
   var timeDomainStart;
   var timeDomainEnd;

--- a/templates/shared/_kernel-support-schedule.html
+++ b/templates/shared/_kernel-support-schedule.html
@@ -42,39 +42,39 @@
             <tbody>
               <tr>
                 <td><strong>Ubuntu 20.04.5 LTS</strong></td>
-                <td>Aug 2022</td>
-                <td>Apr 2025</td>
-                <td>Apr 2030</td>
+                <td>Aug 2022</td>
+                <td>Apr 2025</td>
+                <td>Apr 2030</td>
               </tr>
               <tr>
                 <td><strong>Ubuntu 20.04.4 LTS</strong></td>
-                <td>Feb 2022</td>
-                <td>Aug 2022</td>
+                <td>Feb 2022</td>
+                <td>Aug 2022</td>
                 <td>&nbsp;</td>
               </tr>
               <tr>
                 <td><strong>Ubuntu 20.04.3 LTS</strong></td>
-                <td>Aug 2021</td>
-                <td>Feb 2022</td>
+                <td>Aug 2021</td>
+                <td>Feb 2022</td>
                 <td>&nbsp;</td>
               </tr>
               <tr>
                 <td><strong>Ubuntu 20.04.2 LTS</strong></td>
-                <td>Feb 2021</td>
-                <td>Aug 2021</td>
+                <td>Feb 2021</td>
+                <td>Aug 2021</td>
                 <td>&nbsp;</td>
               </tr>
               <tr>
                 <td><strong>Ubuntu 20.04.1 LTS</strong></td>
-                <td>Jul 2020</td>
-                <td>Apr 2025</td>
-                <td>Apr 2030</td>
+                <td>Jul 2020</td>
+                <td>Apr 2025</td>
+                <td>Apr 2030</td>
               </tr>
               <tr>
                 <td><strong>Ubuntu 20.04.0 LTS</strong></td>
-                <td>Apr 2020</td>
-                <td>Apr 2025</td>
-                <td>Apr 2030</td>
+                <td>Apr 2020</td>
+                <td>Apr 2025</td>
+                <td>Apr 2030</td>
               </tr>
             </tbody>
           </table>
@@ -94,39 +94,39 @@
             <tbody>
               <tr>
                 <td><strong>Ubuntu 18.04.5 LTS</strong></td>
-                <td>Aug 2020</td>
-                <td>Apr 2023</td>
-                <td>Apr 2028</td>
+                <td>Aug 2020</td>
+                <td>Apr 2023</td>
+                <td>Apr 2028</td>
               </tr>
               <tr>
                 <td><strong>Ubuntu 18.04.4 LTS (v5.3)</strong></td>
-                <td>Feb 2020</td>
-                <td>Aug 2020</td>
+                <td>Feb 2020</td>
+                <td>Aug 2020</td>
                 <td>&nbsp;</td>
               </tr>
               <tr>
                 <td><strong>Ubuntu 18.04.3 LTS  (v5.0)</strong></td>
-                <td>Aug 2019</td>
-                <td>Feb 2020</td>
+                <td>Aug 2019</td>
+                <td>Feb 2020</td>
                 <td>&nbsp;</td>
               </tr>
               <tr>
                 <td><strong>Ubuntu 18.04.2 LTS (v4.18)</strong></td>
-                <td>Feb 2019</td>
-                <td>Aug 2019</td>
+                <td>Feb 2019</td>
+                <td>Aug 2019</td>
                 <td>&nbsp;</td>
               </tr>
               <tr>
                 <td><strong>Ubuntu 18.04.1 LTS (v4.15)</strong></td>
-                <td>Jul 2018</td>
-                <td>Apr 2023</td>
-                <td>Apr 2028</td>
+                <td>Jul 2018</td>
+                <td>Apr 2023</td>
+                <td>Apr 2028</td>
               </tr>
               <tr>
                 <td><strong>Ubuntu 18.04.0 LTS (v4.15)</strong></td>
-                <td>Apr 2018</td>
-                <td>Apr 2023</td>
-                <td>Apr 2028</td>
+                <td>Apr 2018</td>
+                <td>Apr 2023</td>
+                <td>Apr 2028</td>
               </tr>
             </tbody>
           </table>
@@ -146,39 +146,39 @@
             <tbody>
               <tr>
                 <td><strong>Ubuntu 16.04.5 LTS (v4.15)</strong></td>
-                <td>Aug 2018</td>
-                <td>Apr 2021</td>
-                <td>Apr 2024</td>
+                <td>Aug 2018</td>
+                <td>Apr 2021</td>
+                <td>Apr 2024</td>
               </tr>
               <tr>
                 <td><strong>Ubuntu 16.04.4 LTS (v4.13)</strong></td>
-                <td>Feb 2018</td>
-                <td>Jul 2018</td>
+                <td>Feb 2018</td>
+                <td>Jul 2018</td>
                 <td>&nbsp;</td>
               </tr>
               <tr>
                 <td><strong>Ubuntu 16.04.3 LTS (v4.10)</strong></td>
-                <td>Aug 2017</td>
-                <td>Jan 2018</td>
+                <td>Aug 2017</td>
+                <td>Jan 2018</td>
                 <td>&nbsp;</td>
               </tr>
               <tr>
                 <td><strong>Ubuntu 16.04.2 LTS (v4.8)</strong></td>
-                <td>Feb 2017</td>
-                <td>Jul 2017</td>
+                <td>Feb 2017</td>
+                <td>Jul 2017</td>
                 <td>&nbsp;</td>
               </tr>
               <tr>
                 <td><strong>Ubuntu 16.04.1 LTS (v4.4)</strong></td>
-                <td>Aug 2016</td>
-                <td>Apr 2021</td>
-                <td>Apr 2024</td>
+                <td>Aug 2016</td>
+                <td>Apr 2021</td>
+                <td>Apr 2024</td>
               </tr>
               <tr>
                 <td><strong>Ubuntu 16.04.0 LTS (v4.4)</strong></td>
-                <td>Apr 2016</td>
-                <td>Apr 2021</td>
-                <td>Apr 2024</td>
+                <td>Apr 2016</td>
+                <td>Apr 2021</td>
+                <td>Apr 2024</td>
               </tr>
             </tbody>
           </table>
@@ -198,39 +198,39 @@
             <tbody>
               <tr>
                 <td><strong>Ubuntu 14.04.5 LTS (v3.13)</strong></td>
-                <td>Aug 2016</td>
-                <td>Apr 2019</td>
-                <td>Apr 2022</td>
+                <td>Aug 2016</td>
+                <td>Apr 2019</td>
+                <td>Apr 2022</td>
               </tr>
               <tr>
                 <td><strong>Ubuntu 14.04.4 LTS (v4.2)</strong></td>
-                <td>Feb 2016</td>
-                <td>Jul 2016</td>
+                <td>Feb 2016</td>
+                <td>Jul 2016</td>
                 <td>&nbsp;</td>
               </tr>
               <tr>
                 <td><strong>Ubuntu 14.04.3 LTS (v3.19)</strong></td>
-                <td>Aug 2015</td>
-                <td>Jul 2016</td>
+                <td>Aug 2015</td>
+                <td>Jul 2016</td>
                 <td>&nbsp;</td>
               </tr>
               <tr>
                 <td><strong>Ubuntu 14.04.2 LTS (v3.16)</strong></td>
-                <td>Feb 2015</td>
-                <td>Jul 2016</td>
+                <td>Feb 2015</td>
+                <td>Jul 2016</td>
                 <td>&nbsp;</td>
               </tr>
               <tr>
                 <td><strong>Ubuntu 14.04.1 LTS (v3.13)</strong></td>
-                <td>Aug 2014</td>
-                <td>Apr 2019</td>
-                <td>Apr 2022</td>
+                <td>Aug 2014</td>
+                <td>Apr 2019</td>
+                <td>Apr 2022</td>
               </tr>
               <tr>
                 <td><strong>Ubuntu 14.04.0 LTS (v3.13)</strong></td>
-                <td>Apr 2014</td>
-                <td>Apr 2019</td>
-                <td>Apr 2022</td>
+                <td>Apr 2014</td>
+                <td>Apr 2019</td>
+                <td>Apr 2022</td>
               </tr>
             </tbody>
           </table>
@@ -250,147 +250,147 @@
             <tbody>
               <tr>
                 <td><strong>Ubuntu 14.04.0 LTS (v3.13)</strong></td>
-                <td>Apr 2014</td>
-                <td>Apr 2016</td>
-                <td>Apr 2019</td>
+                <td>Apr 2014</td>
+                <td>Apr 2016</td>
+                <td>Apr 2019</td>
               </tr>
               <tr>
                 <td><strong>Ubuntu 14.04.1 LTS (v3.13)</strong></td>
-                <td>Aug 2014</td>
-                <td>Apr 2016</td>
-                <td>Apr 2019</td>
+                <td>Aug 2014</td>
+                <td>Apr 2016</td>
+                <td>Apr 2019</td>
               </tr>
               <tr>
                 <td><strong>Ubuntu 14.04.2 LTS (v3.16)</strong></td>
-                <td>Feb 2015</td>
-                <td>May 2015</td>
-                <td>Jul 2016</td>
+                <td>Feb 2015</td>
+                <td>May 2015</td>
+                <td>Jul 2016</td>
               </tr>
               <tr>
                 <td><strong>Ubuntu 14.04.3 LTS (v3.19)</strong></td>
-                <td>Aug 2015</td>
+                <td>Aug 2015</td>
                 <td>&nbsp;</td>
-                <td>Jul 2016</td>
+                <td>Jul 2016</td>
               </tr>
               <tr>
                 <td><strong>Ubuntu 14.04.4 LTS (v4.2)</strong></td>
-                <td>Feb 2016</td>
+                <td>Feb 2016</td>
                 <td>&nbsp;</td>
-                <td>Jul 2016</td>
+                <td>Jul 2016</td>
               </tr>
               <tr>
                 <td><strong>Ubuntu 16.04.0 LTS (v4.4)</strong></td>
-                <td>Apr 2016</td>
-                <td>Apr 2018</td>
-                <td>Mar 2023</td>
+                <td>Apr 2016</td>
+                <td>Apr 2018</td>
+                <td>Mar 2023</td>
               </tr>
               <tr>
                 <td><strong>Ubuntu 14.04.5 LTS (v3.13)</strong></td>
-                <td>Aug 2016</td>
-                <td>Apr 2018</td>
-                <td>Apr 2019</td>
+                <td>Aug 2016</td>
+                <td>Apr 2018</td>
+                <td>Apr 2019</td>
               </tr>
               <tr>
                 <td><strong>Ubuntu 16.04.1 LTS (v4.4)</strong></td>
-                <td>Aug 2016</td>
-                <td>Apr 2018</td>
-                <td>Apr 2021</td>
+                <td>Aug 2016</td>
+                <td>Apr 2018</td>
+                <td>Apr 2021</td>
               </tr>
               <tr>
                 <td><strong>Ubuntu 16.04.2 LTS (v4.8)</strong></td>
-                <td>Feb 2017</td>
+                <td>Feb 2017</td>
                 <td>&nbsp;</td>
-                <td>Jul 2017</td>
+                <td>Jul 2017</td>
               </tr>
               <tr>
                 <td><strong>Ubuntu 16.04.3 LTS (v4.10)</strong></td>
-                <td>Aug 2017</td>
+                <td>Aug 2017</td>
                 <td>&nbsp;</td>
-                <td>Jan 2018</td>
+                <td>Jan 2018</td>
               </tr>
               <tr>
                 <td><strong>Ubuntu 16.04.4 LTS (v4.13)</strong></td>
-                <td>Feb 2018</td>
+                <td>Feb 2018</td>
                 <td>&nbsp;</td>
-                <td>Jul 2018</td>
+                <td>Jul 2018</td>
               </tr>
               <tr>
                 <td><strong>Ubuntu 18.04.0 LTS (v4.15)</strong></td>
-                <td>Apr 2018</td>
-                <td>Apr 2020</td>
-                <td>Mar 2025</td>
+                <td>Apr 2018</td>
+                <td>Apr 2020</td>
+                <td>Mar 2025</td>
               </tr>
               <tr>
                 <td><strong>Ubuntu 18.04.1 LTS (v4.15)</strong></td>
-                <td>Jul 2018</td>
-                <td>Apr 2020</td>
-                <td>Apr 2023</td>
+                <td>Jul 2018</td>
+                <td>Apr 2020</td>
+                <td>Apr 2023</td>
               </tr>
               <tr>
                 <td><strong>Ubuntu 16.04.5 LTS (v4.15)</strong></td>
-                <td>Aug 2018</td>
-                <td>Apr 2020</td>
-                <td>Apr 2021</td>
+                <td>Aug 2018</td>
+                <td>Apr 2020</td>
+                <td>Apr 2021</td>
               </tr>
               <tr>
                 <td><strong>Ubuntu 18.04.2 LTS (v4.18)</strong></td>
-                <td>Feb 2019</td>
+                <td>Feb 2019</td>
                 <td>&nbsp;</td>
-                <td>Jul 2019</td>
+                <td>Jul 2019</td>
               </tr>
               <tr>
                 <td><strong>Ubuntu 18.04.3 LTS (v5.0)</strong></td>
-                <td>Aug 2019</td>
+                <td>Aug 2019</td>
                 <td>&nbsp;</td>
-                <td>Jan 2020</td>
+                <td>Jan 2020</td>
               </tr>
               <tr>
                 <td><strong>Ubuntu 18.04.4 LTS (v5.3)</strong></td>
-                <td>Feb 2020</td>
+                <td>Feb 2020</td>
                 <td>&nbsp;</td>
-                <td>Jul 2020</td>
+                <td>Jul 2020</td>
               </tr>
               <tr>
                 <td><strong>Ubuntu 20.04.0 LTS</strong></td>
-                <td>Apr 2020</td>
-                <td>Apr 2022</td>
-                <td>Apr 2025</td>
+                <td>Apr 2020</td>
+                <td>Apr 2022</td>
+                <td>Apr 2025</td>
               </tr>
               <tr>
                 <td><strong>Ubuntu 20.04.1 LTS</strong></td>
-                <td>Jul 2020</td>
-                <td>Apr 2022</td>
-                <td>Apr 2025</td>
+                <td>Jul 2020</td>
+                <td>Apr 2022</td>
+                <td>Apr 2025</td>
               </tr>
               <tr>
                 <td><strong>Ubuntu 18.04.5 LTS</strong></td>
-                <td>Aug 2020</td>
-                <td>Apr 2022</td>
-                <td>Apr 2023</td>
+                <td>Aug 2020</td>
+                <td>Apr 2022</td>
+                <td>Apr 2023</td>
               </tr>
               <tr>
                 <td><strong>Ubuntu 20.04.2 LTS</strong></td>
-                <td>Feb 2021</td>
+                <td>Feb 2021</td>
                 <td>&nbsp;</td>
-                <td>Aug 2021</td>
+                <td>Aug 2021</td>
               </tr>
               <tr>
                 <td><strong>Ubuntu 20.04.3 LTS</strong></td>
-                <td>Aug 2021</td>
+                <td>Aug 2021</td>
                 <td>&nbsp;</td>
-                <td>Feb 2022</td>
+                <td>Feb 2022</td>
               </tr>
               <tr>
                 <td><strong>Ubuntu 20.04.4 LTS</strong></td>
-                <td>Feb 2022</td>
+                <td>Feb 2022</td>
                 <td>&nbsp;</td>
-                <td>Jul 2022</td>
+                <td>Jul 2022</td>
               </tr>
               <tr>
                 <td><strong>Ubuntu 20.04.5 LTS</strong></td>
-                <td>Aug 2022</td>
-                <td>Aug 2024</td>
-                <td>Apr 2025</td>
+                <td>Aug 2022</td>
+                <td>Aug 2024</td>
+                <td>Apr 2025</td>
               </tr>
             </tbody>
           </table>
@@ -410,159 +410,159 @@
             <tbody>
               <tr>
                 <td><strong>Ubuntu 14.04.0 LTS (v3.13)</strong></td>
-                <td>Jan 2014</td>
-                <td>Apr 2014</td>
-                <td>Apr 2019</td>
+                <td>Jan 2014</td>
+                <td>Apr 2014</td>
+                <td>Apr 2019</td>
               </tr>
               <tr>
                 <td><strong>Ubuntu 14.04.1 LTS (v3.13)</strong></td>
-                <td>May 2014</td>
-                <td>Aug 2014</td>
-                <td>Apr 2019</td>
+                <td>May 2014</td>
+                <td>Aug 2014</td>
+                <td>Apr 2019</td>
               </tr>
               <tr>
                 <td><strong>Ubuntu 14.04.2 LTS (v3.16)</strong></td>
                 <td>&nbsp;</td>
-                <td>Feb 2015</td>
-                <td>Jul 2016</td>
+                <td>Feb 2015</td>
+                <td>Jul 2016</td>
               </tr>
               <tr>
                 <td><strong>Ubuntu 14.04.3 LTS (v3.19)</strong></td>
                 <td>&nbsp;</td>
-                <td>Aug 2015</td>
-                <td>Jul 2016</td>
+                <td>Aug 2015</td>
+                <td>Jul 2016</td>
               </tr>
               <tr>
                 <td><strong>Ubuntu 14.04.4 LTS (v4.2)</strong></td>
                 <td>&nbsp;</td>
-                <td>Feb 2016</td>
-                <td>Jul 2016</td>
+                <td>Feb 2016</td>
+                <td>Jul 2016</td>
               </tr>
               <tr>
                 <td><strong>Ubuntu 16.04.0 LTS (v4.4)</strong></td>
-                <td>Jan 2016</td>
-                <td>Apr 2016</td>
-                <td>Apr 2021</td>
+                <td>Jan 2016</td>
+                <td>Apr 2016</td>
+                <td>Apr 2021</td>
               </tr>
               <tr>
                 <td><strong>Ubuntu 14.04.5 LTS (v3.13)</strong></td>
-                <td>May 2016</td>
-                <td>Aug 2016</td>
-                <td>Apr 2019</td>
+                <td>May 2016</td>
+                <td>Aug 2016</td>
+                <td>Apr 2019</td>
               </tr>
               <tr>
                 <td><strong>Ubuntu 16.04.1 LTS (v4.4)</strong></td>
-                <td>May 2016</td>
-                <td>Aug 2016</td>
-                <td>Apr 2021</td>
+                <td>May 2016</td>
+                <td>Aug 2016</td>
+                <td>Apr 2021</td>
               </tr>
               <tr>
                 <td><strong>Ubuntu 16.04.2 LTS (v4.8)</strong></td>
                 <td>&nbsp;</td>
-                <td>Feb 2017</td>
-                <td>Jul 2017</td>
+                <td>Feb 2017</td>
+                <td>Jul 2017</td>
               </tr>
               <tr>
                 <td><strong>Ubuntu 16.04.3 LTS (v4.10)</strong></td>
                 <td>&nbsp;</td>
-                <td>Aug 2017</td>
-                <td>Jan 2018</td>
+                <td>Aug 2017</td>
+                <td>Jan 2018</td>
               </tr>
               <tr>
                 <td><strong>Ubuntu 16.04.4 LTS (v4.13)</strong></td>
                 <td>&nbsp;</td>
-                <td>Feb 2018</td>
-                <td>Jul 2018</td>
+                <td>Feb 2018</td>
+                <td>Jul 2018</td>
               </tr>
               <tr>
                 <td><strong>Ubuntu 18.04.0 LTS (v4.15)</strong></td>
-                <td>Jan 2018</td>
-                <td>Apr 2018</td>
-                <td>Apr 2023</td>
+                <td>Jan 2018</td>
+                <td>Apr 2018</td>
+                <td>Apr 2023</td>
               </tr>
               <tr>
                 <td><strong>Ubuntu 18.04.1 LTS (v4.15)</strong></td>
-                <td>Apr 2018</td>
-                <td>Jul 2018</td>
-                <td>Apr 2023</td>
+                <td>Apr 2018</td>
+                <td>Jul 2018</td>
+                <td>Apr 2023</td>
               </tr>
               <tr>
                 <td><strong>Ubuntu 16.04.5 LTS (v4.15)</strong></td>
-                <td>May 2018</td>
-                <td>Aug 2018</td>
-                <td>Apr 2021</td>
+                <td>May 2018</td>
+                <td>Aug 2018</td>
+                <td>Apr 2021</td>
               </tr>
               <tr>
                 <td><strong>Ubuntu 18.04.2 LTS (v4.18)</strong></td>
                 <td>&nbsp;</td>
-                <td>Feb 2019</td>
-                <td>Aug 2019</td>
+                <td>Feb 2019</td>
+                <td>Aug 2019</td>
               </tr>
               <tr>
                 <td>Ubuntu 19.04 (v5.0)</td>
                 <td>&nbsp;</td>
-                <td>Apr 2019</td>
-                <td>Jan 2020</td>
+                <td>Apr 2019</td>
+                <td>Jan 2020</td>
               </tr>
               <tr>
                 <td><strong>Ubuntu 18.04.3 LTS (v5.0)</strong></td>
                 <td>&nbsp;</td>
-                <td>Aug 2019</td>
-                <td>Feb 2020</td>
+                <td>Aug 2019</td>
+                <td>Feb 2020</td>
               </tr>
               <tr>
                 <td>Ubuntu 19.10 (v5.3)</td>
                 <td>&nbsp;</td>
-                <td>Oct 2019</td>
-                <td>Jul 2020</td>
+                <td>Oct 2019</td>
+                <td>Jul 2020</td>
               </tr>
               <tr>
                 <td><strong>Ubuntu 18.04.4 LTS (v5.3)</strong></td>
                 <td>&nbsp;</td>
-                <td>Feb 2020</td>
-                <td>Jul 2020</td>
+                <td>Feb 2020</td>
+                <td>Jul 2020</td>
               </tr>
               <tr>
                 <td><strong>Ubuntu 20.04.0 LTS</strong></td>
-                <td>Jan 2020</td>
-                <td>Apr 2020</td>
-                <td>Apr 2025</td>
+                <td>Jan 2020</td>
+                <td>Apr 2020</td>
+                <td>Apr 2025</td>
               </tr>
               <tr>
                 <td><strong>Ubuntu 20.04.1 LTS</strong></td>
-                <td>Apr 2020</td>
-                <td>Jul 2020</td>
-                <td>Apr 2025</td>
+                <td>Apr 2020</td>
+                <td>Jul 2020</td>
+                <td>Apr 2025</td>
               </tr>
               <tr>
                 <td><strong>Ubuntu 18.04.5 LTS</strong></td>
-                <td>May 2020</td>
-                <td>Aug 2020</td>
-                <td>Apr 2023</td>
+                <td>May 2020</td>
+                <td>Aug 2020</td>
+                <td>Apr 2023</td>
               </tr>
               <tr>
                 <td><strong>Ubuntu 20.04.2 LTS</strong></td>
                 <td>&nbsp;</td>
-                <td>Feb 2021</td>
-                <td>Aug 2021</td>
+                <td>Feb 2021</td>
+                <td>Aug 2021</td>
               </tr>
               <tr>
                 <td><strong>Ubuntu 20.04.3 LTS</strong></td>
                 <td>&nbsp;</td>
-                <td>Aug 2021</td>
-                <td>Feb 2022</td>
+                <td>Aug 2021</td>
+                <td>Feb 2022</td>
               </tr>
               <tr>
                 <td><strong>Ubuntu 20.04.4 LTS</strong></td>
                 <td>&nbsp;</td>
-                <td>Feb 2022</td>
-                <td>Aug 2022</td>
+                <td>Feb 2022</td>
+                <td>Aug 2022</td>
               </tr>
               <tr>
                 <td><strong>Ubuntu 20.04.5 LTS</strong></td>
-                <td>May 2022</td>
-                <td>Aug 2022</td>
-                <td>Apr 2025</td>
+                <td>May 2022</td>
+                <td>Aug 2022</td>
+                <td>Apr 2025</td>
               </tr>
             </tbody>
           </table>


### PR DESCRIPTION
## Done

- Makes the y-axis margin spacing based of the longest label length
- Fill in missing data to chart-data.js
- Update spacing in _kernel-support-schedule.html

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- Find different graphs generated by chart.js and check the spacing of the y-axis margin is correct.

## Issue / Card

Fixes https://github.com/canonical-web-and-design/ubuntu.com/issues/11300
