### PR TITLE
Remove 'development board' text

### DIFF
--- a/templates/certified/model-details.html
+++ b/templates/certified/model-details.html
@@ -84,7 +84,7 @@
             {% if release.level == "Enabled" %}
               <p class="u-no-margin--bottom">Pre-installed in some regions with a custom Ubuntu image that takes advantage of the system’s hardware features and may include additional software. Standard images of Ubuntu may not work well, or at all.</p>
             {% elif release.level == "Certified" %}
-              <p>The {{ vendor }} {{ name }} development board with the components described below has been awarded the status of certified for Ubuntu.</p>
+              <p>The {{ vendor }} {{ name }} with the components described below has been awarded the status of certified for Ubuntu.</p>
               <p class="u-no-margin--bottom">
                 {% if category == "Desktop" or category == "Laptop" %}
                 <a href="/download/desktop" class="p-button">Download</a>


### PR DESCRIPTION
Fixes #11518

## Done

This removes the hard coded _development board_ text from the certificate description.

## QA

- View the site at: https://ubuntu-com-11519.demos.haus/certified/202105-29000
    - Be sure to test on mobile, tablet and desktop screen sizes
- expand one of the certificates to verify that _development board_ text is removed.
