### PR TITLE
Fix incorrect codecov reports for pull requests

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -147,6 +147,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0 # fetch all history for codecov
 
       - name: Install requirements
         run: |
@@ -178,6 +180,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0 # fetch all history for codecov
 
       - name: Install dependencies
         run: yarn install --immutable

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -169,7 +169,7 @@ jobs:
         run: /snap/bin/dotrun --env SEARCH_API_KEY=fake-key exec coverage run --source=. -m unittest discover tests
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v2
+        uses: codecov/codecov-action@v3
         with:
           flags: python
 
@@ -187,7 +187,7 @@ jobs:
           yarn test-js --coverage
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v2
+        uses: codecov/codecov-action@v3
         with:
           flags: javascript
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,13 +1,14 @@
 codecov:
-  require_ci_to_pass: yes
+  require_ci_to_pass: True
   branch: main
+  allow_coverage_offsets: True
 
 comment:
   layout: "diff, files"
   behavior: default
-  require_changes: no
-  require_base: no
-  require_head: yes
+  require_changes: False
+  require_base: True
+  require_head: True
 
 coverage:
   status:

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,14 +1,14 @@
 codecov:
-  require_ci_to_pass: True
+  require_ci_to_pass: true
   branch: main
-  allow_coverage_offsets: True
+  allow_coverage_offsets: true
 
 comment:
   layout: "diff, files"
   behavior: default
-  require_changes: False
-  require_base: True
-  require_head: True
+  require_changes: false
+  require_base: true
+  require_head: true
 
 coverage:
   status:


### PR DESCRIPTION
## Done

- Fix incorrect codecov reports for pull requests (will need to be verified once this pull request gets merged, added a task to the related issue)
  - bump codecov/codecov-action to v3
  - set [require_base](https://docs.codecov.com/docs/pull-request-comments#requiring-the-base-andor-head-commit) to true
  - set [allow_coverage_offsets](https://docs.codecov.com/docs/comparing-commits#pseudo-comparison) to true 
  - set actions/checkout@v2 `fetch-depth` to `0` to fetch all history for codecov

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- [List additional steps to QA the new features or prove the bug has been resolved]

## Issue / Card

Fixes #11479 (will need to be verified after this gets merged).

## Screenshots

[If relevant, please include a screenshot.]


## Help

[QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html) - [Commit guidelines](https://canonical-web-and-design.github.io/practices/workflow/commit-messages.html)
