### PR TITLE
Add new purchase endpoint and get purchase v2

### DIFF
--- a/tests/shop/advantage/test_advantage_mapper.py
+++ b/tests/shop/advantage/test_advantage_mapper.py
@@ -40,6 +40,21 @@ class TestGetAccounts(unittest.TestCase):
         for item in response:
             self.assertIsInstance(item, Account)
 
+        expectation = [
+            Account(
+                id="a123AbBcCdDeEfFgGhHiIjJkKlLmMnNoOpP",
+                name="Free",
+                role="admin",
+            ),
+            Account(
+                id="aAbBcCdDeEfFgGhHiIjJkKlLmMnNoOpP",
+                name="Account Name",
+                role="admin",
+            ),
+        ]
+
+        self.assertEqual(to_dict(expectation), to_dict(response))
+
 
 class TestGetAccountContracts(unittest.TestCase):
     def test_returns_list_of_contracts(self):
@@ -316,6 +331,14 @@ class TestGetPurchaseAccount(unittest.TestCase):
         response = advantage_mapper.get_purchase_account("canonical-ua")
 
         self.assertIsInstance(response, Account)
+
+        expectation = Account(
+            id="aAbBcCdDeEfFgGhHiIjJkKlLmMnNoOpP",
+            name="Account Name",
+            role="admin",
+        )
+
+        self.assertEqual(to_dict(expectation), to_dict(response))
 
 
 class TestGetAccountOffers(unittest.TestCase):

--- a/tests/shop/advantage/test_api.py
+++ b/tests/shop/advantage/test_api.py
@@ -197,8 +197,8 @@ class TestGetProductListings(unittest.TestCase):
 class TestGetAccountSubscriptions(unittest.TestCase):
     def test_errors(self):
         cases = [
-            (401, False, UAContractsAPIError),
-            (401, True, UAContractsAPIErrorView),
+            (401, False, UnauthorizedError),
+            (401, True, UnauthorizedError),
             (500, False, UAContractsAPIError),
             (500, True, UAContractsAPIErrorView),
         ]
