### PR TITLE
Fix the OpenStack cheatsheet link on tutorials

### DIFF
--- a/templates/openstack/shared/_cheatsheet.html
+++ b/templates/openstack/shared/_cheatsheet.html
@@ -7,11 +7,11 @@
     </p>
     <p>Perfect for both beginners and more advanced users.</p>
     <p>
-      <a href="/openstack/cheat-sheet" class="p-button--positive">Download the OpenStack cheat sheet</a>
+      <a href="/openstack/openstack-cheat-sheet" class="p-button--positive">Download the OpenStack cheat sheet</a>
     </p>
   </div>
   <div class="col-6 u-hide--medium u-hide--small u-align--center u-hide--medium">
-    {{ 
+    {{
       image (
       url="https://assets.ubuntu.com/v1/7bf0af87-Openstack-cheatsheet-grfx.png",
       alt="", width="1504", height="1085", hi_def=True, loading="auto", ) | safe


### PR DESCRIPTION
## Done
Fix the OpenStack cheatsheet link on tutorials

## QA
- Check the change fixes this issue: https://github.com/canonical-web-and-design/ubuntu.com/runs/6224230574?check_suite_focus=true
- Check the copy doc has been updated: https://docs.google.com/document/d/1_4EJlX-fbcQBVC9Ojhjdbls6kbmITGvHKi5IEqw-HAA/edit#