### PR TITLE
Remove marketing ping when cypress fails

### DIFF
--- a/.github/workflows/cypress-main.yaml
+++ b/.github/workflows/cypress-main.yaml
@@ -58,7 +58,3 @@ jobs:
       - name: Send message on failure
         if: failure()
         run: curl -X POST -F "workflow=${GITHUB_WORKFLOW}" -F "repo_name=${GITHUB_REPOSITORY}" -F "action_id=${GITHUB_RUN_ID}" ${{ secrets.BOT_URL }}?room=web--design
-      
-      - name: Send message on failure
-        if: failure()
-        run: curl -X POST -F "workflow=${GITHUB_WORKFLOW}" -F "repo_name=${GITHUB_REPOSITORY}" -F "action_id=${GITHUB_RUN_ID}" ${{ secrets.BOT_URL }}?room=marketing-pub


### PR DESCRIPTION
## Done
The cypress test is very noisy in the marketing channel and the web team are the ones that should really be alerted.

## QA
Check the code.