### PR TITLE
Fix and schedule cypress test for forms

### DIFF
--- a/.github/workflows/cypress-main.yaml
+++ b/.github/workflows/cypress-main.yaml
@@ -9,9 +9,10 @@ env:
   MARKETO_API_SECRET: ${{secrets.MARKETO_API_SECRET}}
 
 on:
-  push:
-    branches:
-      - main
+  schedule:
+    - cron: "0 14 * 1-5 *"
+      branches:
+        - main
 
 jobs:
   run-cypress:

--- a/templates/core/services/index.html
+++ b/templates/core/services/index.html
@@ -221,7 +221,7 @@
     </p>
 
     <p>
-      <a class="p-button--positive js-invoke-modal" href="/core/services/contact-us" data-testid="interactive-form-link">Contact us</a> 
+      <a class="p-button--positive js-invoke-modal" href="/core/services/contact-us">Contact us</a> 
     </p>
   </div>
 </section>

--- a/templates/shared/_rt-kernel-beta-banner.html
+++ b/templates/shared/_rt-kernel-beta-banner.html
@@ -2,7 +2,7 @@
   <div class="p-notification--information is-inline">
     <div class="p-notification__content">
       <h5 class="p-notification__title">Are you interested in real-time Ubuntu?</h5>
-      <p class="p-notification__message"><a class="js-invoke-kernel-modal" data-testid="interactive-form-link" href="/embedded#beta-signup">Join our free beta programme &nbsp;&rsaquo;</a></p>
+      <p class="p-notification__message"><a class="js-invoke-kernel-modal" href="/embedded#beta-signup">Join our free beta programme &nbsp;&rsaquo;</a></p>
     </div>
   </div>
 </div>

--- a/tests/cypress/forms/forms_spec.js
+++ b/tests/cypress/forms/forms_spec.js
@@ -235,27 +235,6 @@ context("Interactive marketo forms", () => {
       cy.url().should("include", "#success");
     }
   );
-
-
-  // wrote separate test for /robotics page as cypress couldn't find the job title input field by label text
-  it(
-    "should check interactive contact modal on /robotics",
-    { scrollBehavior: "center" },
-    () => {
-      cy.visit("/robotics");
-      cy.acceptCookiePolicy();
-      cy.findByTestId("interactive-form-link").click();
-      cy.findByRole("link", { name: /Next/ }).click();
-      cy.findByLabelText(/First name/).type("Test");
-      cy.findByLabelText(/Last name:/).type("Test");
-      cy.findByLabelText(/Company:/).type("Test");
-      cy.findByTestId("form-jobTitle").type("Test");
-      cy.findByTestId("form-email").type("test@test.com");
-      cy.findByLabelText(/Phone number:/).type("07777777777");
-      cy.findByText(/Let's discuss/).click();
-      cy.url().should("include", "#success");
-    }
-  );
   
   it(
     "should check interactive contact modal on /kubernetes/managed",


### PR DESCRIPTION
## Done

- Removed duplicated data test id that causes error on `/core/services` and `/robotics`
- Removed duplicated cypress test for `/robotics` page
- Scheduled cypress test for forms so it runs only one time a day

## QA

## Issue / Card

Fixes #

