### PR TITLE
Remove iot pages from cypress test

### DIFF
--- a/tests/cypress/forms/forms_spec.js
+++ b/tests/cypress/forms/forms_spec.js
@@ -3,6 +3,7 @@ import {
   standardFormUrls,
   interactiveForms,
   formsWithEmailTestId,
+  internetOfThingsForm
 } from "../utils";
 
 beforeEach(() => {
@@ -199,13 +200,16 @@ context("Interactive marketo forms", () => {
     }
   );
 
-  // wrote separate test for /internet-of-things/digital-signage page as cypress couldn't find the job title input field by label text
+  // wrote separate test for the pages using the same internet-of-things form (The form ids are differnent)
   it(
-    "should check interactive contact modal on /internet-of-things/digital-signage",
+    "should check each contact modal using the internet-of-things form",
     { scrollBehavior: "center" },
     () => {
-      cy.visit("/internet-of-things/digital-signage");
-      cy.acceptCookiePolicy();
+    cy.visit("/");
+    cy.acceptCookiePolicy();
+
+    internetOfThingsForm.forEach((url) => {
+      cy.visit(url);
       cy.findByTestId("interactive-form-link").click();
       cy.findByRole("link", { name: /Next/ }).click();
       cy.findByLabelText(/First name/).type("Test");
@@ -216,8 +220,8 @@ context("Interactive marketo forms", () => {
       cy.findByLabelText(/Mobile\/cell phone number:/).type("07777777777");
       cy.findByText(/Let's discuss/).click();
       cy.url().should("include", "#success");
-    }
-  );
+    });
+  });
 
   // wrote separate test for /robotics page as cypress couldn't find the job title input field by label text
   it(

--- a/tests/cypress/utils.js
+++ b/tests/cypress/utils.js
@@ -145,30 +145,6 @@ export const interactiveForms = [
     noOfPages: 3,
   },
   {
-    url: "/core",
-    inputs: [
-      [/First name/, "test"],
-      [/Last name/, "test"],
-      [/Company:/, "test"],
-      [/Email/, "test@gmail.com"],
-      [/Mobile\/cell phone number:/, "07777777777"],
-    ],
-    submitBtn: /Let's discuss/,
-    noOfPages: 2,
-  },
-  {
-    url: "/core/smartstart",
-    inputs: [
-      [/First name/, "test"],
-      [/Last name/, "test"],
-      [/Company:/, "test"],
-      [/Email/, "test@gmail.com"],
-      [/Mobile\/cell phone number:/, "07777777777"],
-    ],
-    submitBtn: /Let's discuss/,
-    noOfPages: 2,
-  },
-  {
     url: "/dell",
     inputs: [
       [/First name/, "test"],
@@ -388,4 +364,13 @@ export const interactiveForms = [
     submitBtn: /Let's discuss/,
     noOfPages: 3,
   },
+];
+
+export const internetOfThingsForm = [
+    "/internet-of-things/networking",
+    "/internet-of-things/gateways",
+    "/internet-of-things/appstore",
+    "/internet-of-things/digital-signage",
+    "/core",
+    "/core/smartstart"
 ];

--- a/tests/cypress/utils.js
+++ b/tests/cypress/utils.js
@@ -44,39 +44,6 @@ export const formsWithEmailTestId = [
     noOfPages: 3,
   },
   {
-    url: "/internet-of-things/appstore",
-    inputs: [
-      [/First name/, "test"],
-      [/Last name/, "test"],
-      [/Company:/, "test"],
-      [/Mobile\/cell phone number:/, "07777777777"],
-    ],
-    submitBtn: /Let's discuss/,
-    noOfPages: 2,
-  },
-  {
-    url: "/internet-of-things/gateways",
-    inputs: [
-      [/First name/, "test"],
-      [/Last name/, "test"],
-      [/Company:/, "test"],
-      [/Mobile\/cell phone number:/, "07777777777"],
-    ],
-    submitBtn: /Let's discuss/,
-    noOfPages: 2,
-  },
-  {
-    url: "/internet-of-things/networking",
-    inputs: [
-      [/First name/, "test"],
-      [/Last name/, "test"],
-      [/Company:/, "test"],
-      [/Mobile\/cell phone number:/, "07777777777"],
-    ],
-    submitBtn: /Let's discuss/,
-    noOfPages: 2,
-  },
-  {
     url: "/openstack/managed",
     inputs: [
       [/First name/, "test"],


### PR DESCRIPTION
## Done

- The cypress test is failing again because the form in `/shared/forms/interactive/internet-of-things.html` has been updated a few days ago but the cypress test for the pages using that form hasn't been updated (The form is being used in multiple pages)
- I wrote a seperate cypress test for the pages using the same form (`/shared/forms/interactive/internet-of-things.html`) 

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes

## Issue / Card

Fixes #


## Help

[QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html) - [Commit guidelines](https://canonical-web-and-design.github.io/practices/workflow/commit-messages.html)
