### PR TITLE
K8s cs fixes

### DIFF
--- a/templates/kubernetes/docs/1.21/components.md
+++ b/templates/kubernetes/docs/1.21/components.md
@@ -62,7 +62,7 @@ release. These charms are maintained by the Charmed Kubernetes team.
   <td> <a href="/kubernetes/docs/1.21/charm-aws-iam">docs</a> </td>
   <td> <a href="https://github.com/charmed-kubernetes/charm-aws-iam"> source </a> </td>
   <td> <a href="https://bugs.launchpad.net/charmed-kubernetes"> bugs</a> </td>
-  <td> <a href="https://jaas.ai/u/containers/aws-iam/69"> 69 </a></td>
+  <td> 69 </td>
   <td> -- </td>
 </tr>
 <tr>
@@ -71,7 +71,7 @@ release. These charms are maintained by the Charmed Kubernetes team.
   <td> <a href="/kubernetes/docs/1.21/charm-aws-integrator">docs</a> </td>
   <td> <a href="https://github.com/juju-solutions/charm-aws-integrator"> source </a> </td>
   <td> <a href="https://bugs.launchpad.net/charmed-kubernetes"> bugs</a> </td>
-  <td> <a href="https://jaas.ai/u/containers/aws-integrator/126"> 126 </a></td>
+  <td> 126 </td>
   <td> -- </td>
 </tr>
 <tr>
@@ -80,7 +80,7 @@ release. These charms are maintained by the Charmed Kubernetes team.
   <td> <a href="/kubernetes/docs/1.21/charm-azure-integrator">docs</a> </td>
   <td> <a href="https://github.com/juju-solutions/charm-azure-integrator"> source </a> </td>
   <td> <a href="https://bugs.launchpad.net/charmed-kubernetes"> bugs</a> </td>
-  <td> <a href="https://jaas.ai/u/containers/azure-integrator/111"> 111 </a> </td>
+  <td> 111 </td>
   <td> -- </td>
 </tr>
 <tr>
@@ -89,7 +89,7 @@ release. These charms are maintained by the Charmed Kubernetes team.
   <td> <a href="/kubernetes/docs/1.21/charm-calico">docs</a> </td>
   <td> <a href="https://github.com/juju-solutions/layer-calico"> source </a> </td>
   <td> <a href="https://bugs.launchpad.net/charmed-kubernetes"> bugs</a> </td>
-  <td> <a href="https://jaas.ai/u/containers/calico/812"> 812 </a> </td>
+  <td> 812 </td>
   <td> -- </td>
 </tr>
 <tr>
@@ -98,7 +98,7 @@ release. These charms are maintained by the Charmed Kubernetes team.
   <td> <a href="/kubernetes/docs/1.21/charm-canal">docs</a> </td>
   <td> <a href="https://github.com/juju-solutions/layer-canal"> source </a> </td>
   <td> <a href="https://bugs.launchpad.net/charmed-kubernetes"> bugs</a> </td>
-  <td> <a href="https://jaas.ai/u/containers/canal/810"> 810</a> </td>
+  <td> 810 </td>
   <td> -- </td>
 </tr>
 <tr>
@@ -107,7 +107,7 @@ release. These charms are maintained by the Charmed Kubernetes team.
   <td> <a href="/kubernetes/docs/1.21/charm-containerd">docs</a> </td>
   <td> <a href=""> source </a> </td>
   <td> <a href="https://bugs.launchpad.net/charmed-kubernetes"> bugs</a> </td>
-  <td> <a href="https://jaas.ai/u/containers/containerd/146"> 146</a> </td>
+  <td> 146 </td>
   <td> -- </td>
 </tr>
 <tr>
@@ -116,7 +116,7 @@ release. These charms are maintained by the Charmed Kubernetes team.
   <td> <a href="/kubernetes/docs/1.21/charm-docker">docs</a> </td>
   <td> <a href=""> source </a> </td>
   <td> <a href="https://bugs.launchpad.net/charmed-kubernetes"> bugs</a> </td>
-  <td> <a href="https://jaas.ai/u/containers/docker/100"> 100</a> </td>
+  <td> 100 </td>
   <td> -- </td>
 </tr>
 <tr>
@@ -125,7 +125,7 @@ release. These charms are maintained by the Charmed Kubernetes team.
   <td> <a href="/kubernetes/docs/1.21/charm-docker-registry">docs</a> </td>
   <td> <a href="https://github.com/CanonicalLtd/docker-registry-charm"> source </a> </td>
   <td> <a href="https://bugs.launchpad.net/charmed-kubernetes"> bugs</a> </td>
