### PR TITLE
Remove data-testid on `/wsl`

### DIFF
--- a/templates/wsl/index.html
+++ b/templates/wsl/index.html
@@ -8,7 +8,6 @@
 
 {% block meta_description %}Access the Ubuntu terminal on Windows with WSL. Develop cross-platform applications and manage IT infrastructure without leaving Windows.{% endblock %}
 
-{% block outer_content %}
 {% block content %}
 
 <section class="p-strip--suru is-dark">
@@ -239,7 +238,7 @@
       }}
       <h4>Enterprise support</h4>
       <p>Ubuntu is certified on WSL through close collaboration with Microsoft. Enterprise support is provided for Ubuntu from Azure to Windows workstations creating a seamless operating environment.</p>
-      <p><a class="p-button js-invoke-modal" data-testid="interactive-form-link" class="p-button" href="https://ubuntu.com/wsl/contact-us">Get in touch</a></p>
+      <p><a class="p-button js-invoke-modal" class="p-button" href="/wsl/contact-us">Get in touch</a></p>
     </div>            
   </div>  
 </section>
@@ -332,4 +331,3 @@
 </div>
 
 {% endblock content %}
-{% endblock outer_content %}


### PR DESCRIPTION
## Done

- There were two `data-testid` on the `/wsl` page which caused cypress to keep failing and I removed one 

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes

1. Go to `/tests/cypress/forms/forms_spec.js` 
2. Please do `context.skip` or`it.skip` to save time and avoid making a bunch of spam submission
3. Move the` /tests/cypress/forms/forms_spec.js` file to the `/tests/cypress/integration` folder
4. run `yarn run cypress:open`
5. Click `forms_spec.js` in the cypress test window
6. Check the test passes on `/wsl` 

## Issue / Card

Fixes #

## Screenshots
![image](https://user-images.githubusercontent.com/57550290/158861259-754f12e0-8cf1-4c75-9a97-422445968eca.png)



## Help

[QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html) - [Commit guidelines](https://canonical-web-and-design.github.io/practices/workflow/commit-messages.html)
