### PR TITLE
Remove releases from cve view

### DIFF
--- a/webapp/security/views.py
+++ b/webapp/security/views.py
@@ -717,7 +717,7 @@ def cve(cve_id):
 
     security_api = SecurityAPI(
         session=session,
-        base_url="http://192.168.64.6:8030/security/",
+        base_url="http://ubuntu.com/security/",
     )
 
     cve = security_api.get_cve(cve_id)
@@ -730,30 +730,7 @@ def cve(cve_id):
             "%-d %B %Y"
         )
 
-    all_releases = security_api.get_releases().get("releases")
-
-    releases = []
-
-    # filter releases
-    for release in all_releases:
-        if release["codename"] != "upstream":
-            # format dates
-            support_expiry_date = datetime.strptime(
-                release["support_expires"], "%Y-%m-%dT%H:%M:%S"
-            )
-            esm_expiry_date = datetime.strptime(
-                release["esm_expires"], "%Y-%m-%dT%H:%M:%S"
-            )
-            # filter out if support has expired
-            if (
-                support_expiry_date > datetime.now()
-                or esm_expiry_date > datetime.now()
-            ):
-                releases.append(release)
-
-    return flask.render_template(
-        "security/cve/cve.html", cve=cve, releases=releases
-    )
+    return flask.render_template("security/cve/cve.html", cve=cve)
 
 
 # CVE API

--- a/webapp/security/views.py
+++ b/webapp/security/views.py
@@ -730,7 +730,6 @@ def cve(cve_id):
             "%-d %B %Y"
         )
 
-    
     all_releases = security_api.get_releases().get("releases")
 
     releases = []
@@ -739,10 +738,17 @@ def cve(cve_id):
     for release in all_releases:
         if release["codename"] != "upstream":
             # format dates
-            support_expiry_date = datetime.strptime(release["support_expires"], "%Y-%m-%dT%H:%M:%S")
-            esm_expiry_date = datetime.strptime(release["esm_expires"], "%Y-%m-%dT%H:%M:%S")
+            support_expiry_date = datetime.strptime(
+                release["support_expires"], "%Y-%m-%dT%H:%M:%S"
+            )
+            esm_expiry_date = datetime.strptime(
+                release["esm_expires"], "%Y-%m-%dT%H:%M:%S"
+            )
             # filter out if support has expired
-            if support_expiry_date > datetime.now() or esm_expiry_date > datetime.now():
+            if (
+                support_expiry_date > datetime.now()
+                or esm_expiry_date > datetime.now()
+            ):
                 releases.append(release)
 
     return flask.render_template(

--- a/webapp/security/views.py
+++ b/webapp/security/views.py
@@ -717,7 +717,7 @@ def cve(cve_id):
 
     security_api = SecurityAPI(
         session=session,
-        base_url="https://ubuntu.com/security/",
+        base_url="http://192.168.64.6:8030/security/",
     )
 
     cve = security_api.get_cve(cve_id)
@@ -730,7 +730,20 @@ def cve(cve_id):
             "%-d %B %Y"
         )
 
-    releases = security_api.get_releases()
+    
+    all_releases = security_api.get_releases().get("releases")
+
+    releases = []
+
+    # filter releases
+    for release in all_releases:
+        if release["codename"] != "upstream":
+            # format dates
+            support_expiry_date = datetime.strptime(release["support_expires"], "%Y-%m-%dT%H:%M:%S")
+            esm_expiry_date = datetime.strptime(release["esm_expires"], "%Y-%m-%dT%H:%M:%S")
+            # filter out if support has expired
+            if support_expiry_date > datetime.now() or esm_expiry_date > datetime.now():
+                releases.append(release)
 
     return flask.render_template(
         "security/cve/cve.html", cve=cve, releases=releases

--- a/webapp/security/views.py
+++ b/webapp/security/views.py
@@ -717,7 +717,7 @@ def cve(cve_id):
 
     security_api = SecurityAPI(
         session=session,
-        base_url="http://ubuntu.com/security/",
+        base_url="https://ubuntu.com/security/",
     )
 
     cve = security_api.get_cve(cve_id)


### PR DESCRIPTION
## Done

- Removed releases as they are not being used in the cve template

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/cves/CVE-2019-20503
    - Be sure to test on mobile, tablet and desktop screen sizes
- See that cve renders correctly
- You can also try out different cve ids 

## Issue / Card

Fixes https://github.com/canonical-web-and-design/ubuntu.com/issues/11379
