### PR TITLE
Fix typo on /openstack

### DIFF
--- a/templates/openstack/index.html
+++ b/templates/openstack/index.html
@@ -685,7 +685,7 @@
         <p class="p-pull-quote__quote">Canonical is providing us with the 'cloud-native' foundation that enables us to create a smart and fully converged network.</p>
         <cite class="p-pull-quote__citation">Neil J. McRae, Group Chief Architect at BT</cite>
       </blockquote>
-      <a href="/blog/bt-turns-to-canonical-ubuntu-to-enable-next-generation-5g-cloud-core">Read the announement&nbsp;&rsaquo;</a>
+      <a href="/blog/bt-turns-to-canonical-ubuntu-to-enable-next-generation-5g-cloud-core">Read the announcement&nbsp;&rsaquo;</a>
     </div>
   </div>
 </section>


### PR DESCRIPTION
## Done

- Update `announement` to `annoucement`

## QA

- Go to `/openstack`
- Compare page against [copy doc](https://docs.google.com/document/d/1eqHK0hc9v7Mn-XV36QRyNkJenTXgBQR_-RULKm5rZ5o/edit#)

## Issue / Card

Fixes [#5278](https://github.com/canonical-web-and-design/web-squad/issues/5278)


