### PR TITLE
Add unlisted engage pages

### DIFF
--- a/redirects.yaml
+++ b/redirects.yaml
@@ -467,6 +467,8 @@ engage/отчет-о-ценах-на-бесплатные-облачные-хр�
 engage/от-vmware-к-charmed-openstack/?: "/engage/ru/vmware-to-charmed-openstack"
 engage/сравнение-платформ-kubernetes/?: "/engage/ru/enterprise-kubernetes-comparison"
 engage/сравнение-платформ-red-hat-openstack-canonical-charmed-openstack/?: "/engage/ru/cloud-pricing-report-2021"
+engage/custom-ubuntu-pro-image-on-azure: "/engage/unlisted/custom-ubuntu-pro-image-on-azure"
+engage/ShellOnboarding: "/engage/unlisted/shell-onboarding"
 enterprise-canonical-kubernetes/?: "https://assets.ubuntu.com/v1/Enterprise-Canonical-Kubernetes.pdf"
 es/?: "/"
 esm/?: "/security/esm"

--- a/templates/engage/base_engage_unlisted.html
+++ b/templates/engage/base_engage_unlisted.html
@@ -1,0 +1,12 @@
+{% set hide_nav = True %}
+{% extends "templates/base.html" %}
+
+{% block head_extra %}
+<meta name="robots" content="noindex, nofollow" />
+{% endblock %}
+
+{% block meta_copydoc %}https://drive.google.com/drive/folders/1FyMcu6vqGnyQMdWLRjvxJVWm8gHgslk4{% endblock meta_copydoc %}
+
+{% block outer_content %}
+  {% block content %}{% endblock %}
+{% endblock %}

--- a/templates/engage/unlisted/custom-ubuntu-pro-image-on-azure.html
+++ b/templates/engage/unlisted/custom-ubuntu-pro-image-on-azure.html
@@ -1,0 +1,65 @@
+{% extends "engage/base_engage.html" %}
+
+{% block title %}Using Shell's Ubuntu Pro image on Azure{% endblock %}
+{% block meta_description %}Get started with custom images of Ubuntu Pro with Support on Azure{% endblock %}
+
+{% block head_extra %}
+<meta name="robots" content="noindex, nofollow" />
+{% endblock %}
+
+{% block meta_copydoc %}{% endblock meta_copydoc %}
+
+{% block content %}
+<section class="p-strip p-engage-banner--grad">
+  <div class="u-fixed-width navigation-logo-engage">
+    <a href="/">
+      {{
+        image(
+          url="https://assets.ubuntu.com/v1/f263d9c4-logo-ubuntu-white.svg",
+          alt="Ubuntu",
+          height="32",
+          width="143",
+          hi_def=True,
+          loading="auto"
+        ) | safe
+      }}
+    </a>
+  </div>
+
+  <div class="row">
+    <div class="col-7 u-vertically-center">
+      <h1>Using Shell&#39;s Ubuntu Pro image on Azure</h1>
+      <p class="u-no-padding--top p-heading--4">
+        Get started with custom images of Ubuntu Pro with Support on Azure
+      </p>
+      
+    </div>
+    
+    <div class="col-5 u-hide--small u-vertically-center u-align--center">
+      {{
+        image(
+          url="https://assets.ubuntu.com/v1/605efe63-ubuntu-microsoft-azure-logos.svg",
+          alt="",
+          height="133",
+          width="160",
+          hi_def=True,
+          loading="auto"
+        ) | safe
+      }}
+    </div>
+  </div>
+</section>
+
+<section class="p-strip is-shallow is-bordered">
+  <div class="row">
+    <div class="col-12">
+      <p>A quick overview of the work that we at Canonical (the company that makes Ubuntu) have been doing with <b>Ubuntu Pro Shell</b>, how to deploy the secure/supported image we have built together on Azure and how to make the most of its features.</p>
+
+      <h2>Arrange onboarding</h2>
+
+      <iframe src="https://calendly.com/niklas-brag/30min-1?hide_gdpr_banner=1" height="1000px" width="1000px"></iframe>
+    </div>
+  </div>
+</section>
+
+{% endblock content %}

