### PR TITLE
K8s subnav update

### DIFF
--- a/navigation.yaml
+++ b/navigation.yaml
@@ -344,8 +344,6 @@ kubernetes:
   children:
     - title: Overview
       path: /kubernetes
-    - title: Industry report
-      path: /kubernetes/cloud-native-kubernetes-usage-report-2021
     - title: What is Kubernetes
       path: /kubernetes/what-is-kubernetes
     - title: Charmed Kubernetes


### PR DESCRIPTION
## Done

- Remove industry report from k8s subnav

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: https://ubuntu-com-11566.demos.haus/kubernetes
    - Be sure to test on mobile, tablet and desktop screen sizes
- See that subnav item has been removed

## Issue / Card

Fixes https://github.com/canonical-web-and-design/ubuntu.com/issues/11557