-  <td> <a href="https://jaas.ai/u/containers/docker-registry/188"> 188</a> </td>
+  <td> 188 </td>
   <td> -- </td>
 </tr>
 <tr>
@@ -134,7 +134,7 @@ release. These charms are maintained by the Charmed Kubernetes team.
   <td> <a href="/kubernetes/docs/1.21/charm-easyrsa">docs</a> </td>
   <td> <a href="https://github.com/charmed-kubernetes/layer-easyrsa"> source </a> </td>
   <td> <a href="https://bugs.launchpad.net/charmed-kubernetes"> bugs</a> </td>
-  <td> <a href="https://jaas.ai/u/containers/easyrsa/395"> 395</a> </td>
+  <td> 395 </td>
   <td> -- </td>
 </tr>
 <tr>
@@ -143,7 +143,7 @@ release. These charms are maintained by the Charmed Kubernetes team.
   <td> <a href="/kubernetes/docs/1.21/charm-etcd">docs</a> </td>
   <td> <a href="https://github.com/charmed-kubernetes/layer-etcd"> source </a> </td>
   <td> <a href="https://bugs.launchpad.net/charmed-kubernetes"> bugs</a> </td>
-  <td> <a href="https://jaas.ai/u/containers/etcd/607"> 607</a> </td>
+  <td> 607 </td>
   <td> -- </td>
 </tr>
 <tr>
@@ -152,7 +152,7 @@ release. These charms are maintained by the Charmed Kubernetes team.
   <td> <a href="/kubernetes/docs/1.21/charm-flannel">docs</a> </td>
   <td> <a href="https://github.com/coreos/flannel"> source </a> </td>
   <td> <a href="https://bugs.launchpad.net/charmed-kubernetes"> bugs</a> </td>
-  <td> <a href="https://jaas.ai/u/containers/flannel/571"> 571</a> </td>
+  <td> 571 </td>
   <td> -- </td>
 </tr>
 <tr>
@@ -161,7 +161,7 @@ release. These charms are maintained by the Charmed Kubernetes team.
   <td> <a href="/kubernetes/docs/1.21/charm-gcp-integrator">docs</a> </td>
   <td> <a href="https://github.com/juju-solutions/charm-gcp-integrator"> source </a> </td>
   <td> <a href="https://bugs.launchpad.net/charmed-kubernetes"> bugs</a> </td>
-  <td> <a href="https://jaas.ai/u/containers/gcp-integrator/118"> 118</a> </td>
+  <td> 118 </td>
   <td> -- </td>
 </tr>
 <tr>
@@ -170,7 +170,7 @@ release. These charms are maintained by the Charmed Kubernetes team.
   <td> <a href="/kubernetes/docs/1.21/charm-kata">docs</a> </td>
   <td> <a href=""> source </a> </td>
   <td> <a href="https://bugs.launchpad.net/charmed-kubernetes"> bugs</a> </td>
-  <td> <a href="https://jaas.ai/u/containers/kata/108"> 108</a> </td>
+  <td> 108 </td>
   <td> -- </td>
 </tr>
 <tr>
@@ -179,7 +179,7 @@ release. These charms are maintained by the Charmed Kubernetes team.
   <td> <a href="/kubernetes/docs/1.21/charm-keepalived">docs</a> </td>
   <td> <a href="https://github.com/juju-solutions/charm-keepalived"> source </a> </td>
   <td> <a href="https://bugs.launchpad.net/charmed-kubernetes"> bugs</a> </td>
-  <td> <a href="https://jaas.ai/u/containers/keepalived/85"> 85</a> </td>
+  <td> 85 </td>
   <td> -- </td>
 </tr>
 <tr>
@@ -188,7 +188,7 @@ release. These charms are maintained by the Charmed Kubernetes team.
   <td> <a href="/kubernetes/docs/1.21/charm-kubeapi-load-balancer">docs</a> </td>
   <td> <a href="https://nginx.org/en/"> source </a> </td>
   <td> <a href="https://bugs.launchpad.net/charmed-kubernetes"> bugs</a> </td>
-  <td> <a href="https://jaas.ai/u/containers/kubeapi-load-balancer/814"> 814</a> </td>
+  <td> 814 </td>
   <td> -- </td>
 </tr>
 <tr>
@@ -197,7 +197,7 @@ release. These charms are maintained by the Charmed Kubernetes team.
   <td> <a href="/kubernetes/docs/1.21/charm-kubernetes-master">docs</a> </td>
   <td> <a href="https://github.com/charmed-kubernetes/charm-kubernetes-master"> source </a> </td>
   <td> <a href="https://bugs.launchpad.net/charmed-kubernetes"> bugs</a> </td>
