### PR TITLE
Update cancellation modal

### DIFF
--- a/static/js/src/advantage/react/components/Subscriptions/SubscriptionCancel/SubscriptionCancelFields/SubscriptionCancelFields.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/SubscriptionCancel/SubscriptionCancelFields/SubscriptionCancelFields.tsx
@@ -33,7 +33,8 @@ const SubscriptionCancelFields = ({ setIsValid, isTrial }: Props) => {
           services at the end of the billing period.
         </li>
         <li>
-          Additional subscriptions purchased directly with Canonical will not be affected.
+          Additional subscriptions purchased directly with Canonical will not be
+          affected.
         </li>
       </ul>
       <p>

--- a/static/js/src/advantage/react/components/Subscriptions/SubscriptionCancel/SubscriptionCancelFields/SubscriptionCancelFields.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/SubscriptionCancel/SubscriptionCancelFields/SubscriptionCancelFields.tsx
@@ -32,6 +32,9 @@ const SubscriptionCancelFields = ({ setIsValid, isTrial }: Props) => {
           The <strong>10 machines</strong> will stop receiving updates and
           services at the end of the billing period.
         </li>
+        <li>
+          Additional subscriptions purchased directly with Canonical will not be affected.
+        </li>
       </ul>
       <p>
         Want help or advice? <a href="/contact-us">Chat with us</a>.


### PR DESCRIPTION
## Done

- Add _Additional subscriptions purchased directly with Canonical will not be affected._ line to the cancellation modal.

## QA

- Have a monthly subscription
- Open the cancel modal
- You will see the new line

## Issue / Card

Fixes #https://github.com/canonical-web-and-design/ubuntu.com/issues/9468