### PR TITLE
Add resources link to relevant k8s pages

### DIFF
--- a/templates/kubernetes/compare.html
+++ b/templates/kubernetes/compare.html
@@ -412,11 +412,12 @@
     <div class="col-4 p-divider__block">
       <div class="p-heading-icon--muted">
         <div class="p-heading-icon__header">
-          {{ image (
+          {{ 
+            image (
             url="https://assets.ubuntu.com/v1/f6d6f78b-Case+study.svg",
             alt="",
-            width="32",
-            height="28",
+            width="171",
+            height="150",
             hi_def=True,
             loading="lazy"
             ) | safe
@@ -425,6 +426,7 @@
         </div>
       </div>
       <p class="p-heading--4"><a href="/engage/atresmedia-charmed-kubernetes-case-study">Atresmedia dominates Spain's OTT media market with Charmed Kubernetes</a></p>
+      <p><a class="p-link--inverted" href="/kubernetes/resources">Find more resources&nbsp;&rsaquo;</a></p>
     </div>
   </div>
 </section>

--- a/templates/kubernetes/compare.html
+++ b/templates/kubernetes/compare.html
@@ -426,7 +426,7 @@
         </div>
       </div>
       <p class="p-heading--4"><a href="/engage/atresmedia-charmed-kubernetes-case-study">Atresmedia dominates Spain's OTT media market with Charmed Kubernetes</a></p>
-      <p><a class="p-link--inverted" href="/kubernetes/resources">Find more resources&nbsp;&rsaquo;</a></p>
+      <p><a href="/kubernetes/resources">Find more resources&nbsp;&rsaquo;</a></p>
     </div>
   </div>
 </section>

--- a/templates/kubernetes/what-is-kubernetes.html
+++ b/templates/kubernetes/what-is-kubernetes.html
@@ -264,7 +264,7 @@
             }}
             <h3 class="p-heading--4">Whitepaper</h3>
           </div>
-          <p><a class="p-link--inverted" href="https://ubuntu.com/engage/kubernetes-deployment-enterprise-whitepaper">Five strategies to accelerate Kubernetes deployment in the enterprise</a></h3>
+          <p><a class="p-link--inverted" href="/engage/kubernetes-deployment-enterprise-whitepaper">Five strategies to accelerate Kubernetes deployment in the enterprise</a></h3>
           <p><a class="p-link--inverted" href="/kubernetes/resources">Find more resources&nbsp;&rsaquo;</a></p>
         </div>
       </div>

--- a/templates/kubernetes/what-is-kubernetes.html
+++ b/templates/kubernetes/what-is-kubernetes.html
@@ -265,6 +265,7 @@
             <h3 class="p-heading--4">Whitepaper</h3>
           </div>
           <p><a class="p-link--inverted" href="https://ubuntu.com/engage/kubernetes-deployment-enterprise-whitepaper">Five strategies to accelerate Kubernetes deployment in the enterprise</a></h3>
+          <p><a class="p-link--inverted" href="/kubernetes/resources">Find more resources&nbsp;&rsaquo;</a></p>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Done

- Added resources link to /kubernetes/what-is-kubernetes([doc](https://docs.google.com/document/d/19ZAsyujRHjOBIKP15F-4Z9L24KpfoYrx0YpL-0gO6sE/edit#)) and /kubernetes/compare([doc](https://docs.google.com/document/d/1JngYmRhohPo62yU72V1xpzCCILI21SmHKKttBxHjPog/edit#))

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: 
    - https://ubuntu-com-11567.demos.haus/kubernetes/compare
    - https://ubuntu-com-11567.demos.haus/kubernetes/what-is-kubernetes
- See that requested changes have been made
- Test resources link

## Issue / Card

Fixes https://github.com/canonical-web-and-design/web-squad/issues/5225 https://github.com/canonical-web-and-design/web-squad/issues/5224
