### PR TITLE
Fix broken link in /kubernetes/docs/ingress

### DIFF
--- a/templates/kubernetes/docs/ingress.md
+++ b/templates/kubernetes/docs/ingress.md
@@ -48,7 +48,7 @@ manually manage [`VirtualServices`][virt-svc] for your applications, or even use
 <div class="p-notification--positive is-inline">
   <div markdown="1" class="p-notification__content">
     <span class="p-notification__title">Note:</span>
-    <p class="p-notification__message">The Istio bundle requires a load balancer provider. If you're not using a cloud integrator which provides this, [MetalLB][] can be used.</p>
+    <p class="p-notification__message">The Istio bundle requires a load balancer provider. If you're not using a cloud integrator which provides this, <a href="/kubernetes/docs/metallb">MetalLB</a> can be used.</p>
   </div>
 </div>
 


### PR DESCRIPTION
## Done

- Fixed a link broken by markdown/HTML mismatch

## QA

- View the site in your web browser at: https://ubuntu-com-11579.demos.haus/kubernetes/docs/ingress
- See that the link in the notification in the Istio Ingress section works, and isn't rendered as [MetalLB][]

## Issue / Card

Fixes https://github.com/canonical-web-and-design/ubuntu.com/issues/11534

## Screenshots
Before:
![Screenshot from 2022-05-05 17-19-15](https://user-images.githubusercontent.com/2376968/166968062-aa41f562-6ad7-4b98-ba00-9a63192d65c4.png)

After
![Screenshot from 2022-05-05 17-20-38](https://user-images.githubusercontent.com/2376968/166968133-b5001750-08d0-4c92-9073-20a161d36513.png)
:

