### PR TITLE
add new "jammy" takeover class for pre release

### DIFF
--- a/static/sass/_pattern_takeovers.scss
+++ b/static/sass/_pattern_takeovers.scss
@@ -88,6 +88,67 @@
     color: $color-x-light;
   }
 
+  @include p-takeovers("jammy") {
+    background-color: #772953;
+    background-image: linear-gradient(
+        to bottom left,
+        rgba(119, 41, 83, 0.16) 0,
+        rgba(119, 41, 83, 0.16) 49.9%,
+        transparent 50%
+      ),
+      linear-gradient(
+        to bottom right,
+        rgba(228, 228, 228, 0.5) 0,
+        rgba(228, 228, 228, 0.5) 49.9%,
+        transparent 50%
+      ),
+      linear-gradient(
+        to top left,
+        rgba(255, 255, 255, 1) 0%,
+        rgba(255, 255, 255, 1) 49.3%,
+        rgba(255, 255, 255, 0) 50%,
+        rgba(255, 255, 255, 0) 100%
+      ),
+      linear-gradient(-89deg, #e95420 0%, #772953 42%, #2c001e 94%);
+    @supports not (background-blend-mode: multiply) {
+      background-image: linear-gradient(
+          to bottom left,
+          rgba(119, 41, 83, 0.16) 0,
+          rgba(119, 41, 83, 0.16) 49.9%,
+          transparent 50%
+        ),
+        linear-gradient(
+          to bottom right,
+          rgba(228, 228, 228, 0.1) 0,
+          rgba(228, 228, 228, 0.1) 49.9%,
+          transparent 50%
+        ),
+        linear-gradient(
+          to top left,
+          rgba(255, 255, 255, 1) 0%,
+          rgba(255, 255, 255, 1) 49.3%,
+          rgba(255, 255, 255, 0) 50%,
+          rgba(255, 255, 255, 0) 100%
+        ),
+        linear-gradient(-89deg, #e95420 0%, #772953 42%, #2c001e 94%);
+    }
+
+    color: $color-x-light;
+
+    &::before {
+      @media (min-width: $breakpoint-medium) {
+        background-image: url("https://assets.ubuntu.com/v1/d7c0ef52-JJ_Takeover_Pre.svg");
+        background-position: top right 10%;
+        background-repeat: no-repeat;
+        background-size: 40%;
+        content: "";
+        height: 100%;
+        position: absolute;
+        width: 100%;
+      }
+    }
+  }
+
   @include p-takeovers("k8s") {
     background-color: #326de6;
     background-image: linear-gradient(

--- a/templates/takeovers/shared/_takeover.html
+++ b/templates/takeovers/shared/_takeover.html
@@ -8,6 +8,9 @@
       {% if subtitle %}<h4 class="{% if subtitleClass %}{{ subtitleClass }}{% else %}{% endif %}">
         {{ subtitle }}
       </h4>{% endif %}
+      {% if class == "jammy" %}
+        <button class="p-button--positive" disabled>Coming April 21</button>
+      {% endclass %}
       {% if ctaBtn or ctaLink %}
       <ul class="p-inline-list u-hide--small">
           {% if ctaBtn %}


### PR DESCRIPTION
## Done

- Added a new takeover class for a 22.04 pre-release special

## QA

- The takeover won't exist until this is merged so you'll need to inspect the page and do the following to replicate the screenshot
  - Visit the [demo](https://ubuntu-com-11486.demos.haus/)
  - Open dev tools
  - Change the class of the takeover to `p-takeover--jammy`
  - You could also hide the image, change the text to match what's in the screenshot and replace the CTA with:
```
<button class="p-button--positive" disabled>Coming April 21</button>
```
(The button will appear automatically when the takeover is created and has its `class` metadata set to `jammy`)

## Issue / Card

Fixes https://github.com/canonical-web-and-design/web-squad/issues/5106

## Screenshots

![Screenshot from 2022-04-19 08-58-18](https://user-images.githubusercontent.com/2376968/163954429-aa9e8821-6556-4353-acc9-aca43a9dfcd7.png)

