### PR TITLE
Fix bug where takeovers would show an empty anchor element if not CTA data was present

### DIFF
--- a/templates/base_index.html
+++ b/templates/base_index.html
@@ -1481,8 +1481,14 @@
     image.removeAttribute("style");
     image.width = selectedTakeover.image_width;
     image.height = selectedTakeover.image_height;
-    primaryUrl.href = selectedTakeover.primary_url;
-    primaryUrl.textContent = selectedTakeover.primary_cta;
+
+    if (selectedTakeover.primary_url && selectedTakeover.primary_cta) {
+      primaryUrl.href = selectedTakeover.primary_url;
+      primaryUrl.textContent = selectedTakeover.primary_cta;
+    } else {
+      primaryUrl.remove();
+    }
+
     if (selectedTakeover.secondary_url && selectedTakeover.secondary_url !== "") {
       secondaryUrl.href = selectedTakeover.secondary_url;
       secondaryUrl.innerHTML = selectedTakeover.secondary_cta + "&nbsp;&rsaquo;";


### PR DESCRIPTION
## Done

Prevented an empty link appearing when a takeover doesn't have a primary CTA:

![Screenshot from 2022-04-19 17-26-12](https://user-images.githubusercontent.com/2376968/164050948-df17cef4-6367-4667-9e1a-d30d5ce0c68a.png)

## QA

- Visit the [demo](https://ubuntu-com-11496.demos.haus/)
- Refresh the page until you see the Jammy takeover
- See that the empty green `a` element is not there
