### PR TITLE
Remove and redirect canonical annoucement blogs

### DIFF
--- a/redirects.yaml
+++ b/redirects.yaml
@@ -859,7 +859,8 @@ blog/category/(?P<category>[^/]+)/?: /blog/archives?category={category}
 blog/category/(?P<category>[^/]+)/year/(?P<year>[0-9]{4})/?: /blog/archives?category={category}&year={year}
 
 # Group archive pages
-blog/canonical-announcements/?: /blog/press-centre
+blog/canonical-announcements/?: https://canonical.com/press-centre
+blog/press-centre/?: https://canonical.com/press-centre
 blog/people-and-culture/?: /blog/archives?group=people-and-culture
 blog/phone-and-tablet/?: /blog/archives?group=phone-and-tablet
 blog/page/(?P<page>[0-9]+)/(?P<group>[^/]+)/?: /blog/archives?group={group}&page={page}
@@ -886,7 +887,7 @@ resources/?: "/blog"
 # Redirects from the soon-to-be-retired Apache+Squid frontend
 # From https://pastebin.canonical.com/p/3TXyyNkWkg/
 search/google-appliance/(?P<query>.*)/?: /search?q={query}
-news/pressreleasearchive/?: /blog/press-centre
+news/pressreleasearchive/?: https://canonical.com/press-centre
 legal/ubuntu-advantage/service-description/?: /legal/ubuntu-advantage-service-description
 download/desktop/questions/?: /download/desktop/thank-you
 

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -67,9 +67,6 @@ class TestRoutes(VCRTestCase):
             self.client.get("/blog/topics/design").status_code, 200
         )
         self.assertEqual(
-            self.client.get("/blog/press-centre").status_code, 200
-        )
-        self.assertEqual(
             self.client.get("/blog/internet-of-things").status_code, 200
         )
         self.assertEqual(

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -54,7 +54,7 @@ from webapp.shop.cube.views import (
 from webapp.views import (
     BlogCustomGroup,
     BlogCustomTopic,
-    BlogPressCentre,
+    BlogRedirects,
     BlogSitemapIndex,
     BlogSitemapPage,
     build_tutorials_index,
@@ -535,16 +535,16 @@ app.add_url_rule(
     view_func=BlogCustomGroup.as_view("blog_group", blog_views=blog_views),
 )
 app.add_url_rule(
-    "/blog/press-centre",
-    view_func=BlogPressCentre.as_view("press_centre", blog_views=blog_views),
-)
-app.add_url_rule(
     "/blog/sitemap.xml",
     view_func=BlogSitemapIndex.as_view("sitemap", blog_views=blog_views),
 )
 app.add_url_rule(
     "/blog/sitemap/<regex('.+'):slug>.xml",
     view_func=BlogSitemapPage.as_view("sitemap_page", blog_views=blog_views),
+)
+app.add_url_rule(
+    "/blog/<slug>",
+    view_func=BlogRedirects.as_view("blog_redirects", blog_views=blog_views),
 )
 app.register_blueprint(build_blueprint(blog_views), url_prefix="/blog")
 

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -616,6 +616,19 @@ class BlogView(flask.views.View):
         self.blog_views = blog_views
 
 
+class BlogRedirects(BlogView):
+    def dispatch_request(self, slug):
+        article = self.blog_views.api.get_article(
+            slug, self.blog_views.tag_ids, self.blog_views.excluded_tags
+        )
+
+        # Redirect canonical annoucements
+        if article["group"]["id"] == 2100:
+            return flask.redirect(f"https://canonical.com/blog/{slug}")
+
+        return flask.render_template("blog/article.html", article=article)
+
+
 class BlogCustomTopic(BlogView):
     def dispatch_request(self, slug):
         page_param = flask.request.args.get("page", default=1, type=int)
@@ -633,19 +646,6 @@ class BlogCustomGroup(BlogView):
         context = self.blog_views.get_group(slug, page_param, category_param)
 
         return flask.render_template(f"blog/{slug}.html", **context)
-
-
-class BlogPressCentre(BlogView):
-    def dispatch_request(self):
-        page_param = flask.request.args.get("page", default=1, type=int)
-        category_param = flask.request.args.get(
-            "category", default="", type=str
-        )
-        context = self.blog_views.get_group(
-            "canonical-announcements", page_param, category_param
-        )
-
-        return flask.render_template("blog/press-centre.html", **context)
 
 
 class BlogSitemapIndex(BlogView):


### PR DESCRIPTION
## Done

Remove and redirect canonical annoucement blogs

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- Check that https://ubuntu-com-11459.demos.haus/blog/press-centre redirects to https://canonical.com/press-centre
- Check that the rest of https://ubuntu-com-11459.demos.haus/blog works
- Anything else that you may think of that can break blog

    - Be sure to test on mobile, tablet and desktop screen sizes

## Issue / Card

Fixes https://github.com/canonical-web-and-design/web-squad/issues/5052

## Help

[QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html) - [Commit guidelines](https://canonical-web-and-design.github.io/practices/workflow/commit-messages.html)
