### PR TITLE
Prevent 404 sentry errors from advantage/users

### DIFF
--- a/static/js/src/advantage/users/hooks/useRequestAccountUsers.tsx
+++ b/static/js/src/advantage/users/hooks/useRequestAccountUsers.tsx
@@ -9,9 +9,9 @@ const useRequestAccountUsers = () => {
         await requestAccountUsers();
       } catch (error) {
         if (error?.response?.status === 404) {
-          return ([]);
+          return [];
         } else {
-          throw(error);
+          throw error;
         }
       }
     }

--- a/static/js/src/advantage/users/hooks/useRequestAccountUsers.tsx
+++ b/static/js/src/advantage/users/hooks/useRequestAccountUsers.tsx
@@ -6,9 +6,14 @@ const useRequestAccountUsers = () => {
     "accountUsers",
     async () => {
       try {
-        await requestAccountUsers();
+        const res = await requestAccountUsers();
+
+        return res;
       } catch (error) {
-        if (error?.response?.status === 404) {
+        if (
+          error instanceof Error &&
+          error.message.includes("cannot find purchase account")
+        ) {
           return [];
         } else {
           throw error;

--- a/static/js/src/advantage/users/hooks/useRequestAccountUsers.tsx
+++ b/static/js/src/advantage/users/hooks/useRequestAccountUsers.tsx
@@ -14,7 +14,7 @@ const useRequestAccountUsers = () => {
           error instanceof Error &&
           error.message.includes("cannot find purchase account")
         ) {
-          return [];
+          return undefined;
         } else {
           throw error;
         }

--- a/static/js/src/advantage/users/hooks/useRequestAccountUsers.tsx
+++ b/static/js/src/advantage/users/hooks/useRequestAccountUsers.tsx
@@ -5,8 +5,15 @@ const useRequestAccountUsers = () => {
   const { isLoading, isError, isSuccess, data, error } = useQuery(
     "accountUsers",
     async () => {
-      const res = await requestAccountUsers();
-      return res;
+      try {
+        await requestAccountUsers();
+      } catch (error) {
+        if (error?.response?.status === 404) {
+          return ([]);
+        } else {
+          throw(error);
+        }
+      }
     }
   );
 

--- a/webapp/shop/advantage/views.py
+++ b/webapp/shop/advantage/views.py
@@ -63,9 +63,8 @@ def get_user_subscriptions(advantage_mapper, **kwargs):
 def get_account_users(advantage_mapper, **kwargs):
     try:
         account = advantage_mapper.get_purchase_account("canonical-ua")
-    except UAContractsUserHasNoAccount as error:
-        # if no account throw 404
-        raise UAContractsAPIError(error)
+    except UAContractsUserHasNoAccount:
+        return flask.jsonify({"errors": "cannot find purchase account"}), 404
 
     account_users = advantage_mapper.get_account_users(account_id=account.id)
 

--- a/webapp/shop/advantage/views.py
+++ b/webapp/shop/advantage/views.py
@@ -17,7 +17,6 @@ from webapp.shop.api.ua_contracts.helpers import (
 )
 from webapp.shop.api.ua_contracts.api import (
     UAContractsUserHasNoAccount,
-    UAContractsAPIError,
     AccessForbiddenError,
 )
 


### PR DESCRIPTION
## Done

- Prevent sentry errors for 404 errors on /advantage/users

## QA

- Open console
- Go to /advantage with a user without a purchase account
- You will get a 404 from `account-users` request, but it will not retry the call.
- Use the demo. If you go to sentry you will not see any errors for your user 