### PR TITLE
Update Canonical Kubernetes release cycle chart

### DIFF
--- a/static/js/src/chart-data.js
+++ b/static/js/src/chart-data.js
@@ -1232,61 +1232,61 @@ export var kubernetesReleases = [
     startDate: new Date("2019-03-01T00:00:00"),
     endDate: new Date("2019-12-01T00:00:00"),
     taskName: "Kubernetes 1.14",
-    status: "CHARMED_KUBERNETES_EXPIRED_SUPPORT",
+    status: "CANONICAL_KUBERNETES_EXPIRED_SUPPORT",
   },
   {
     startDate: new Date("2019-06-14T00:00:00"),
     endDate: new Date("2020-03-02T00:00:00"),
     taskName: "Kubernetes 1.15",
-    status: "CHARMED_KUBERNETES_EXPIRED_SUPPORT",
+    status: "CANONICAL_KUBERNETES_EXPIRED_SUPPORT",
   },
   {
     startDate: new Date("2019-10-22T00:00:00"),
     endDate: new Date("2020-07-22T00:00:00"),
     taskName: "Kubernetes 1.16",
-    status: "CHARMED_KUBERNETES_EXPIRED_SUPPORT",
+    status: "CANONICAL_KUBERNETES_EXPIRED_SUPPORT",
   },
   {
     startDate: new Date("2020-01-07T00:00:00"),
     endDate: new Date("2020-12-07T00:00:00"),
     taskName: "Kubernetes 1.17",
-    status: "CHARMED_KUBERNETES_EXPIRED_SUPPORT",
+    status: "CANONICAL_KUBERNETES_EXPIRED_SUPPORT",
   },
   {
     startDate: new Date("2020-03-24T00:00:00"),
     endDate: new Date("2021-04-08T00:00:00"),
     taskName: "Kubernetes 1.18",
-    status: "CHARMED_KUBERNETES_EXPIRED_SUPPORT",
+    status: "CANONICAL_KUBERNETES_EXPIRED_SUPPORT",
   },
   {
     startDate: new Date("2020-08-16T00:00:00"),
     endDate: new Date("2021-08-16T00:00:00"),
     taskName: "Kubernetes 1.19",
-    status: "CHARMED_KUBERNETES_EXPIRED_SUPPORT",
+    status: "CANONICAL_KUBERNETES_EXTENDED_SECURITY_MAINTENANCE",
   },
   {
     startDate: new Date("2020-12-08T00:00:00"),
     endDate: new Date("2021-12-08T00:00:00"),
     taskName: "Kubernetes 1.20",
-    status: "CHARMED_KUBERNETES_EXPIRED_SUPPORT",
+    status: "CANONICAL_KUBERNETES_EXTENDED_SECURITY_MAINTENANCE",
   },
   {
     startDate: new Date("2021-04-08T00:00:00"),
     endDate: new Date("2022-04-08T00:00:00"),
     taskName: "Kubernetes 1.21",
-    status: "CHARMED_KUBERNETES_SUPPORT",
+    status: "CANONICAL_KUBERNETES_SUPPORT",
   },
   {
     startDate: new Date("2021-08-01T00:00:00"),
     endDate: new Date("2022-08-01T00:00:00"),
     taskName: "Kubernetes 1.22",
-    status: "CHARMED_KUBERNETES_SUPPORT",
+    status: "CANONICAL_KUBERNETES_SUPPORT",
   },
   {
     startDate: new Date("2021-12-07T00:00:00"),
     endDate: new Date("2022-12-07T00:00:00"),
     taskName: "Kubernetes 1.23",
-    status: "CHARMED_KUBERNETES_SUPPORT",
+    status: "CANONICAL_KUBERNETES_CURRENT_VERSION",
   },
 ];
 
