### PR TITLE
Disable cypress test on `/wsl` temporarily

### DIFF
--- a/tests/cypress/utils.js
+++ b/tests/cypress/utils.js
@@ -432,16 +432,4 @@ export const interactiveForms = [
     submitBtn: /Let's discuss/,
     noOfPages: 3,
   },
-  {
-    url: "/wsl",
-    inputs: [
-      [/First name/, "test"],
-      [/Last name/, "test"],
-      [/Company/, "test"],
-      [/Work email/, "test@gmail.com"],
-      [/Mobile\/cell phone number:/, "07777777777"],
-    ],
-    submitBtn: /Let's discuss/,
-    noOfPages: 3,
-  },
 ];


### PR DESCRIPTION
## Done

- Disable cypress test on `/wsl` temporarily
- The test will be reverted when this [issue](https://github.com/canonical-web-and-design/ubuntu.com/issues/11389) is resolved. 

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes

## Issue / Card

Fixes #

## Screenshots

[If relevant, please include a screenshot.]


## Help

[QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html) - [Commit guidelines](https://canonical-web-and-design.github.io/practices/workflow/commit-messages.html)
