### PR TITLE
Update desktop image on /raspberry-pi/desktop

### DIFF
--- a/templates/raspberry-pi/desktop.html
+++ b/templates/raspberry-pi/desktop.html
@@ -20,16 +20,14 @@
           Download Raspberry Pi Ubuntu Desktop&nbsp;&rsaquo;</a>
       </p>
     </div>
-    <div class="col-6 u-align--right">
-      {{
-        image(
-          url="https://assets.ubuntu.com/v1/ef12c6a7-Ubuntu-Desktop-for-Raspberry-Pi.png",
-          alt="Ubuntu Desktop for Raspberry-Pi",
-          width="370",
-          height="312",
-          hi_def=True,
-          loading="auto",
-          attrs={"class": "u-hide--small"},
+    <div class="col-6 u-hide--small u-hide--medium u-align--right">
+      {{ image (
+        url="https://assets.ubuntu.com/v1/a6419f4d-ubuntu-desktop-rasberry-pi.png",
+        alt="",
+        width="941",
+        height="798",
+        hi_def=True,
+        loading="auto"
         ) | safe
       }}
     </div>


### PR DESCRIPTION
## Done

- Update desktop image on /raspberry-pi/desktop to use 22.04

## QA

- Check the imag on /raspberry-pi/desktop

## Issue / Card

Fixes https://github.com/canonical-web-and-design/ubuntu.com/issues/11525
