### PR TITLE
Improve handling of API errors

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-canonicalwebteam.flask-base==0.9.3
+canonicalwebteam.flask-base==1.0.2
 alembic==1.7.5
 canonicalwebteam.http==1.0.3
 canonicalwebteam.blog==6.4.0
@@ -27,5 +27,3 @@ macaroonbakery==1.3.1
 sortedcontainers==2.4.0
 vcrpy-unittest==0.1.7
 webargs==7.0.1
-markupsafe==2.0.1
-itsdangerous==2.0.1

--- a/templates/404.html
+++ b/templates/404.html
@@ -20,11 +20,13 @@
     <div class="col-6 u-vertically-center">
       <div>
         <h1>404: Page not found</h1>
-        {% if message %}
-          <p class="p-heading--4">{{ message }}</p>
-        {% else %}
-          <p class="p-heading--4">Sorry, we couldn't find that page.</p>
-        {% endif %}
+        <p class="p-heading--4">
+          {% if message %}
+            {{ message }}
+          {% else %}
+            Sorry, we couldn't find that page.
+          {% endif %}
+        </p>
       </div>
     </div>
   </div>

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -193,21 +193,23 @@ discourse_api = DiscourseAPI(
 # Error pages
 @app.errorhandler(400)
 def bad_request_error(error):
-    return flask.render_template("400.html"), 400
+    return flask.render_template("400.html", message=error.description), 400
+
+
+@app.errorhandler(410)
+def deleted_error(error):
+    return flask.render_template("410.html", message=error.description), 410
 
 
 @app.errorhandler(SecurityAPIError)
 def security_api_error(error):
-
-    message = error.response.json().get("message")
-
-    if error.response.status_code == 404:
-        return flask.render_template("404.html", message=message), 404
-    else:
-        return (
-            flask.render_template("security-error-500.html", message=message),
-            500,
-        )
+    return (
+        flask.render_template(
+            "security-error-500.html",
+            message=error.response.json().get("message"),
+        ),
+        500,
+    )
 
 
 @app.errorhandler(UAContractsValidationError)
@@ -263,11 +265,6 @@ def ua_contracts_api_error_view(error):
         return flask.redirect(flask.request.url)
 
     return flask.render_template("500.html"), 500
-
-
-@app.errorhandler(410)
-def deleted_error(error):
-    return flask.render_template("410.html"), 410
 
 
 # Template context

--- a/webapp/security/api.py
+++ b/webapp/security/api.py
@@ -21,14 +21,12 @@ class SecurityAPI:
         Defines get request set up, returns data if succesful,
         raises HTTP errors if not
         """
+
         uri = f"{self.base_url}{path}"
 
         response = self.session.get(uri, params=params)
 
-        try:
-            response.raise_for_status()
-        except HTTPError as error:
-            raise SecurityAPIError(error)
+        response.raise_for_status()
 
         return response
 
@@ -40,7 +38,15 @@ class SecurityAPI:
         Makes request for specific cve_id,
         returns json object if found
         """
-        return self._get(f"cves/{id.upper()}.json").json()
+
+        try:
+            cve_response = self._get(f"cves/{id.upper()}.json")
+        except HTTPError as error:
+            if error.response.status_code == 404:
+                return None
+            raise SecurityAPIError(error)
+
+        return cve_response.json()
 
     def get_releases(self):
         """
@@ -48,4 +54,9 @@ class SecurityAPI:
         returns json object if found
         """
 
-        return self._get("releases.json").json()
+        try:
+            releases_response = self._get("releases.json")
+        except HTTPError as error:
+            raise SecurityAPIError(error)
+
+        return releases_response.json()

--- a/webapp/security/views.py
+++ b/webapp/security/views.py
@@ -723,7 +723,7 @@ def cve(cve_id):
     cve = security_api.get_cve(cve_id)
 
     if not cve:
-        flask.abort(404)
+        flask.abort(404, f"Cannot find a CVE with ID '{cve_id}'")
 
     if cve.get("published"):
         cve["published"] = dateutil.parser.parse(cve["published"]).strftime(


### PR DESCRIPTION
This is an attempt to provide a better structure for handling CVE 404 errors following my comment here:

https://github.com/canonical-web-and-design/ubuntu.com/pull/11305#discussion_r824645422

Basically, we ended up in a situation where we were trying to raise a 404 error from within the `security_api_error` error handler, but we had to do it manually with `flask.render_template` rather than the more proper `flask.abort` because you can't `abort` from within an active `errorhandler`.

I think this was pointing to a sort of code smell, that we shouldn't really have got as far as raising a `SecurityAPIError` if really all that happened is that a CVE is missing. In fact, I think it would be much more reasonable for `SecurityAPI.get_cve` to simply return `None`, rather than an error, if the CVE in question doesn't exist. This is reinforced by the fact that the code to turn that `None` response into a `flask.abort(404)` actually [already existed](https://github.com/canonical-web-and-design/ubuntu.com/blob/b001f4e0a14af6ac586ab4de8c318f6ff99b0a8c/webapp/security/views.py#L725-L726) in the `cve` view, even though it was not not being used.

So I've restructured the code to do the logic of reading the `404` code from the API's response inside the `SecurityAPIError.get_cve` method itself, and return `None` in that case. The `SecurityAPIError._get` method now simply does `raise_for_status()`, which seems reasonable as it is simply a generic HTTP request method and shouldn't have any greater knowledge than that, and then it's up to the public methods (currently `get_cve` and `get_releases`) to turn those `HTTPError` exceptions into `SecurityAPIError`s or `None` as appropriate. I hope this makes sense.

To facilitate this branch I've also [proposed a change](https://github.com/canonical-web-and-design/canonicalwebteam.flask-base/pull/56) to canonicalwebteam.flask-base. This branch uses that new version. A review of this branch is effectively a review of that one. Please go and approve that one once this is reviewed, but don't merge this until that PR is merged and published and this PR's `requirements.txt` is updated.

QA
--

Go to https://ubuntu-com-11343.demos.haus/security/CVE-1234-5678, see a beautiful 404 page, with a custom error message.

Go to https://ubuntu-com-11343.demos.haus/zfgzdfsd check the normal 404 page still works.

Go to https://ubuntu-com-11343.demos.haus/security/CVE-2022-23639, check a normal CVE still displays properly.