-  <td> <a href="https://jaas.ai/u/containers/kubernetes-master/1034"> 1034</a> </td>
+  <td> 1034 </td>
   <td> -- </td>
 </tr>
 <tr>
@@ -206,7 +206,7 @@ release. These charms are maintained by the Charmed Kubernetes team.
   <td> <a href="/kubernetes/docs/1.21/charm-kubernetes-worker">docs</a> </td>
   <td> <a href="https://github.com/charmed-kubernetes/charm-kubernetes-worker"> source </a> </td>
   <td> <a href="https://bugs.launchpad.net/charmed-kubernetes"> bugs</a> </td>
-  <td> <a href="https://jaas.ai/u/containers/kubernetes-worker/788"> 788</a> </td>
+  <td> 788 </td>
   <td> -- </td>
 </tr>
 <tr>
@@ -215,7 +215,7 @@ release. These charms are maintained by the Charmed Kubernetes team.
   <td> <a href="/kubernetes/docs/1.21/charm-openstack-integrator">docs</a> </td>
   <td> <a href="https://github.com/juju-solutions/charm-openstack-integrator"> source </a> </td>
   <td> <a href="https://bugs.launchpad.net/charmed-kubernetes"> bugs</a> </td>
-  <td> <a href="https://jaas.ai/u/containers/openstack-integrator/153"> 153</a> </td>
+  <td> 153 </td>
   <td> -- </td>
 </tr>
 <tr>
@@ -224,7 +224,7 @@ release. These charms are maintained by the Charmed Kubernetes team.
   <td> <a href="/kubernetes/docs/1.21/charm-tigera-secure-ee">docs</a> </td>
   <td> <a href=""> source </a> </td>
   <td> <a href="https://bugs.launchpad.net/charmed-kubernetes"> bugs</a> </td>
-  <td> <a href="https://jaas.ai/u/containers/tigera-secure-ee/205"> 205</a> </td>
+  <td> 205 </td>
   <td> -- </td>
 </tr>
 <tr>
@@ -233,7 +233,7 @@ release. These charms are maintained by the Charmed Kubernetes team.
   <td> <a href="/kubernetes/docs/1.21/charm-vsphere-integrator">docs</a> </td>
   <td> <a href="https://github.com/juju-solutions/charm-vsphere-integrator"> source </a> </td>
   <td> <a href="https://bugs.launchpad.net/charmed-kubernetes"> bugs</a> </td>
-  <td> <a href="https://jaas.ai/u/containers/vsphere-integrator/98"> 98</a> </td>
+  <td> 98 </td>
   <td> -- </td>
 </tr>
 </tbody>

--- a/templates/kubernetes/docs/1.22/components.md
+++ b/templates/kubernetes/docs/1.22/components.md
@@ -59,181 +59,181 @@ release. These charms are maintained by the Charmed Kubernetes team.
 <tr>
   <td> aws-iam </td>
   <td> A charm that enables using AWS IAM to authenticate with Kubernetes </td>
-  <td> <a href="/kubernetes/docs/1.22/charm-aws-iam">docs</a> </td>
+  <td> <a href="/kubernetes/docs/1.22/charm-aws-iam">docs</a> </td> 
   <td> <a href="https://github.com/charmed-kubernetes/charm-aws-iam"> source </a> </td>
   <td> <a href="https://bugs.launchpad.net/charmed-kubernetes"> bugs</a> </td>
-  <td> <a href="https://jaas.ai/u/containers/aws-iam/94"> 94 </a> </td>
+  <td> 94 </td>
   <td> -- </td>
 </tr>
 <tr>
   <td> aws-integrator </td>
   <td> Charm to enable AWS integrations via Juju relations. </td>
-  <td> <a href="/kubernetes/docs/1.22/charm-aws-integrator">docs</a> </td>
+  <td> <a href="/kubernetes/docs/1.22/charm-aws-integrator">docs</a> </td> 
   <td> <a href="https://github.com/juju-solutions/charm-aws-integrator"> source </a> </td>
   <td> <a href="https://bugs.launchpad.net/charmed-kubernetes"> bugs</a> </td>
-  <td> <a href="https://jaas.ai/u/containers/aws-integrator/153"> 153 </a> </td>
+  <td> 153 </td>
   <td> -- </td>
 </tr>
 <tr>
   <td> azure-integrator </td>
   <td> Proxy charm to enable Azure integrations via Juju relations. </td>
