### PR TITLE
Update cypress test on /pricing/devices

### DIFF
--- a/tests/cypress/utils.js
+++ b/tests/cypress/utils.js
@@ -265,18 +265,6 @@ export const interactiveForms = [
     noOfPages: 3,
   },
   {
-    url: "/pricing/devices",
-    inputs: [
-      [/First name/, "test"],
-      [/Last name/, "test"],
-      [/Company/, "test"],
-      [/Email/, "test@gmail.com"],
-      [/Mobile\/cell phone number:/, "07777777777"],
-    ],
-    submitBtn: /Let's discuss/,
-    noOfPages: 2,
-  },
-  {
     url: "/pricing/consulting",
     inputs: [
       [/First name/, "test"],
@@ -372,5 +360,6 @@ export const internetOfThingsForm = [
     "/internet-of-things/appstore",
     "/internet-of-things/digital-signage",
     "/core",
-    "/core/smartstart"
+    "/core/smartstart",
+    "/pricing/devices",
 ];


### PR DESCRIPTION
## Done
-  `/pricing/devices` was missing from this [PR](https://github.com/canonical-web-and-design/ubuntu.com/pull/11409)

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes

## Issue / Card

Fixes #

