### PR TITLE
update version of ubuntu pro datasheet

### DIFF
--- a/templates/azure/pro.html
+++ b/templates/azure/pro.html
@@ -233,7 +233,7 @@
             </tr>
           </tbody>
         </table>
-        <p><a href="https://assets.ubuntu.com/v1/0bc0c006-Ubuntu.Pro.for.Azure.Datasheet_07.12.21.pdf">Read the Ubuntu Pro datasheet&nbsp;&rsaquo;</a></p>
+        <p><a href="https://assets.ubuntu.com/v1/e7592d40-Ubuntu.Pro.for.Azure.Datasheet_31.03.22.pdf">Read the Ubuntu Pro datasheet&nbsp;&rsaquo;</a></p>
       </div>
     </div>
   </div>
@@ -341,7 +341,7 @@
   </div>
   <div class="row">
     <p class="u-no-margin--bottom">
-      <a href="https://assets.ubuntu.com/v1/0bc0c006-Ubuntu.Pro.for.Azure.Datasheet_07.12.21.pdf">
+      <a href="https://assets.ubuntu.com/v1/e7592d40-Ubuntu.Pro.for.Azure.Datasheet_31.03.22.pdf">
         Read the Ubuntu Pro datasheet&nbsp;&rsaquo;
       </a>
     </p>


### PR DESCRIPTION
## Done

- Updated links to a new version of the Ubuntu Pro datasheet on /azure/pro

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/azure/pro
    - Be sure to test on mobile, tablet and desktop screen sizes
- Click "Read the Ubuntu Pro datasheet ›" in the "Choose the right Ubuntu for you" and "Get Ubuntu Pro on Azure now:" sections
- See that it takes you to a PDF that lists "Walmart, AT&T, Deliotte, and AVAYA." at the end of the first paragraph in the right hand column, rather than "Netflix, Paypal, Heroku and Acquia."

## Issue / Card

Fixes https://github.com/canonical-web-and-design/web-squad/issues/5020
