### PR TITLE
Update download nav link text

### DIFF
--- a/templates/templates/navigation-download-h.html
+++ b/templates/templates/navigation-download-h.html
@@ -50,7 +50,7 @@
               Intel IEI TANK 870
             </a></li>
             <li class='p-list__item'><a class='p-link' href='/download/xilinx'>
-              Xilinx Evaluation kits & SOMs
+              AMD-Xilinx Evaluation kits & SOMs
             </a></li>
           </ul>
         </div>


### PR DESCRIPTION
## Done

- Updated as per [copy doc](https://docs.google.com/document/d/11pX5gxOE6UWljIGRBZdwuCL1MHzs4pNgxJpK0mcIqdQ/edit#)

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: https://ubuntu-com-11612.demos.haus/#download > "Ubuntu for IoT"
- Check that the link text has been updated

## Issue / Card

Fixes https://github.com/canonical-web-and-design/web-squad/issues/5318
