### PR TITLE
Add recruitment page to /legal/data-privacy

### DIFF
--- a/navigation.yaml
+++ b/navigation.yaml
@@ -530,7 +530,7 @@ kubernetes:
           hidden: True
         - title: Inclusive naming
           path: /kubernetes/docs/inclusive-naming
-          hidden: True 
+          hidden: True
         - title: Get in touch
           path: /kubernetes/docs/get-in-touch
           hidden: True
@@ -540,7 +540,6 @@ kubernetes:
         - title: Supported versions
           path: /kubernetes/docs/supported-versions
           hidden: True
-        
 
           children:
             - title: 1.16 Charm canal
@@ -1487,6 +1486,9 @@ legal:
       children:
         - title: Data protection enquiry
           path: /legal/data-privacy/enquiry
+        - title: Recruitment
+          path: /legal/data-privacy/recruitment
+          hidden: True
         - title: Newsletter
           path: /legal/data-privacy/newsletter
           hidden: True

--- a/templates/legal/data-privacy/index.html
+++ b/templates/legal/data-privacy/index.html
@@ -40,6 +40,7 @@
         <li class="p-list__item"><a href="/legal/data-privacy/online-competitions">Online competitions privacy notice&nbsp;&rsaquo;</a></li>
         <li class="p-list__item"><a href="/legal/data-privacy/unilateral-nda">Confidentiality agreement privacy notice&nbsp;&rsaquo;</a></li>
         <li class="p-list__item"><a href="/legal/data-privacy/cube-beta">CUBE Beta privacy notice&nbsp;&rsaquo;</a></li>
+        <li class="p-list__item"><a href="/legal/data-privacy/recruitment">Recruitment privacy notice&nbsp;&rsaquo;</a></li>
       </ul>
       <h2 id="information-we-collect-from-you">Information we collect from you</h2>
       <ul class="p-list">

--- a/templates/legal/data-privacy/recruitment.html
+++ b/templates/legal/data-privacy/recruitment.html
@@ -10,13 +10,13 @@
       <h4 class="p-muted-heading">Last Updated: 18/02/2022</h4>
       <hr style="margin-bottom: 2rem;" />
 
-      <h1>Canonical Recruitment Privacy Notice</h1>
+      <h1>Recruitment Privacy Notice</h1>
 
       <h2 id="introduction">1. Introduction</h2>
 
       <p>This Recruitment Privacy Notice describes how Canonical Group Limited (“Canonical”) collects, uses and retains personal information about you, when you apply or take part in our recruitment process. As such, this policy applies to potential candidates for employment, or those who may take part in recruitment programmes at Canonical.</p>
 
-      <p>At Canonical, we consider your privacy to be extremely important to us. Further information regarding our fundamental principles and practices can be found in our <a href="https://ubuntu.com/legal/data-privacy#:~:text=Canonical%20collects%20personal%20information%20from%20you%20in%20a%20number%20of%20different%20ways.&text=We%20don't%20share%20your,or%20to%20protect%20our%20rights.">Privacy Policy</a>.</p>
+      <p>At Canonical, we consider your privacy to be extremely important to us. Further information regarding our fundamental principles and practices can be found in our <a href="/legal/data-privacy#:~:text=Canonical%20collects%20personal%20information%20from%20you%20in%20a%20number%20of%20different%20ways.&text=We%20don't%20share%20your,or%20to%20protect%20our%20rights.">Privacy Policy</a>.</p>
 
       <p>We are Canonical Group Limited and are the “data controller” for the purposes of applicable data protection regulations relevant to your personal information. This means that we are responsible for determining how we hold and use your personal information.</p>
 
@@ -138,7 +138,7 @@
 
       <p>If you wish to make a complaint to us about how we use or retain your personal information, please contact us at <a href="mailto:dataprotection@canonical.com">dataprotection@canonical.com</a>.</p>
 
-      <p>You also have the right to submit a complaint with the UK data protection authority, which is the Information Commissioner's Office (ICO). If you wish to file a complaint with the ICO, you may find the following information helpful: https://ico.org.uk/make-a-complaint/</p>
+      <p>You also have the right to submit a complaint with the UK data protection authority, which is the Information Commissioner's Office (ICO). If you wish to file a complaint with the ICO, you may find the following information helpful: <a href="https://ico.org.uk/make-a-complaint/">https://ico.org.uk/make-a-complaint/</a></p>
 
       <h2 id="contact-information">13. Contact information</h2>
 

