### PR TITLE
Advantage: only update customer info if the payment form has changed

### DIFF
--- a/static/js/src/PurchaseModal/components/PaymentMethodForm.tsx
+++ b/static/js/src/PurchaseModal/components/PaymentMethodForm.tsx
@@ -44,6 +44,7 @@ function PaymentMethodForm({ setCardValid }: Props) {
   const isEmailPrepopulated = !!userInfo?.customerInfo?.email;
 
   const {
+    dirty,
     errors,
     touched,
     values,
@@ -135,7 +136,7 @@ function PaymentMethodForm({ setCardValid }: Props) {
   }, [values.country]);
 
   useEffect(() => {
-    if (window.accountId) {
+    if (window.accountId && dirty) {
       updateCustomerInfoForPurchasePreviewDebounced(values);
     }
   }, [values.country, values.VATNumber]);


### PR DESCRIPTION
## Done

- Only call the customer info update endpoint once the form as been changed

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- Log in
- Go to `/advantage/subscribe`
- Make sure `/customer-info-anon` is not called when the page loads and the VAT number is not deleted