-  <td> <a href="/kubernetes/docs/1.22/charm-azure-integrator">docs</a> </td>
+  <td> <a href="/kubernetes/docs/1.22/charm-azure-integrator">docs</a> </td> 
   <td> <a href="https://github.com/juju-solutions/charm-azure-integrator"> source </a> </td>
   <td> <a href="https://bugs.launchpad.net/charmed-kubernetes"> bugs</a> </td>
-  <td> <a href="https://jaas.ai/u/containers/azure-integrator/137"> 137 </a> </td>
+  <td> 137 </td>
   <td> -- </td>
 </tr>
 <tr>
   <td> calico </td>
   <td> A robust Software Defined Network from Project Calico </td>
-  <td> <a href="/kubernetes/docs/1.22/charm-calico">docs</a> </td>
+  <td> <a href="/kubernetes/docs/1.22/charm-calico">docs</a> </td> 
   <td> <a href="https://github.com/juju-solutions/layer-calico"> source </a> </td>
   <td> <a href="https://bugs.launchpad.net/charmed-kubernetes"> bugs</a> </td>
-  <td> <a href="https://jaas.ai/u/containers/calico/838"> 838 </a> </td>
+  <td> 838 </td>
   <td> -- </td>
 </tr>
 <tr>
   <td> canal </td>
   <td> A Software Defined Network based on Flannel and Calico </td>
-  <td> <a href="/kubernetes/docs/1.22/charm-canal">docs</a> </td>
+  <td> <a href="/kubernetes/docs/1.22/charm-canal">docs</a> </td> 
   <td> <a href="https://github.com/juju-solutions/layer-canal"> source </a> </td>
   <td> <a href="https://bugs.launchpad.net/charmed-kubernetes"> bugs</a> </td>
-  <td> <a href="https://jaas.ai/u/containers/canal/837"> 837 </a> </td>
+  <td> 837 </td>
   <td> -- </td>
 </tr>
 <tr>
   <td> containerd </td>
   <td> Containerd container runtime subordinate </td>
-  <td> <a href="/kubernetes/docs/1.22/charm-containerd">docs</a> </td>
+  <td> <a href="/kubernetes/docs/1.22/charm-containerd">docs</a> </td> 
   <td> <a href="https://github.com/charmed-kubernetes/charm-containerd"> source </a> </td>
   <td> <a href="https://bugs.launchpad.net/charmed-kubernetes"> bugs</a> </td>
-  <td> <a href="https://jaas.ai/u/containers/containerd/178"> 178 </a> </td>
+  <td> 178 </td>
   <td> -- </td>
 </tr>
 <tr>
   <td> docker </td>
   <td> Docker container runtime subordinate </td>
-  <td> <a href="/kubernetes/docs/1.22/charm-docker">docs</a> </td>
+  <td> <a href="/kubernetes/docs/1.22/charm-docker">docs</a> </td> 
   <td> <a href="https://github.com/juju-solutions/layer-docker"> source </a> </td>
   <td> <a href="https://bugs.launchpad.net/charmed-kubernetes"> bugs</a> </td>
-  <td> <a href="https://jaas.ai/u/containers/docker/131"> 131 </a> </td>
+  <td> 131 </td>
   <td> -- </td>
 </tr>
 <tr>
   <td> docker-registry </td>
   <td> Registry for docker images </td>
-  <td> <a href="/kubernetes/docs/1.22/charm-docker-registry">docs</a> </td>
+  <td> <a href="/kubernetes/docs/1.22/charm-docker-registry">docs</a> </td> 
   <td> <a href="https://github.com/CanonicalLtd/docker-registry-charm"> source </a> </td>
   <td> <a href="https://bugs.launchpad.net/charmed-kubernetes"> bugs</a> </td>
-  <td> <a href="https://jaas.ai/u/containers/docker-registry/218"> 218 </a> </td>
+  <td> 218 </td>
   <td> -- </td>
 </tr>
 <tr>
   <td> easyrsa </td>
   <td> Delivers EasyRSA to create a Certificate Authority (CA). </td>
-  <td> <a href="/kubernetes/docs/1.22/charm-easyrsa">docs</a> </td>
+  <td> <a href="/kubernetes/docs/1.22/charm-easyrsa">docs</a> </td> 
   <td> <a href="https://github.com/charmed-kubernetes/layer-easyrsa"> source </a> </td>
   <td> <a href="https://bugs.launchpad.net/charmed-kubernetes"> bugs</a> </td>
-  <td> <a href="https://jaas.ai/u/containers/easyrsa/420"> 420 </a> </td>
+  <td> 420 </td>
   <td> -- </td>
 </tr>
 <tr>
   <td> etcd </td>
   <td> Deploy a TLS terminated ETCD Cluster </td>
