### PR TITLE
update text of cloud survey banner

### DIFF
--- a/templates/server/index.html
+++ b/templates/server/index.html
@@ -8,7 +8,8 @@
 
 {% block content %} 
 
-<div class="p-strip--suru is-dark"> {% include "shared/_cloud-survey-banner.html" %} 
+<div class="p-strip--suru is-dark"> 
+  {% include "shared/_cloud-survey-banner.html" %}
   <div class="row u-equal-height">
     <div class="col-7">
       <h1>Scale out with Ubuntu Server</h1>

--- a/templates/shared/_cloud-survey-banner.html
+++ b/templates/shared/_cloud-survey-banner.html
@@ -2,7 +2,9 @@
   <div class="{% if cols %}col-{{ cols }}{% else %}col-12{% endif %}">
     <div class="p-notification">
       <div class="p-notification__content">
-        <p class="p-notification__message">Fill in the <a href="https://docs.google.com/forms/d/e/1FAIpQLSdDECWbUMkJ1gqk8iOylEF9sli23tuMWHQRVrC2JUOzSDM_Tg/viewform">Cloud Pricing Survey 2022</a> and have a chance to win a virtual pass to KubeCon Europe 2022!</p>
+        <p class="p-notification__message">
+          <a href="https://docs.google.com/forms/d/e/1FAIpQLSdDECWbUMkJ1gqk8iOylEF9sli23tuMWHQRVrC2JUOzSDM_Tg/viewform">Win a virtual pass to KubeCon Europe 2022!</a>
+        </p>
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Done

- Updated the text on the Cloud pricing survey banner

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site in your web browser at: https://ubuntu-com-11577.demos.haus/ceph
- See that the text matches what's given in the [issue](https://github.com/canonical-web-and-design/web-squad/issues/5233)

## Issue / Card

Fixes https://github.com/canonical-web-and-design/web-squad/issues/5233
