### PR TITLE
Make takeover ctas that don't have href unclickable

### DIFF
--- a/templates/base_index.html
+++ b/templates/base_index.html
@@ -1483,11 +1483,24 @@
     image.height = selectedTakeover.image_height;
     primaryUrl.href = selectedTakeover.primary_url;
     primaryUrl.textContent = selectedTakeover.primary_cta;
+
     if (selectedTakeover.secondary_url && selectedTakeover.secondary_url !== "") {
       secondaryUrl.href = selectedTakeover.secondary_url;
       secondaryUrl.innerHTML = selectedTakeover.secondary_cta + "&nbsp;&rsaquo;";
     } else {
       secondaryUrl.remove();
+    }
+
+    // Make cta unclickable if there is no link
+    // This doesn't work with href property, as it always returns at least the homepage
+    if (!selectedTakeover.primary_url) {
+      primaryUrl.style.cursor = "default";
+      primaryUrl.style.pointerEvents = "none";
+    }
+
+    if (!selectedTakeover.secondary_url) {
+      secondaryUrl.style.cursor = "default";
+      secondaryUrl.style.pointerEvents = "none";
     }
     
     dataLayer.push({


### PR DESCRIPTION
## Done

Takeover ctas will not be clickable if `href` is empty.
This cannot be achieved with CSS, since all the content is rendered using JS, that's why the styles in JS will override dynamically.

## QA

- Go to https://ubuntu-com-11495.demos.haus/ and make sure all cta links are working as usual
- Refresh a bunch of times until the Jammy Jellifish takeover and check that if it doesn't have a href, it will not be clickable.

## Issue / Card

Fixes 

## Help

[QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html) - [Commit guidelines](https://canonical-web-and-design.github.io/practices/workflow/commit-messages.html)
