### PR TITLE
fix exception on hardware details page

### DIFF
--- a/templates/certified/hardware-details.html
+++ b/templates/certified/hardware-details.html
@@ -82,6 +82,8 @@
               </td>
             </tr>
             {% endif %}
+          {% else %}
+            There are no hardware details available for this machine.
           {% endfor %}
         </tbody>
       </table>

--- a/webapp/certified/views.py
+++ b/webapp/certified/views.py
@@ -100,15 +100,11 @@ def certified_hardware_details(canonical_id, release):
 
         hardware_details[category].append(device_info)
 
-    # default to category, which contains the least specific form_factor
-    form_factor = release_details.get("form_factor", category)
-
     return render_template(
         "certified/hardware-details.html",
         canonical_id=canonical_id,
         model_name=models["model"],
         form=models["category"],
-        form_factor=form_factor,
         vendor=models["make"],
         major_release=models["major_release"],
         hardware_details=hardware_details,


### PR DESCRIPTION


On certificates with no hardware details the hardware
details through an exception due to an attempt to
use a variable that didn't get set.

## Done

On review, the variable wasn't actually needed.

- I removed it
- and also updated the hardware details page to show a message when no details are available.

## QA

- Check out this feature branch
- Edit webapp/certified/views.py to update the url to point to staging.
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/certified/201906-27103 and http://0.0.0.0:8001/certified/201906-27103/18.04%20LTS
    - Be sure to test on mobile, tablet and desktop screen sizes
- Verify that both pages load without any error and that they show no hardware details.

## Issue / Card

Fixes #11403

## Screenshots

Here are screenshots of the sections of the pages for people who cannot run dotrun.

![modeldetails](https://user-images.githubusercontent.com/529748/161976819-d4710f5a-f5db-4753-acdf-eae28a8fec52.png)

![hardwaredetails](https://user-images.githubusercontent.com/529748/161976728-624fbdb8-0969-4a0a-8791-bb0bf69a40ac.png)


## Help

[QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html) - [Commit guidelines](https://canonical-web-and-design.github.io/practices/workflow/commit-messages.html)
