### PR TITLE
Remove contact us and newsletter from Ukraine blog

### DIFF
--- a/templates/blog/article.html
+++ b/templates/blog/article.html
@@ -110,14 +110,14 @@
           {{ article.content.rendered|safe }}
         </div>
       </div>
-
-      <div class="col-4">
-        {% include 'blog/product-cards.html' %}
-
-        <div>
-          {% include 'blog/newsletter-form.html' %}
+      {% if article.slug != 'canonical-standing-with-ukraine' %}
+        <div class="col-4">
+            {% include 'blog/product-cards.html' %}
+          <div>
+            {% include 'blog/newsletter-form.html' %}
+          </div>
         </div>
-      </div>
+      {% endif %}
     </div>
   </section>
 </article>


### PR DESCRIPTION
## Done

- Remove contextual Marketing elements from Ukraine blog post 
- 
## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- Ensure https://ubuntu-com-11456.demos.haus/blog/canonical-standing-with-ukraine contains no contact us CTA or newsletter form.
- Ensure they are still present on other blog posts.
