### PR TITLE
Release cycle 1.24

### DIFF
--- a/static/js/src/chart-data.js
+++ b/static/js/src/chart-data.js
@@ -1274,7 +1274,7 @@ export var kubernetesReleases = [
     startDate: new Date("2021-04-08T00:00:00"),
     endDate: new Date("2022-04-08T00:00:00"),
     taskName: "Kubernetes 1.21",
-    status: "CANONICAL_KUBERNETES_SUPPORT",
+    status: "CANONICAL_KUBERNETES_EXTENDED_SECURITY_MAINTENANCE",
   },
   {
     startDate: new Date("2021-08-01T00:00:00"),
@@ -1286,6 +1286,12 @@ export var kubernetesReleases = [
     startDate: new Date("2021-12-07T00:00:00"),
     endDate: new Date("2022-12-07T00:00:00"),
     taskName: "Kubernetes 1.23",
+    status: "CANONICAL_KUBERNETES_SUPPORT",
+  },
+  {
+    startDate: new Date("2022-05-06T00:00:00"),
+    endDate: new Date("2022-05-06T00:00:00"),
+    taskName: "Kubernetes 1.24",
     status: "CANONICAL_KUBERNETES_CURRENT_VERSION",
   },
 ];
@@ -1507,6 +1513,7 @@ export var openStackReleaseNames = [
 ];
 
 export var kubernetesReleaseNames = [
+  "Kubernetes 1.24",
   "Kubernetes 1.23",
   "Kubernetes 1.22",
   "Kubernetes 1.21",

--- a/static/js/src/chart-data.js
+++ b/static/js/src/chart-data.js
@@ -1290,7 +1290,7 @@ export var kubernetesReleases = [
   },
   {
     startDate: new Date("2022-05-06T00:00:00"),
-    endDate: new Date("2022-05-06T00:00:00"),
+    endDate: new Date("2023-05-06T00:00:00"),
     taskName: "Kubernetes 1.24",
     status: "CANONICAL_KUBERNETES_CURRENT_VERSION",
   },

--- a/templates/about/release-cycle.html
+++ b/templates/about/release-cycle.html
@@ -587,6 +587,11 @@
           </thead>
           <tbody>
             <tr>
+              <td><strong>1.24.x</strong></td>
+              <td align='right'>May 2022</td>
+              <td align='right'>May 2023</td>
+            </tr>
+            <tr>
               <td><strong>1.23.x</strong></td>
               <td align='right'>Dec 2021</td>
               <td align='right'>Dec 2022</td>


### PR DESCRIPTION
## Done

- Update the release cycle page and chart for latest k8s
- 
## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
