### PR TITLE
Update extendable containers illustration

### DIFF
--- a/templates/openstack/index.html
+++ b/templates/openstack/index.html
@@ -610,9 +610,9 @@
   <div class="row u-vertically-center">
     <div class="col-6 u-hide--small u-align--center">
       {{ image (
-        url="https://assets.ubuntu.com/v1/a21ceaf9-Openstack-extendable-containers-layers.svg",
+        url="https://assets.ubuntu.com/v1/03019c46-Openstack-extendable-containers-layers.svg",
         alt="",
-        width="387",
+        width="389",
         height="330",
         hi_def=True,
         loading="lazy"
@@ -749,7 +749,7 @@
         Upgrades included, fully automated
       </h2>
       <p>
-        OpenStack upgrades are known to be painful due to the complexity of the process. By leveraging the model-driven architecture and using OpenStack Charms for automation purposes, Charmed OpenStack <a class="p-link--external" href="https://docs.openstack.org/project-deploy-guide/charm-deployment-guide/latest/upgrade-overview.html">can be easily upgraded</a> between its consecutive versions. This allows you to stay up to date with the upstream features, while not putting additional pressure on your operations team.
+        OpenStack upgrades are known to be painful due to the complexity of the process. By leveraging the model-driven architecture and using OpenStack Charms for automation purposes, Charmed OpenStack <a href="https://docs.openstack.org/project-deploy-guide/charm-deployment-guide/latest/upgrade-overview.html">can be easily upgraded</a> between its consecutive versions. This allows you to stay up to date with the upstream features, while not putting additional pressure on your operations team.
       </p>
     </div>
     <div class="col-6">
@@ -776,7 +776,7 @@
   <div class="row">
     <div class="u-hide--small u-hide--medium col-6">
       <h2>Number 1 platform for OpenStack implementation</h2>
-      <p>According to the <a class="p-link--external" href="https://www.openstack.org/analytics/">OpenStack User Survey 2021</a> results, Ubuntu Server is the most popular operating system for OpenStack implementation. Ubuntu Server powers 40% of OpenStack clouds all over the world. It has been chosen as a platform for private cloud implementation by leading companies in the telco, finance, hardware manufacturing, retail, automotive and healthcare sectors.</p>
+      <p>According to the <a href="https://www.openstack.org/analytics/">OpenStack User Survey 2021</a> results, Ubuntu Server is the most popular operating system for OpenStack implementation. Ubuntu Server powers 40% of OpenStack clouds all over the world. It has been chosen as a platform for private cloud implementation by leading companies in the telco, finance, hardware manufacturing, retail, automotive and healthcare sectors.</p>
       <a href="/openstack/compare">Compare OpenStack distros&nbsp;&rsaquo;</a>
     </div>
     <div class="u-hide--small col-6">
@@ -787,7 +787,7 @@
     </div>
   </div>
   <div class="u-hide--large u-fixed-width">
-    <p>According to the <a href="https://www.openstack.org/analytics/" class="p-link--external">OpenStack User Survey 2020</a> results, Ubuntu Server is the most popular operating system for OpenStack implementation. Ubuntu Server powers 40% of OpenStack clouds all over the world. It has been chosen as a platform for OpenStack implementation by leading companies in the telco, finance, hardware manufacturing, retail, automotive and healthcare sectors.</p>
+    <p>According to the <a href="https://www.openstack.org/analytics/">OpenStack User Survey 2020</a> results, Ubuntu Server is the most popular operating system for OpenStack implementation. Ubuntu Server powers 40% of OpenStack clouds all over the world. It has been chosen as a platform for OpenStack implementation by leading companies in the telco, finance, hardware manufacturing, retail, automotive and healthcare sectors.</p>
     <a href="/openstack/compare">Compare OpenStack distros&nbsp;&rsaquo;</a>
   </div>
 
@@ -837,11 +837,11 @@
     <div class="row u-equal-height">
       <div class="col-6">
         <h2 class="p-heading--4">Long-term community member</h2>
-        <p>Open source comes through contribution and community collaboration. Canonical is a long-term member of the OpenStack community, <a href="https://www.stackalytics.io/?release=all&metric=commits" class="p-link--external">one of the top contributors</a> to the OpenStack code and Gold Member of the <a href="https://openinfra.dev/" class="p-link--external">Open Infrastructure Foundation</a>. Together with other leaders we constantly drive the evolution of OpenStack towards new challenges.</p>
+        <p>Open source comes through contribution and community collaboration. Canonical is a long-term member of the OpenStack community, <a href="https://www.stackalytics.io/?release=all&metric=commits">one of the top contributors</a> to the OpenStack code and Gold Member of the <a href="https://openinfra.dev/">Open Infrastructure Foundation</a>. Together with other leaders we constantly drive the evolution of OpenStack towards new challenges.</p>
       </div>
       <div class="col-6">
         <h2 class="p-heading--4">The most popular open source cloud platform</h2>
-        <p><a href="https://www.statista.com/statistics/511526/worldwide-survey-private-coud-services-running-application/" class="p-link--external">OpenStack adoption continues to grow</a> every year. Its combined market size worldwide is approaching $8,000,000,000. OpenStack is supported by leading industry players, and successfully used by thousands of organisations all over the world. The popularity of OpenStack comes from its better economics, stability and openness of the code.</p>
+        <p><a href="https://www.statista.com/statistics/511526/worldwide-survey-private-coud-services-running-application/">OpenStack adoption continues to grow</a> every year. Its combined market size worldwide is approaching $8,000,000,000. OpenStack is supported by leading industry players, and successfully used by thousands of organisations all over the world. The popularity of OpenStack comes from its better economics, stability and openness of the code.</p>
       </div>
     </div>
     <div class="row u-equal-height">
@@ -852,7 +852,7 @@
       </div>
       <div class="col-6">
         <h2 class="p-heading--4">Install OpenStack yourself</h2>
-        <p>Looking for the most straightforward installation instructions for OpenStacK? <a href="https://microstack.run" class="p-link--external">MicroStack</a> allows you to install a fully functional OpenStack on your workstation in just two commands. The entire process takes around twenty minutes.</p>
+        <p>Looking for the most straightforward installation instructions for OpenStacK? <a href="https://microstack.run">MicroStack</a> allows you to install a fully functional OpenStack on your workstation in just two commands. The entire process takes around twenty minutes.</p>
         <a href="/openstack/install">Get started with OpenStack today&nbsp;&rsaquo;</a>
       </div>
     </div>

--- a/templates/telco/vnf.html
+++ b/templates/telco/vnf.html
@@ -19,7 +19,7 @@
           Carrier-grade infrastructure for your VNFs
         </p>
         <p>
-          Through Charmed OpenStack, you can have an OpenStack distribution that’s deployable, maintainable and upgradable economically. This is achieved by putting full automation around OpenStack deployments and exposed deployment operations.
+          Through Charmed OpenStack, you can have an OpenStack distribution that's deployable, maintainable and upgradable economically. This is achieved by putting full automation around OpenStack deployments and exposed deployment operations.
         </p>
         <p>
           <a href="/telco/contact-us" class="p-button--positive js-invoke-modal">Contact us about NFV</a>
@@ -146,12 +146,12 @@
       <p>Extend your cloud with a <a href="/kubernetes">Kubernetes</a> layer running on top of it and benefit from a unified approach to both containers and legacy workloads management.</p>
       <p>The entire stack is supported under the same <a href="/advantage">subscription</a>.</p>
     </div>
-    <div class="col-6 u-align--center u-vertically-center">
+    <div class="col-6 u-align--center u-hide--small u-hide--medium u-vertically-center">
       {{ image (
-        url="https://assets.ubuntu.com/v1/a21ceaf9-Openstack-extendable-containers-layers.svg",
+        url="https://assets.ubuntu.com/v1/03019c46-Openstack-extendable-containers-layers.svg",
         alt="",
-        width="352",
-        height="300",
+        width="389",
+        height="330",
         hi_def=True,
         loading="lazy"
         ) | safe


### PR DESCRIPTION
## Done

- Update extendable containers illustration on `/telco/vnf` and `/openstack`

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- Compare against [copydoc](https://docs.google.com/document/d/1eqHK0hc9v7Mn-XV36QRyNkJenTXgBQR_-RULKm5rZ5o/edit#) and see [issue](https://github.com/canonical-web-and-design/web-squad/issues/4879) for more information

## Issue / Card

Fixes https://github.com/canonical-web-and-design/web-squad/issues/4879
