### PR TITLE
Create separate form for `/download/iot/intel-iotg`

### DIFF
--- a/templates/download/iot/intel-iotg.html
+++ b/templates/download/iot/intel-iotg.html
@@ -16,7 +16,7 @@
       <p>Pick your chosen OS image and follow the install instruction to load it onto your board and away you go.</p>
       <p>If you have any questions about the supported Intel IOTG platforms or would like information about our certification program, please contact us.</p>
       <p>
-        <a href="/download/contact-us" class="p-button--positive js-invoke-modal">Get in touch</a>
+        <a href="/download/contact-us" class="p-button--positive js-invoke-modal" data-testid="interactive-form-link">Get in touch</a>
       </p>
     </div>
     <div class="col-5 u-hide--medium u-hide--small u-align--center">
@@ -106,7 +106,7 @@
 {% with first_item="_download_iot_iotg_newsletter", no_shadow="true" %}{% include "shared/contextual_footers/_contextual_footer.html" %}{% endwith %}
 
 <!-- Set default Marketo information for contact form below-->
-<div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/internet-of-things" data-form-id="4205" data-lp-id="2065" data-return-url="https://ubuntu.com/pricing/thank-you" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
+<div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/intel-iotg.html" data-form-id="4205" data-lp-id="2065" data-return-url="https://ubuntu.com/pricing/thank-you" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
 </div>
 
 {% endblock content %}

--- a/templates/shared/forms/interactive/intel-iotg.html
+++ b/templates/shared/forms/interactive/intel-iotg.html
@@ -50,19 +50,75 @@
               </label>
             </div>
           </div>
+        </div>
+      </div>
+      <div class="js-formfield">
+        <div class="u-sv3">
+          <h3 class="p-heading--5">What platform are you interested in?</h3>
           <div class="row u-no-padding">
-            <div class="col-6 u-sv3">
-              <label for="about-project">Tell us more about your project</label>
-              <textarea name="about-project" id="about-project"></textarea>
+            <div class="u-sv3">
+              <label class="p-radio">
+                <input class="p-radio__input" type="radio" aria-labelledby="platform-elkhart-lake" name="platform" value="elkhart-lake">
+                <span class="p-radio__label" id="platform-elkhart-lake">Intel Atom® X6000E Series and Intel® Pentium® and Celeron® N and J Series Processors (Elkhart Lake)</span>
+              </label>
+              <label class="p-radio">
+                <input class="p-radio__input" type="radio" aria-labelledby="platform-intel-11th-core" name="platform" value="intel-11th-core">
+                <span class="p-radio__label" id="platform-intel-11th-core">Intel 11th Gen Intel® Core™ processors (Tiger Lake)</span>
+              </label>
+              <label class="p-radio">
+                <input class="p-radio__input" type="radio" aria-labelledby="platform-intel-12th-mobile" name="platform" value="intel-12th-mobile">
+                <span class="p-radio__label" id="platform-intel-12th-mobile">12th Gen Intel® Core™ mobile processors for IoT applications (Alder Lake-S)</span>
+              </label>
+              <label class="p-radio">
+                <input class="p-radio__input" type="radio" aria-labelledby="platform-intel-12th-core-desktop" name="platform" value="intel-12th-core-desktop">
+                <span class="p-radio__label" id="platform-intel-12th-core-desktop"> 12th Gen Intel® Core™ desktop processors for IoT applications (Alder Lake-P)
+                </span>
+              </label>
+              <label class="p-radio">
+                <input class="p-radio__input" type="radio" aria-labelledby="platform-all-of-them" name="platform" value="all-of-them">
+                <span class="p-radio__label" id="platform-all-of-them">All of them</span>
+              </label>
+            </div>  
+          </div>
+        </div>
+      </div>
+      <div class="js-formfield">
+        <div class="u-sv3">
+          <h3 class="p-heading--5">What Ubuntu flavour are you interested in?</h3>
+          <div class="row u-no-padding">
+            <div class="col-4 u-sv3">
+              <label class="p-radio">
+                <input class="p-radio__input" type="radio" aria-labelledby="ubuntu-flavour-ubnutu-server" name="ubuntu-flavour" value="ubnutu-server">
+                <span class="p-radio__label" id="ubuntu-flavour-ubnutu-server">Ubuntu Server</span>
+              </label>
+              <label class="p-radio">
+                <input class="p-radio__input" type="radio" aria-labelledby="ubuntu-flavour-ubnutu-desktop" name="ubuntu-flavour" value="ubnutu-desktop">
+                <span class="p-radio__label" id="ubuntu-flavour-ubnutu-desktop">Ubuntu Desktop</span>
+              </label>
+            </div>
+            <div class="col-4 u-sv3">
+              <label class="p-radio">
+                <input class="p-radio__input" type="radio" aria-labelledby="ubuntu-flavour-ubnutu-core" name="ubuntu-flavour" value="ubnutu-core">
+                <span class="p-radio__label" id="ubuntu-flavour-ubnutu-core">Ubuntu Core</span>
+              </label>
+              <label class="p-radio">
+                <input class="p-radio__input" type="radio" aria-labelledby="ubuntu-flavour-all-of-them" name="ubuntu-flavour" value="all-of-them">
+                <span class="p-radio__label" id="ubuntu-flavour-all-of-them">All of them</span>
+              </label>
             </div>
           </div>
         </div>
