### PR TITLE
Update footer and meganav landscape links

### DIFF
--- a/navigation.yaml
+++ b/navigation.yaml
@@ -1887,3 +1887,5 @@ landscape:
       path: /landscape/install
     - title: Docs
       path: https://docs.ubuntu.com/landscape/en/
+    - title: Log in to Landscape
+      path: https://landscape.canonical.com/login/authenticate

--- a/templates/templates/footer.html
+++ b/templates/templates/footer.html
@@ -106,6 +106,7 @@
               {% endwith %}
               <li class="p-footer__item p-footer__item--spaced">
                 <a href="/model-driven-operations">Model-driven operations</a>
+                <a href="/landscape">Landscape</a>
               </li>
             </ul>
           </li>

--- a/templates/templates/navigation-enterprise-h.html
+++ b/templates/templates/navigation-enterprise-h.html
@@ -112,8 +112,8 @@
             <li class="p-list__item u-show--small u-hide--medium u-hide--large"><a href="/support">Get support</a></li>
             <li class="p-list__item"><a href="/livepatch">Livepatch security updates</a></li>
             <li class="p-list__item"><a href="/esm">Extended Security Maintenance</a></li>
-            <li class="p-list__item"><a href="https://landscape.canonical.com">Landscape remote management</a></li>
-            <li class="p-list__item"><a href="https://landscape.canonical.com/landscape-features">Compliance reporting</a></li>
+            <li class="p-list__item"><a href="/landscape">Landscape remote management</a></li>
+            <li class="p-list__item"><a href="/landscape/features">Compliance reporting</a></li>
             <li class="p-list__item"><a href="/model-driven-operations">Model-driven operations</a></li>
             <li class="p-list__item"><a href="/managed/apps">Managed Apps</a></li>
             <li class="p-list__item"><a href="/pricing">Pricing</a></li>


### PR DESCRIPTION
## Done

- Updated meganav landscape links
- Added /landscape link to footer
- Added link to login portal to landscape subnav

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: 
    - https://ubuntu-com-11603.demos.haus/#enterprise
    - https://ubuntu-com-11603.demos.haus/landscape
    - Be sure to test on mobile, tablet and desktop screen sizes
- Check meganav > support and services and find that "Landscape remote management" and "Compliance reporting" route to new correct pages on u.com
- Test footer link
- Test subnav link

## Issue / Card

Fixes https://github.com/canonical-web-and-design/web-squad/issues/5298
