### PR TITLE
Update copy on ua for infra table and related pages

### DIFF
--- a/templates/ceph/index.html
+++ b/templates/ceph/index.html
@@ -198,7 +198,7 @@
       <ul class="p-list">
         <li class="p-list__item is-ticked">Ceph support is included in Ubuntu Advantage for Infrastructure</li>
         <li class="p-list__item is-ticked">Simple and predictable pricing model</li>
-        <li class="p-list__item is-ticked">Up to 72 TB of raw storage included per node</li>
+        <li class="p-list__item is-ticked">Up to 192 TB of raw storage included per node</li>
         <li class="p-list__item is-ticked">Get access to the storage experts 24x7 or during business hours</li>
         <li class="p-list__item is-ticked">Alternatively, get extended security maintenance if all you need is peace of mind by consuming security patches from the world's leading security team</li>
       </ul>

--- a/templates/openstack/features.html
+++ b/templates/openstack/features.html
@@ -556,7 +556,7 @@
       <p>Canonical's approach towards storage architecture optimisation leverages multiple storage tiers. While big, cheap, low performance disks are used as ultimate storage devices, several smaller, more expensive, high performance devices serve as a cache in front. This approach ensures the required performance of the entire cloud, while not affecting hardware costs significantly.</p>
       <p>With Canonical's Charmed OpenStack you get:</p>
       <ul class="p-list">
-        <li class="p-list__item is-ticked">Up to 72TB raw storage per node</li>
+        <li class="p-list__item is-ticked">Up to 192TB raw storage per node</li>
         <li class="p-list__item is-ticked">Data encryption in transit and at rest</li>
         <li class="p-list__item is-ticked">Data protection and data durability</li>
         <li class="p-list__item is-ticked">A mix of block and object storage based on personal requirements</li>

--- a/templates/openstack/support.html
+++ b/templates/openstack/support.html
@@ -4,7 +4,7 @@
 
 {% block meta_description %}Canonical is a global leader in OpenStack support, offering enterprise full-stack support subscription at the best server/annum cost.{% endblock meta_description %}
 
-{% block meta_copydoc %}https://docs.google.com/document/d/1mHaZQ_VZnISTUEpYKiVK-Ejr5ne8lVevpxEc0LpXYKI/edit#heading=h.wtb1j7wwfobn{% endblock meta_copydoc %}
+{% block meta_copydoc %}https://docs.google.com/document/d/1mHaZQ_VZnISTUEpYKiVK-Ejr5ne8lVevpxEc0LpXYKI/{% endblock meta_copydoc %}
 
 {% block content %}
 <section class="p-strip--suru-bottomed">

--- a/templates/pricing/infra.html
+++ b/templates/pricing/infra.html
@@ -12,7 +12,7 @@
 <section id="ua-infra" class="p-strip--suru-topped is-bordered">
   <div class="u-fixed-width">
     <h1>Open Infrastructure support & security</h1>
-    <p>Ubuntu Advantage for Infrastructure covers all aspects of open infrastructure - Ubuntu, KVM, OpenStack, Kubernetes, Docker, storage, networking, Ceph, Swift, SDN, logging, alerting and monitoring.</p>
+    <p>Ubuntu Advantage for Infrastructure covers all aspects of open infrastructure &ndash; Ubuntu, KVM, OpenStack, Kubernetes, Docker, storage, networking, Ceph, Swift, SDN, logging, alerting and monitoring.</p>
     <ul class="p-inline-list">
       <li class="p-inline-list__item">
         <a href="/support/contact-us" class="p-button--positive js-invoke-modal" data-testid="interactive-form-link">Get in touch</a>
@@ -41,7 +41,7 @@
 
 <section class="p-strip--light is-shallow" id="storage">
   <div class="u-fixed-width">
-    <h3>Software-defined storage - Ceph and Swift</h3>
+    <h3>Software-defined storage &ndash; Ceph and Swift</h3>
     <p>Only applies if attaching more than 192TB of raw Ceph/Swift capacity per node in the cluster. Priced by the amount exceeding the total of 192TB per node included in UA.</p>
   </div>
   {% include "shared/pricing/_ua-advanced-storage.html" %}

--- a/templates/pricing/infra.html
+++ b/templates/pricing/infra.html
@@ -12,7 +12,7 @@
 <section id="ua-infra" class="p-strip--suru-topped is-bordered">
   <div class="u-fixed-width">
     <h1>Open Infrastructure support & security</h1>
-    <p>Ubuntu Advantage for Infrastructure covers all aspects of open infrastructure - Ubuntu, KVM, OpenStack, Kubernetes, Docker, storage, networking, Ceph, SWIFT, SDN, logging, alerting and monitoring.</p>
+    <p>Ubuntu Advantage for Infrastructure covers all aspects of open infrastructure - Ubuntu, KVM, OpenStack, Kubernetes, Docker, storage, networking, Ceph, Swift, SDN, logging, alerting and monitoring.</p>
     <ul class="p-inline-list">
       <li class="p-inline-list__item">
         <a href="/support/contact-us" class="p-button--positive js-invoke-modal" data-testid="interactive-form-link">Get in touch</a>
