### PR TITLE
fix heading typo

### DIFF
--- a/templates/landscape/index.html
+++ b/templates/landscape/index.html
@@ -9,7 +9,7 @@
 <section class="p-strip--suru-topped is-bordered">
   <div class="row">
     <div class="col-6">
-      <h1>Take control of your infrasctucture</h1>
+      <h1>Take control of your infrastructure</h1>
       <p>Landscape is the leading management and administration tool for Ubuntu.</p>
       <p>
         <a class="p-button--positive" href="/landscape/pricing">Get Landscape</a>


### PR DESCRIPTION
## Done

- Fixed typo in "infrastructure"

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/landscape
- Check typo has been fixed

## Issue / Card

Fixes https://github.com/canonical-web-and-design/ubuntu.com/issues/11609