### PR TITLE
Lead the help button to the support form on the advantage page

### DIFF
--- a/templates/shared/contextual_footers/_ua_got_questions.html
+++ b/templates/shared/contextual_footers/_ua_got_questions.html
@@ -1,5 +1,5 @@
 <div class="col-4 p-divider__block">
   <h3 class="p-heading--4">Got questions?</h3>
   <p>Let our experts help you in the right direction with Ubuntu Advantage.</p>
-  <p><a href="/support/contact-us?product=contextual-footer-ua" class="p-button js-invoke-modal" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'UA questions', 'eventLabel' : 'Contact us', 'eventValue' : undefined });">Contact us</a></p>
+  <p><a href="/support/contact-us?product=contextual-footer-ua" class="p-button" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'UA questions', 'eventLabel' : 'Contact us', 'eventValue' : undefined });">Contact us</a></p>
 </div>

--- a/templates/support/thank-you.html
+++ b/templates/support/thank-you.html
@@ -14,7 +14,7 @@
 
 {% else %}
 
-  {% with thanks_context="contacting us about Ubuntu Advantage for Infrastructure" %}{% include "shared/_thank_you.html" %}{% endwith %}
+  {% with thanks_context="contacting us about Ubuntu Advantage" %}{% include "shared/_thank_you.html" %}{% endwith %}
 
 {% endif %}
 


### PR DESCRIPTION
## Done
Remove the modal trigger on the get help button to lead the user to the support contact form.

## QA
- Go to /advantage
- Login and scroll down to the contextual footer
- Click the "Contact us" button 
- See you end up somewhere useful for a user with questions

## Issue / Card
Fixes https://github.com/canonical-web-and-design/ubuntu.com/issues/11538
