### PR TITLE
Update references to 18.04 to 20.04 on /azure

### DIFF
--- a/templates/azure/index.html
+++ b/templates/azure/index.html
@@ -120,7 +120,7 @@
           <li class="p-list__item is-ticked">Updates mirrored and images published in all Azure regions worldwide</li>
           <li class="p-list__item is-ticked">5-year lifetime</li>
         </ul>
-        <p>Run Ubuntu 18.04 LTS: <a href="https://azuremarketplace.microsoft.com/en-us/marketplace/apps/canonical.0001-com-ubuntu-server-bionic" class="p-link--external">Standard</a></p>
+        <p>Run Ubuntu 20.04 LTS: <a href="https://azuremarketplace.microsoft.com/en-gb/marketplace/apps/canonical.0001-com-ubuntu-server-focal?tab=Overview">Standard</a></p>
       </div>
     </div>
     <div class="col-6 p-card">
@@ -136,7 +136,7 @@
           <li class="p-list__item is-ticked">Integration with Azure security and compliance features</li>
           <li class="p-list__item is-ticked">10-year lifetime</li>
         </ul>
-        <p><a href="https://azuremarketplace.microsoft.com/en-us/marketplace/apps/canonical.0001-com-ubuntu-pro-bionic" class="p-button--positive"><span class="p-link--external">Launch Ubuntu Pro 18.04 LTS</span></a></p>
+        <p><a href="https://azuremarketplace.microsoft.com/en-us/marketplace/apps/canonical.0001-com-ubuntu-pro-focal" class="p-button--positive p-link--external">Launch Ubuntu Pro 20.04 LTS</a></p>
         <p><a href="/azure/pro">More about Ubuntu Pro for Azure&nbsp;&rsaquo;</a></p>
       </div>
     </div>


### PR DESCRIPTION
## Done

- Update references to 18.04 to 20.04 on /azure to match the message of the upcoming campaign on feb 21st.

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- See [copydoc](https://docs.google.com/document/d/1GUlSATrqZmGrsk4DhP9W0s-gcOuFxpdKVgx7YE4g780/edit#)


## Issue / Card

Fixes https://github.com/canonical-web-and-design/web-squad/issues/4883