-        <div class="pagination">
-          <a class="p-button--positive pagination__link--next" href="">Next</a>
+        <div class="row u-no-padding">
+          <div class="col-6 u-sv3">
+            <label for="about-project">Tell us more about your project</label>
+            <textarea name="about-project" id="about-project"></textarea>
+          </div>
         </div>
       </div>
+      <div class="pagination">
+        <a class="p-button--positive pagination__link--next" href="">Next</a>
+      </div>
     </div>
-
     <div class="js-pagination js-pagination--2 u-hide">
       <h3 class="p-heading--5">How should we get in touch?</h3>
       <div class="row u-no-padding">
@@ -80,6 +136,10 @@
               <li class="p-list__item">
                 <label for="company">Company:</label>
                 <input required id="company" name="company" maxlength="255" type="text" required="required" />
+              </li>
+              <li class="p-list__item">
+                <label for="title">Job title:</label>
+                <input data-testid="form-jobTitle" required id="title" name="title" maxlength="255" type="text">
               </li>
               <li class="p-list__item">
                 <label for="email">Email:</label>

--- a/tests/cypress/forms/forms_spec.js
+++ b/tests/cypress/forms/forms_spec.js
@@ -3,7 +3,6 @@ import {
   standardFormUrls,
   interactiveForms,
   formsWithEmailTestId,
-  internetOfThingsForm
 } from "../utils";
 
 beforeEach(() => {
@@ -217,16 +216,13 @@ context("Interactive marketo forms", () => {
     }
   );
 
-  // wrote separate test for the pages using the same internet-of-things form (The form ids are differnent)
+  // wrote separate test for /download/iot/intel-iotg as cypress couldn't find the job title input field by label text
   it(
-    "should check each contact modal using the internet-of-things form",
+    "should check interactive contact modal on /download/iot/intel-iotg",
     { scrollBehavior: "center" },
     () => {
-    cy.visit("/");
-    cy.acceptCookiePolicy();
-
-    internetOfThingsForm.forEach((url) => {
-      cy.visit(url);
+      cy.visit("/download/iot/intel-iotg");
+      cy.acceptCookiePolicy();
       cy.findByTestId("interactive-form-link").click();
       cy.findByRole("link", { name: /Next/ }).click();
       cy.findByLabelText(/First name/).type("Test");
@@ -237,8 +233,9 @@ context("Interactive marketo forms", () => {
       cy.findByLabelText(/Mobile\/cell phone number:/).type("07777777777");
       cy.findByText(/Let's discuss/).click();
       cy.url().should("include", "#success");
-    });
-  });
+    }
+  );
+
 
   // wrote separate test for /robotics page as cypress couldn't find the job title input field by label text
   it(

--- a/tests/cypress/utils.js
+++ b/tests/cypress/utils.js
@@ -44,6 +44,50 @@ export const formsWithEmailTestId = [
     noOfPages: 3,
   },
   {
+    url: "/internet-of-things/smart-displays",
+    inputs: [
+      [/First name/, "test"],
+      [/Last name/, "test"],
+      [/Company:/, "test"],
+      [/Mobile\/cell phone number:/, "07777777777"],
+    ],
+    submitBtn: /Let's discuss/,
+    noOfPages: 2,
+  },
+  {
+    url: "/internet-of-things/appstore",
+    inputs: [
+      [/First name/, "test"],
+      [/Last name/, "test"],
+      [/Company:/, "test"],
+      [/Mobile\/cell phone number:/, "07777777777"],
+    ],
+    submitBtn: /Let's discuss/,
+    noOfPages: 2,
+  },
+  {
+    url: "/internet-of-things/gateways",
+    inputs: [
+      [/First name/, "test"],
+      [/Last name/, "test"],
+      [/Company:/, "test"],
+      [/Mobile\/cell phone number:/, "07777777777"],
+    ],
+    submitBtn: /Let's discuss/,
+    noOfPages: 2,
+  },
+  {
+    url: "/internet-of-things/networking",
+    inputs: [
+      [/First name/, "test"],
+      [/Last name/, "test"],
+      [/Company:/, "test"],
+      [/Mobile\/cell phone number:/, "07777777777"],
+    ],
+    submitBtn: /Let's discuss/,
+    noOfPages: 2,
+  },
+  {
     url: "/openstack/managed",
     inputs: [
       [/First name/, "test"],
@@ -143,6 +187,30 @@ export const interactiveForms = [
     ],
     submitBtn: /Let's discuss/,
     noOfPages: 3,
+  },
+  {
+    url: "/core",
+    inputs: [
+      [/First name/, "test"],
+      [/Last name/, "test"],
+      [/Company:/, "test"],
+      [/Email/, "test@gmail.com"],
+      [/Mobile\/cell phone number:/, "07777777777"],
+    ],
+    submitBtn: /Let's discuss/,
+    noOfPages: 2,
+  },
+  {
+    url: "/core/smartstart",
+    inputs: [
+      [/First name/, "test"],
+      [/Last name/, "test"],
+      [/Company:/, "test"],
+      [/Email/, "test@gmail.com"],
+      [/Mobile\/cell phone number:/, "07777777777"],
+    ],
+    submitBtn: /Let's discuss/,
+    noOfPages: 2,
   },
   {
     url: "/dell",
@@ -265,6 +333,18 @@ export const interactiveForms = [
     noOfPages: 3,
   },
   {
+    url: "/pricing/devices",
+    inputs: [
+      [/First name/, "test"],
+      [/Last name/, "test"],
+      [/Company/, "test"],
+      [/Email/, "test@gmail.com"],
+      [/Mobile\/cell phone number:/, "07777777777"],
+    ],
+    submitBtn: /Let's discuss/,
+    noOfPages: 2,
+  },
+  {
     url: "/pricing/consulting",
     inputs: [
       [/First name/, "test"],
@@ -352,14 +432,4 @@ export const interactiveForms = [
     submitBtn: /Let's discuss/,
     noOfPages: 3,
   },
-];
-
-export const internetOfThingsForm = [
-    "/internet-of-things/networking",
-    "/internet-of-things/gateways",
-    "/internet-of-things/appstore",
-    "/internet-of-things/digital-signage",
-    "/core",
-    "/core/smartstart",
-    "/pricing/devices",
 ];


### PR DESCRIPTION
## Done

- Create a new interactive form for `/download/iot/intel-iotg` and update `/download/iot/intel-iotg` to point to it
- Revert the original form (`/templates/shared/forms/interactive/internet-of-things.html)
     - The form was recently updated in https://github.com/canonical-web-and-design/ubuntu.com/pull/11396
- Update cypress test for both forms

## QA
- Check `Get it touch` in the `/download/iot/intel-iotg`page  points to `templates/shared/forms/interactive/intel-iotg.html`
- Check these pages below point to `/templates/shared/forms/interactive/internet-of-things.html`
     - "/internet-of-things/networking",
     - "/internet-of-things/gateways",
     - "/internet-of-things/appstore",
     - "/internet-of-things/smart-displays",
     - "/core",
     - "/core/smartstart",
     -  "/pricing/devices"

## Issue / Card

Fixes #11423 


## Help

[QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html) - [Commit guidelines](https://canonical-web-and-design.github.io/practices/workflow/commit-messages.html)
