### PR TITLE
Update ubuntu protips pdf

### DIFF
--- a/templates/download/shared/_server_weekly_news.html
+++ b/templates/download/shared/_server_weekly_news.html
@@ -48,7 +48,7 @@
       <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" id="utm_term" value="" />
       <input type="hidden" aria-hidden="true" aria-label="hidden field" name="GCLID__c" id="GCLID__c" value="" />
       <input type="hidden" aria-hidden="true" aria-label="hidden field" name="Facebook_Click_ID__c" id="Facebook_Click_ID__c" value="" />
-      <input type="hidden" name="returnURL" value="https://assets.ubuntu.com/v1/f401c3f4-Ubuntu_Server_CLI_pro_tips_2020-04.pdf" />
+      <input type="hidden" name="returnURL" value="https://github.com/canonical-web-and-design/brand-squad/files/8532487/Ubuntu.Server.CLI.pro.tips.19.04.22.pdf" />
     </form>
   </div>
 </div>


### PR DESCRIPTION
## Done

Update protips pdf, which is available after you fill in the Protips form.

## QA

- Go to /download/server
- Fill in the Ubuntu pro tips form with test data and download the **new pdf**
- You can do the same process on current https://ubuntu.com/download/server


## Issue / Card

Fixes https://github.com/canonical-web-and-design/web-squad/issues/5176

## Help

[QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html) - [Commit guidelines](https://canonical-web-and-design.github.io/practices/workflow/commit-messages.html)
