### PR TITLE
Update report link on /kubernetes/resources

### DIFF
--- a/templates/kubernetes/resources.html
+++ b/templates/kubernetes/resources.html
@@ -298,7 +298,7 @@
   <article class="p-strip is-shallow">
     <div class="row">
       <div class="col-4">
-        <h3 class="p-heading--4"><a href="https://juju.is/cloud-native-kubernetes-usage-report-2021">Kubernetes and cloud-native operations report</a></h3>
+        <h3 class="p-heading--4"><a href="https://juju.is/cloud-native-kubernetes-usage-report-2022">Kubernetes and cloud-native operations report</a></h3>
       </div>
       <div class="col-4">
         <p>Canonical is a proud member of the CNCF and MicroK8s is a very popular Kubernetes distribution for developers and enterprises alike.</p>

--- a/templates/kubernetes/resources.html
+++ b/templates/kubernetes/resources.html
@@ -20,6 +20,28 @@
 </section>
 <section class="p-strip">
   <div class="u-fixed-width">
+    <h2>Canonical Kubernetes FAQ</h2>
+  </div>
+  <article class="p-strip is-shallow">
+    <div class="row">
+      <div class="col-4">
+        <h3 id="what-is-microk8s" class="p-heading--4"><a href="/kubernetes/compare">How does Canonical Kubernetes compare with other Kubernetes platforms?</a></h3>
+      </div>
+      <div class="col-4">
+        <p>The Kubernetes landscape is vast and complex. If you are looking to compare different enterprise Kubernetes distributions, this webpage provides a detailed overview.</p>
+      </div>
+      <div class="col-4">
+        <div class="u-hide--small u-align--center">
+          <a href="/kubernetes/compare">
+            <img src="https://assets.ubuntu.com/v1/198b738b-Compare_Kubernetes-Openshift-Rancher.svg" alt="How does Canonical Kubernetes compare with other Kubernetes platforms?" width="560" height="302" style="max-height: 315px; padding: 20px">
+           </a>
+        </div>
+      </div>
+    </div>
+  </article>
+</section>
+<section class="p-strip--light">
+  <div class="u-fixed-width">
     <h2>Videos and webinars</h2>
   </div>
   <article class="p-strip is-shallow">
@@ -174,7 +196,7 @@
     </div>
   </article>
 </section>
-<section class="p-strip--light">
+<section class="p-strip">
   <div class="u-fixed-width">
     <h2>Case studies/Whitepapers/Industry reports</h2>
   </div>
@@ -292,7 +314,7 @@
     </div>
   </article>
 </section>
-<section class="p-strip">
+<section class="p-strip--light">
   <div class="u-fixed-width">
     <h2>Blogs</h2>
     <p>All Canonical blogs related to Kubernetes can be found here. This rich set of content covers everything from high-level product announcements to hands-on technical guides that dig into more complicated topics.</p> 
@@ -448,7 +470,7 @@
     </div>
   </article>
 </section>
-<section class="p-strip--light">
+<section class="p-strip">
   <div class="u-fixed-width">
     <h2>Reference architectures/Solution briefs</h2>
   </div>

--- a/templates/kubernetes/resources.html
+++ b/templates/kubernetes/resources.html
@@ -284,8 +284,8 @@
       </div>
       <div class="col-4">
         <div class="u-hide--small u-align--center">
-          <a href="https://juju.is/cloud-native-kubernetes-usage-report-2021">
-            <img src="https://assets.ubuntu.com/v1/aea32a0d-Kubernetes+and+cloud-native+operations.png" alt="Kubernetes and cloud-native operations report" width="560" height="302">
+          <a href="https://juju.is/cloud-native-kubernetes-usage-report-2022">
+            <img src="https://ubuntu.com/wp-content/uploads/bc04/Screen-Shot-2022-05-16-at-6.22.31-AM.png" alt="Kubernetes and cloud-native operations report" width="560" height="302">
            </a>
         </div>
       </div>


### PR DESCRIPTION

## Done

- Update Kubernetes and cloud-native operations report link

## QA

- go to `/kubernetes/resources` or https://ubuntu-com-11615.demos.haus/kubernetes/resources
- compare page against [copy doc](https://docs.google.com/document/d/1enaCJ4Vt9a_2_l6xYccnZ-fBVUejPSmfMi8LP2aDA9c/edit#)

## Issue / Card

Fixes [#5211](https://github.com/canonical-web-and-design/web-squad/issues/5211)
