### PR TITLE
Change instances of  'e-book' to 'eBook'

### DIFF
--- a/templates/azure/ebook/index.html
+++ b/templates/azure/ebook/index.html
@@ -1,6 +1,6 @@
 {% extends "azure/base_azure.html" %}
 
-{% block title %}Why do Cloud innovators migrate to Pro? Get the e-book.{% endblock %}
+{% block title %}Why do Cloud innovators migrate to Pro? Get the eBook.{% endblock %}
 {% block meta_description %}Learn about the security compliance and support features of the Linux based Ubuntu Pro image on Azure.{% endblock %}
 {% block meta_copydoc %}https://docs.google.com/document/d/1JL_TeFBg1tSqiYIiXU0IwJTKWRDKJEXWtEgLRWFnToI/edit#{% endblock meta_copydoc %}
 
@@ -21,10 +21,10 @@
       <div>
         <h1>Why do cloud innovators migrate to Ubuntu Pro?</h1>
 
-        <p class="u-no-padding--top p-heading--4">Get our e-book to find out</p>
+        <p class="u-no-padding--top p-heading--4">Get our eBook to find out</p>
 
         <p>
-          <a href="#ubuntu-pro-ebook" class="p-button--positive">Download<span class="u-off-screen"> the Why do Cloud innovators migrate to Pro? e-book by completing this form</span></a>
+          <a href="#ubuntu-pro-ebook" class="p-button--positive">Download<span class="u-off-screen"> the Why do Cloud innovators migrate to Pro? eBook by completing this form</span></a>
         </p>
       </div>
     </div>
@@ -56,11 +56,11 @@
 
       <p>As the publishers of Ubuntu, we went one step further and developed a premium Ubuntu Pro image in partnership with public cloud providers, to deliver a preferred open-source solution for cloud innovators.</p>
 
-      <p>Here is our latest e-book, where we share the details of how Ubuntu Pro on Azure delivers extended open-source security, enterprise compliance, 10 years of extended maintenance and more.</p>
+      <p>Here is our latest eBook, where we share the details of how Ubuntu Pro on Azure delivers extended open-source security, enterprise compliance, 10 years of extended maintenance and more.</p>
     </div>
 
     <div class="col-5" id="ubuntu-pro-ebook">
-      {% with id="4393", returnURL="/azure/ebook/thank-you", cta="Get the e-book", cta_class="p-button--positive" %}
+      {% with id="4393", returnURL="/azure/ebook/thank-you", cta="Get the eBook", cta_class="p-button--positive" %}
         {% include "engage/shared/_en_engage_form.html" %}
       {% endwith %}
     </div>

--- a/templates/azure/fips.html
+++ b/templates/azure/fips.html
@@ -432,7 +432,7 @@
       </a>
       <h4>Optimised scaling in the cloud</h4>
       <p>Building enterprise-grade infrastructure with open source quickly with stability seems impossible, but Ubuntu Pro for Azure allows organisations to do just that. Ubuntu Pro is a premium image delivering the most comprehensive security and compliance features and is suitable for small to large-scale Linux enterprise operations offering pay-as-you-go billing on a single invoice through Azure. This piece explains the new ways Ubuntu and Microsoft Azure are driving reliability and security at speed and scale.</p>
-      <p><a class="p-button--positive p-link--external" href="https://assets.ubuntu.com/v1/a60c04fd-Optimized+Scaling+In+The+Cloud.pdf" >Download the e-book</a></p>
+      <p><a class="p-button--positive p-link--external" href="https://assets.ubuntu.com/v1/a60c04fd-Optimized+Scaling+In+The+Cloud.pdf" >Download the eBook</a></p>
     </div>
   </div>
 </section>

--- a/templates/azure/pro.html
+++ b/templates/azure/pro.html
@@ -165,7 +165,7 @@
       </a>
       <h4>Scaling with Ubuntu Pro</h4>
       <p>Building enterprise-grade infrastructure with open source, speed, reliability, and support.</p>
-      <p><a class="p-button--positive" href="https://assets.ubuntu.com/v1/a60c04fd-Optimized+Scaling+In+The+Cloud.pdf">Download the e-book</a></p>
+      <p><a class="p-button--positive" href="https://assets.ubuntu.com/v1/a60c04fd-Optimized+Scaling+In+The+Cloud.pdf">Download the eBook</a></p>
     </div>
     <div class="col-6">
       <a href="/engage/azure-webinar" aria-hidden="true" tabindex="-1">
@@ -387,7 +387,7 @@
       </a>
       <h4>Simple VM provisioning with cloud-init</h4>
       <p>Cloud-init automates the provisioning of an operating system image into a fully running state. Typical tasks handled by cloud-init include networking and storage initialisation and optional package installation and configuration. This means users can build up-to-date images in no time and with minimum maintenance efforts.</p>
-      <p><a class="p-button--positive" href="https://assets.ubuntu.com/v1/05994c5c-Cloud-init_on_Azure.pdf">Download the e-book</a></p>
+      <p><a class="p-button--positive" href="https://assets.ubuntu.com/v1/05994c5c-Cloud-init_on_Azure.pdf">Download the eBook</a></p>
     </div>
   </div>
 </section>


### PR DESCRIPTION
## Done

- Change instances of  'e-book' to 'eBook' on `/azure/eBook`, see [copydoc](https://docs.google.com/document/d/1JL_TeFBg1tSqiYIiXU0IwJTKWRDKJEXWtEgLRWFnToI/edit)
- Changed any other instances I found in the codebase

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- Search the codebase for any instances of 'e-Book' and check they have been replaced by 'eBook'
- specifically search: https://ubuntu-com-11372.demos.haus/azure/ebook
https://ubuntu-com-11372.demos.haus/azure/fips
https://ubuntu-com-11372.demos.haus/azure/pro

## Issue / Card

Fixes https://github.com/canonical-web-and-design/web-squad/issues/4912
