### PR TITLE
make sure takeover text appears if image is not present

### DIFF
--- a/templates/base_index.html
+++ b/templates/base_index.html
@@ -1472,6 +1472,11 @@
         takeoverAnimation.className +=  " is-loaded";
       }
     }
+
+    if (image.getAttribute("src") === "") {
+      takeoverAnimation.className = takeoverAnimation.className.replace(" is-loading", "");
+      takeoverAnimation.className +=  " is-loaded";
+    }
     
     image.removeAttribute("style");
     image.width = selectedTakeover.image_width;

--- a/templates/takeovers/shared/_takeover.html
+++ b/templates/takeovers/shared/_takeover.html
@@ -8,9 +8,6 @@
       {% if subtitle %}<h4 class="{% if subtitleClass %}{{ subtitleClass }}{% else %}{% endif %}">
         {{ subtitle }}
       </h4>{% endif %}
-      {% if class == "jammy" %}
-        <button class="p-button--positive" disabled>Coming April 21</button>
-      {% endclass %}
       {% if ctaBtn or ctaLink %}
       <ul class="p-inline-list u-hide--small">
           {% if ctaBtn %}


### PR DESCRIPTION
## Done

- Fixed an issue where the takeover text wouldn't become visible if an image isn't present

## QA

- Visit the [demo](https://ubuntu-com-11488.demos.haus/)
- Refresh the page until you see the Jammy Jellyfish takeover
- See that the text is visible