--- a/templates/engage/unlisted/custom-ubuntu-pro-image-on-azure.html
+++ b/templates/engage/unlisted/custom-ubuntu-pro-image-on-azure.html
@@ -1,13 +1,6 @@
-{% extends "engage/base_engage.html" %}
+{% extends "engage/base_engage_unlisted.html" %}
 
 {% block title %}Using Shell's Ubuntu Pro image on Azure{% endblock %}
-{% block meta_description %}Get started with custom images of Ubuntu Pro with Support on Azure{% endblock %}
-
-{% block head_extra %}
-<meta name="robots" content="noindex, nofollow" />
-{% endblock %}
-
-{% block meta_copydoc %}{% endblock meta_copydoc %}
 
 {% block content %}
 <section class="p-strip p-engage-banner--grad">

--- a/templates/engage/unlisted/shell-onboarding.html
+++ b/templates/engage/unlisted/shell-onboarding.html
@@ -1,0 +1,97 @@
+{% extends "engage/base_engage.html" %}
+
+{% block title %}Using Shell's Ubuntu Pro image on Azure{% endblock %}
+{% block meta_description %}Get started with custom images of Ubuntu Pro with Support on Azure{% endblock %}
+
+{% block head_extra %}
+<meta name="robots" content="noindex, nofollow" />
+{% endblock %}
+
+{% block meta_copydoc %}https://docs.google.com/document/d/1UPN4IWGJ6YAjs0GDEDan63VXWw7MRSjSPYToh-It1WM/edit#heading=h.rcfu0dm2tvnr{% endblock meta_copydoc %}
+
+{% block content %}
+<section class="p-strip p-engage-banner--grad">
+  <div class="u-fixed-width navigation-logo-engage">
+    <a href="/">
+      {{
+        image(
+        url="https://assets.ubuntu.com/v1/f263d9c4-logo-ubuntu-white.svg",
+        alt="Ubuntu",
+        height="32",
+        width="143",
+        hi_def=True,
+        loading="auto"
+        ) | safe
+      }}
+    </a>
+  </div>
+  
+  <div class="row">
+    <div class="col-7 u-vertically-center">
+      <h1>Getting started with Shell&#39;s custom Ubuntu Pro image on Azure</h1>
+      <p class="u-no-padding--top p-heading--4">In this technical video you&#39;ll learn how to get started with Shell&#39;s custom images of Ubuntu Pro with Support on Azure.</p>
+      <p>
+        <a href="#vimeo-section" class="p-button--positive">
+          Watch the video
+        </a>
+        
+        <a href="https://ubuntu.com/azure/pro#get-in-touch" class="p-button">
+          Contact us
+        </a>
+      </p>
+    </div>
+    
+    <div class="col-5 u-hide--small u-vertically-center u-align--center">
+      {{
+        image(
+        url="https://assets.ubuntu.com/v1/605efe63-ubuntu-microsoft-azure-logos.svg",
+        alt="",
+        height="267",
+        width="320",
+        hi_def=True,
+        loading="auto"
+        ) | safe
+      }}
+    </div>
+  </div>
+</section>
+
+<section class="p-strip is-shallow is-bordered">
+  <div class="row">
+    <div class="col-12">
+      <p>This onboarding presentation is aimed at those who will be using the Ubuntu Pro images and dives into some of the details of how to use the features and what they do. The video covers:</p>
+      
+      <ul>
+        <li>How to launch the custom Shell Ubuntu Pro with Support image</li>
+        <li>the advantages of the Shell Ubuntu Pro with Support image over other Ubuntu instances on the Public Cloud</li>
+        <li>the extended security coverage of the Shell Ubuntu Pro with Support image</li>
+        <li>Kernel Livepatch; and</li>
+        <li>the hardening that Canonical and Shell have implemented together in these images</li>
+      </ul>
+      
+      <p>If you would like to speak about a specific project requirement, or have any questions, please contact us:</p>
+      
+      <ul>
+        <li>
+          <a href="mailto:jonathan.kopra@canonical.com">Jonathan Kopra</a> (Shell account manager):
+        </li>
+        <li>
+          <a href="mailto:aaron.whitehouse@canonical.com">Aaron Whitehouse</a> (Azure Strategic Alliances Director)
+        </li>
+        <li>
+          <a href="mailto:customersuccess@canonical.com">Canonical customer success</a>
+        </li>
+      </ul>
+    
+      <p>You can execute <a href="https://ubuntu.com/security/docker-images">secured containers</a> on top of VMs running Ubuntu Pro with Support. The LTS Docker Image Portfolio on Docker Hub and public cloud container registries provides compliant, secure application images, with a long term maintenance commitment by Canonical.</p>
+    </div>
+  </div>
+</section>
+
+<section class="p-strip is-shallow" id="vimeo-section">
+  <div class="row" id="webinar">
+    <iframe src="https://player.vimeo.com/video/670718263" width="560" height="315" frameborder="0" allow="autoplay; fullscreen" allowfullscreen></iframe>
+  </div>
+</section>
+{% endblock content %}
+    

