### PR TITLE
Updates inline-images to logo-section

### DIFF
--- a/templates/ai/what-is-kubeflow.html
+++ b/templates/ai/what-is-kubeflow.html
@@ -160,8 +160,8 @@
     </div>
     <div class="col-5 u-hide--small u-hide--medium">
       <div class="p-logo-section">
-      <div class="p-inline-images__items">
-        <div class="p-inline-images__item">
+      <div class="p-logo-section__items">
+        <div class="p-logo-section__item">
         {{
           image(
             url="https://assets.ubuntu.com/v1/8ee86883-jupyter-logo.png",
@@ -169,12 +169,12 @@
             height="90",
             width="80",
             hi_def=True,
-            attrs={"class": "p-inline-images__logos"},
+            attrs={"class": "p-logo-section__logos"},
             loading="lazy",
           ) | safe
         }}
         </div>
-        <div class="p-inline-images__item ">
+        <div class="p-logo-section__item ">
         {{
           image(
             url="https://assets.ubuntu.com/v1/c4da5b86-Tensor-flow-logo.png",
@@ -182,12 +182,12 @@
             height="90",
             width="90",
             hi_def=True,
-            attrs={"class": "p-inline-images__logos"},
+            attrs={"class": "p-logo-section__logos"},
             loading="lazy",
           ) | safe
         }}
         </div>
-        <div class="p-inline-images__item">
+        <div class="p-logo-section__item">
         {{
           image(
             url="https://assets.ubuntu.com/v1/6d6b4148-seldon-logo.png",
@@ -195,12 +195,12 @@
             height="90",
             width="100",
             hi_def=True,
-            attrs={"class": "p-inline-images__logos"},
+            attrs={"class": "p-logo-section__logos"},
             loading="lazy",
           ) | safe
         }}
         </div>
-        <div class="p-inline-images__item">
+        <div class="p-logo-section__item">
         {{
           image(
             url="https://assets.ubuntu.com/v1/a774cbbb-py-torch-logo.png",
@@ -208,12 +208,12 @@
             height="90",
             width="100",
             hi_def=True,
-            attrs={"class": "p-inline-images__logos"},
+            attrs={"class": "p-logo-section__logos"},
             loading="lazy",
           ) | safe
         }}
         </div>
-        <div class="p-inline-images__item">
+        <div class="p-logo-section__item">
         {{
           image(
             url="https://assets.ubuntu.com/v1/5d796b1c-itsio-logo.png",
@@ -221,12 +221,12 @@
             height="60",
             width="100",
             hi_def=True,
-            attrs={"class": "p-inline-images__logos"},
+            attrs={"class": "p-logo-section__logos"},
             loading="lazy",
           ) | safe
         }}
         </div>
-        <div class="p-inline-images__item">
+        <div class="p-logo-section__item">
         {{
           image(
             url="https://assets.ubuntu.com/v1/6b57da22-mxnet-logo.png",
@@ -234,12 +234,12 @@
             height="40",
             width="110",
             hi_def=True,
-            attrs={"class": "p-inline-images__logos"},
+            attrs={"class": "p-logo-section__logos"},
             loading="lazy",
           ) | safe
         }}
         </div>
-        <div class="p-inline-images__item">
+        <div class="p-logo-section__item">
         {{
           image(
             url="https://assets.ubuntu.com/v1/41913ead-katib-logo.png",
@@ -247,12 +247,12 @@
             height="90",
             width="75",
             hi_def=True,
-            attrs={"class": "p-inline-images__logos"},
+            attrs={"class": "p-logo-section__logos"},
             loading="lazy",
           ) | safe
         }}
         </div>
-        <div class="p-inline-images__item">
+        <div class="p-logo-section__item">
         {{
           image(
             url="https://assets.ubuntu.com/v1/826d5be3-1200px-Prometheus_software_logo.svg.png",
@@ -260,12 +260,12 @@
             height="80",
             width="80",
             hi_def=True,
-            attrs={"class": "p-inline-images__logos"},
+            attrs={"class": "p-logo-section__logos"},
             loading="lazy",
           ) | safe
         }}
         </div>
-        <div class="p-inline-images__item">
+        <div class="p-logo-section__item">
         {{
           image(
             url="https://assets.ubuntu.com/v1/3d0a8131-ambassador-logo.png",
@@ -273,12 +273,12 @@
             height="100",
             width="80",
             hi_def=True,
-            attrs={"class": "p-inline-images__logos"},
+            attrs={"class": "p-logo-section__logos"},
             loading="lazy",
           ) | safe
         }}
         </div>
-        <div class="p-inline-images__item">
+        <div class="p-logo-section__item">
         {{
           image(
             url="https://assets.ubuntu.com/v1/653daa8b-onnx-logo.png",
@@ -286,12 +286,12 @@
             height="30",
             width="110",
             hi_def=True,
-            attrs={"class": "p-inline-images__logos"},
+            attrs={"class": "p-logo-section__logos"},
             loading="lazy",
           ) | safe
         }}
         </div>
-        <div class="p-inline-images__item">
+        <div class="p-logo-section__item">
         {{
           image(
             url="https://assets.ubuntu.com/v1/2af7ca99-xgboost-logo.png",
@@ -299,12 +299,12 @@
             height="37",
             width="110",
             hi_def=True,
-            attrs={"class": "p-inline-images__logos"},
+            attrs={"class": "p-logo-section__logos"},
             loading="lazy",
           ) | safe
         }}
         </div>
-        <div class="p-inline-images__item">
+        <div class="p-logo-section__item">
         {{
           image(
             url="https://assets.ubuntu.com/v1/f4ffa06e-scikit-learn-logo.png",
@@ -312,12 +312,12 @@
             height="60",
             width="110",
             hi_def=True,
-            attrs={"class": "p-inline-images__logos"},
+            attrs={"class": "p-logo-section__logos"},
             loading="lazy",
           ) | safe
         }}
         </div>
-        <div class="p-inline-images__item ">
+        <div class="p-logo-section__item ">
         {{
           image(
             url="https://assets.ubuntu.com/v1/7c4d800a-pachyderm-logo.png",
@@ -325,7 +325,7 @@
             height="100",
             width="110",
             hi_def=True,
-            attrs={"class": "p-inline-images__logos"},
+            attrs={"class": "p-logo-section__logos"},
             loading="lazy",
           ) | safe
         }}


### PR DESCRIPTION
## Done

- Updates inline-images to logo-section

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes