### PR TITLE
Fix aria controls for Canonical k8s release chart

### DIFF
--- a/templates/about/release-cycle.html
+++ b/templates/about/release-cycle.html
@@ -42,7 +42,7 @@
             <a href="#openstack-release-cycle" class="p-tabs__link" id="openstack-release-cycle-tab" role="tab" aria-controls="openstack-release-cycle">OpenStack</a>
           </li>
           <li class="p-tabs__item" role="presentation">
-            <a href="#canonical-kubernetes-release-cycle" class="p-tabs__link" id="canonical-kubernetes-release-cycle-tab" role="tab" aria-controls="kubernetes-release-cycle">Kubernetes</a>
+            <a href="#canonical-kubernetes-release-cycle" class="p-tabs__link" id="canonical-kubernetes-release-cycle-tab" role="tab" aria-controls="canonical-kubernetes-release-cycle">Kubernetes</a>
           </li>
         </ul>
       </nav>


### PR DESCRIPTION
## Done

- Fixed aria controls so that the chart is hidden until clicked

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: https://ubuntu-com-11550.demos.haus/about/release-cycle
    - Be sure to test on mobile, tablet and desktop screen sizes
- Click through each tab and make sure everything shows as expected

## Issue / Card

Fixes https://github.com/canonical-web-and-design/ubuntu.com/issues/11542
