### PR TITLE
Reduce width of success notification banner

### DIFF
--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -725,10 +725,12 @@ body {
 // Styling to display a success message when forms are successfully submitted.
 #success {
   display: none;
+  position: absolute;
 }
 
 #success:target {
   display: block;
+  z-index: 10;
 }
 
 html {

--- a/templates/templates/base.html
+++ b/templates/templates/base.html
@@ -79,12 +79,14 @@
   {% endif %}
 
   <div class="wrapper u-no-margin--top">
-    <div id="success">
+    <div id="success" class="p-strip u-no-padding--top">
+      <div class="u-fixed-width">
         <div class="p-notification--positive u-no-margin--bottom">
-            <div class="p-notification__content">
-              <p class="p-notification__message">Your submission was sent successfully! <a href="#" onclick="location.href = document.referrer; return false;"><i class="p-notification__close">Close</i></a></p>
-            </div>
+          <div class="p-notification__content">
+            <p class="p-notification__message">Your submission was sent successfully! <a href="#" onclick="location.href = document.referrer; return false;"><i class="p-notification__close">Close</i></a></p>
+          </div>
         </div>
+      </div>
     </div>
     <div id="main-content" class="inner-wrapper">
       {% block content_head %}{% endblock %}


### PR DESCRIPTION
## Done

- Wrapped the notification in a `p-strip` < `u-fixed-width` so it follows the size conventions of vanilla.
- Set a z-index of 10 on targeting so it is visible and interact-able. This is under the z-index of the navigation (39) and p-modal (100)

## QA

- Go to https://ubuntu-com-11381.demos.haus/#success and make sure the width follows the rest of the page.
- Check for any other screen overlays that have a lower z-index than 10.

## Issue / Card

Fixes https://github.com/canonical-web-and-design/ubuntu.com/issues/11316

## Screenshots

![image](https://user-images.githubusercontent.com/58276363/159485193-c72bc86c-e8fb-4671-8e82-71ab4936cc41.png)


