### PR TITLE
Fix /invoices page

### DIFF
--- a/webapp/shop/api/ua_contracts/models.py
+++ b/webapp/shop/api/ua_contracts/models.py
@@ -175,8 +175,8 @@ class Purchase:
         id: str,
         marketplace: str,
         status: str,
-        subscription_id: str,
         items: List[PurchaseItem],
+        subscription_id: str = None,
         invoice: Invoice = None,
     ):
         self.account_id = account_id

--- a/webapp/shop/api/ua_contracts/schema.py
+++ b/webapp/shop/api/ua_contracts/schema.py
@@ -53,7 +53,7 @@ class PurchaseSchema(BaseSchema):
     id = String(required=True)
     createdAt = String(required=True, attribute="created_at")
     status = String(required=True)
-    subscriptionID = String(required=True, attribute="subscription_id")
+    subscriptionID = String(attribute="subscription_id")
     invoice = Nested(InvoiceSchema)
     purchaseItems = List(
         Nested(PurchaseItemSchema), required=True, attribute="items"


### PR DESCRIPTION
## Done

- Make subscription_id optional for purchases payload.

## QA

- Can Will visit /account/invoices? 
- For some reason he has purchases without subscription info.

## Issue / Card

Fixes #https://github.com/canonical-web-and-design/commercial-squad/issues/551