### PR TITLE
Update copy, add cta button on /cloud/public-cloud

### DIFF
--- a/templates/cloud/public-cloud.html
+++ b/templates/cloud/public-cloud.html
@@ -7,10 +7,22 @@
 {% block content %}
 <section class="p-strip--suru-topped is-deep is-bordered">
   <div class="row">
-    <div class="col-8">
+    <div class="col-6">
       <h1>Ubuntu on public clouds</h1>
       <p>Ubuntu is the world's most popular cloud operating system across public clouds. Thanks to its security, versatility and policy of regular updates, Ubuntu is the leading cloud guest OS and the only free cloud operating system with the option of enterprise-grade commercial support.</p>
       <p><a class="p-button--positive js-invoke-modal" href="/openstack/managed">Contact us</a></p>
+    </div>
+    <div class="col-6 u-hide--small u-align--center u-vertically-center">
+      {{
+        image(
+          url="https://assets.ubuntu.com/v1/1c786630-image-cloud.svg",
+          alt="Ubuntu image cloud",
+          height="236",
+          width="365",
+          hi_def=True,
+          loading="lazy",
+        ) | safe
+      }}
     </div>
   </div>
 </section>
@@ -41,7 +53,7 @@
         }}
       </div>
       <p>Juju is the fastest way to deploy and scale out your workloads on the leading public clouds. With Juju charm bundles, you can launch an entire cloud environment with one click, or just one command using the CLI. Use Juju to  deploy your entire application infrastructure, all in one.</p>
-      <p><a href="https://jujucharms.com/">Learn more about Juju</a></p>
+      <p><a href="https://jujucharms.com/">Learn more about Juju&nbsp;&rsaquo;</a></p>
     </div>
     <div class="col-6 p-divider__block">
       <h2 class="p-heading--3">Trusted Container (OCI) Images</h2>
@@ -102,6 +114,9 @@
       <p>Ubuntu Pro includes optimised kernel, hardening and security coverage for the entire collection of software packages shipped with Ubuntu.</p>
       <p>
         <a class="p-button--positive" href="/download/cloud">Start using Ubuntu today</a>
+      </p>
+      <p>
+        <a class="p-button--positive js-invoke-modal" href="/openstack/managed">Contact us</a>
       </p>
     </div>
     <div class="col-6 u-vertically-center">

--- a/templates/shared/_ubuntu_pro_on_public_cloud.html
+++ b/templates/shared/_ubuntu_pro_on_public_cloud.html
@@ -5,7 +5,8 @@
       <ul class="p-list">
         <li class="p-list__item is-ticked">10 years of package updates and security maintenance with Ubuntu Pro</li>
         <li class="p-list__item is-ticked">Kernel <a href="/livepatch">Livepatch</a>, which allows for continuous security patching and higher uptime and availability by allowing kernel security updates to be applied without a reboot</li>
-        <li class="p-list__item is-ticked">Customised FIPS and Common Criteria EAL-compliant components for use in environments under compliance regimes such as FedRAMP, PCI, HIPAA and ISO</li>
+        <li class="p-list__item is-ticked">Rigorous compliance profiles such as CIS benchmarks and DISA-STIG to enable high security and regulated environments</li>
+        <li class="p-list__item is-ticked">FIPS 140 certified components for use in environments under compliance regimes such as FedRAMP, PCI, HIPAA and ISO</li>
         <li class="p-list__item is-ticked">Patch coverage for Ubuntu's infrastructure and application repositories, spanning hundreds of open source workloads including Apache Kafka, MongoDB, Node.js, RabbitMQ, Redis and more</li>
       </ul>
       <div class="row">


### PR DESCRIPTION
## Done

- Updated as per [copy doc](https://docs.google.com/document/d/1ZzUIh9Tfz5SvkrHyo4-izzmUjRka1Tn0UQisKcXGEPA/edit#)


## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/cloud/public-cloud
    - Be sure to test on mobile, tablet and desktop screen sizes
- Check against doc to see all changes have been made
- Test button on last section

## Issue / Card

Fixes https://github.com/canonical-web-and-design/web-squad/issues/5040
