### PR TITLE
Fix switches on /advantage

### DIFF
--- a/static/js/src/advantage/react/components/FeatureSwitch/FeatureSwitch.tsx
+++ b/static/js/src/advantage/react/components/FeatureSwitch/FeatureSwitch.tsx
@@ -16,7 +16,7 @@ const FeatureSwitch = ({
       <input
         disabled={isDisabled}
         type="checkbox"
-        className="p-switch"
+        className="p-switch__input"
         checked={isChecked}
         onChange={handleOnChange}
       />


### PR DESCRIPTION
## Done

Switch inputs on /advantage are currently broken, this fixes them

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/advantage
    - Be sure to test on mobile, tablet and desktop screen sizes
- Check your subscriptions, under "Features", the switch inputs should render correctly

## Screenshots
Before:
![image](https://user-images.githubusercontent.com/2376968/159695599-fd775a5b-afb5-400b-a04a-5db70a2cdc30.png)

After:
![Screenshot from 2022-03-23 12-08-13](https://user-images.githubusercontent.com/2376968/159695735-abf04727-c740-4b52-b512-c8b4467a6f70.png)
