### PR TITLE
update "Visually stunning" section on /desktop for 22.04

### DIFF
--- a/templates/desktop/index.html
+++ b/templates/desktop/index.html
@@ -81,7 +81,7 @@
           Visually stunning, wherever it's used
         </h2>
         <p>
-          Ubuntu gets the most from your screen, with high definition and touchscreen support. 20.04 has a new default theme, Yaru, as well as integrated light and dark themes, resulting in Ubuntu getting a fresh new look while maintaining its signature feel.
+          Ubuntu gets the most from your screen, with high definition, touchscreen support, fractional scaling and touchpad gestures. 22.04 refreshes its signature Yaru theme, with system-wide dark style preference support, accent colours and the largest selection of community wallpapers yet.
         </p>
       </div>
     </div>


### PR DESCRIPTION
## Done

- The "Visually stunning" section on /desktop included a reference to 20.04, this PR updates it to match Oliver's suggestions in the [copy doc](https://docs.google.com/document/d/1ZhMkLlkXcimHTIe1taXy24vbbR9pBkZd49H2sJqeQH0/edit)

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/desktop
- See that the "Visually stunning" section matches Oliver's suggestions in the copy doc

## Issue / Card

Fixes https://github.com/canonical-web-and-design/ubuntu.com/issues/11592
