### PR TITLE
Update copy on /download/xilinx

### DIFF
--- a/templates/download/xilinx/index.html
+++ b/templates/download/xilinx/index.html
@@ -37,12 +37,12 @@ familiar developer experience and an accelerated path to production.{% endblock 
     <div class="p-tabs">
       <div class="p-tabs__list js-tabbed-content" role="tablist" aria-label="Install xilinx">
         <div class="p-tabs__item">
-          <button class="p-tabs__link" role="tab" aria-selected="true" aria-controls="kira-kv260-vision-ai-tab" id="kira-kv260-vision-ai">Xilinx
-            Kria KV260 Vision AI Starter Kit</button>
+          <button class="p-tabs__link" role="tab" aria-selected="false" aria-controls="zynq-ultrascale-tab" id="zynq-ultrascale" tabindex="-1">Ubuntu 20.04 Xilinx Zynq UltraScale+ MPSoC
+            Development Boards</button>
         </div>
         <div class="p-tabs__item">
-          <button class="p-tabs__link" role="tab" aria-selected="false" aria-controls="zynq-ultrascale-tab" id="zynq-ultrascale" tabindex="-1">Xilinx Zynq UltraScale+ MPSoC
-            Development Boards</button>
+          <button class="p-tabs__link" role="tab" aria-selected="true" aria-controls="kira-kv260-vision-ai-tab" id="kira-kv260-vision-ai">Ubuntu 20.04 Xilinx
+            Kria KV260 Vision AI Starter Kit</button>
         </div>
       </div>
 
@@ -50,7 +50,7 @@ familiar developer experience and an accelerated path to production.{% endblock 
         <div class="row u-vertically-center u-no-padding">
           <div class="col-6">
             <h2>Download Ubuntu Desktop</h2>
-            <h3 class="p-heading--4">Ubuntu Desktop 20.04 LTS</h3>
+            <h3 class="p-heading--4">Ubuntu Desktop 20.04.3 LTS</h3>
             <p class="u-sv1">The version of Ubuntu with up to 10 years of long term support, until April 2030.</p>
             <p>
               <a class="p-button--positive"
@@ -132,7 +132,7 @@ familiar developer experience and an accelerated path to production.{% endblock 
         <div class="row u-vertically-center u-no-padding">
           <div class="col-6">
             <h2>Download Ubuntu Desktop</h2>
-            <h3 class="p-heading--4">Ubuntu Desktop 20.04 LTS</h3>
+            <h3 class="p-heading--4">Ubuntu Desktop 20.04.3 LTS</h3>
             <p class="u-sv1">The version of Ubuntu with up to 10 years of long term support, until April 2030.</p>
             <p>
               <a class="p-button--positive"


### PR DESCRIPTION
## Done

- Updated as per [copy doc](https://docs.google.com/document/d/1DZxf-ZbJtyS69XQBslJry3Ien1FSHYLB2Qt78iRkhOs/edit)
- Switched tab order to reflect doc

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: https://ubuntu-com-11570.demos.haus/download/xilinx
    - Be sure to test on mobile, tablet and desktop screen sizes
- See that requested changes have been made

## Issue / Card

Fixes https://github.com/canonical-web-and-design/web-squad/issues/5200
