### PR TITLE
Reintroduce beta notification

### DIFF
--- a/templates/advantage/index-no-login.html
+++ b/templates/advantage/index-no-login.html
@@ -9,6 +9,22 @@
 
     <div class="row">
       <div class="col-12">
+        <div class="p-notification">
+          <div class="p-notification__content">
+            <p class="p-notification__message">
+              Are you using Ubuntu in production?
+            </p>
+          </div>
+          <div class="p-notification__meta">
+            <div class="p-notification__actions">
+              <a class="p-notification__action js-invoke-modal" data-testid="interactive-form-link" href="/support/contact-us">Join our free beta programme for Ubuntu Pro on prem&nbsp;&rsaquo;</a>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class="row">
+      <div class="col-12">
         <h1>Ubuntu Advantage for&nbsp;Infrastructure</h1>
         <p>Ubuntu Advantage for Infrastructure is the most comprehensive Linux enterprise subscription, covering all aspects of open infrastructure.</p>
         <h5>

--- a/templates/advantage/index.html
+++ b/templates/advantage/index.html
@@ -18,6 +18,22 @@
       });
     </script>
 
+    <div class="row">
+      <div class="col-12">
+        <div class="p-notification">
+          <div class="p-notification__content">
+            <p class="p-notification__message">
+              Are you using Ubuntu in production?
+            </p>
+          </div>
+          <div class="p-notification__meta">
+            <div class="p-notification__actions">
+              <a class="p-notification__action js-invoke-modal" data-testid="interactive-form-link" href="/support/contact-us">Join our free beta programme for Ubuntu Pro on prem&nbsp;&rsaquo;</a>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
     <div class="row u-equal-height u-sv3">
       <div class="col-5 u-vertically-center">
         <h1 class="p-subscriptions__header-title">Your subscriptions</h1>

--- a/templates/shared/forms/interactive/advantage-beta.html
+++ b/templates/shared/forms/interactive/advantage-beta.html
@@ -1,7 +1,7 @@
 <div class="p-modal" id="contact-modal">
   <div class="p-modal__dialog" role="dialog" aria-labelledby="modal-title" aria-describedby="modal-description">
     <header class="p-modal__header" style="display: block; border-bottom: 0;">
-      <button class="p-modal__close" aria-label="Close active modal" style="margin-left: -1rem">Close</button>
+      <button class="p-modal__close js-close" aria-label="Close active modal" style="margin-left: -1rem">Close</button>
       <h2 class="p-modal__title  u-sv1" id="modal-title">Register your interest for the Ubuntu Pro on-prem beta</h2>
     </header>
     <div class="js-pagination js-pagination--1">

--- a/tests/cypress/forms/forms_spec.js
+++ b/tests/cypress/forms/forms_spec.js
@@ -160,6 +160,23 @@ context("Interactive marketo forms", () => {
     }
   );
 
+  it("should check interactive contact modal on /advantage", () => {
+    cy.visit("/advantage");
+    cy.acceptCookiePolicy();
+    cy.findByRole("link", {
+      name: /Join our free beta programme for Ubuntu Pro on prem/,
+    }).click();
+    cy.findByRole("link", { name: /Next/ }).click();
+    cy.findByLabelText(/First name:/).type("Test");
+    cy.findByLabelText(/Last name:/).type("Test");
+    cy.findByLabelText(/Work email:/).type("test@test.com");
+    cy.findByLabelText(/I agree to receive information/).click({
+      force: true,
+    });
+    cy.findByText(/Let's discuss/).click();
+    cy.findByRole("heading", { name: /Thank you/ });
+  });
+
   // wrote separate test for /robotics page as cypress couldn't find the job title input field by label text
   it(
     "should check interactive contact modal on /robotics",


### PR DESCRIPTION
## Done

- Added the prompt to sign up for the beta programme back
- Added e2e tests checking for this message
- updated the notification to use the new action pattern

## QA

- go to https://ubuntu-com-11414.demos.haus/advantage
- see the notification
- log in
- see that the notification is still here

## Issue / Card

Fixes #11413

## Screenshots
![image](https://user-images.githubusercontent.com/11927929/160630164-b6490fac-49f6-4949-bc60-88602c0f3eb7.png)