-  <td> <a href="/kubernetes/docs/1.22/charm-etcd">docs</a> </td>
+  <td> <a href="/kubernetes/docs/1.22/charm-etcd">docs</a> </td> 
   <td> <a href="https://github.com/charmed-kubernetes/layer-etcd"> source </a> </td>
   <td> <a href="https://bugs.launchpad.net/charmed-kubernetes"> bugs</a> </td>
-  <td> <a href="https://jaas.ai/u/containers/etcd/634"> 634 </a> </td>
+  <td> 634 </td>
   <td> -- </td>
 </tr>
 <tr>
   <td> flannel </td>
   <td> A charm that provides a robust Software Defined Network </td>
-  <td> <a href="/kubernetes/docs/1.22/charm-flannel">docs</a> </td>
+  <td> <a href="/kubernetes/docs/1.22/charm-flannel">docs</a> </td> 
   <td> <a href="https://github.com/coreos/flannel"> source </a> </td>
   <td> <a href="https://bugs.launchpad.net/charmed-kubernetes"> bugs</a> </td>
-  <td> <a href="https://jaas.ai/u/containers/flannel/597"> 597 </a> </td>
+  <td> 597 </td>
   <td> -- </td>
 </tr>
 <tr>
   <td> gcp-integrator </td>
   <td> Charm to enable GCP integrations via Juju relations. </td>
-  <td> <a href="/kubernetes/docs/1.22/charm-gcp-integrator">docs</a> </td>
+  <td> <a href="/kubernetes/docs/1.22/charm-gcp-integrator">docs</a> </td> 
   <td> <a href="https://github.com/juju-solutions/charm-gcp-integrator"> source </a> </td>
   <td> <a href="https://bugs.launchpad.net/charmed-kubernetes"> bugs</a> </td>
-  <td> <a href="https://jaas.ai/u/containers/gcp-integrator/145"> 145 </a> </td>
+  <td> 145 </td>
   <td> -- </td>
 </tr>
 <tr>
   <td> kata </td>
   <td> Kata untrusted container runtime subordinate </td>
-  <td> <a href="/kubernetes/docs/1.22/charm-kata">docs</a> </td>
+  <td> <a href="/kubernetes/docs/1.22/charm-kata">docs</a> </td> 
   <td> <a href="https://github.com/charmed-kubernetes/charm-kata"> source </a> </td>
   <td> <a href="https://bugs.launchpad.net/charmed-kubernetes"> bugs</a> </td>
-  <td> <a href="https://jaas.ai/u/containers/kata/138"> 138 </a> </td>
+  <td> 138 </td>
   <td> -- </td>
 </tr>
 <tr>
   <td> keepalived </td>
   <td> Failover and monitoring daemon for LVS clusters </td>
-  <td> <a href="/kubernetes/docs/1.22/charm-keepalived">docs</a> </td>
+  <td> <a href="/kubernetes/docs/1.22/charm-keepalived">docs</a> </td> 
   <td> <a href="https://github.com/juju-solutions/charm-keepalived"> source </a> </td>
   <td> <a href="https://bugs.launchpad.net/charmed-kubernetes"> bugs</a> </td>
-  <td> <a href="https://jaas.ai/u/containers/keepalived/110"> 110 </a> </td>
+  <td> 110 </td>
   <td> -- </td>
 </tr>
 <tr>
   <td> kubeapi-load-balancer </td>
   <td> Nginx Load Balancer </td>
-  <td> <a href="/kubernetes/docs/1.22/charm-kubeapi-load-balancer">docs</a> </td>
+  <td> <a href="/kubernetes/docs/1.22/charm-kubeapi-load-balancer">docs</a> </td> 
   <td> <a href="https://nginx.org/en/"> source </a> </td>
   <td> <a href="https://bugs.launchpad.net/charmed-kubernetes"> bugs</a> </td>
-  <td> <a href="https://jaas.ai/u/containers/kubeapi-load-balancer/844"> 844 </a> </td>
+  <td> 844 </td>
   <td> -- </td>
 </tr>
 <tr>
   <td> kubernetes-master </td>
   <td> The Kubernetes control plane. </td>
-  <td> <a href="/kubernetes/docs/1.22/charm-kubernetes-master">docs</a> </td>
+  <td> <a href="/kubernetes/docs/1.22/charm-kubernetes-master">docs</a> </td> 
   <td> <a href="https://github.com/charmed-kubernetes/charm-kubernetes-master"> source </a> </td>
   <td> <a href="https://bugs.launchpad.net/charmed-kubernetes"> bugs</a> </td>
