### PR TITLE
add a title to the blog RSS feed

### DIFF
--- a/webapp/app.py
+++ b/webapp/app.py
@@ -528,6 +528,7 @@ blog_views = BlogViews(
     api=BlogAPI(session=session),
     excluded_tags=[3184, 3265, 3408, 3960],
     per_page=11,
+    blog_title="Ubuntu blog",
 )
 app.add_url_rule(
     "/blog/topics/<regex('maas|design|juju|robotics|snapcraft'):slug>",


### PR DESCRIPTION
## Done

- Add a blog title to Ubuntu blog (by default it's "Blog")

## QA

- Go to https://ubuntu-com-11607.demos.haus/blog/feed
- Make sure that the title tag contains the new title as a value
