### PR TITLE
Fix the pricing-calculator link on what-is-openstack

### DIFF
--- a/templates/openstack/what-is-openstack.html
+++ b/templates/openstack/what-is-openstack.html
@@ -40,13 +40,13 @@ https://docs.google.com/document/d/15xrgIq_KUwHaCyFoI7-yS_JmBbsoyXJ4GpRMFAa7_is/
         Since more and more organisations are using <a href="/cloud/hybrid-cloud">hybrid multi-cloud architecture</a>, implementing an own
         cloud is a natural step once the number of workloads grows. Although
         CapEx costs associated with an initial deployment of the OpenStack
-        are high, its OpEx costs are significantly lower compared to hyperscalers. 
+        are high, its OpEx costs are significantly lower compared to hyperscalers.
         As a result, the aggregated total cost of ownership (TCO) is lower when running workloads in the long term
         and at scale. This allows businesses to optimise their cloud maintenance
         costs and service providers to build an infrastructure competitive to hyperscalers.
       </p>
       <p>
-        <a href="/pricing-calculator"
+        <a href="/openstack/pricing-calculator"
           >Learn how much you can save with OpenStack&nbsp;&rsaquo;</a
         >
       </p>
@@ -68,7 +68,7 @@ https://docs.google.com/document/d/15xrgIq_KUwHaCyFoI7-yS_JmBbsoyXJ4GpRMFAa7_is/
         vSphere or Red Hat Virtualization Manager, OpenStack is a fully
         functional cloud platform as defined by the
         <a
-         
+
           href="https://www.nist.gov/programs-projects/nist-cloud-computing-program-nccp"
           >National Institute of Standards and Technology</a
         >. This means that OpenStack basically resembles the behaviour of public
@@ -429,7 +429,7 @@ https://docs.google.com/document/d/15xrgIq_KUwHaCyFoI7-yS_JmBbsoyXJ4GpRMFAa7_is/
       <p class="u-sv3">
         According to the
         <a
-         
+
           href="https://451research.com/search?products=OpenStack"
           >451 Research Market Monitor (Open Source Software, OpenStack)</a
         >
@@ -768,7 +768,7 @@ https://docs.google.com/document/d/15xrgIq_KUwHaCyFoI7-yS_JmBbsoyXJ4GpRMFAa7_is/
       </div>
       <hr class="u-sv1" />
       <p class="p-card__content">
-        Charmed OpenStack is an enterprise cloud platform 
+        Charmed OpenStack is an enterprise cloud platform
         engineered for price-performance that is designed to run mission-critical workloads.
       </p>
       <br />


### PR DESCRIPTION
## Done
Fix the pricing-calculator link on what-is-openstack

## QA
- Check the link is the correct one.

## Issue / Card
Fixes https://github.com/canonical-web-and-design/ubuntu.com/runs/6520688424?check_suite_focus=true