-  <td> <a href="https://jaas.ai/u/containers/kubernetes-master/1078"> 1078 </a> </td>
+  <td> 1078 </td>
   <td> -- </td>
 </tr>
 <tr>
   <td> kubernetes-worker </td>
   <td> The workload bearing units of a kubernetes cluster </td>
-  <td> <a href="/kubernetes/docs/1.22/charm-kubernetes-worker">docs</a> </td>
+  <td> <a href="/kubernetes/docs/1.22/charm-kubernetes-worker">docs</a> </td> 
   <td> <a href="https://github.com/charmed-kubernetes/charm-kubernetes-worker"> source </a> </td>
   <td> <a href="https://bugs.launchpad.net/charmed-kubernetes"> bugs</a> </td>
-  <td> <a href="https://jaas.ai/u/containers/kubernetes-worker/816"> 816 </a> </td>
+  <td> 816 </td>
   <td> -- </td>
 </tr>
 <tr>
   <td> openstack-integrator </td>
   <td> Proxy charm to enable OpenStack integrations via Juju relations. </td>
-  <td> <a href="/kubernetes/docs/1.22/charm-openstack-integrator">docs</a> </td>
+  <td> <a href="/kubernetes/docs/1.22/charm-openstack-integrator">docs</a> </td> 
   <td> <a href="https://github.com/juju-solutions/charm-openstack-integrator"> source </a> </td>
   <td> <a href="https://bugs.launchpad.net/charmed-kubernetes"> bugs</a> </td>
-  <td> <a href="https://jaas.ai/u/containers/openstack-integrator/182"> 182 </a> </td>
+  <td> 182 </td>
   <td> -- </td>
 </tr>
 <tr>
   <td> tigera-secure-ee </td>
   <td> Tigera Secure Enterprise Edition </td>
-  <td> <a href="/kubernetes/docs/1.22/charm-tigera-secure-ee">docs</a> </td>
+  <td> <a href="/kubernetes/docs/1.22/charm-tigera-secure-ee">docs</a> </td> 
   <td> <a href="https://github.com/charmed-kubernetes/layer-tigera-secure-ee"> source </a> </td>
   <td> <a href="https://bugs.launchpad.net/charmed-kubernetes"> bugs</a> </td>
-  <td> <a href="https://jaas.ai/u/containers/tigera-secure-ee/230"> 230 </a> </td>
+  <td> 230 </td>
   <td> -- </td>
 </tr>
 <tr>
   <td> vsphere-integrator </td>
   <td> Proxy charm to enable VMware vSphere integrations via Juju relations. </td>
-  <td> <a href="/kubernetes/docs/1.22/charm-vsphere-integrator">docs</a> </td>
+  <td> <a href="/kubernetes/docs/1.22/charm-vsphere-integrator">docs</a> </td> 
   <td> <a href="https://github.com/juju-solutions/charm-vsphere-integrator"> source </a> </td>
   <td> <a href="https://bugs.launchpad.net/charmed-kubernetes"> bugs</a> </td>
-  <td> <a href="https://jaas.ai/u/containers/vsphere-integrator/123"> 123 </a> </td>
+  <td> 123 </td>
   <td> -- </td>
 </tr>
 
@@ -349,7 +349,7 @@ These charms are frequently used with Charmed Kubernetes.
 These are the container images used by this release:
 
 <!-- GENERATED CONTAINER IMAGES -->
- 
+
 -  cdkbot/microbot-amd64:latest
 -  cdkbot/microbot-arm64:latest
 -  cdkbot/microbot-s390x:latest

--- a/templates/kubernetes/docs/install-manual.md
+++ b/templates/kubernetes/docs/install-manual.md
@@ -18,15 +18,15 @@ a quick and easy general install of **Charmed Kubernetes**.
 However, in some cases it may be useful to
 customise the install:
 
-- Adding additional components
-- Configuring storage or networking
-- Copying an existing configuration
-- Testing a pre-release version
-- ...and many more
+  - Adding additional components
+  - Configuring storage or networking
+  - Copying an existing configuration
+  - Testing a pre-release version
+  - ...and many more
 
 ## What you will need
 
