### PR TITLE
Fix typo on /lxd

### DIFF
--- a/templates/lxd/index.html
+++ b/templates/lxd/index.html
@@ -171,10 +171,10 @@
         <h3 class="p-stepped-list__title">Install the OS you’d like to use in your container or VM</h3>
         <div class="p-stepped-list__content">
           <h4>Container</h4>
-            <p>Command: <pre><code>lxc launch &lt;image_server&gt;:&lt;image_name&gt;&lt;instance_name&lt;</code></pre></p>
+            <p>Command: <pre><code>lxc launch &lt;image_server&gt;:&lt;image_name&gt;&lt;instance_name&gt;</code></pre></p>
             <p>Example: <pre><code>lxc launch ubuntu:20.04 ubuntu-container</code></pre></p>
           <h4>VM</h4>
-            <p>Command: <pre><code>lxc launch &lt;image_server&gt;:&lt;image_name&gt; &lt;instance_name&gt; --vm</code></pre></p>
+            <p>Command: <pre><code>lxc launch &lt;image_server&gt;:&lt;image_name&gt;&lt;instance_name&gt; --vm</code></pre></p>
             <p>Example: <pre><code>lxc launch ubuntu:20.04 ubuntu-container-vm --vm</code></pre></p>
             <p>Check the <a href="https://images.linuxcontainers.org/">community image server</a> for other Linux distributions.</p>
         </div>


### PR DESCRIPTION
## Done

- Fix a typo
Before:
![image](https://user-images.githubusercontent.com/57550290/160390677-4544a823-c7ee-4082-a7c7-6cc76ed46f74.png)
After:
![image](https://user-images.githubusercontent.com/57550290/160390790-a97eaade-163b-4c8d-abed-05fac6cb583b.png)


## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes

## Issue / Card

Fixes #