--- a/templates/engage/unlisted/shell-onboarding.html
+++ b/templates/engage/unlisted/shell-onboarding.html
@@ -1,11 +1,6 @@
-{% extends "engage/base_engage.html" %}
+{% extends "engage/base_engage_unlisted.html" %}
 
 {% block title %}Using Shell's Ubuntu Pro image on Azure{% endblock %}
-{% block meta_description %}Get started with custom images of Ubuntu Pro with Support on Azure{% endblock %}
-
-{% block head_extra %}
-<meta name="robots" content="noindex, nofollow" />
-{% endblock %}
 
 {% block meta_copydoc %}https://docs.google.com/document/d/1UPN4IWGJ6YAjs0GDEDan63VXWw7MRSjSPYToh-It1WM/edit#heading=h.rcfu0dm2tvnr{% endblock meta_copydoc %}
 

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -64,6 +64,7 @@ from webapp.views import (
     show_template,
     build_engage_index,
     engage_thank_you,
+    unlisted_engage_page,
     sitemap_index,
     account_query,
     sixteen_zero_four,
@@ -623,6 +624,10 @@ app.add_url_rule(
     "/engage/<language>/<page>/thank-you",
     endpoint="alternative_thank-you",
     view_func=engage_thank_you(engage_pages),
+)
+app.add_url_rule(
+    "/engage/unlisted/<slug>",
+    view_func=unlisted_engage_page,
 )
 
 

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -501,6 +501,14 @@ def engage_thank_you(engage_pages):
     return render_template
 
 
+def unlisted_engage_page(slug):
+    """
+    Renders an engage page that is separate from the
+    discourse implementation
+    """
+    return flask.render_template(f"engage/unlisted/{slug}.html")
+
+
 def openstack_install():
     """
     OpenStack install docs


### PR DESCRIPTION
## Done

We had a complaint recently that an engage page went live, and it should not have been visible in the index or "You may be interested in" section on engage page thank you pages. We didn't have the functionality to support that, so this PR adds it, with two pages that should not appear on /engage, or in the "You may be interested in" section.

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: 
  - https://ubuntu-com-11375.demos.haus/engage/unlisted/custom-ubuntu-pro-image-on-azure
  - https://ubuntu-com-11375.demos.haus/engage/unlisted/shell-onboarding
- You should see two engage pages
- Attempt to visit:
  - https://ubuntu-com-11375.demos.haus/engage/custom-ubuntu-pro-image-on-azure
  - https://ubuntu-com-11375.demos.haus/engage/ShellOnboarding
- You should be redirected to their unlisted counterparts

