### PR TITLE
Update p-inline-image to p-logo-section on /what-is-kubeflow

### DIFF
--- a/templates/ai/what-is-kubeflow.html
+++ b/templates/ai/what-is-kubeflow.html
@@ -159,8 +159,9 @@
 
     </div>
     <div class="col-5 u-hide--small u-hide--medium">
-      <ul class="p-inline-images">
-        <li class="p-inline-images__item">
+      <div class="p-logo-section">
+      <div class="p-inline-images__items">
+        <div class="p-inline-images__item">
         {{
           image(
             url="https://assets.ubuntu.com/v1/8ee86883-jupyter-logo.png",
@@ -172,8 +173,8 @@
             loading="lazy",
           ) | safe
         }}
-        </li>
-        <li class="p-inline-images__item ">
+        </div>
+        <div class="p-inline-images__item ">
         {{
           image(
             url="https://assets.ubuntu.com/v1/c4da5b86-Tensor-flow-logo.png",
@@ -185,8 +186,8 @@
             loading="lazy",
           ) | safe
         }}
-        </li>
-        <li class="p-inline-images__item">
+        </div>
+        <div class="p-inline-images__item">
         {{
           image(
             url="https://assets.ubuntu.com/v1/6d6b4148-seldon-logo.png",
@@ -198,8 +199,8 @@
             loading="lazy",
           ) | safe
         }}
-        </li>
-        <li class="p-inline-images__item">
+        </div>
+        <div class="p-inline-images__item">
         {{
           image(
             url="https://assets.ubuntu.com/v1/a774cbbb-py-torch-logo.png",
@@ -211,8 +212,8 @@
             loading="lazy",
           ) | safe
         }}
-        </li>
-        <li class="p-inline-images__item">
+        </div>
+        <div class="p-inline-images__item">
         {{
           image(
             url="https://assets.ubuntu.com/v1/5d796b1c-itsio-logo.png",
@@ -224,8 +225,8 @@
             loading="lazy",
           ) | safe
         }}
-        </li>
-        <li class="p-inline-images__item">
+        </div>
+        <div class="p-inline-images__item">
         {{
           image(
             url="https://assets.ubuntu.com/v1/6b57da22-mxnet-logo.png",
@@ -237,8 +238,8 @@
             loading="lazy",
           ) | safe
         }}
-        </li>
-        <li class="p-inline-images__item">
+        </div>
+        <div class="p-inline-images__item">
         {{
           image(
             url="https://assets.ubuntu.com/v1/41913ead-katib-logo.png",
@@ -250,8 +251,8 @@
             loading="lazy",
           ) | safe
         }}
-        </li>
-        <li class="p-inline-images__item">
+        </div>
+        <div class="p-inline-images__item">
         {{
           image(
             url="https://assets.ubuntu.com/v1/826d5be3-1200px-Prometheus_software_logo.svg.png",
@@ -263,8 +264,8 @@
             loading="lazy",
           ) | safe
         }}
-        </li>
-        <li class="p-inline-images__item">
+        </div>
+        <div class="p-inline-images__item">
         {{
           image(
             url="https://assets.ubuntu.com/v1/3d0a8131-ambassador-logo.png",
@@ -276,8 +277,8 @@
             loading="lazy",
           ) | safe
         }}
-        </li>
-        <li class="p-inline-images__item">
+        </div>
+        <div class="p-inline-images__item">
         {{
           image(
             url="https://assets.ubuntu.com/v1/653daa8b-onnx-logo.png",
@@ -289,8 +290,8 @@
             loading="lazy",
           ) | safe
         }}
-        </li>
-        <li class="p-inline-images__item">
+        </div>
+        <div class="p-inline-images__item">
         {{
           image(
             url="https://assets.ubuntu.com/v1/2af7ca99-xgboost-logo.png",
@@ -302,8 +303,8 @@
             loading="lazy",
           ) | safe
         }}
-        </li>
-        <li class="p-inline-images__item">
+        </div>
+        <div class="p-inline-images__item">
         {{
           image(
             url="https://assets.ubuntu.com/v1/f4ffa06e-scikit-learn-logo.png",
@@ -315,8 +316,8 @@
             loading="lazy",
           ) | safe
         }}
-        </li>
-        <li class="p-inline-images__item ">
+        </div>
+        <div class="p-inline-images__item ">
         {{
           image(
             url="https://assets.ubuntu.com/v1/7c4d800a-pachyderm-logo.png",
@@ -328,8 +329,8 @@
             loading="lazy",
           ) | safe
         }}
-        </li>
-      </ul>
+        </div>
+      </div>
     </div>
   </div>
 </section>
@@ -402,8 +403,9 @@
       <p>Forward-looking enterprises are using Kubeflow to empower their data scientists.</p>
     </div>
  <div class="col-6 u-vertically-center">
-      <ul class="p-inline-images">
-        <li class="p-inline-images__item">
+   <div class="p-logo-section">
+      <div class="p-logo-section__items">
+        <div class="p-logo-section__item">
           {{
             image(
               url="https://assets.ubuntu.com/v1/0c18b0ae-paypal_logo.svg",


### PR DESCRIPTION
## Done

- Updates p-inline-image to p-logo-section on /what-is-kubeflow

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: https://ubuntu-com-11362.demos.haus/ai/what-is-kubeflow
    - Be sure to test on mobile, tablet and desktop screen sizes
- Check the logo sections are rendering correctly


