### PR TITLE
Redirects calls to /index to the same url minus /index

### DIFF
--- a/redirects.yaml
+++ b/redirects.yaml
@@ -901,6 +901,9 @@ internet-of-things/robotics/?: /robotics
 templates/_(?P<path>.*)/?: /templates/{path}
 shared/forms/interactive/_(?P<path>.*)/?: /shared/forms/interactive/{path}
 
+# Redirect direct calls to /index
+(?P<path>.*)/index: /{path}
+
 # Download harness
 download/server/thank-you: /download/server
 


### PR DESCRIPTION
## Done

- Added a rule in redirects.yaml to redirect any url calls ending in `/index` to the same url without `/index`
ex. `/security/index` redirects to `/security`

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- Test some different urls adding /index to the end. This will only work with the main page.

## Issue / Card

Fixes https://github.com/canonical-web-and-design/web-squad/issues/4761