### PR TITLE
Render all wsl tutorials from discourse on `/wsl`

### DIFF
--- a/templates/wsl/index.html
+++ b/templates/wsl/index.html
@@ -300,7 +300,7 @@
 
   <div class="row p-divider">
     {% for item in tutorials %}
-    <div class="col-4 p-divider__block" id="ubuntu-com_core_left">
+    <div class="col-4 {% if loop.index0 % 3 != 0 %}p-divider__block{% endif %}" id="ubuntu-com_core_left">
       <div class="p-heading-icon--muted">
         <div class="p-heading-icon__header">
           {{
@@ -320,6 +320,24 @@
       <h3 class="p-heading--4"><a href="{{ item.link }}">{{ item.title }}</a></h3>
     </div>
     {% endfor %}
+    <div class="col-4 {% if total_results % 3 != 0 %}p-divider__block{% endif %}" id="ubuntu-com_core_left">
+      <div class="p-heading-icon--muted">
+        <div class="p-heading-icon__header">
+          {{ image (
+            url="https://assets.ubuntu.com/v1/df54bb6a-document-open-icon.svg",
+            alt="",
+            width="56",
+            height="47",
+            hi_def=True,
+            loading="lazy",
+            attrs={"class": "p-heading-icon__img p-heading-icon__img--small"}
+            ) | safe
+          }}
+          <h4 class="p-heading-icon__title">Docs</h4>
+        </div>
+      </div>
+      <h3 class="p-heading--4"><a href="https://wiki.ubuntu.com/WSL">Check out the Ubuntu docs for more information</a></h3>
+    </div>
   </div>
 </section>
 

--- a/templates/wsl/index.html
+++ b/templates/wsl/index.html
@@ -299,6 +299,7 @@
   </div>
 
   <div class="row p-divider">
+    {% for item in tutorials %}
     <div class="col-4 p-divider__block" id="ubuntu-com_core_left">
       <div class="p-heading-icon--muted">
         <div class="p-heading-icon__header">
@@ -316,48 +317,9 @@
           <h4 class="p-heading-icon__title">Tutorial</h4>
         </div>
       </div>
-      <h3 class="p-heading--4"><a class="p-link--external" href="https://wiki.ubuntu.com/WSL?action=subscribe#Installing_Packages_on_Ubuntu">Installing packages on Ubuntu on WSL</a></h3>
+      <h3 class="p-heading--4"><a href="{{ item.link }}">{{ item.title }}</a></h3>
     </div>
-
-    <div class="col-4 p-divider__block">
-      <div class="p-heading-icon--muted">
-        <div class="p-heading-icon__header">
-          {{
-            image(
-            url="https://assets.ubuntu.com/v1/e2315503-tutorial.svg",
-            alt="",
-            height="32",
-            width="38",
-            hi_def=True,
-            loading="lazy",
-            attrs={"class": "p-heading-icon__img p-heading-icon__img--small"}
-            ) | safe
-          }}
-          <h4 class="p-heading-icon__title">Tutorial</h4>
-        </div>
-      </div>
-      <h3 class="p-heading--4"><a class="p-link--external" href="https://wiki.ubuntu.com/WSL#Running_Graphical_Applications">Running graphical applications with X on WSL</a></h3>
-    </div>
-
-    <div class="col-4 p-divider__block">
-      <div class="p-heading-icon--muted">
-        <div class="p-heading-icon__header">
-          {{
-            image(
-            url="https://assets.ubuntu.com/v1/e2315503-tutorial.svg",
-            alt="",
-            height="32",
-            width="38",
-            hi_def=True,
-            loading="lazy",
-            attrs={"class": "p-heading-icon__img p-heading-icon__img--small"}
-            ) | safe
-          }}
-          <h4 class="p-heading-icon__title">Tutorial</h4>
-        </div>
-      </div>
-      <h3 class="p-heading--4"><a class="p-link--external" href="https://wiki.ubuntu.com/WSL#Hello_World">Hello World on WSL</a></h3>
-    </div>
+    {% endfor %}
   </div>
 </section>
 

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -71,6 +71,7 @@ from webapp.views import (
     marketo_submit,
     thank_you,
     mirrors_query,
+    build_wsl_tutorials,
 )
 
 from webapp.shop.views import (
@@ -720,6 +721,10 @@ app.add_url_rule(
     tutorials_path, view_func=build_tutorials_index(session, tutorials_docs)
 )
 tutorials_docs.init_app(app)
+
+app.add_url_rule(
+    "/wsl", view_func=build_wsl_tutorials(tutorials_docs)
+)
 
 # Ceph docs
 ceph_docs = Docs(

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -722,9 +722,7 @@ app.add_url_rule(
 )
 tutorials_docs.init_app(app)
 
-app.add_url_rule(
-    "/wsl", view_func=build_wsl_tutorials(tutorials_docs)
-)
+app.add_url_rule("/wsl", view_func=build_wsl_tutorials(tutorials_docs))
 
 # Ceph docs
 ceph_docs = Docs(

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -548,6 +548,26 @@ def openstack_install():
     )
 
 
+def build_wsl_tutorials(tutorials_docs):
+    def wsl_tutorials():
+        topic = "wsl2"
+
+        tutorials_docs.parser.parse()
+        tutorials_docs.parser.parse_topic(tutorials_docs.parser.index_topic)
+
+        tutorials = [
+            doc
+            for doc in tutorials_docs.parser.tutorials
+            if topic in doc["categories"]
+        ]
+
+        return flask.render_template(
+            "/wsl/index.html",
+            tutorials=tutorials,
+        )
+    return wsl_tutorials
+
+
 # Blog
 # ===
 class BlogView(flask.views.View):

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -550,7 +550,7 @@ def openstack_install():
 
 def build_wsl_tutorials(tutorials_docs):
     def wsl_tutorials():
-        topic = "wsl2"
+        topic = "wsl"
 
         tutorials_docs.parser.parse()
         tutorials_docs.parser.parse_topic(tutorials_docs.parser.index_topic)
@@ -561,10 +561,18 @@ def build_wsl_tutorials(tutorials_docs):
             if topic in doc["categories"]
         ]
 
+        tutorials = sorted(
+            tutorials, key=lambda k: k["difficulty"], reverse=False
+        )
+
+        total_results = len(tutorials)
+
         return flask.render_template(
             "/wsl/index.html",
             tutorials=tutorials,
+            total_results=total_results,
         )
+
     return wsl_tutorials
 
 


### PR DESCRIPTION
## Done

- Create view_func to pull just the wsl tutorials and render them on `/wsl`
- More details on [copydoc](https://docs.google.com/document/d/1M7e2B08GgPA7K6Wx0ThE6s9_xQINM0MSkarfdKUTEYI/edit#)


## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: https://ubuntu-com-11346.demos.haus/wsl
    - Be sure to test on mobile, tablet and desktop screen sizes
- [List additional steps to QA the new features or prove the bug has been resolved]

## Issue / Card

Fixes https://github.com/canonical-web-and-design/web-squad/issues/4848