### PR TITLE
Update search with new arguments

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ canonicalwebteam.flask-base==1.0.5
 alembic==1.7.5
 canonicalwebteam.http==1.0.3
 canonicalwebteam.blog==6.4.0
-canonicalwebteam.search==1.1.0
+canonicalwebteam.search==1.2.0
 canonicalwebteam.templatefinder==1.0.0
 canonicalwebteam.image-template==1.3.1
 canonicalwebteam.discourse==4.0.8

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -724,6 +724,7 @@ app.add_url_rule(
         site="ubuntu.com/server/docs",
         template_path="/server/docs/search-results.html",
         search_engine_id=search_engine_id,
+        site_restricted_search=True,
     ),
 )
 
@@ -748,7 +749,8 @@ tutorials_docs = Tutorials(
     blueprint_name="tutorials",
 )
 app.add_url_rule(
-    tutorials_path, view_func=build_tutorials_index(session, tutorials_docs)
+    tutorials_path,
+    view_func=build_tutorials_index(session, tutorials_docs),
 )
 tutorials_docs.init_app(app)
 
@@ -776,6 +778,7 @@ app.add_url_rule(
         site="ubuntu.com/ceph/docs",
         template_path="ceph/docs/search-results.html",
         search_engine_id=search_engine_id,
+        site_restricted_search=True,
     ),
 )
 
@@ -797,6 +800,7 @@ app.add_url_rule(
         site="ubuntu.com/core/docs",
         template_path="/core/docs/search-results.html",
         search_engine_id=search_engine_id,
+        site_restricted_search=True,
     ),
 )
 core_docs.init_app(app)
@@ -922,6 +926,7 @@ app.add_url_rule(
         site="ubuntu.com/openstack/docs",
         template_path="openstack/docs/search-results.html",
         search_engine_id=search_engine_id,
+        site_restricted_search=True,
     ),
 )
 
@@ -948,6 +953,7 @@ app.add_url_rule(
         site="ubuntu.com/security/livepatch/docs",
         template_path="/security/livepatch/docs/search-results.html",
         search_engine_id=search_engine_id,
+        site_restricted_search=True,
     ),
 )
 
@@ -974,6 +980,7 @@ app.add_url_rule(
         site="ubuntu.com/security/certifications/docs",
         template_path="/security/certifications/docs/search-results.html",
         search_engine_id=search_engine_id,
+        site_restricted_search=True,
     ),
 )
 

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -306,6 +306,7 @@ def build_tutorials_index(session, tutorials_docs):
                 search_engine_id=search_engine_id,
                 siteSearch="ubuntu.com/tutorials",
                 query=query,
+                site_restricted_search=True,
             )
 
         tutorials_docs.parser.parse()


### PR DESCRIPTION
## Done

A replacement for the [renovate PR](https://github.com/canonical-web-and-design/ubuntu.com/pull/11667) as it needs some code updating

## QA

Search keyword on https://ubuntu-com-11471.demos.haus/server/docs e.g. "Ubuntu" it should return results
Another example search "packer" with the global search https://ubuntu-com-11471.demos.haus/search?q=packer

Same steps for https://ubuntu-com-11471.demos.haus/tutorials

Same steps for the global search

Same steps for the other doc searches such https://ubuntu-com-11471.demos.haus/core/docs. All the others should work if these work.

## Help

[QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html) - [Commit guidelines](https://canonical-web-and-design.github.io/practices/workflow/commit-messages.html)
