### PR TITLE
Improve TAX message

### DIFF
--- a/static/sass/_pattern_shop-cart.scss
+++ b/static/sass/_pattern_shop-cart.scss
@@ -57,6 +57,11 @@
       }
       @media (min-width: $breakpoint-medium) {
         margin-top: 0;
+        flex-wrap: wrap;
+
+        > button {
+          margin-right: 0;
+        }
       }
 
       > span {

--- a/static/sass/_pattern_shop-cart.scss
+++ b/static/sass/_pattern_shop-cart.scss
@@ -56,8 +56,8 @@
         flex-direction: row;
       }
       @media (min-width: $breakpoint-medium) {
-        margin-top: 0;
         flex-wrap: wrap;
+        margin-top: 0;
 
         > button {
           margin-right: 0;

--- a/templates/advantage/subscribe/index.html
+++ b/templates/advantage/subscribe/index.html
@@ -106,6 +106,9 @@
         >
           Buy now
         </button>
+        <p class="p-text--small">
+          Any applicable taxes are calculated before payment
+        </p>
       </div>
       <div class="col-8 col-start-large-4 js-trial-unavailable">
         <p>Free Trial is not available for this account. <a href="/contact-us">Contact us</a> for further information.</p>


### PR DESCRIPTION
Fixes canonical-web-and-design/commercial-squad#455

## Done

- Added small copy explaining that taxes will be calculated

## QA

- Go to [/advantage/subscribe](https://ubuntu-com-11498.demos.haus/advantage/subscribe)
- check that there is a text underneath the button explaining that taxes will be calculated


## Screenshots

![image](https://user-images.githubusercontent.com/11927929/164190071-c309330d-e0bd-4a17-bf2e-f42995c4fcce.png)