--- a/templates/legal/data-privacy/recruitment.html
+++ b/templates/legal/data-privacy/recruitment.html
@@ -1,0 +1,179 @@
+{% extends "legal/_base_legal.html" %}
+
+{% block title %}Canonical recruitment{% endblock %}
+{% block meta_copydoc %}https://docs.google.com/document/d/1D_irZPx4n67_Lhg-9P2-Iu9jZM9Va7n0/edit{% endblock meta_copydoc %}
+
+{% block content %}
+<div class="p-strip is-deep" style="overflow-x: visible;">
+  <div class="row">
+    <div class="col-8">
+      <h4 class="p-muted-heading">Last Updated: 18/02/2022</h4>
+      <hr style="margin-bottom: 2rem;" />
+
+      <h1>Canonical Recruitment Privacy Notice</h1>
+
+      <h2 id="introduction">1. Introduction</h2>
+
+      <p>This Recruitment Privacy Notice describes how Canonical Group Limited (“Canonical”) collects, uses and retains personal information about you, when you apply or take part in our recruitment process. As such, this policy applies to potential candidates for employment, or those who may take part in recruitment programmes at Canonical.</p>
+
+      <p>At Canonical, we consider your privacy to be extremely important to us. Further information regarding our fundamental principles and practices can be found in our <a href="https://ubuntu.com/legal/data-privacy#:~:text=Canonical%20collects%20personal%20information%20from%20you%20in%20a%20number%20of%20different%20ways.&text=We%20don't%20share%20your,or%20to%20protect%20our%20rights.">Privacy Policy</a>.</p>
+
+      <p>We are Canonical Group Limited and are the “data controller” for the purposes of applicable data protection regulations relevant to your personal information. This means that we are responsible for determining how we hold and use your personal information.</p>
+
+      <p>Canonical is a limited company registered in England and Wales with registered number 06870835. Our registered office is 5 New Street Square, London EC4A 3TW.</p>
+
+      <h2 id="what-information-we-collect">2. What information we collect</h2>
+
+      <p>In connection with our recruitment activities and your application to work with us, we will collect, store, and use the following categories of personal information about you:</p>
+
+      <ul>
+        <li>Your name, date of birth, nationality, contact information such as e-mail and telephone number,</li>
+        <li>Any information on your identification and right to work documentation,</li>
+        <li>Any information provided to us in your CV, references, and cover letter,</li>
+        <li>Any information and documentation you have provided in relation to your qualifications, educational and employment background,</li>
+        <li>Any correspondence you may have had with us during the recruitment application process,</li>
+        <li>Any information you may provide us with during your application interviews, and any interview feedback that your interviewer may have,</li>
+        <li>Your psychometric test results, including your rank and percentile, if you undertake a recruitment test with our providers Thomas or ClassMarker.</li>
+      </ul>
+
+      <h2 id="how-we-collect-your-information">3. How we collect your information</h2>
+
+      <p>We may collect personal information about you from the following sources:</p>
+
+      <ul>
+        <li>Directly from you, when you submit your application and information to us,</li>
+        <li>Recruitment services platforms such as Greenhouse,</li>
+        <li>Your named referees, if you have submitted them in your application,</li>
+        <li>Your public profile on professional social media platforms such as LinkedIn.</li>
+      </ul>
+      
+      <h2 id="why-we-use-your-information">4. Why we use your information</h2>
+
+      <p>We use your personal information as part of the recruitment process at Canonical. Using your information allows us to:</p>
+
+      <ul>
+        <li>Carry out recruitment operations,</li>
+        <li>Assess your skills, qualifications, and suitability for the role,</li>
+        <li>Communicate with you as part of the recruitment process,</li>
+        <li>Communicate with and verify your references where required,</li>
+        <li>Keep records regarding our recruitment and hiring processes,</li>
+        <li>Comply with our legal or regulatory requirements,</li>
+        <li>Respond to and defend against legal claims.</li>
+      </ul>
+
+      <p>We use your information because we believe we have a legitimate business interest in managing our recruitment operations and enabling the hiring of new employees for our organisation. We also process your personal information to decide whether to enter a contract of employment with you.</p>
+
+      <p>Having received your application via the recruitment platform Greenhouse, we will process your information to decide whether you meet the requirements for the role. If your application progresses to the next stage, we may send you further communications regarding psychometric testing and interviews. We will use the information you provide during any testing and interviews to determine your suitability for the role that you are applying for.</p>
+
+      <h2 id="who-we-share-your-information-with">5. Who we share your information with</h2>
+
+      <p>We only share your personal information for the purposes of facilitating the recruitment process. To achieve this, we may share your information amongst other international Canonical group entities and third-party companies providing services to us. Your personal information may be:</p>
+
+      <p><b>Transferred to other international Canonical group entities</b></p>
+      
+      <p>We may share your personal information with other Canonical group entities where necessary for HR, recruitment, administrative and support services. Further information on international transfers has been included in Section 6. International Data Transfers below.</p>
+
+      <p><b>Transferred to third-party organisations that provide services to us</b></p>
+      
+      <p>We use third-party service providers that support us in operating our recruitment processes, including application management and psychometric testing platforms. We may also ask for feedback on the recruitment process. These third-party service providers are listed below:</p>
+
+      <ul>
+        <li>Greenhouse Software, Inc.</li>
+        <li>ClassMarker Pty Ltd.</li>
+        <li>Thomas International Ltd.</li>
+        <li>Talenthub.io</li>
+        <li>Devskiller S.A</li>
+      </ul>
+
+      <p>We also use third party service providers who help facilitate, run and manage our internal administrative systems. For example, we use service providers for scheduling and conducting interviews, data storage and back-up services.</p>
+
+      <p><b>Transferred to government agencies and/or regulators</b></p>
+      
+      <p>We may also transfer your personal information to government agencies or regulators as required to comply with our legal obligations.</p>
+      
+      <p>Where we share your data with third parties, we implement appropriate legal mechanisms and security measures to ensure the protection of your personal information.</p>
+
+      <h2 id="international-data-transfers">6. International data transfers</h2>
+
+      <p>As Canonical is an international organisation, we may process, transfer and store your personal information outside the UK and European Economic Area (“EEA”).</p>
+
+      <p>Where your personal information is transferred to international Canonical entities and third parties outside the UK and EEA, we will always undertake reasonable steps to ensure that adequate security mechanisms are implemented to protect your information to the same standard as within the UK and EEA, allowing you to exercise the same rights over your data. To ensure that the data protection policies of the receiving organisations meet the UK and EEA regulatory standards, we use approved standard contractual clauses to protect your personal information.</p>
+
+      <h2 id="how-we-protect-your-information">7. How we protect your information</h2>
+
+      <p>We take the security of your personal information seriously, and have implemented appropriate security measures, internal policies and controls to prevent your information from being lost, misused, accessed without authorisation, altered or accidentally destroyed. Our security policy includes systems restrictions, encrypted and password protected files, retention protocols and security training for management.</p>
+
+      <p>In addition, we use strict access controls to ensure that your information is only accessible on a need-to-know basis, by employees who are directly involved in your recruitment application. Any third parties that process your information act on our instructions and are subject to a duty of confidentiality.</p>
+
+      <h2 id="how-long-we-keep-your-information">8. How long we keep your information</h2>
+
+      <p>We keep your personal information for a period of 2 years, after your recruitment application is decided. We keep your information for that period in order to respond to or defend against any legal claims. After this period, we will securely delete or anonymise your personal information, in accordance with the applicable laws and regulations. When we anonymise your information, this makes it unidentifiable as to whom it originally belonged to.</p>
+
+      <p>If you are unsuccessful with your application, we may also keep your information in case there are any similar opportunities that may be suitable for you in the future. In any event, we will not hold your data for more than 2 years.</p>
+
+      <p>If you do not want us to keep your information after the recruitment process has ended, please contact us at <a href="mailto:dataprotection@canonical.com">dataprotection@canonical.com</a>.</p>
+
+      <h2 id="automated-decision-making">9. Automated decision-making</h2>
+
+      <p>We do not use automated decision-making for recruitment purposes. All applications are reviewed by Canonical employees, who assess your suitability for the role you have applied for.</p>
+
+      <h2 id="your-rights">10. Your rights</h2>
+
+      <p>You have a number of rights which you may be able to exercise with regards to your personal information. These rights have been listed below:</p>
+
+      <ul>
+        <li><b>Rights to Access and Data Portability:</b> You have the right to access your personal information and may make a request to do so either verbally or in writing. You also have the right to data portability and may request to receive your personal information in a standard use, machine readable format.</li>
+        <li><b>Right to Rectification:</b> You have the right to request us to rectify any inaccurate or incomplete personal information that we may hold on you. If you make this request, we will update your personal information with the correct information provided.</li>
+        <li><b>Rights to Objection, Restriction and Erasure:</b> You have the right to restrict how your personal information is being used, and the right to request us to delete your information.</li>
+        <li><b>Right to Withdraw Consent:</b> Although we do not generally process your personal information based on your consent, in circumstances which this is the case, you may withdraw your consent at any time.</li>
+        <li><b>Right to be Informed:</b> You have the right to be informed about how we collect, use and retain your personal information, which is why we have set these out within this policy. If you have further queries on how we use your personal information, you may contact us at any time.</li>
+        <li><b>Rights Against Automated Decision-Making and Profiling:</b> We do not use automated decision-making or profiling for recruitment purposes.</li>
+      </ul>
+
+      <h2 id="exercising-your-rights">11. Exercising your rights</h2>
+
+      <p>To exercise any of these rights above, please contact us at <a href="mailto:dataprotection@canonical.com">dataprotection@canonical.com</a>, providing your name and contact details. Depending on your request, we may ask for further verification of your identity, or additional information in order to fulfil your request.</p>
+
+      <h2 id="right-to-complain">12. Right to complain</h2>
+
+      <p>If you wish to make a complaint to us about how we use or retain your personal information, please contact us at <a href="mailto:dataprotection@canonical.com">dataprotection@canonical.com</a>.</p>
+
+      <p>You also have the right to submit a complaint with the UK data protection authority, which is the Information Commissioner's Office (ICO). If you wish to file a complaint with the ICO, you may find the following information helpful: https://ico.org.uk/make-a-complaint/</p>
+
+      <h2 id="contact-information">13. Contact information</h2>
+
+      <p>If you have any questions about this notice, or about how we use or retain your personal information, please contact us at <a href="mailto:dataprotection@canonical.com">dataprotection@canonical.com</a>.</p>
+
+      <h2 id="policy-changes">14. Policy changes</h2>
+
+      <p>This is the latest version of our Recruitment Privacy Notice and is in effect as of the “Last Updated” date which may be found at the top of the notice. As we may change this notice from time to time, you should check here regularly for the most up-to-date version.</p>
+    </div>
+
+    <div class="col-4 p-sticky-toc">
+      <aside class="p-table-of-contents">
+        <div class="p-table-of-contents__section">
+          <h4 class="p-table-of-contents__header">Contents</h4>
+          <nav class="p-table-of-contents__nav">
+            <ul class="p-list u-no-margin--bottom">
+              <li><a href="#introduction">1. Introduction</a></li>
+              <li><a href="#what-information-we-collect">2. What information we collect</a></li>
+              <li><a href="#how-we-collect-your-information">3. How we collect your information</a></li>
+              <li><a href="#why-we-use-your-information">4. Why we use your information</a></li>
+              <li><a href="#who-we-share-your-information-with">5. Who we share your information with</a></li>
+              <li><a href="#international-data-transfers">6. International data transfers</a></li>
+              <li><a href="#how-we-protect-your-information">7. How we protect your information</a></li>
+              <li><a href="#how-long-we-keep-your-information">8. How long we keep your information</a></li>
+              <li><a href="#automated-decision-making">9. Automated decision-making</a></li>
+              <li><a href="#your-rights">10. Your rights</a></li>
+              <li><a href="#exercising-your-rights">11. Exercising your rights</a></li>
+              <li><a href="#right-to-complain">12. Right to complain</a></li>
+              <li><a href="#contact-information">13. Contact information</a></li>
+              <li><a href="#policy-changes">14. Policy changes</a></li>
+            </ul>
+          </nav>
+        </div>
+      </aside>
+    </div>
+  </div>
+</div>
+{% endblock %}


### PR DESCRIPTION
## Done

- Added /legal/data-privacy/recruitment based on the [copy doc](https://docs.google.com/document/d/1D_irZPx4n67_Lhg-9P2-Iu9jZM9Va7n0/edit#)

## QA

- Visit https://ubuntu-com-11606.demos.haus/legal/data-privacy/recruitment
- See that it matches the copy doc

