### PR TITLE
UA selector: Set billing period to monthly when selecting apps.

### DIFF
--- a/static/js/src/advantage/subscribe/reducers/form-reducer.js
+++ b/static/js/src/advantage/subscribe/reducers/form-reducer.js
@@ -9,7 +9,7 @@ const productsArray = Object.entries(window.productList);
 
 const initialFormState = {
   type: "physical",
-  version: "18.0a",
+  version: "20.04",
   feature: "infra",
   support: "unset",
   quantity: isSmallVP ? 0 : 1,

--- a/static/js/src/advantage/subscribe/reducers/form-reducer.js
+++ b/static/js/src/advantage/subscribe/reducers/form-reducer.js
@@ -166,9 +166,12 @@ const formSlice = createSlice({
         state.support = "essential";
       }
 
-      if (action.payload !== "infra") {
+      if (action.payload === "apps") {
+        state.billing = "monthly";
+      } else {
         state.billing = "yearly";
       }
+
       state.product = getProduct(state);
       state.periods = getProductPeriods(state.product.productID);
     },

--- a/templates/advantage/subscribe/form/_feature_coverage.html
+++ b/templates/advantage/subscribe/form/_feature_coverage.html
@@ -31,7 +31,7 @@
         </div>
 
         <div class="p-card--radio--feature js-radio">
-          <div class="p-radio">
+          <label class="p-radio">
             <input class="p-radio__input" autocomplete="off" type="radio" aria-labelledby="feature_apps" name="feature" value="apps" />
             <span class="p-radio__label" id="feature_apps">
               <div class="p-card__title">
@@ -54,7 +54,7 @@
               </ul>
               <span>Select Apps only</span>
             </span>
-          </div>
+          </label>
         </div>
 
         <div class="p-card--radio--feature js-radio">


### PR DESCRIPTION
## Done
UA selector: Set billing period to monthly when selecting apps. 
This will allow users who have UA apps in their offerings to purchase them.

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- Login with an account that has been offered an UA apps listing.
- Go to `/advantage/subscribe`
- Try to buy `UA Apps`


