### PR TITLE
Update Get in touch button url

### DIFF
--- a/navigation.yaml
+++ b/navigation.yaml
@@ -1635,7 +1635,7 @@ legal:
       path: /legal/solution-support
 
 lxd:
-  title: Lxd
+  title: LXD
   path: /lxd
 
   children:

--- a/templates/lxd/index.html
+++ b/templates/lxd/index.html
@@ -16,7 +16,7 @@
       <p> LXD provides a unified user experience for managing system containers and virtual machines. For more demanding workloads, LXD can be set up in a cluster environment to run containers, VMs, or a combination of the two on a set of machines. LXD has direct hardware access, minimising overhead and matching the density and efficiency of containers.</p>
       <p>
         <a class="p-button--positive" href="https://linuxcontainers.org/lxd/try-it/">Try LXD Online</a>
-        <a class="p-button js-invoke-modal" data-testid="interactive-form-link" href="/kubernetes/contact-us">Get in touch</a>
+        <a class="p-button js-invoke-modal" data-testid="interactive-form-link" href="/lxd#get-in-touch">Get in touch</a>
       </p>
     </div>
     <div class="col-6 u-hide--medium u-hide--small u-align--center">


### PR DESCRIPTION
## Done

- Update `Get in touch` button's href from `/kubernetes/contact-us` to `/lxd#get-in-touch` 
- Capitalise `Lxd` in the navigation 

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- [List additional steps to QA the new features or prove the bug has been resolved]

## Issue / Card

Fixes #

## Screenshots

<img width="220" alt="image" src="https://user-images.githubusercontent.com/57550290/160782521-e878fe8e-77ba-4388-b624-9d3a59616750.png">
<img width="198" alt="image" src="https://user-images.githubusercontent.com/57550290/160782551-aa4acd79-4fc6-49ec-8b3d-b9e7c87d079c.png">



## Help

[QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html) - [Commit guidelines](https://canonical-web-and-design.github.io/practices/workflow/commit-messages.html)
