### PR TITLE
Set codecov reports to informational

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -13,12 +13,22 @@ coverage:
   status:
     project:
       javascript:
+        # set to non-blocking until we fix codecov reports https://github.com/canonical-web-and-design/ubuntu.com/issues/11479
+        informational: true
         target: auto
-        threshold: 0%
+        # this allows a 1% drop in code coverage
+        threshold: 1%
         flags:
           - javascript
       python:
+        # set to non-blocking until we fix codecov reports https://github.com/canonical-web-and-design/ubuntu.com/issues/11479
+        informational: true
         target: auto
-        threshold: 0%
+        # this allows a 1% drop in code coverage
+        threshold: 1%
         flags:
           - python
+    patch:
+      default:
+        # set to non-blocking until we fix codecov reports https://github.com/canonical-web-and-design/ubuntu.com/issues/11479
+        informational: true


### PR DESCRIPTION
## Done

- set codecov reports to `informational`[^1] and increase the threshold that triggers failures[^2]
  - temporary workaround until we figure out why codecov reports incorrect code coverage diff https://github.com/canonical-web-and-design/ubuntu.com/issues/11479

[^1]: https://docs.codecov.com/docs/common-recipe-list#set-non-blocking-status-checks
[^2]: https://docs.codecov.com/docs/common-recipe-list#ease-target-coverage

