### PR TITLE
Drive-by to make line of copy be more accurate

### DIFF
--- a/static/js/src/advantage/react/components/Subscriptions/SubscriptionDetails/DetailsContent/DetailsContent.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/SubscriptionDetails/DetailsContent/DetailsContent.tsx
@@ -157,7 +157,7 @@ const DetailsContent = ({ selectedId }: Props) => {
                       {subscription.number_of_active_machines}
                       <Tooltip
                         tooltipClassName="p-subscriptions-tooltip"
-                        message="The number of machines that contacted Ubuntu Advantage in the last 24 hour period (Beta)"
+                        message="The number of machines with this token that contacted Ubuntu Advantage in the last 24 hours (Beta)"
                         position="right"
                       >
                         <Button


### PR DESCRIPTION
it's per-token.. so adding token into this line to make it clearer and more accurate

## Done

- changed a line of UI copy

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- Hover machine activity number tooltip
- See that the correct text is displayed 


[QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html) - [Commit guidelines](https://canonical-web-and-design.github.io/practices/workflow/commit-messages.html)
