### PR TITLE
ua service description: fix wrong Japanese translation

### DIFF
--- a/templates/shared/_ubuntu-advantage-service-description-ja.html
+++ b/templates/shared/_ubuntu-advantage-service-description-ja.html
@@ -29,7 +29,7 @@
             <td class="u-align--center">{{ image(url="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg", alt="Yes", width="16", height="16", hi_def=True, loading="lazy",) | safe }}</td>
           </tr>
           <tr>
-            <td><a href="/esm">拡張済みセキュリティメンテナンス (ESM)</a></td>
+            <td><a href="/esm">拡張セキュリティメンテナンス (ESM)</a></td>
             <td class="u-align--center">{{ image(url="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg", alt="Yes", width="16", height="16", hi_def=True, loading="lazy",) | safe }}</td>
             <td class="u-align--center">{{ image(url="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg", alt="Yes", width="16", height="16", hi_def=True, loading="lazy",) | safe }}</td>
             <td class="u-align--center">{{ image(url="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg", alt="Yes", width="16", height="16", hi_def=True, loading="lazy",) | safe }}</td>


### PR DESCRIPTION
On this page, ESM is translated as "拡張セキュリティメンテナンス", not
"拡張済みセキュリティメンテナンス", so we have algined it with that.

## Done

The UA service description page in Japanese has wrong Japanese translation.

- https://ubuntu.com/legal/ubuntu-advantage-service-description/ja
- Correct: 拡張セキュリティメンテナンス（ESM）
- Wrong: 拡張済みセキュリティメンテナンス (ESM)

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/

## Issue / Card

Fixes #11483