@@ -718,8 +718,8 @@ class TestGetPurchaseAccount(unittest.TestCase):
         cases = [
             (403, False, AccessForbiddenError),
             (403, False, AccessForbiddenError),
-            (401, False, UAContractsAPIError),
-            (401, True, UAContractsAPIErrorView),
+            (401, False, UnauthorizedError),
+            (401, True, UnauthorizedError),
             (404, False, UAContractsUserHasNoAccount),
             (404, True, UAContractsUserHasNoAccount),
             (500, False, UAContractsAPIError),
@@ -1021,8 +1021,8 @@ class TestPostSubscriptionAutoRenewal(unittest.TestCase):
 class TestEnsurePurchaseAccount(unittest.TestCase):
     def test_errors(self):
         cases = [
-            (401, False, UnauthorizedError),
-            (401, True, UnauthorizedError),
+            (401, False, UAContractsAPIError),
+            (401, True, UAContractsAPIErrorView),
             (500, False, UAContractsAPIError),
             (500, True, UAContractsAPIErrorView),
         ]

--- a/tests/shop/advantage/test_parsers.py
+++ b/tests/shop/advantage/test_parsers.py
@@ -12,8 +12,6 @@ from webapp.shop.api.ua_contracts.models import (
     Offer,
 )
 from webapp.shop.api.ua_contracts.parsers import (
-    parse_account,
-    parse_accounts,
     parse_offer_items,
     parse_offer,
     parse_offers,
@@ -32,7 +30,6 @@ from webapp.shop.api.ua_contracts.parsers import (
     parse_users,
 )
 from webapp.shop.api.ua_contracts.primitives import (
-    Account,
     Subscription,
     SubscriptionItem,
     ContractItem,
@@ -43,39 +40,6 @@ from webapp.shop.api.ua_contracts.primitives import (
 
 
 class TestParsers(unittest.TestCase):
-    def test_parse_account(self):
-        raw_account = get_fixture("account")
-        parsed_account = parse_account(raw_account=raw_account)
-
-        expectation = Account(
-            id="aAbBcCdDeEfFgGhHiIjJkKlLmMnNoOpP",
-            name="Account Name",
-            role="admin",
-        )
-
-        self.assertIsInstance(parsed_account, Account)
-        self.assertEqual(to_dict(expectation), to_dict(parsed_account))
-
-    def test_parse_accounts(self):
-        raw_accounts = get_fixture("accounts")
-        parsed_accounts = parse_accounts(raw_accounts=raw_accounts)
-
-        expectation = [
-            Account(
-                id="a123AbBcCdDeEfFgGhHiIjJkKlLmMnNoOpP",
-                name="Free",
-                role="admin",
-            ),
-            Account(
-                id="aAbBcCdDeEfFgGhHiIjJkKlLmMnNoOpP",
-                name="Account Name",
-                role="admin",
-            ),
-        ]
-
-        self.assertIsInstance(parsed_accounts, List)
-        self.assertEqual(to_dict(expectation), to_dict(parsed_accounts))
-
     def test_parse_subscription_items(self):
         raw_subscription_items = get_fixture("subscription-items")
         parsed_subscription_items = parse_subscription_items(

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -85,6 +85,7 @@ from webapp.shop.views import (
     post_customer_info,
     post_anonymised_customer_info,
     get_purchase,
+    get_purchase_v2,
     post_stripe_invoice_id,
     get_last_purchase_ids,
     support,
@@ -113,6 +114,7 @@ from webapp.shop.advantage.views import (
     blender_shop_view,
     post_offer,
     get_advantage_offers,
+    post_advantage_purchase,
 )
 
 from webapp.login import login_handler, logout, user_info, empty_session
@@ -447,6 +449,11 @@ app.add_url_rule(
     methods=["GET"],
 )
 app.add_url_rule(
+    "/account/purchases_v2/<purchase_id>",
+    view_func=get_purchase_v2,
+    methods=["GET"],
+)
+app.add_url_rule(
     "/account/<tx_type>/<tx_id>/invoices/<invoice_id>",
     view_func=post_stripe_invoice_id,
     methods=["POST"],
@@ -455,6 +462,18 @@ app.add_url_rule("/support", view_func=support)
 app.add_url_rule(
     "/account/last-purchase-ids/<account_id>",
     view_func=get_last_purchase_ids,
+)
+app.add_url_rule(
+    "/advantage/purchase",
+    view_func=post_advantage_purchase,
+    methods=["POST"],
+    defaults={"preview": False},
+)
+app.add_url_rule(
+    "/advantage/purchase/preview",
+    view_func=post_advantage_purchase,
+    methods=["POST"],
+    defaults={"preview": True},
 )
 # end of shop
 

--- a/webapp/shop/api/ua_contracts/api.py
+++ b/webapp/shop/api/ua_contracts/api.py
@@ -23,6 +23,12 @@ class UAContractsAPI:
         self.api_url = api_url.rstrip("/")
         self.is_for_view = is_for_view
 
+    def set_authentication_token(self, token):
+        self.authentication_token = token
+
+    def set_token_type(self, token_type):
+        self.token_type = token_type
+
     def set_is_for_view(self, is_for_view):
         self.is_for_view = is_for_view
 
@@ -200,7 +206,7 @@ class UAContractsAPI:
                 f"/marketplace/{marketplace}"
                 f"/subscriptions{filters}"
             ),
-            error_rules=["default"],
+            error_rules=["default", "auth"],
         ).json()
 
     def get_account_purchases(
@@ -234,14 +240,14 @@ class UAContractsAPI:
                 "accountName": account_name,
                 "recaptchaToken": captcha_value,
             },
-            error_rules=["default", "ensure-purchase-account"],
+            error_rules=["default"],
         ).json()
 
     def get_purchase_account(self, marketplace: str = "") -> dict:
         return self._request(
             method="get",
             path=f"v1/marketplace/{marketplace}/account",
-            error_rules=["default", "no-found", "user-role"],
+            error_rules=["default", "auth", "no-found", "user-role"],
         ).json()
 
     def purchase_from_marketplace(
@@ -306,7 +312,7 @@ class UAContractsAPI:
         if "user-role" in error_rules and status_code == 403:
             raise AccessForbiddenError(error)
 
-        if "ensure-purchase-account" in error_rules and status_code == 401:
+        if "auth" in error_rules and status_code == 401:
             raise UnauthorizedError(error)
 
         if "no-found" in error_rules and status_code == 404:

--- a/webapp/shop/api/ua_contracts/parsers.py
+++ b/webapp/shop/api/ua_contracts/parsers.py
@@ -1,7 +1,6 @@
 from typing import List, Dict
 
 from webapp.shop.api.ua_contracts.primitives import (
-    Account,
     Contract,
     ContractItem,
     Entitlement,
@@ -60,18 +59,6 @@ def parse_product_listings(
         )
         for product_listing in raw_product_listings
     }
-
-
-def parse_account(raw_account: Dict) -> Account:
-    return Account(
-        id=raw_account.get("id"),
-        name=raw_account.get("name"),
-        role=raw_account.get("userRoleOnAccount"),
-    )
-
-
-def parse_accounts(raw_accounts: List[Dict]) -> List[Account]:
-    return [parse_account(raw_account) for raw_account in raw_accounts]
 
 
 def parse_entitlements(

--- a/webapp/shop/api/ua_contracts/primitives.py
+++ b/webapp/shop/api/ua_contracts/primitives.py
@@ -121,12 +121,14 @@ class Account:
     def __init__(
         self,
         id: str,
-        name: str,
-        role: str,
+        name: str = None,
+        role: str = None,
+        token: str = None,
     ):
         self.id = id
         self.name = name
         self.role = role
+        self.token = token
 
 
 class User:

--- a/webapp/shop/api/ua_contracts/schema.py
+++ b/webapp/shop/api/ua_contracts/schema.py
@@ -2,6 +2,7 @@ from marshmallow import Schema, post_load, validate, EXCLUDE
 from marshmallow.fields import Function, String, Integer, Nested, List
 
 from webapp.shop.api.ua_contracts.models import Purchase, PurchaseItem, Invoice
+from webapp.shop.api.ua_contracts.primitives import Account
 
 
 class BaseSchema(Schema):
@@ -65,3 +66,22 @@ class PurchaseSchema(BaseSchema):
     @post_load
     def make_purchase(self, data, **kwargs) -> Purchase:
         return Purchase(**data)
+
+
+class AccountSchema(BaseSchema):
+    id = String(required=True, attribute="id")
+    name = String(required=True)
+    userRoleOnAccount = String(required=True, attribute="role")
+
+    @post_load
+    def make_purchase(self, data, **kwargs) -> Account:
+        return Account(**data)
+
+
+class EnsurePurchaseAccountSchema(BaseSchema):
+    accountID = String(required=True, attribute="id")
+    token = String(required=True)
+
+    @post_load
+    def make_purchase(self, data, **kwargs) -> Account:
+        return Account(**data)

--- a/webapp/shop/decorators.py
+++ b/webapp/shop/decorators.py
@@ -43,6 +43,21 @@ MARKETING_FLAGS = {
     "fbclid": "facebook-click-id",
 }
 
+SERVICES = {
+    "canonical-ua": {
+        "short": "ua",
+        "name": "Canonical UA",
+    },
+    "blender": {
+        "short": "blender",
+        "name": "Blender Support",
+    },
+    "canonical-cube": {
+        "short": "cube",
+        "name": "Canonical CUBE",
+    },
+}
+
 
 def shop_decorator(area=None, permission=None, response="json", redirect=None):
     permission = permission if permission in PERMISSION_LIST else None

--- a/webapp/shop/schemas.py
+++ b/webapp/shop/schemas.py
@@ -40,6 +40,33 @@ class SubscriptionRenewalSchema(Schema):
     should_auto_renew = Boolean()
 
 
+class ProductListing(Schema):
+    product_listing_id = String(required=True)
+    quantity = Int(required=True)
+
+
+class CustomerInfo(Schema):
+    email = String()
+    name = String()
+    payment_method_id = String()
+    address = Nested(AddressSchema())
+    tax_id = Nested(TaxIdSchema())
+
+
+account_purhcase = {
+    "account_id": String(),
+    "captcha_value": String(requied=True),
+    "customer_info": Nested(CustomerInfo),
+    "products": List(Nested(ProductListing), required=True),
+    "previous_purchase_id": String(required=True),
+    "marketplace": String(
+        validate=validate.OneOf(["canonical-ua", "canonical-cube", "blender"]),
+        required=True,
+    ),
+    "action": String(validate=validate.OneOf(["purchase", "resize", "trial"])),
+}
+
+
 post_advantage_subscriptions = {
     "account_id": String(required=True),
     "period": String(enum=["monthly", "yearly"], required=True),


### PR DESCRIPTION
## Done

- Add new purchase endpoint which does:
  - Get purchase account ensure a purchase account
  - PUT customer info
  - Preview or make purchase
  - Endpoint info: `POST /advantage/purchase/{preview}` Returns an `Invoice` if preview or `Purchase` if not preview.
  - Payload sample:
```
{
    "customer_info": {
        "payment_method_id": "",
        "email": "albert.kolozsvari+testerabcd340@canonical.com",
        "name": "abc",
        "address": {
            "city" : "London2",
            "country": "GB",
            "line1": "",
            "postal_code": "123123",
            "state": ""
        },
        "tax_id": {
            "type": "",
            "value": ""
        }
    },
    "products": [
        {
            "product_listing_id": "lAObiUcHYzxOh_EVHCLGHoc8eARipfgy7itnjK1xSOiE",
            "quantity": 1
        }
    ],
    "marketplace": "canonical-ua",
    "action": "purchase",  // can be resize or trial too
    "previous_purchase_id": "",
    "captcha_value": "123"
}
```
- Add get purchase v2 endpoint mapped version of the old purchase endpoint

## QA

- Will be easier to test with the front-end

## Issue / Card

Fixes #https://github.com/canonical-web-and-design/commercial-squad/issues/508
