### PR TITLE
Update notice views to consume security api

### DIFF
--- a/templates/security/notices/lsn.html
+++ b/templates/security/notices/lsn.html
@@ -7,7 +7,7 @@
   <div class="row">
     <div class="col-12">
 	    <h1>{{ notice.id }}: {{ notice.title }}</h1>
-      <p class="p-muted-heading">{{ notice.published.strftime("%d %B %Y") }}</p>
+      <p class="p-muted-heading">{{ notice.published }}</p>
       <p>{{ notice.summary | safe }}</p>
       <h2>Releases</h2>
       <ul class="p-inline-list u-no-margin--bottom">

--- a/templates/security/notices/usn.html
+++ b/templates/security/notices/usn.html
@@ -7,7 +7,7 @@
   <div class="row">
     <div class="col-12">
 	    <h1>{{ notice.id }}: {{ notice.title }}</h1>
-      <p class="p-muted-heading">{{ notice.published.strftime("%d %B %Y") }}</p>
+      <p class="p-muted-heading">{{ notice.published }}</p>
       <p>{{ notice.summary | safe }}</p>
       <h2>Releases</h2>
       <ul class="p-inline-list u-no-margin--bottom">
@@ -106,7 +106,7 @@
       <ul class="p-list">
         {% for notice in notice.related_notices %}
           <li class="p-list__item">
-            <a href="/security/notices/{{ notice.id }}">{{ notice.id }}</a>: {{ notice.package_list }}
+            <a href="/security/notices/{{ notice.id }}">{{ notice.id }}</a>: {{ notice.packages }}
           </li>
         {% endfor %}
       </ul>

--- a/webapp/security/api.py
+++ b/webapp/security/api.py
@@ -60,3 +60,21 @@ class SecurityAPI:
             raise SecurityAPIError(error)
 
         return releases_response.json()
+
+    def get_notice(
+        self,
+        id: str,
+    ):
+        """
+        Makes request for specific notice_id,
+        returns json object if found
+        """
+
+        try:
+            notice_response = self._get(f"notices/{id.upper()}.json")
+        except HTTPError as error:
+            if error.response.status_code == 404:
+                return None
+            raise SecurityAPIError(error)
+
+        return notice_response.json()

--- a/webapp/security/views.py
+++ b/webapp/security/views.py
@@ -60,7 +60,6 @@ def notice(notice_id):
     releases = {
         release["codename"]: release["version"] for release in all_releases
     }
-    print(releases)
 
     if notice["release_packages"]:
         for codename, pkgs in notice["release_packages"].items():

--- a/webapp/security/views.py
+++ b/webapp/security/views.py
@@ -43,7 +43,7 @@ def notice(notice_id):
 
     security_api = SecurityAPI(
         session=session,
-        base_url="http://192.168.64.6:8030/security/",
+        base_url="http://ubuntu.com/security/",
     )
 
     notice = security_api.get_notice(notice_id)

--- a/webapp/security/views.py
+++ b/webapp/security/views.py
@@ -30,6 +30,11 @@ markdown_parser = Markdown(
 )
 session = talisker.requests.get_session()
 
+security_api = SecurityAPI(
+    session=session,
+    base_url="https://ubuntu.com/security/",
+)
+
 
 def get_processed_details(notice):
     pattern = re.compile(r"(cve|CVE-)\d{4}-\d{4,7}", re.MULTILINE)
@@ -41,11 +46,6 @@ def get_processed_details(notice):
 
 def notice(notice_id):
 
-    security_api = SecurityAPI(
-        session=session,
-        base_url="http://ubuntu.com/security/",
-    )
-
     notice = security_api.get_notice(notice_id)
 
     if not notice:
@@ -55,10 +55,9 @@ def notice(notice_id):
     package_versions = {}
     release_packages = SortedDict()
 
-    all_releases = security_api.get_releases().get("releases")
-
     releases = {
-        release["codename"]: release["version"] for release in all_releases
+        release["codename"]: release["version"]
+        for release in notice["releases"]
     }
 
     if notice["release_packages"]:
@@ -720,11 +719,6 @@ def cve(cve_id):
     """
     Retrieve and display an individual CVE details page
     """
