### PR TITLE
Add roles explaining table

### DIFF
--- a/static/js/src/advantage/users/AccountUsers.tsx
+++ b/static/js/src/advantage/users/AccountUsers.tsx
@@ -3,6 +3,7 @@ import { useQueryClient, useMutation } from "react-query";
 import * as Sentry from "@sentry/react";
 import { User, AccountUsersData, NewUserValues, UserRole } from "./types";
 import Organisation from "./components/Organisation";
+import ExplainingTable from "./components/ExplainingTable";
 import AddNewUser from "./components/AddNewUser/AddNewUser";
 import TableView from "./components/TableView/TableView";
 import DeleteConfirmationModal from "./components/DeleteConfirmationModal/DeleteConfirmationModal";
@@ -207,6 +208,9 @@ const AccountUsers = ({
             />
           </div>
         </div>
+      </section>
+      <section>
+        <ExplainingTable />
       </section>
     </div>
   );

--- a/static/js/src/advantage/users/components/ExplainingTable.tsx
+++ b/static/js/src/advantage/users/components/ExplainingTable.tsx
@@ -1,0 +1,124 @@
+import React from "react";
+import { MainTable, Icon, ICONS } from "@canonical/react-components";
+
+const ExplainingTable = () => (
+  <>
+    <h2 className="p-heading--3">Roles descriptions</h2>
+    <MainTable
+      headers={[
+        {
+          content: null,
+        },
+        {
+          content: "Manage users",
+          className: "u-align--center",
+        },
+        {
+          content: "Access tokens",
+          className: "u-align--center",
+        },
+        {
+          content: "Buy subscriptions",
+          className: "u-align--center",
+        },
+        {
+          content: "Payment & Invoices",
+          className: "u-align--center",
+        },
+        {
+          content: "Support Portal seat",
+          className: "u-align--center",
+        },
+      ]}
+      rows={[
+        {
+          columns: [
+            {
+              content: "Admin",
+              role: "rowheader",
+            },
+            {
+              content: <Icon name={ICONS.success} />,
+              className: "u-align--center",
+            },
+            {
+              content: <Icon name={ICONS.success} />,
+              className: "u-align--center",
+            },
+            {
+              content: <Icon name={ICONS.success} />,
+              className: "u-align--center",
+            },
+            {
+              content: <Icon name={ICONS.success} />,
+              className: "u-align--center",
+            },
+            {
+              content: <Icon name={ICONS.success} />,
+              className: "u-align--center",
+            },
+          ],
+        },
+        {
+          columns: [
+            {
+              content: "Technical",
+              role: "rowheader",
+            },
+            {
+              content: <Icon name={ICONS.error} />,
+              className: "u-align--center",
+            },
+            {
+              content: <Icon name={ICONS.success} />,
+              className: "u-align--center",
+            },
+            {
+              content: <Icon name={ICONS.error} />,
+              className: "u-align--center",
+            },
+            {
+              content: <Icon name={ICONS.error} />,
+              className: "u-align--center",
+            },
+            {
+              content: <Icon name={ICONS.success} />,
+              className: "u-align--center",
+            },
+          ],
+        },
+        {
+          columns: [
+            {
+              content: "Billing",
+              role: "rowheader",
+            },
+            {
+              content: <Icon name={ICONS.error} />,
+              className: "u-align--center",
+            },
+            {
+              content: <Icon name={ICONS.error} />,
+              className: "u-align--center",
+            },
+            {
+              content: <Icon name={ICONS.error} />,
+              className: "u-align--center",
+            },
+            {
+              content: <Icon name={ICONS.success} />,
+              className: "u-align--center",
+            },
+            {
+              content: <Icon name={ICONS.error} />,
+              className: "u-align--center",
+            },
+          ],
+        },
+      ]}
+      responsive
+    />
+  </>
+);
+
+export default ExplainingTable;

--- a/static/js/src/advantage/users/components/ExplainingTable.tsx
+++ b/static/js/src/advantage/users/components/ExplainingTable.tsx
@@ -3,7 +3,7 @@ import { MainTable, Icon, ICONS } from "@canonical/react-components";
 
 const ExplainingTable = () => (
   <>
-    <h2 className="p-heading--3">Roles descriptions</h2>
+    <h2 className="p-heading--3">Role permissions</h2>
     <MainTable
       headers={[
         {


### PR DESCRIPTION
## Done

- Add a table explaining user roles

## QA

- Go to https://ubuntu-com-11476.demos.haus/advantage?test_backend=true
- Log in
- navigate to https://ubuntu-com-11476.demos.haus/advantage/users?test_backend=true
- check that there is a table explaining user roles at the bottom and that the info is correct

## Issue / Card

Fixes https://github.com/canonical-web-and-design/commercial-squad/issues/557

## Screenshots

![image](https://user-images.githubusercontent.com/11927929/162987034-1795b2ec-de77-4f69-91fc-f462295ed7c2.png)


--------------------------------------------------
--------------------------------------------------


![image](https://user-images.githubusercontent.com/11927929/162987168-c17dbf59-4af2-4e9b-b745-09baf7195d8f.png)

