### PR TITLE
Update notice list view to consume api

### DIFF
--- a/templates/security/_notice-brief.html
+++ b/templates/security/_notice-brief.html
@@ -1,6 +1,6 @@
 <article class="notice" style="padding-bottom: 32px;">
   <h3 class="u-no-margin p-heading--4" style="padding-bottom: 8px;"><a href="/security/notices/{{notice.id}}">{{ notice.id }}: {{ notice.title }} ›</a></h3>
-  <p class="u-no-margin u-no-padding--top" style="color: #666; font-size: 14px; padding-bottom: 8px;">{{ notice.published.strftime("%d %B %Y") }}</p>
+  <p class="u-no-margin u-no-padding--top" style="color: #666; font-size: 14px; padding-bottom: 8px;">{{ notice.published }}</p>
   <p class="u-no-margin u-no-padding--top" style="padding-bottom: 16px;">{{ notice.summary | safe }}</p>
   <p class="u-no-margin u-no-padding--top" style="padding-bottom: 16px;">
     <small>

--- a/templates/security/notices.html
+++ b/templates/security/notices.html
@@ -98,7 +98,7 @@
     </div>
     {% endif %}
   </div>
-  {% with total_pages = total_pages, current_page=current_page, offset=offset%}
+  {% with total_pages = total_pages, current_page=current_page, offset=offset %}
     {% include "shared/_pagination.html" %}
   {% endwith %}
   {% if not search %}

--- a/templates/security/notices.html
+++ b/templates/security/notices.html
@@ -86,9 +86,7 @@
       {% endif %}
       {% if notices %}
         {% for notice in notices %} 
-          {% if loop.index <= limit * page and loop.index >= limit * page - limit + 1 %}
-            {% include "security/_notice-brief.html" %}
-          {% endif %}
+          {% include "security/_notice-brief.html" %}
         {% endfor %}
       {% else %}
         <h2 class="p-heading--4">No notices found</h2>
@@ -100,7 +98,7 @@
     </div>
     {% endif %}
   </div>
-  {% with total_pages = total_pages, current_page=current_page%}
+  {% with total_pages = total_pages, current_page=current_page, offset=offset%}
     {% include "shared/_pagination.html" %}
   {% endwith %}
   {% if not search %}

--- a/templates/security/notices.html
+++ b/templates/security/notices.html
@@ -62,7 +62,7 @@
     <div class="row">
       <div class="col-8">
         <h2 class="p-heading--4">
-          {{ pagination.page_first_result}} - {{ pagination.page_last_result }} of {{ pagination.total_results }} results
+          {{ page_first_result}} - {{ page_last_result }} of {{ total_results }} results
         </h2>
       </div>
       <div class="col-4 p-form p-form--inline">
@@ -85,8 +85,10 @@
         <h2>Latest Notices</h2>
       {% endif %}
       {% if notices %}
-        {% for notice in notices %}
-        {% include "security/_notice-brief.html" %}
+        {% for notice in notices %} 
+          {% if loop.index <= limit * page and loop.index >= limit * page - limit + 1 %}
+            {% include "security/_notice-brief.html" %}
+          {% endif %}
         {% endfor %}
       {% else %}
         <h2 class="p-heading--4">No notices found</h2>
@@ -98,7 +100,7 @@
     </div>
     {% endif %}
   </div>
-  {% with total_pages = pagination.total_pages, current_page=pagination.current_page %}
+  {% with total_pages = total_pages, current_page=current_page%}
     {% include "shared/_pagination.html" %}
   {% endwith %}
   {% if not search %}

--- a/templates/shared/_pagination.html
+++ b/templates/shared/_pagination.html
@@ -3,7 +3,7 @@
     <ol class="p-pagination u-align--center">
       <li class="p-pagination__item">
         {% if current_page > 1 %}
-          <a href="?{{ modify_query({'page': current_page - 1}) }}" class="p-pagination__link--previous">
+          <a href="?{{ modify_query({'offset': offset - limit}) }}" class="p-pagination__link--previous">
             <i class="p-icon--chevron-down">Previous page</i>
           </a>
         {% else %}
