### PR TITLE
Ignore amd link from blog linkchecker

### DIFF
--- a/.github/workflows/blog-links.yaml
+++ b/.github/workflows/blog-links.yaml
@@ -25,7 +25,8 @@ jobs:
           	--ignore-url c_fill \
           	--ignore-url e_sharpen \
           	--ignore-url w_[0-9]* \
-          	--ignore-url h_[0-9]*
+          	--ignore-url h_[0-9]* \
+            --ignore-url https://www.amd.com/*
 
       - name: Send message on failure
         if: failure()


### PR DESCRIPTION
## Done
The AMD site is causing regular timeouts and so ignoring them for now.

## QA
Check code.
