### PR TITLE
Update old intel logo across site

### DIFF
--- a/templates/gov/index.html
+++ b/templates/gov/index.html
@@ -275,15 +275,15 @@
           }}
         </div>
         <div class="p-logo-section__item">
-          {{
-            image(
-                url="https://assets.ubuntu.com/v1/c24cb4b9-logo-intel.svg",
-                alt="Intel",
-                width="133",
-                height="88",
-                hi_def=True,
-                loading="lazy",
-                attrs={"class": "p-logo-section__logo"},
+          {{ 
+            image (
+            url="https://assets.ubuntu.com/v1/67f81bfe-intel-new-logo.png",
+            alt="Intel",
+            width="288",
+            height="288",
+            hi_def=True,
+            loading="lazy",
+            attrs={"class": "p-logo-section__logo"}
             ) | safe
           }}
         </div>

--- a/templates/server/index.html
+++ b/templates/server/index.html
@@ -173,15 +173,15 @@
           }}
         </div>
         <div class="p-logo-section__item">
-          {{
-            image(
-            url="https://assets.ubuntu.com/v1/c24cb4b9-logo-intel.svg",
+          {{ 
+            image (
+            url="https://assets.ubuntu.com/v1/67f81bfe-intel-new-logo.png",
             alt="Intel",
-            width="133",
-            height="88",
+            width="288",
+            height="288",
             hi_def=True,
             loading="lazy",
-            attrs={"class": "p-logo-section__logo"},
+            attrs={"class": "p-logo-section__logo"}
             ) | safe
           }}
         </div>


### PR DESCRIPTION
## Done

- Use find tool to find instances of the old intel logo and replace it with the new one.
- **This does not fix logo that are pulled from the partners DB**

## QA

- Search the site for any uses of the old intel logo. This can be visually or by using the asset link: https://assets.ubuntu.com/v1/c24cb4b9-logo-intel.svg

## Issue / Card

Fixes https://github.com/canonical-web-and-design/ubuntu.com/issues/11297
