### PR TITLE
Update lenovo laptop images

### DIFF
--- a/templates/desktop/developers.html
+++ b/templates/desktop/developers.html
@@ -178,10 +178,10 @@
       </div>
       <div class="col-5 u-vertically-center">
         {{ image (
-          url="https://assets.ubuntu.com/v1/6502b4ae-laptop_X1_Carbon.png",
+          url="https://assets.ubuntu.com/v1/8c02c97a-Laptop-X1-Carbon.png",
           alt="",
-          width="725",
-          height="515",
+          width="622",
+          height="489",
           hi_def=True,
           loading="lazy"
           ) | safe

--- a/templates/desktop/organisations.html
+++ b/templates/desktop/organisations.html
@@ -17,12 +17,12 @@
     </div>
     <div class="col-6">
       {{ image (
-        url="https://assets.ubuntu.com/v1/6502b4ae-laptop_X1_Carbon.png",
+        url="https://assets.ubuntu.com/v1/8c02c97a-Laptop-X1-Carbon.png",
         alt="",
-        width="725",
-        height="515",
+        width="622",
+        height="489",
         hi_def=True,
-        loading="auto"
+        loading="lazy"
         ) | safe
       }}
     </div>


### PR DESCRIPTION
## Done

- Updates Lenovo laptop running 22.04 image, as the old one had a windows toolbar at the bottom

## QA

- Go /organisations /developers
- Make sure they *dont* look like the image below:
![image](https://user-images.githubusercontent.com/58276363/164714676-d56dc11b-f684-4b19-aae1-f8e4c34f57a4.png)


## Issue / Card

Fixes https://github.com/canonical-web-and-design/ubuntu.com/issues/11524