@@ -42,7 +42,7 @@
 <section class="p-strip--light is-shallow" id="storage">
   <div class="u-fixed-width">
     <h3>Software-defined storage - Ceph and Swift</h3>
-    <p>Only applies if attaching more than 72TB of raw Ceph/SWIFT disks per node in the cluster. Priced by the amount exceeding the total of 72TB per node included in UA.</p>
+    <p>Only applies if attaching more than 192TB of raw Ceph/Swift capacity per node in the cluster. Priced by the amount exceeding the total of 192TB per node included in UA.</p>
   </div>
   {% include "shared/pricing/_ua-advanced-storage.html" %}
   <div class="u-fixed-width">
@@ -54,7 +54,7 @@
 <section class="p-strip is-shallow" id="managed">
   <div class="u-fixed-width">
     <h3>Fully managed OpenStack, Kubernetes and LMA</h3>
-    <p>We manage infrastructure at both the host and the guest level. Infrastructure includes Ceph and SWIFT storage, Kubernetes, OpenStack and the recommended logging, monitoring and alerting stack.</p>
+    <p>We manage infrastructure at both the host and the guest level. Infrastructure includes Ceph and Swift storage, Kubernetes, OpenStack and the recommended logging, monitoring and alerting stack.</p>
   </div>
   {% include "shared/pricing/_openstack-kubernetes-lma.html" %}
   <div class="u-fixed-width">

--- a/templates/shared/pricing/_ua-for-infrastructure.html
+++ b/templates/shared/pricing/_ua-for-infrastructure.html
@@ -108,6 +108,12 @@
           <td class="u-align--center">{{ image(url="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg", alt="Yes", width="16", height="16", hi_def=True, loading="lazy",) | safe }}</td>
         </tr>
         <tr>
+          <td><a href="/security/certifications">FIPS 140-2 Level 1</a> certified crypto modules</td>
+          <td class="u-align--center">{{ image(url="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg", alt="Yes", width="16", height="16", hi_def=True, loading="lazy",) | safe }}</td>
+          <td class="u-align--center">{{ image(url="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg", alt="Yes", width="16", height="16", hi_def=True, loading="lazy",) | safe }}</td>
+          <td class="u-align--center">{{ image(url="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg", alt="Yes", width="16", height="16", hi_def=True, loading="lazy",) | safe }}</td>
+        </tr>
+        <tr>
           <td><a href="/security/certifications#common-criteria">Common Criteria EAL2</a></td>
           <td class="u-align--center">{{ image(url="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg", alt="Yes", width="16", height="16", hi_def=True, loading="lazy",) | safe }}</td>
           <td class="u-align--center">{{ image(url="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg", alt="Yes", width="16", height="16", hi_def=True, loading="lazy",) | safe }}</td>
@@ -152,8 +158,8 @@
         <tr>
           <td>Ceph/Swift raw storage support included</td>
           <td class="u-align--center">&ndash;</td>
-          <td class="u-align--center">72TB per storage node</td>
-          <td class="u-align--center">72TB per storage node</td>
+          <td class="u-align--center">192TB per storage node</td>
+          <td class="u-align--center">192TB per storage node</td>
         </tr>
       </tbody>
     </table>


### PR DESCRIPTION
## Done

- Change all instance of 72tb to 192tb pages listed below
- Implemented related copy changes where needed
- Originally requested via:
  - /pricing/infra [copy doc](https://docs.google.com/document/d/1Ynk0iLa9hjrdich6ATTsybtPbDwW_k4vRI0nk_HNhcI/edit#)
  - /openstack/support [copy doc](https://docs.google.com/document/d/1mHaZQ_VZnISTUEpYKiVK-Ejr5ne8lVevpxEc0LpXYKI/edit#)
  - /openstack [copy doc](https://docs.google.com/document/d/1eqHK0hc9v7Mn-XV36QRyNkJenTXgBQR_-RULKm5rZ5o/edit#heading=h.hf5huil04ges)
  - /openstack/features [copy doc](https://docs.google.com/document/d/1odFXuFtN1GjuZvgd8tW48HB4J9PjZJtP3w6wY0xlmog/edit#)
  - /ceph [copy doc](https://docs.google.com/document/d/1gpEjTcdJor2yTGfMz7T_xIfs7BtV6rbBPFYfNZFe52Y/edit#)
  
**NOTE: The issue also requests these changes for cn.ubuntu.com/cloud/openstack, will open an issue for that on that codebase** 

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at:
   - [x] https://ubuntu-com-11516.demos.haus/pricing/infra
   - [x] https://ubuntu-com-11516.demos.haus/openstack/support
   - [x] https://ubuntu-com-11516.demos.haus/openstack
   - [x] https://ubuntu-com-11516.demos.haus/openstack/features
   - [x] https://ubuntu-com-11516.demos.haus/ceph 

- See that the requested changes have been made

## Issue / Card

Fixes https://github.com/canonical-web-and-design/web-squad/issues/5116
