### PR TITLE
Fix error handling for unauthorized exceptions

### DIFF
--- a/tests/shop/advantage/test_api.py
+++ b/tests/shop/advantage/test_api.py
@@ -11,6 +11,7 @@ from webapp.shop.api.ua_contracts.api import (
     UAContractsAPIErrorView,
     UAContractsUserHasNoAccount,
     UnauthorizedError,
+    UnauthorizedErrorView,
     AccessForbiddenError,
 )
 
@@ -198,7 +199,7 @@ class TestGetAccountSubscriptions(unittest.TestCase):
     def test_errors(self):
         cases = [
             (401, False, UnauthorizedError),
-            (401, True, UnauthorizedError),
+            (401, True, UnauthorizedErrorView),
             (500, False, UAContractsAPIError),
             (500, True, UAContractsAPIErrorView),
         ]
@@ -719,7 +720,7 @@ class TestGetPurchaseAccount(unittest.TestCase):
             (403, False, AccessForbiddenError),
             (403, False, AccessForbiddenError),
             (401, False, UnauthorizedError),
-            (401, True, UnauthorizedError),
+            (401, True, UnauthorizedErrorView),
             (404, False, UAContractsUserHasNoAccount),
             (404, True, UAContractsUserHasNoAccount),
             (500, False, UAContractsAPIError),

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -26,6 +26,8 @@ from webapp.shop.context import get_stripe_publishable_key
 from webapp.shop.api.ua_contracts.api import (
     UAContractsAPIError,
     UAContractsAPIErrorView,
+    UnauthorizedError,
+    UnauthorizedErrorView,
 )
 from webapp.security.api import SecurityAPIError
 from webapp.context import (
@@ -234,6 +236,7 @@ def ua_contracts_validation_error(error):
 
 
 @app.errorhandler(UAContractsAPIError)
+@app.errorhandler(UnauthorizedError)
 def ua_contracts_api_error(error):
     sentry.captureException(
         extra={
@@ -255,6 +258,7 @@ def ua_contracts_api_error(error):
 
 
 @app.errorhandler(UAContractsAPIErrorView)
+@app.errorhandler(UnauthorizedErrorView)
 def ua_contracts_api_error_view(error):
     sentry.captureException(
         extra={

--- a/webapp/shop/api/ua_contracts/api.py
+++ b/webapp/shop/api/ua_contracts/api.py
@@ -313,6 +313,8 @@ class UAContractsAPI:
             raise AccessForbiddenError(error)
 
         if "auth" in error_rules and status_code == 401:
+            if self.is_for_view:
+                raise UnauthorizedErrorView(error)
             raise UnauthorizedError(error)
 
         if "no-found" in error_rules and status_code == 404:
@@ -330,6 +332,11 @@ class AccessForbiddenError(HTTPError):
 
 
 class UnauthorizedError(HTTPError):
+    def __init__(self, error: HTTPError):
+        super().__init__(request=error.request, response=error.response)
+
+
+class UnauthorizedErrorView(HTTPError):
     def __init__(self, error: HTTPError):
         super().__init__(request=error.request, response=error.response)
 


### PR DESCRIPTION
## Done

- There is an uncaught exception happening when your session expires.
- Now we catch it again.

## QA

- Go to ubuntu.com and login
- Switch to testing environment
- You will get the 500 page
- Try the same on this demo
- You will not get a 500