### PR TITLE
Replace the deploy kubeflow tutorial with get started docs

### DIFF
--- a/templates/blog/product-cards/_kubeflow_deploy-tutorial.html
+++ b/templates/blog/product-cards/_kubeflow_deploy-tutorial.html
@@ -2,11 +2,11 @@
   <img class="p-card__thumbnail" src="https://assets.ubuntu.com/v1/b1f04506-Kubeflow-Logo-RGB.svg" alt="kubeflow logo" style="width: 137px;height: 32px;">
   <hr class="u-sv1">
   <h3>
-    <a href="/tutorials/deploy-kubeflow-ubuntu-windows-mac">Install Kubeflow</a>
+    <a href="https://charmed-kubeflow.io/docs/quickstart">Install Kubeflow</a>
   </h3>
   <p>The Kubeflow project is dedicated to making deployments of machine learning workflows on Kubernetes simple,
     portable and scalable.
     <br /><br />You can install Kubeflow on your workstation, local server or public cloud VM. It is easy to install
     with MicroK8s on any of these environments and can be scaled to high-availability.</p>
-  <p><a href="/tutorials/deploy-kubeflow-ubuntu-windows-mac">Install Kubeflow&nbsp;&rsaquo;</a></p>
+  <p><a href="https://charmed-kubeflow.io/docs/quickstart">Install Kubeflow&nbsp;&rsaquo;</a></p>
 </div>


### PR DESCRIPTION
## Done
Replace the deploy kubeflow tutorial with get started docs

## QA
- Check the new link works

## Issue / Card
Fixes https://github.com/canonical-web-and-design/ubuntu.com/runs/6124698153?check_suite_focus=true
