### PR TITLE
Don't display support options for 14.04 and 16.04

### DIFF
--- a/static/js/src/advantage/subscribe/reducers/form-reducer.js
+++ b/static/js/src/advantage/subscribe/reducers/form-reducer.js
@@ -153,7 +153,16 @@ const formSlice = createSlice({
       state.periods = getProductPeriods(state.product.productID);
     },
     changeVersion(state, action) {
+      if (
+        (action.payload === "14.04" || action.payload === "16.04") &&
+        state.support !== "unset"
+      ) {
+        state.support = "essential";
+      }
       state.version = action.payload;
+
+      state.product = getProduct(state);
+      state.periods = getProductPeriods(state.product.productID);
     },
     changeFeature(state, action) {
       state.feature = state.isAppsEnabled ? action.payload : "infra"; //if ESM Apps is disabled we default to infra

--- a/static/js/src/advantage/subscribe/renderers/form-renderer.js
+++ b/static/js/src/advantage/subscribe/renderers/form-renderer.js
@@ -122,7 +122,12 @@ function renderSupport(state) {
   setSupportCost(state, "advanced");
 
   // disable all the options but essential if desktop and apps are selected
-  if (state.type === "desktop" && state.feature === "apps") {
+  // or if 16.04 or 14.04 is selected
+  if (
+    (state.type === "desktop" && state.feature === "apps") ||
+    state.version === "16.04" ||
+    state.version === "14.04"
+  ) {
     radios.forEach((radio) => {
       const input = radio.querySelector("input");
       if (input.value !== "essential") {


### PR DESCRIPTION


## Done

- Prevent users from selecting any other support than essential if they selected 16.04 or 14.04

## QA

- go to /subscribe
- select 16.04 in the version section
- support options except essential should be greyed out
- go back up and select 20.04
- select 24/7 support
- go back up and select 14.04
- it should have changed your selection to essential and greyed out the other options

## Issue / Card

Fixes canonical-web-and-design/commercial-squad#542
