### PR TITLE
Remove Honeywell logo

### DIFF
--- a/templates/core/index.html
+++ b/templates/core/index.html
@@ -148,17 +148,6 @@
         </div>
         <div class="p-logo-section__item">
           {{ image (
-          url="https://assets.ubuntu.com/v1/53de61ea-honeywell-logo.png",
-          alt="Honeywell",
-          width="156",
-          height="30",
-          hi_def=True,
-          loading="lazy"
-          ) | safe
-          }}
-        </div>
-        <div class="p-logo-section__item">
-          {{ image (
           url="https://assets.ubuntu.com/v1/156ddbf8-rexroth_logo.svg",
           alt="rexroth",
           width="131",


### PR DESCRIPTION
## Done

- Removed Honeywell logo as per PdM request

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/core
- Make sure the logo has been removed

## Issue / Card

Fixes # https://github.com/canonical-web-and-design/ubuntu.com/issues/11506