@@ -16,66 +16,66 @@
       {# always show 5 pages in pagination #}
       {% if current_page > 4 and current_page == total_pages %}
         <li class="p-pagination__item">
-          <a href="?{{ modify_query({'page': current_page - 4}) }}" class="p-pagination__link">{{ current_page - 4 }}</a>
+          <a href="?{{ modify_query({'offset': (current_page - 5) * limit}) }}" class="p-pagination__link">{{ current_page - 4 }}</a>
         </li>
       {% endif %}
 
       {% if current_page > 3 and current_page == total_pages %}
         <li class="p-pagination__item">
-          <a href="?{{ modify_query({'page': current_page - 3}) }}" class="p-pagination__link">{{ current_page - 3 }}</a>
+          <a href="?{{ modify_query({'offset': (current_page - 4) * limit}) }}" class="p-pagination__link">{{ current_page - 3 }}</a>
         </li>
       {% endif %}
 
       {% if current_page > 2 %}
         <li class="p-pagination__item">
-          <a href="?{{ modify_query({'page': current_page - 2}) }}" class="p-pagination__link">{{ current_page - 2 }}</a>
+          <a href="?{{ modify_query({'offset': (current_page - 3) * limit}) }}" class="p-pagination__link">{{ current_page - 2 }}</a>
         </li>
       {% endif %}
 
       {% if current_page > 1 %}
         <li class="p-pagination__item">
-          <a href="?{{ modify_query({'page': current_page - 1}) }}" class="p-pagination__link">{{ current_page - 1 }}</a>
+          <a href="?{{ modify_query({'offset': (current_page - 2) * limit}) }}" class="p-pagination__link">{{ current_page - 1 }}</a>
         </li>
       {% endif %}
 
       {# current current_page #}
       <li class="p-pagination__item">
-        <a href="?{{ modify_query({'page': current_page }) }}" class="p-pagination__link is-active">{{ current_page }}</a>
+        <a href="?{{ modify_query({'offset': current_page - 1}) }}" class="p-pagination__link is-active">{{ current_page }}</a>
       </li>
 
       {% if current_page < total_pages %}
         <li class="p-pagination__item">
-          <a href="?{{ modify_query({'page': current_page + 1}) }}" class="p-pagination__link">{{ current_page + 1 }}</a>
+          <a href="?{{ modify_query({'offset': current_page * limit}) }}" class="p-pagination__link">{{ current_page + 1 }}</a>
         </li>
       {% endif %}
 
       {% if current_page < total_pages - 1 %}
         <li class="p-pagination__item">
-          <a href="?{{ modify_query({'page': current_page + 2}) }}" class="p-pagination__link">{{ current_page + 2 }}</a>
+          <a href="?{{ modify_query({'offset': (current_page + 1) * limit}) }}" class="p-pagination__link">{{ current_page + 2 }}</a>
         </li>
       {% endif %}
 
       {% if current_page < total_pages - 2 and current_page == 1 %}
         <li class="p-pagination__item">
-          <a href="?{{ modify_query({'page': current_page + 3}) }}" class="p-pagination__link">{{ current_page + 3 }}</a>
+          <a href="?{{ modify_query({'offset': (current_page + 2) * limit}) }}" class="p-pagination__link">{{ current_page + 3 }}</a>
         </li>
       {% endif %}
 
       {% if current_page < total_pages - 3 and current_page == 1 %}
         <li class="p-pagination__item">
-          <a href="?{{ modify_query({'page': current_page + 4}) }}" class="p-pagination__link">{{ current_page + 4 }}</a>
+          <a href="?{{ modify_query({'offset': (current_page + 3) * limit}) }}" class="p-pagination__link">{{ current_page + 4 }}</a>
         </li>
       {% endif %}
 
       {% if current_page < total_pages - 3 and current_page == 2 %}
         <li class="p-pagination__item">
-          <a href="?{{ modify_query({'page': current_page + 3}) }}" class="p-pagination__link">{{ current_page + 3 }}</a>
+          <a href="?{{ modify_query({'offset': (current_page + 2) * limit}) }}" class="p-pagination__link">{{ current_page + 3 }}</a>
         </li>
       {% endif %}
 
       <li class="p-pagination__item">
         {% if current_page != total_pages %}
-          <a href="?{{ modify_query({'page': current_page + 1}) }}" class="p-pagination__link--next">
+          <a href="?{{ modify_query({'offset': current_page * limit}) }}" class="p-pagination__link--next">
             <i class="p-icon--chevron-down">Next page</i>
           </a>
         {% else %}

--- a/templates/shared/_pagination.html
+++ b/templates/shared/_pagination.html
@@ -3,9 +3,15 @@
     <ol class="p-pagination u-align--center">
       <li class="p-pagination__item">
         {% if current_page > 1 %}
-          <a href="?{{ modify_query({'offset': offset - limit}) }}" class="p-pagination__link--previous">
-            <i class="p-icon--chevron-down">Previous page</i>
-          </a>
+          {% if limit %}
+            <a href="?{{ modify_query({'offset': offset - limit}) }}" class="p-pagination__link--previous">
+              <i class="p-icon--chevron-down">Previous page</i>
+            </a>
+          {% else %}
+            <a href="?{{ modify_query({'page': current_page - 1}) }}" class="p-pagination__link--previous">
+              <i class="p-icon--chevron-down">Previous page</i>
+            </a>
+          {% endif %}
         {% else %}
         <span class="p-pagination__link--previous is-disabled">
           <i class="p-icon--chevron-down">Previous page</i>
@@ -16,68 +22,114 @@
       {# always show 5 pages in pagination #}
       {% if current_page > 4 and current_page == total_pages %}
         <li class="p-pagination__item">
-          <a href="?{{ modify_query({'offset': (current_page - 5) * limit}) }}" class="p-pagination__link">{{ current_page - 4 }}</a>
+          {% if limit %}
+            <a href="?{{ modify_query({'offset': (current_page - 5) * limit}) }}" class="p-pagination__link">{{ current_page - 4 }}</a>
+          {% else %}
+            <a href="?{{ modify_query({'page': current_page - 4}) }}" class="p-pagination__link">{{ current_page - 4 }}</a>
+          {% endif %}  
         </li>
       {% endif %}
 
       {% if current_page > 3 and current_page == total_pages %}
         <li class="p-pagination__item">
-          <a href="?{{ modify_query({'offset': (current_page - 4) * limit}) }}" class="p-pagination__link">{{ current_page - 3 }}</a>
-        </li>
+          {% if limit %}
+            <a href="?{{ modify_query({'offset': (current_page - 4) * limit}) }}" class="p-pagination__link">{{ current_page - 3 }}</a>
+          {% else %}
+            <a href="?{{ modify_query({'page': current_page - 3}) }}" class="p-pagination__link">{{ current_page - 3 }}</a>
+          {% endif %}
+          </li>
       {% endif %}
 
       {% if current_page > 2 %}
         <li class="p-pagination__item">
-          <a href="?{{ modify_query({'offset': (current_page - 3) * limit}) }}" class="p-pagination__link">{{ current_page - 2 }}</a>
-        </li>
+          {% if limit %}
+            <a href="?{{ modify_query({'offset': (current_page - 3) * limit}) }}" class="p-pagination__link">{{ current_page - 2 }}</a>
+          {% else %}
+            <a href="?{{ modify_query({'page': current_page - 2}) }}" class="p-pagination__link">{{ current_page - 2 }}</a>
+          {% endif %}
+          </li>
       {% endif %}
 
       {% if current_page > 1 %}
         <li class="p-pagination__item">
-          <a href="?{{ modify_query({'offset': (current_page - 2) * limit}) }}" class="p-pagination__link">{{ current_page - 1 }}</a>
-        </li>
+          {% if limit %}
+            <a href="?{{ modify_query({'offset': (current_page - 2) * limit}) }}" class="p-pagination__link">{{ current_page - 1 }}</a>
+          {% else %}
+            <a href="?{{ modify_query({'page': current_page - 1}) }}" class="p-pagination__link">{{ current_page - 1 }}</a>
+          {% endif %}
+          </li>
       {% endif %}
 
       {# current current_page #}
       <li class="p-pagination__item">
-        <a href="?{{ modify_query({'offset': current_page - 1}) }}" class="p-pagination__link is-active">{{ current_page }}</a>
-      </li>
+        {% if limit %}
+          <a href="?{{ modify_query({'offset': current_page - 1}) }}" class="p-pagination__link is-active">{{ current_page }}</a>
+        {% else %}
+          <a href="?{{ modify_query({'page': current_page }) }}" class="p-pagination__link is-active">{{ current_page }}</a>
+        {% endif %}
+        </li>
 
       {% if current_page < total_pages %}
         <li class="p-pagination__item">
-          <a href="?{{ modify_query({'offset': current_page * limit}) }}" class="p-pagination__link">{{ current_page + 1 }}</a>
-        </li>
+          {% if limit %}
+            <a href="?{{ modify_query({'offset': current_page * limit}) }}" class="p-pagination__link">{{ current_page + 1 }}</a>
+          {% else %}
+            <a href="?{{ modify_query({'page': current_page + 1}) }}" class="p-pagination__link">{{ current_page + 1 }}</a>
+          {% endif %}
+          </li>
       {% endif %}
 
       {% if current_page < total_pages - 1 %}
         <li class="p-pagination__item">
-          <a href="?{{ modify_query({'offset': (current_page + 1) * limit}) }}" class="p-pagination__link">{{ current_page + 2 }}</a>
-        </li>
+          {% if limit %}
+            <a href="?{{ modify_query({'offset': (current_page + 1) * limit}) }}" class="p-pagination__link">{{ current_page + 2 }}</a>
+          {% else %}
+            <a href="?{{ modify_query({'page': current_page + 2}) }}" class="p-pagination__link">{{ current_page + 2 }}</a>
+          {% endif %}
+          </li>
       {% endif %}
 
       {% if current_page < total_pages - 2 and current_page == 1 %}
         <li class="p-pagination__item">
-          <a href="?{{ modify_query({'offset': (current_page + 2) * limit}) }}" class="p-pagination__link">{{ current_page + 3 }}</a>
-        </li>
+          {% if limit %}
+            <a href="?{{ modify_query({'offset': (current_page + 2) * limit}) }}" class="p-pagination__link">{{ current_page + 3 }}</a>
+          {% else %}
+            <a href="?{{ modify_query({'page': current_page + 3}) }}" class="p-pagination__link">{{ current_page + 3 }}</a>
+          {% endif %}
+          </li>
       {% endif %}
 
       {% if current_page < total_pages - 3 and current_page == 1 %}
         <li class="p-pagination__item">
-          <a href="?{{ modify_query({'offset': (current_page + 3) * limit}) }}" class="p-pagination__link">{{ current_page + 4 }}</a>
-        </li>
+          {% if limit %}
+            <a href="?{{ modify_query({'offset': (current_page + 3) * limit}) }}" class="p-pagination__link">{{ current_page + 4 }}</a>
+          {% else %}
+            <a href="?{{ modify_query({'page': current_page + 4}) }}" class="p-pagination__link">{{ current_page + 4 }}</a>
+          {% endif %}
+          </li>
       {% endif %}
 
       {% if current_page < total_pages - 3 and current_page == 2 %}
         <li class="p-pagination__item">
-          <a href="?{{ modify_query({'offset': (current_page + 2) * limit}) }}" class="p-pagination__link">{{ current_page + 3 }}</a>
-        </li>
+          {% if limit %}
+            <a href="?{{ modify_query({'offset': (current_page + 2) * limit}) }}" class="p-pagination__link">{{ current_page + 3 }}</a>
+          {% else %}
+            <a href="?{{ modify_query({'page': current_page + 3}) }}" class="p-pagination__link">{{ current_page + 3 }}</a>
+          {% endif %}
+          </li>
       {% endif %}
 
       <li class="p-pagination__item">
         {% if current_page != total_pages %}
-          <a href="?{{ modify_query({'offset': current_page * limit}) }}" class="p-pagination__link--next">
-            <i class="p-icon--chevron-down">Next page</i>
-          </a>
+          {% if limit %}
+            <a href="?{{ modify_query({'offset': current_page * limit}) }}" class="p-pagination__link--next">
+              <i class="p-icon--chevron-down">Next page</i>
+            </a>
+          {% else %}
+            <a href="?{{ modify_query({'page': current_page + 1}) }}" class="p-pagination__link--next">
+              <i class="p-icon--chevron-down">Next page</i>
+            </a>
+          {% endif %}
         {% else %}
         <span class="p-pagination__link--next is-disabled">
           <i class="p-icon--chevron-down">Next page</i>

--- a/webapp/security/api.py
+++ b/webapp/security/api.py
@@ -1,5 +1,6 @@
 from requests import Session
 from requests.exceptions import HTTPError
+from urllib.parse import urlencode
 
 
 class SecurityAPIError(HTTPError):
@@ -91,19 +92,21 @@ class SecurityAPI:
         returns json object if found
         """
 
-        if release:
-            try:
-                notices_response = self._get(
-                    f"notices.json?limit={limit}&offset={offset}&release={release}&details={details}"
-                )
-            except HTTPError as error:
-                raise SecurityAPIError(error)
-        else:
-            try:
-                notices_response = self._get(
-                    f"notices.json?limit={limit}&offset={offset}&details={details}"
-                )
-            except HTTPError as error:
-                raise SecurityAPIError(error)
+        parameters = {
+            "limit": limit,
+            "offset": offset,
+            "details": details,
+            "release": release,
+        }
+
+        # Remove falsey items from dictionary
+        parameters = {k: v for k, v in parameters.items() if v}
+
+        filtered_parameters = urlencode(parameters)
+
+        try:
+            notices_response = self._get(f"notices.json?{filtered_parameters}")
+        except HTTPError as error:
+            raise SecurityAPIError(error)
 
         return notices_response.json()

--- a/webapp/security/api.py
+++ b/webapp/security/api.py
@@ -59,7 +59,7 @@ class SecurityAPI:
         except HTTPError as error:
             raise SecurityAPIError(error)
 
-        return releases_response.json()
+        return releases_response.json().get("releases")
 
     def get_notice(
         self,
@@ -79,16 +79,20 @@ class SecurityAPI:
 
         return notice_response.json()
 
-    def get_notices(self):
+    def get_notices(
+        self,
+        limit: int,
+        offset: int,   
+    ):
         """
         Makes request for all releases with ongoing support,
         returns json object if found
         """
 
         try:
-            notices_response = self._get("notices.json?limit=50")
+            notices_response = self._get(f"notices.json?limit={limit}&offset={offset}")
             print (notices_response)
         except HTTPError as error:
             raise SecurityAPIError(error)
 
-        return notices_response.json()
+        return notices_response.json().get("notices")

--- a/webapp/security/api.py
+++ b/webapp/security/api.py
@@ -90,7 +90,7 @@ class SecurityAPI:
         Makes request for all releases with ongoing support,
         returns json object if found
         """
-       
+
         if release:
             try:
                 notices_response = self._get(

--- a/webapp/security/api.py
+++ b/webapp/security/api.py
@@ -103,7 +103,6 @@ class SecurityAPI:
                 notices_response = self._get(
                     f"notices.json?limit={limit}&offset={offset}&details={details}"
                 )
-                print(notices_response.json().get("total_results"))
             except HTTPError as error:
                 raise SecurityAPIError(error)
 

--- a/webapp/security/api.py
+++ b/webapp/security/api.py
@@ -86,8 +86,9 @@ class SecurityAPI:
         """
 
         try:
-            releases_response = self._get("notices.json")
+            notices_response = self._get("notices.json?limit=50")
+            print (notices_response)
         except HTTPError as error:
             raise SecurityAPIError(error)
 
-        return releases_response.json()
+        return notices_response.json()

--- a/webapp/security/api.py
+++ b/webapp/security/api.py
@@ -78,3 +78,18 @@ class SecurityAPI:
             raise SecurityAPIError(error)
 
         return notice_response.json()
+
+    def get_notices(self):
+        """
+        Makes request for all releases with ongoing support,
+        returns json object if found
+        """
+
+        try:
+            releases_response = self._get("notices.json")
+        except HTTPError as error:
+            raise SecurityAPIError(error)
+
+        return releases_response.json()
+
+    

--- a/webapp/security/api.py
+++ b/webapp/security/api.py
@@ -82,17 +82,29 @@ class SecurityAPI:
     def get_notices(
         self,
         limit: int,
-        offset: int,   
+        offset: int,
+        details: str,
+        release: str,
     ):
         """
         Makes request for all releases with ongoing support,
         returns json object if found
         """
+       
+        if release:
+            try:
+                notices_response = self._get(
+                    f"notices.json?limit={limit}&offset={offset}&release={release}&details={details}"
+                )
+            except HTTPError as error:
+                raise SecurityAPIError(error)
+        else:
+            try:
+                notices_response = self._get(
+                    f"notices.json?limit={limit}&offset={offset}&details={details}"
+                )
+                print(notices_response.json().get("total_results"))
+            except HTTPError as error:
+                raise SecurityAPIError(error)
 
-        try:
-            notices_response = self._get(f"notices.json?limit={limit}&offset={offset}")
-            print (notices_response)
-        except HTTPError as error:
-            raise SecurityAPIError(error)
-
-        return notices_response.json().get("notices")
+        return notices_response.json()

--- a/webapp/security/api.py
+++ b/webapp/security/api.py
@@ -91,5 +91,3 @@ class SecurityAPI:
             raise SecurityAPIError(error)
 
         return releases_response.json()
-
-    

--- a/webapp/security/views.py
+++ b/webapp/security/views.py
@@ -129,17 +129,18 @@ def notices():
     limit = flask.request.args.get("limit", default=10, type=int)
     offset = flask.request.args.get("offset", default=0, type=int)
 
-    # call endpopint to get all releases
+    # call endpopint to get all releases and notices
     all_releases = security_api.get_releases()
 
     api_call = security_api.get_notices(
         limit=limit, offset=offset, details=details, release=release
     )
 
+    # get notices and total results from response object
     notices_query = api_call.get("notices")
     total_results = api_call.get("total_results")
 
-    # filter releases
+    # filter releases for dropdown
     releases = []
     for single_release in all_releases:
         if single_release["codename"] != "upstream":

--- a/webapp/security/views.py
+++ b/webapp/security/views.py
@@ -131,7 +131,7 @@ def notices():
     offset = flask.request.args.get("offset", default=0, type=int)
 
     # call endpopint to get all releases
-    all_releases = security_api.get_releases().get("releases")
+    all_releases = security_api.get_releases()
 
     # filter releases
     releases = []
@@ -141,7 +141,7 @@ def notices():
                 releases.append(single_release)
 
     # call endpoint to get notices
-    notices_query = security_api.get_notices().get("notices")
+    notices_query = security_api.get_notices(limit=limit, offset=offset)
 
     # filter notices based on release query
     release_filtered_notices = []

--- a/webapp/security/views.py
+++ b/webapp/security/views.py
@@ -132,13 +132,13 @@ def notices():
     # call endpopint to get all releases and notices
     all_releases = security_api.get_releases()
 
-    api_call = security_api.get_notices(
+    notices_response = security_api.get_notices(
         limit=limit, offset=offset, details=details, release=release
     )
 
     # get notices and total results from response object
-    notices_query = api_call.get("notices")
-    total_results = api_call.get("total_results")
+    notices = notices_response.get("notices")
+    total_results = notices_response.get("total_results")
 
     # filter releases for dropdown
     releases = []
@@ -149,15 +149,14 @@ def notices():
 
     # order notice query by publish date
     if order_by == "oldest":
-        notices = sorted(notices_query, key=lambda d: d["published"])
+        notices = sorted(notices, key=lambda d: d["published"])
     else:
-        notices = sorted(
-            notices_query, key=lambda d: d["published"], reverse=True
-        )
+        notices = sorted(notices, key=lambda d: d["published"], reverse=True)
 
     total_pages = ceil(total_results / limit)
     page_number = floor(offset / limit) + 1
 
+    # format date
     for notice in notices:
         if notice.get("published"):
             notice["published"] = dateutil.parser.parse(


### PR DESCRIPTION
## Done

- Add function to api class for getting all notices
- Update notice list view to consume endpoint and refactor filtering accordingly 
- Remove date formatting from template (now handled in view)

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/security/notices
    - Be sure to test on mobile, tablet and desktop screen sizes
- See that notice list loads as expected
- Test pagination
- Test searching by notice id, cve id, notice title, or notice description (lower and upper case)
- Test ability to toggle order 

## Issue / Card

Fixes https://github.com/canonical-web-and-design/master-epics/issues/409
