### PR TITLE
Add a regex match on USN routes.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -27,3 +27,5 @@ macaroonbakery==1.3.1
 sortedcontainers==2.4.0
 vcrpy-unittest==0.1.7
 webargs==7.0.1
+jinja2==3.0.3
+

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -527,12 +527,17 @@ app.add_url_rule(
     "/security/notices", view_func=create_notice, methods=["POST"]
 )
 
-app.add_url_rule("/security/notices/<notice_id>", view_func=notice)
 app.add_url_rule(
-    "/security/notices/<notice_id>", view_func=update_notice, methods=["PUT"]
+    r"/security/notices/<regex('(lsn-|LSN-|usn-|USN-)\d{1,10}-\d{1,2}'):notice_id>",  # noqa: E501
+    view_func=notice,
 )
 app.add_url_rule(
-    "/security/notices/<notice_id>",
+    r"/security/notices/<regex('(lsn-|LSN-|usn-|USN-)\d{1,10}-\d{1,2}'):notice_id>",  # noqa: E501
+    view_func=update_notice,
+    methods=["PUT"],
+)
+app.add_url_rule(
+    r"/security/notices/<regex('(lsn-|LSN-|usn-|USN-)\d{1,10}-\d{1,2}'):notice_id>",  # noqa: E501
     view_func=delete_notice,
     methods=["DELETE"],
 )


### PR DESCRIPTION
## Done

Match the USN IDs are valid so we don't match potentially problematic strings.

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/security/notices
- Make sure you can still view USN and LSN detail pages

