### PR TITLE
Update cloud survey banner text

### DIFF
--- a/templates/shared/_cloud-survey-banner.html
+++ b/templates/shared/_cloud-survey-banner.html
@@ -3,7 +3,7 @@
     <div class="p-notification">
       <div class="p-notification__content">
         <p class="p-notification__message">
-          <a href="https://docs.google.com/forms/d/e/1FAIpQLSdDECWbUMkJ1gqk8iOylEF9sli23tuMWHQRVrC2JUOzSDM_Tg/viewform">Win a virtual pass to KubeCon Europe 2022!</a>
+          <a href="https://docs.google.com/forms/d/e/1FAIpQLSdDECWbUMkJ1gqk8iOylEF9sli23tuMWHQRVrC2JUOzSDM_Tg/viewform">Fill in cloud pricing survey!</a>
         </p>
       </div>
     </div>


### PR DESCRIPTION
## Done

- Updated banner text (no copy doc, see issue)

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/ceph (or any other page listed in the issue)
    - Be sure to test on mobile, tablet and desktop screen sizes
- See that banner has been updated according to request

## Issue / Card

Fixes https://github.com/canonical-web-and-design/web-squad/issues/5299