### PR TITLE
Update typo on /aws

### DIFF
--- a/templates/aws/index.html
+++ b/templates/aws/index.html
@@ -34,7 +34,7 @@
 <section class="p-strip--light">
   <div class="u-fixed-width">
     <div class="p-logo-section">
-      <h2 class="p-logo-section__title u-align--center">Ubuntu on Azure powers cloud leaders like</h2>
+      <h2 class="p-logo-section__title u-align--center">Ubuntu on AWS powers cloud leaders like</h2>
       <div class="p-logo-section__items u-no-margin--bottom">
         <div class="p-logo-section__item">
           {{ image (


### PR DESCRIPTION
## Done

- Updates 'Azure' to 'AWS' on `/aws' as per [copydoc](https://docs.google.com/document/d/1lkH-MSPmgjCMP4gI0FW29YIKVDvBuddxA63iQhmsYIU/edit#heading=h.tx97ex3wcna4)

## QA

- Go to https://ubuntu-com-11401.demos.haus/aws
- Compare against [copydoc](https://docs.google.com/document/d/1lkH-MSPmgjCMP4gI0FW29YIKVDvBuddxA63iQhmsYIU/edit#heading=h.tx97ex3wcna4) 

## Issue / Card

Fixes https://github.com/canonical-web-and-design/web-squad/issues/4976