-The rest of this page assumes you already have Juju installed and have added
+The rest of this page assumes you already have Juju installed and  have added
 credentials for a cloud and bootstrapped a controller.
 
 If you still need to do this, please take a look at the [quickstart
@@ -37,7 +37,9 @@ To install **Charmed Kubernetes** entirely on your local machine (using
 containers to create a cluster), please see the separate
 [Localhost instructions][localhost].
 
+
 ## Quick custom installs
+
 
 The details of how to edit and customise the **Charmed Kubernetes** bundle are
 outlined [below](#). However, using overlays (also explained in more
@@ -54,9 +56,11 @@ Sample overlay files are available to download directly from
 the links shown here. Be advised that you should use only **one** overlay from
 each category!
 
+
 #### Networking
 
 ---
+
 
 <div class="CNI">
  <div class="row">
@@ -100,7 +104,6 @@ each category!
 </div>
 </div>
 <br>
-
 <div class="p-notification--positive is-inline">
   <div markdown="1" class="p-notification__content">
     <span class="p-notification__title">Note:</span>
@@ -174,7 +177,12 @@ each category!
 </div>
 </div>
 
-You can use multiple overlays (of different types) if required. Note that all
+
+
+
+
+
+You can use multiple overlays (of different types) if required.  Note that all
 the 'integrator' charms require the use of the `--trust` option. For example,
 to deploy with Calico networking and AWS integration:
 
@@ -200,7 +208,7 @@ revision number. For example, to deploy the **Charmed Kubernetes** bundle for th
 release, you could run:
 
 ```bash
-juju deploy cs:~containers/charmed-kubernetes-733
+juju deploy charmed-kubernetes --revision=733
 ```
 
 <div class="p-notification--positive is-inline">
@@ -211,6 +219,7 @@ juju deploy cs:~containers/charmed-kubernetes-733
     <code>charmed-kubernetes</code>.</p>
   </div>
 </div>
+
 
 The revision numbers for bundles are generated automatically when the bundle is
 updated, including for testing and beta versions, so it isn't always the case
@@ -237,8 +246,8 @@ versions of the **Charmed Kubernetes** bundle are shown in the table below:
     <span class="p-notification__status">Note:</span>
 Only the latest three versions of Charmed Kubernetes are supported at any time.
   </p>
-
 </div>
+
 
 ## Customising the bundle install
 
@@ -246,8 +255,8 @@ A number of the scenarios outlined at the start of this document involved
 customising the **Charmed Kubernetes** install. There are two main ways to
 do this:
 
-1.  Using [overlays](#overlay) in conjunction with the published Charmed Kubernetes bundle.
-2.  [Editing the bundle file itself](#edit).
+ 1.  Using [overlays](#overlay) in conjunction with the published Charmed Kubernetes bundle.
+ 2.  [Editing the bundle file itself](#edit).
 
 Using an overlay means you can easily apply your customisation to different
 versions of the bundle, with the possible downside that changes in the
@@ -261,7 +270,6 @@ file for each version of **Charmed Kubernetes**.
 Both methods are described below.
 
 <a id="overlay"></a>
-
 ### Using overlays
 
 A _bundle overlay_ is a fragment of valid YAML which is dynamically merged on
@@ -277,9 +285,9 @@ applications:
     num_units: 1
     trust: true
 relations:
-  - ["aws-integrator", "kubernetes-master"]
-  - ["aws-integrator", "kubernetes-worker"]
-```
+  - ['aws-integrator', 'kubernetes-master']
+  - ['aws-integrator', 'kubernetes-worker']
+  ```
 
 You can also [download the fragment here][asset-aws-overlay].
 
@@ -329,8 +337,8 @@ charm. For example, if you look at the fragment for the `kubernetes-worker` in t
 ```yaml
 kubernetes-worker:
   annotations:
-    gui-x: "100"
-    gui-y: "850"
+    gui-x: '100'
+    gui-y: '850'
   charm: cs:~containers/kubernetes-worker
   constraints: cores=4 mem=4G root-disk=16G
   expose: true
@@ -357,7 +365,6 @@ values:
 juju config containerd https_proxy=https://proxy.example.com
 juju config kubernetes-worker snap_proxy:=https://snap-proxy.example.com
 ```
-
 ... we can instead use the following YAML fragment as an overlay:
 
 ```yaml
@@ -420,12 +427,14 @@ For more information on the Juju GUI, see the [Juju documentation][juju-gui].
 Now you have a cluster up and running, check out the
 [Operations guide][operations] for how to use it!
 
+
 <!-- IMAGES -->
 
 [image-gui]: https://assets.ubuntu.com/v1/19f13565-bundle-export.png
 
 <!-- LINKS -->
 
+[latest-bundle-file]: https://charmhub.io/charmed-kubernetes
 [jaas]: https://jaas.ai/
 [juju-docs]: https://juju.is/docs/olm/installing-juju
 [controller-config]: https://juju.is/docs/olm/create-controllers
@@ -435,7 +444,6 @@ Now you have a cluster up and running, check out the
 [juju-gui]: https://juju.is/docs/olm/accessing-juju%E2%80%99s-web-interface
 [juju-constraints]: https://juju.is/docs/olm/constraints
 [asset-aws-overlay]: https://raw.githubusercontent.com/charmed-kubernetes/bundle/main/overlays/aws-overlay.yaml
-[latest-bundle-file]: https://charmhub.io/charmed-kubernetes
 [charm-kworker]: https://charmhub.io/containers-kubernetes-worker
 [snaps]: https://docs.snapcraft.io/snap-documentation
 [kubectl]: https://kubernetes.io/docs/tasks/tools/install-kubectl/

--- a/templates/kubernetes/docs/supported-versions.md
+++ b/templates/kubernetes/docs/supported-versions.md
@@ -22,11 +22,11 @@ Supported releases: **1.23.x,1.22.x, 1.21.x**
 
 ## Charmed Kubernetes bundle versions
 
-The **Juju Charm Store** hosts the **Charmed Kubernetes** bundles as well as
+**Charmhub.io** hosts the **Charmed Kubernetes** bundles as well as
 individual charms. To deploy the latest, stable bundle, run the command:
 
 ```bash
-juju deploy cs:charmed-kubernetes
+juju deploy charmed-kubernetes
 ```
 
 It is also possible to deploy a specific version of the bundle by including the
@@ -34,7 +34,7 @@ revision number. For example, to deploy the **Charmed Kubernetes** bundle for th
 release, you could run:
 
 ```bash
-juju deploy cs:~containers/charmed-kubernetes-733
+juju deploy charmed-kubernetes --revision=733
 ```
 
 <div class="p-notification--positive is-inline">
@@ -47,13 +47,13 @@ juju deploy cs:~containers/charmed-kubernetes-733
   </div>
 </div>
 
+
 The revision numbers for bundles are generated automatically when the bundle is
 updated, including for testing and beta versions, so it isn't always the case
 that a higher revision number is 'better'. The revision numbers for the release
 versions of the **Charmed Kubernetes** bundle are shown in the table below:
 
 <a  id="table"></a>
-
 
 | Kubernetes version | Charmed Kubernetes bundle |
 | --- | --- |
@@ -74,6 +74,7 @@ versions of the **Charmed Kubernetes** bundle are shown in the table below:
 Only the latest three versions of Charmed Kubernetes are supported at any time.
   </p>
 </div>
+
 
 ## Finding version info
 
@@ -98,7 +99,7 @@ description: |
   for the api objects which include pods, services, replicationcontrollers, and others. The API
   Server services REST operations and provides the frontend to the cluster’s shared state through
   which all other components interact.
-
+  
   For more information, consult the [reference
   documentation](https://kubernetes.io/docs/reference/command-line-tools-reference/kube-apiserver/).
 snap-id: KMZLusdClmUyLXAjjcI4sVnpjk1kM653
@@ -107,9 +108,9 @@ channels:
   latest/candidate: 1.23.0         2021-12-15 (2493) 23MB -
   latest/beta:      1.23.0         2021-12-15 (2493) 23MB -
   latest/edge:      1.23.0         2021-12-15 (2493) 23MB -
-  1.24/stable:      –
-  1.24/candidate:   –
-  1.24/beta:        –
+  1.24/stable:      –                                     
+  1.24/candidate:   –                                     
+  1.24/beta:        –                                     
   1.24/edge:        1.24.0-alpha.1 2021-12-11 (2513) 23MB -
   1.23/stable:      1.23.0         2021-12-08 (2493) 23MB -
   1.23/candidate:   1.23.0         2021-12-08 (2493) 23MB -
@@ -198,6 +199,10 @@ If you are looking for additional support, find out about [Ubuntu Advantage][sup
 
 Canonical can also provide [managed solutions][managed] for Kubernetes.
 
+<!-- LINKS -->
+[support]: /support
+[managed]: /kubernetes/managed
+
 <!-- FEEDBACK -->
 <div class="p-notification--information">
   <p class="p-notification__content">
@@ -207,9 +212,3 @@ Canonical can also provide [managed solutions][managed] for Kubernetes.
     <a href="https://github.com/charmed-kubernetes/kubernetes-docs/issues/new" >file a bug here</a>.
   </p>
 </div>
-
-<!-- LINKS -->
-
-[support]: /support
-[managed]: /kubernetes/managed
-```


### PR DESCRIPTION
## Done

- Fix install instructions as th cs -> charmhub redirection was returning wrong versions
- Remove links to versioned charms in cs as these no longer exist

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