-
-    security_api = SecurityAPI(
-        session=session,
-        base_url="https://ubuntu.com/security/",
-    )
 
     cve = security_api.get_cve(cve_id)
 

--- a/webapp/security/views.py
+++ b/webapp/security/views.py
@@ -31,8 +31,22 @@ markdown_parser = Markdown(
 session = talisker.requests.get_session()
 
 
+def get_processed_details(notice):
+    pattern = re.compile(r"(cve|CVE-)\d{4}-\d{4,7}", re.MULTILINE)
+
+    return re.sub(
+        pattern, r'<a href="/security/\g<0>">\g<0></a>', notice["description"]
+    )
+
+
 def notice(notice_id):
-    notice = db_session.query(Notice).get(notice_id)
+
+    security_api = SecurityAPI(
+        session=session,
+        base_url="http://192.168.64.6:8030/security/",
+    )
+
+    notice = security_api.get_notice(notice_id)
 
     if not notice:
         flask.abort(404)
@@ -41,13 +55,15 @@ def notice(notice_id):
     package_versions = {}
     release_packages = SortedDict()
 
-    releases = {
-        release.codename: release.version
-        for release in db_session.query(Release).all()
-    }
+    all_releases = security_api.get_releases().get("releases")
 
-    if notice.release_packages:
-        for codename, pkgs in notice.release_packages.items():
+    releases = {
+        release["codename"]: release["version"] for release in all_releases
+    }
+    print(releases)
+
+    if notice["release_packages"]:
+        for codename, pkgs in notice["release_packages"].items():
             release_version = releases[codename]
             release_packages[release_version] = {}
             for package in pkgs:
@@ -59,7 +75,7 @@ def notice(notice_id):
                     release_packages[release_version][name] = package
                     continue
 
-                if notice.get_type == "LSN":
+                if notice["type"] == "LSN":
                     if name not in package_descriptions:
                         package_versions[name] = []
 
@@ -80,38 +96,29 @@ def notice(notice_id):
             for key in sorted(package_descriptions.keys())
         }
 
-    notice_cve_ids = [cve.id for cve in notice.cves]
-    related_notices = (
-        db_session.query(Notice)
-        .filter(Notice.cves.any(CVE.id.in_(notice_cve_ids)))
-        .filter(Notice.id != notice.id)
-        .all()
-    )
-
-    if notice.get_type == "LSN":
+    if notice["type"] == "LSN":
         template = "security/notices/lsn.html"
     else:
         template = "security/notices/usn.html"
 
+    if notice.get("published"):
+        notice["published"] = dateutil.parser.parse(
+            notice["published"]
+        ).strftime("%-d %B %Y")
+
     notice = {
-        "id": notice.id,
-        "title": notice.title,
-        "published": notice.published,
-        "summary": notice.summary,
-        "details": markdown_parser(notice.get_processed_details),
-        "instructions": markdown_parser(notice.instructions),
+        "id": notice["id"],
+        "title": notice["title"],
+        "published": notice["published"],
+        "summary": notice["summary"],
+        "details": markdown_parser(get_processed_details(notice)),
+        "instructions": markdown_parser(notice["instructions"]),
         "package_descriptions": package_descriptions,
         "release_packages": release_packages,
-        "releases": notice.releases,
-        "cves": notice.cves,
-        "references": notice.references,
-        "related_notices": [
-            {
-                "id": related_notice.id,
-                "package_list": ", ".join(related_notice.package_list),
-            }
-            for related_notice in related_notices
-        ],
+        "releases": notice["releases"],
+        "cves": notice["cves"],
+        "references": notice["references"],
+        "related_notices": notice["related_notices"],
     }
 
     return flask.render_template(template, notice=notice)


### PR DESCRIPTION
## Done

- add get notice function to api class
- refactor notice view to comply with new payload structure
- update usn template to comply with new variable names 
**NOTE: Must be merged AFTER releases endpoint has been updated on security api as base_url needs will need to be updated**

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/security/notices
    - Be sure to test on mobile, tablet and desktop screen sizes
- Click on any notice and see that it renders correctly
- Try out any and all links on the template and make sure that they work

## Issue / Card

Fixes https://github.com/canonical-web-and-design/ubuntu.com/issues/11272