### PR TITLE
Update '/azure/private-offer' buttons lengths

### DIFF
--- a/templates/azure/private-offer.html
+++ b/templates/azure/private-offer.html
@@ -25,7 +25,7 @@
         <a href="#private-offer-form" class="p-button--positive">Get private offer</a>
       </p>
     </div>
-    <div class="col-5 u-hide--small u-vertically-center u-align--center">
+    <div class="col-5 u-hide--small u-hide--medium u-vertically-center u-align--center">
       {{ image (
         url="https://assets.ubuntu.com/v1/71fe6a11-private-offer-shield.svg",
         alt="",
@@ -44,7 +44,7 @@
 <section class="p-strip--light">
   <div class="row">
     <div class="col-7">
-      <h2 class="p-heading--4">Ubuntu Pro for Azure is a premium image delivering the most comprehensive open source security and complianc</h2>
+      <h2 class="p-heading--4">Ubuntu Pro for Azure is a premium image delivering the most comprehensive open source security and compliance</h2>
 
       <hr class="p-separator u-no-margin--top" />
       
@@ -55,7 +55,7 @@
       <p>The private offer also supports an ability to work from a set of images that have been hardened and optimised for security and operations for the whole organisation. This simplifies IT governance and allows all your internal users to seamlessly follow your strategy.</p>
     </div>
     <div class="col-5" id="private-offer-form">
-      {% with id="4394", returnURL="/azure/thank-you", cta="Get the exclusive private offer", cta_class="p-button--positive" %}
+      {% with id="4394", returnURL="/azure/thank-you", cta="Get private offer", cta_class="p-button--positive" %}
         {% include "engage/shared/_en_engage_form.html" %}
       {% endwith %}
     </div>
@@ -108,7 +108,7 @@
       <p>Canonical has the expertise to assist you in your project, whether it involves compliance, application architecture, optimisation or streaming operations at scale.</p>
 
       <p>
-        <a href="#private-offer-form" class="p-button--positive">Get the exclusive private offer</a>
+        <a href="#private-offer-form" class="p-button--positive">Get private offer</a>
       </p>
     </div>
   </div>


### PR DESCRIPTION
## Done

- Update '/azure/private-offer' buttons lengths but shortening text, as per [copydoc](https://docs.google.com/document/d/1P4sqhsi6jqWwbqjrBDuAOABGIcbJDM6Efy59ztaroVk/edit)

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: https://ubuntu-com-11373.demos.haus/azure/private-offer
    - Be sure to test on mobile, tablet and desktop screen sizes
- Check that the text on the buttons matches that on the [copydoc](https://docs.google.com/document/d/1P4sqhsi6jqWwbqjrBDuAOABGIcbJDM6Efy59ztaroVk/edit)

## Issue / Card

Fixes https://github.com/canonical-web-and-design/web-squad/issues/4906