@@ -1328,8 +1328,10 @@ export var openStackStatus = {
 };
 
 export var kubernetesStatus = {
-  CHARMED_KUBERNETES_SUPPORT: "chart__bar--orange",
-  CHARMED_KUBERNETES_EXPIRED_SUPPORT: "chart__bar--grey",
+  CANONICAL_KUBERNETES_CURRENT_VERSION: "chart__bar--green",
+  CANONICAL_KUBERNETES_SUPPORT: "chart__bar--orange",
+  CANONICAL_KUBERNETES_EXTENDED_SECURITY_MAINTENANCE: "chart__bar--aubergine",
+  CANONICAL_KUBERNETES_EXPIRED_SUPPORT: "chart__bar--grey",
 };
 
 export var smallReleaseNames = [

--- a/templates/about/release-cycle.html
+++ b/templates/about/release-cycle.html
@@ -42,7 +42,7 @@
             <a href="#openstack-release-cycle" class="p-tabs__link" id="openstack-release-cycle-tab" role="tab" aria-controls="openstack-release-cycle">OpenStack</a>
           </li>
           <li class="p-tabs__item" role="presentation">
-            <a href="#kubernetes-release-cycle" class="p-tabs__link" id="kubernetes-release-cycle-tab" role="tab" aria-controls="kubernetes-release-cycle">Kubernetes</a>
+            <a href="#canonical-kubernetes-release-cycle" class="p-tabs__link" id="canonical-kubernetes-release-cycle-tab" role="tab" aria-controls="kubernetes-release-cycle">Kubernetes</a>
           </li>
         </ul>
       </nav>
@@ -564,7 +564,7 @@
   </div>
 </section>
 
-<section class="p-tabs__content" id="kubernetes-release-cycle" role="tabpanel" aria-labelledby="kubernetes-release-cycle-tab">
+<section class="p-tabs__content" id="canonical-kubernetes-release-cycle" role="tabpanel" aria-labelledby="canonical-kubernetes-release-cycle-tab">
   <div class="p-strip is-shallow">
     <div class="u-fixed-width">
       <h2>Canonical Kubernetes release cycle</h2>

--- a/templates/about/release-cycle.html
+++ b/templates/about/release-cycle.html
@@ -569,9 +569,9 @@
     <div class="u-fixed-width">
       <h2>Canonical Kubernetes release cycle</h2>
 
-      <p>The release cycles of Charmed Kubernetes and MicroK8s are tightly synchronised to the release of upstream Kubernetes<sup>&reg;</sup>. The current release and two prior releases are supported, giving an effective support period of twelve months, subject to changes in the upstream release cycle. Canonical also provides security maintenance for N-4 Kubernetes releases in the stable release channel.</p>
+      <p>The release cycles of Canonical Kubernetes and MicroK8s are tightly synchronised to the release of upstream Kubernetes<sup>&reg;</sup>. The current release and two prior releases are supported, giving an effective support period of twelve months, subject to changes in the upstream release cycle. Canonical also provides security maintenance for N-4 Kubernetes releases in the stable release channel.</p>
 
-      <p>The Charmed Kubernetes support lifecycle can be represented this way:</p>
+      <p>The Canonical Kubernetes support lifecycle can be represented this way:</p>
     </div>
 
     <div class="row">
@@ -647,7 +647,7 @@
     </div>
 
     <div class="u-fixed-width">
-      <p>For more information on previous and current releases, please see the <a href="/kubernetes/docs/release-notes">Charmed Kubernetes</a> release notes or the <a href="https://microk8s.io/docs/release-notes">MicroK8s release notes.</a></p>
+      <p>For more information on previous and current releases, please see the <a href="/kubernetes/docs/release-notes">Canonical Kubernetes</a> release notes or the <a href="https://microk8s.io/docs/release-notes">MicroK8s release notes.</a></p>
     </div>
   </div>
 </section>


### PR DESCRIPTION
## Done

- Updated chart data and legend
- Changed all instances of "Charmed Kubernetes" to "Canonical Kubernetes"
- Specific changes were discussed and approved on MM with Pdm, here is the original [copy doc](https://docs.google.com/document/d/1-l3B7AoyDoETaL80UhlfEWCVKmMWPdy3zoF5LpsGcYQ/edit)

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/about/release-cycle#kubernetes-release-cycle
    - Be sure to test on mobile, tablet and desktop screen sizes
- See that the chart has been updated matching the new screen shot
- See that all instances of "Charmed Kubernetes" have been changes to "Canonical Kubernetes"

## Issue / Card

Fixes https://github.com/canonical-web-and-design/web-squad/issues/5103
