### PR TITLE
k8s doc updates

### DIFF
--- a/templates/kubernetes/docs/aws-iam-auth.md
+++ b/templates/kubernetes/docs/aws-iam-auth.md
@@ -31,7 +31,7 @@ following overlay([download it here][asset-aws-iam-overlay]):
 ```yaml
 applications:
   aws-iam:
-    charm: cs:~containers/aws-iam
+    charm: aws-iam
 relations:
   - ['aws-iam', 'kubernetes-control-plane']
   - ['aws-iam', 'vault']
@@ -42,7 +42,7 @@ or if using easyrsa:
 ```yaml
 applications:
   aws-iam:
-    charm: cs:~containers/aws-iam
+    charm: aws-iam
 relations:
   - ['aws-iam', 'kubernetes-control-plane']
   - ['aws-iam', 'easyrsa']

--- a/templates/kubernetes/docs/aws-integration.md
+++ b/templates/kubernetes/docs/aws-integration.md
@@ -38,7 +38,7 @@ applications:
     annotations:
       gui-x: "600"
       gui-y: "300"
-    charm: cs:~containers/aws-integrator
+    charm: aws-integrator
     num_units: 1
     trust: true
 relations:

--- a/templates/kubernetes/docs/azure-integration.md
+++ b/templates/kubernetes/docs/azure-integration.md
@@ -38,7 +38,7 @@ applications:
     annotations:
       gui-x: "600"
       gui-y: "300"
-    charm: cs:~containers/azure-integrator
+    charm: azure-integrator
     num_units: 1
     trust: true
 relations:

--- a/templates/kubernetes/docs/backups.md
+++ b/templates/kubernetes/docs/backups.md
@@ -85,9 +85,7 @@ sha256sum etcd-snapshot-2018-09-26-18.04.02.tar.gz
 As restoring only works when there is a single unit of **etcd**, it is usual to deploy a new instance of the application first.
 
 ```bash
-juju deploy etcd new-etcd --series=bionic --config channel=3.2/stable
-juju deploy cs:~containers/easyrsa new-easyrsa --series=bionic
-juju add-relation new-etcd:certificates new-easyrsa:client
+juju deploy etcd new-etcd --series=focal --config channel=3.4/stable
 ```
 
 The `--series` option is included here to illustrate how to specify which series the new unit should be running on.
@@ -108,11 +106,8 @@ juju run-action new-etcd/0 restore --wait
 Once the restore action has finished, you should see output confirming that the operation is `completed`. The new etcd application will need to be connected to the rest of the deployment:
 
 ```bash
-juju add-relation new-etcd flannel
+juju add-relation new-etcd [calico|flannel|$cni]
 juju add-relation new-etcd kubernetes-control-plane
-juju add-relation kubeapi-load-balancer:certificates new-easyrsa:client
-juju add-relation kubernetes-control-plane:certificates new-easyrsa:client
-juju add-relation kubernetes-worker:certificates new-easyrsa:client
 ```
 
 To restore the cluster capabilities of etcd, you can now add more units:

--- a/templates/kubernetes/docs/cdk-addons.md
+++ b/templates/kubernetes/docs/cdk-addons.md
@@ -46,7 +46,7 @@ to cross-model relate it to kubernetes-control-plane:
 juju config -m cluster-model kubernetes-control-plane dns-provider=none
 juju add-k8s k8s-cloud --controller mycontroller
 juju add-model k8s-model k8s-cloud
-juju deploy cs:~containers/coredns
+juju deploy coredns --channel=latest/stable --trust
 juju offer coredns:dns-provider
 juju consume -m cluster-model k8s-model.coredns
 juju relate -m cluster-model coredns kubernetes-control-plane
@@ -57,11 +57,7 @@ charm as their DNS provider. The CoreDNS charm config allows you to change
 the cluster domain, the IP address or config file to forward unhandled
 queries to, add additional DNS servers, or even override the Corefile entirely.
 
-It is also possible to use `kube-dns` as the DNS provider, or turn off DNS
-altogether using the `dns-provider` [kubernetes-control-plane configuration][].
-
 ## Kubernetes Dashboard
-
 Sourced from: <https://github.com/kubernetes/dashboard.git>
 
 The Kubernetes Dashboard is a standard and easy way to inspect and
@@ -84,18 +80,16 @@ juju config kubernetes-control-plane enable-dashboard-addons=false
 juju config kubernetes-control-plane enable-dashboard-addons=true
 ```
 
-For additional control over the Kubernetes Dashboard (Different versions,
-authentication methods...) you can also deploy it into the cluster using the
-[Kubernetes Dashboard operator bundle][kubernetes-dashboard-bundle].
-
+For additional control over the Kubernetes Dashboard, you can also deploy it into
+the cluster using the [Kubernetes Dashboard operator charm][kubernetes-dashboard-charm].
 To do so, set the `enable-dashboard-addons` [kubernetes-control-plane configuration][]
 option to `false` and deploy the charm into a Kubernetes model on your cluster:
 
 ```bash
 juju config -m cluster-model kubernetes-control-plane enable-dashboard-addons=false
 juju add-k8s k8s-cloud --controller mycontroller
-juju add-model kubernetes-dashboard k8s-cloud
-juju deploy cs:~containers/kubernetes-dashboard-bundle
+juju add-model k8s-model k8s-cloud
+juju deploy kubernetes-dashboard --channel=latest/stable --trust
 ```
 
 For accessing the Dashboard use the same instructions in the [Operations page][].
@@ -224,8 +218,8 @@ This charm offers the following options
 [GPU workers page]: /kubernetes/docs/gpu-workers
 [LDAP and Keystone page]: /kubernetes/docs/ldap
 [monitoring docs]: /kubernetes/docs/monitoring
-[coredns-charm]: https://jaas.ai/u/containers/coredns
-[kubernetes-dashboard-bundle]: https://jaas.ai/u/containers/kubernetes-dashboard-bundle
+[coredns-charm]: https://charmhub.io/coredns
+[kubernetes-dashboard-charm]: https://charmhub.io/kubernetes-dashboard
 [kube-state-metrics example]: https://github.com/kubernetes/kube-state-metrics/tree/master/examples/standard
 [metrics-server releases]: https://github.com/kubernetes-sigs/metrics-server/releases
 [add a k8s cloud]: https://juju.is/docs/olm/get-started-on-kubernetes#heading--register-the-cluster-with-juju

--- a/templates/kubernetes/docs/charm-reference.md
+++ b/templates/kubernetes/docs/charm-reference.md
@@ -19,42 +19,40 @@ These are the core charms used by Charmed Kubernetes. See the individual pages
 linked below for specific usage and configuration.
 
 
-[charm-aws-iam](https://charmhub.io/charm-aws-iam)
+[aws-iam](https://charmhub.io/aws-iam)
 
-[charm-aws-integrator](https://charmhub.io/charm-aws-integrator)
+[aws-integrator](https://charmhub.io/aws-integrator)
 
-[charm-calico](https://charmhub.io/charm-calico)
+[calico](https://charmhub.io/calico)
 
-[charm-canal](https://charmhub.io/charm-canal)
+[canal](https://charmhub.io/canal)
 
-[charm-containerd](https://charmhub.io/charm-containerd)
+[containerd](https://charmhub.io/containerd)
 
-[charm-docker](https://charmhub.io/charm-docker)
+[docker-registry](https://charmhub.io/docker-registry)
 
-[charm-docker-registry](https://charmhub.io/charm-docker-registry)
+[easyrsa](https://charmhub.io/easyrsa)
 
-[charm-easyrsa](https://charmhub.io/charm-easyrsa)
+[etcd](https://charmhub.io/etcd)
 
-[charm-etcd](https://charmhub.io/charm-etcd)
+[flannel](https://charmhub.io/flannel)
 
-[charm-flannel](https://charmhub.io/charm-flannel)
+[gcp-integrator](https://charmhub.io/gcp-integrator)
 
-[charm-gcp-integrator](https://charmhub.io/charm-gcp-integrator)
+[kata](https://charmhub.io/kata)
 
-[charm-kata](https://charmhub.io/charm-kata)
+[keepalived](https://charmhub.io/keepalived)
 
-[charm-keepalived](https://charmhub.io/charm-keepalived)
+[kubeapi-load-balancer](https://charmhub.io/kubeapi-load-balancer)
 
-[charm-kubeapi-load-balancer](https://charmhub.io/charm-kubeapi-load-balancer)
+[kubernetes-control-plane](https://charmhub.io/kubernetes-control-plane)
 
-[charm-kubernetes-master](https://charmhub.io/charm-kubernetes-master)
+[kubernetes-worker](https://charmhub.io/kubernetes-worker)
 
-[charm-kubernetes-worker](https://charmhub.io/charm-kubernetes-worker)
+[openstack-integrator](https://charmhub.io/openstack-integrator)
 
-[charm-openstack-integrator](https://charmhub.io/charm-openstack-integrator)
+[tigera-secure-ee](https://charmhub.io/tigera-secure-ee)
 
-[charm-tigera-secure-ee](https://charmhub.io/charm-tigera-secure-ee)
-
-[charm-vsphere-integrator](https://charmhub.io/charm-vsphere-integrator)
+[vsphere-integrator](https://charmhub.io/vsphere-integrator)
 
 

--- a/templates/kubernetes/docs/cni-calico.md
+++ b/templates/kubernetes/docs/cni-calico.md
@@ -51,15 +51,9 @@ documentation for instructions.
 
 ## Deploying Charmed Kubernetes with Calico
 
-To deploy Charmed Kubernetes with Calico, deploy the kubernetes-calico bundle:
-
-```bash
-juju deploy cs:~containers/kubernetes-calico
-```
-
-The Calico bundle is identical to the standard `charmed-kubernetes` bundle with the
-exception of replacing Flannel with Calico. You can apply any customisation overlays
-that would apply to `charmed-kubernetes` to this bundle also.
+Calico became the default choice for networking with **Charmed Kubernetes** 1.24.
+If you [deploy the bundle][quickstart] without changing the default settings,
+calico will be the CNI.
 
 ## Calico configuration options
 

--- a/templates/kubernetes/docs/cni-canal.md
+++ b/templates/kubernetes/docs/cni-canal.md
@@ -23,15 +23,15 @@ special configuration.
 
 ## Deploying Charmed Kubernetes with Canal
 
-To deploy a cluster with Canal, deploy the kubernetes-canal bundle:
+To deploy a cluster with Canal, deploy the `charmed-kubernetes` bundle with the
+[canal overlay][canal-overlay]:
 
 ```bash
-juju deploy cs:bundle/canonical-kubernetes-canal
+juju deploy charmed-kubernetes --overlay canal-overlay.yaml
 ```
 
-The canal bundle is identical to the standard `charmed-kubernetes` bundle with the
-exception of replacing flannel with canal. You can apply any customisation overlays
-that would apply to `charmed-kubernetes` to this bundle also.
+You can apply any additional customisation overlays that would apply to
+`charmed-kubernetes` to this deployment as well.
 
 ## Canal configuration options
 
@@ -76,6 +76,7 @@ For additional troubleshooting pointers, please see the
 <!-- LINKS -->
 
 [canal]: https://docs.projectcalico.org/v3.7/getting-started/kubernetes/installation/flannel
+[canal-overlay]: https://raw.githubusercontent.com/charmed-kubernetes/bundle/main/overlays/canal-overlay.yaml
 [troubleshooting]: /kubernetes/docs/troubleshooting
 
 <!-- FEEDBACK -->

--- a/templates/kubernetes/docs/cni-flannel.md
+++ b/templates/kubernetes/docs/cni-flannel.md
@@ -17,14 +17,20 @@ toc: False
 [Flannel][] is a simple, lightweight layer 3 fabric for Kubernetes. Flannel manages an
 IPv4 network between multiple nodes in a cluster. It does not control how containers
 are networked to the host, only how the traffic is transported between hosts. For
-more complicated scenarios, see also [Calico][] and [Canal][]
+more complicated scenarios, see also [Calico][] and [Canal][].
 
 
-## Deploying **Charmed Kubernetes** with flannel
+## Deploying Charmed Kubernetes with Flannel
 
-Flannel is the default choice for networking with **Charmed Kubernetes**. If you
-[deploy the bundle][quickstart] without changing the default settings,
-flannel will be used for CNI.
+To deploy a cluster with Flannel, deploy the `charmed-kubernetes` bundle with the
+[flannel overlay][flannel-overlay]:
+
+```bash
+juju deploy charmed-kubernetes --overlay flannel-overlay.yaml
+```
+
+You can apply any additional customisation overlays that would apply to
+`charmed-kubernetes` to this deployment as well.
 
 ## Flannel options
 
@@ -68,6 +74,7 @@ For additional troubleshooting pointers, please see the [dedicated troubleshooti
 <!-- LINKS -->
 
 [Flannel]: https://github.com/coreos/flannel
+[flannel-overlay]: https://raw.githubusercontent.com/charmed-kubernetes/bundle/main/overlays/flannel-overlay.yaml
 [troubleshooting]: /kubernetes/docs/troubleshooting
 [quickstart]:  /kubernetes/docs/quickstart
 [install-manual]:  /kubernetes/docs/install-manual

--- a/templates/kubernetes/docs/cni-multus.md
+++ b/templates/kubernetes/docs/cni-multus.md
@@ -69,7 +69,7 @@ Once all of the requirements have been met, you can deploy Multus into a
 Kubernetes model by running:
 
 ```
-juju deploy cs:~containers/multus
+juju deploy multus
 ```
 
 ## Configuring the Default CNI

--- a/templates/kubernetes/docs/cni-overview.md
+++ b/templates/kubernetes/docs/cni-overview.md
@@ -29,12 +29,12 @@ Kubernetes**, which are listed below:
 
 The currently supported base CNI solutions for **Charmed Kubernetes** are:
 
- -   [Flannel][flannel]
  -   [Calico][calico]
  -   [Canal][canal]
+ -   [Flannel][flannel]
  -   [Tigera Secure EE][tigera]
 
-By default, **Charmed Kubernetes** will deploy the cluster using flannel. To chose a different CNI provider, see the individual links above.
+By default, **Charmed Kubernetes** will deploy the cluster using calico. To chose a different CNI provider, see the individual links above.
 
 The following CNI addons are also available:
  -   [Multus][multus]
@@ -49,9 +49,9 @@ Kubernetes, such a migration should be manageable with no downtime.
 
 <!-- LINKS -->
 
-[flannel]: /kubernetes/docs/cni-flannel
 [calico]: /kubernetes/docs/cni-calico
 [canal]: /kubernetes/docs/cni-canal
+[flannel]: /kubernetes/docs/cni-flannel
 [tigera]: /kubernetes/docs/tigera-secure-ee
 [multus]: /kubernetes/docs/cni-multus
 [sr-iov]: /kubernetes/docs/cni-sriov

--- a/templates/kubernetes/docs/cni-sriov.md
+++ b/templates/kubernetes/docs/cni-sriov.md
@@ -82,8 +82,8 @@ Once all of the requirements have been met, you can deploy the SR-IOV charms
 into a Kubernetes model by running:
 
 ```
-juju deploy cs:~containers/sriov-cni
-juju deploy cs:~containers/sriov-network-device-plugin
+juju deploy sriov-cni
+juju deploy sriov-network-device-plugin
 ```
 
 ## Creating SR-IOV Virtual Functions

--- a/templates/kubernetes/docs/container-runtime.md
+++ b/templates/kubernetes/docs/container-runtime.md
@@ -4,7 +4,7 @@ markdown_includes:
   nav: "kubernetes/docs/shared/_side-navigation.md"
 context:
   title: "Container runtimes"
-  description: Configure and use containerd or docker as the container runtime
+  description: Configure and use containerd as the container runtime
 keywords: containerd, docker, runtime, image
 tags: [architecture]
 sidebar: k8smain-sidebar
@@ -13,13 +13,12 @@ layout: [base, ubuntu-com]
 toc: False
 ---
 
-From 1.15 onwards, **Charmed Kubernetes** uses **containerd** as part of a pluggable architecture for
-container runtimes, instead of directly using Docker only. This change has been
-demonstrated to increase performance, and also provides scope for using different
-runtimes on a case-by case basis.
+From 1.15 onwards, **Charmed Kubernetes** uses **containerd** as part of a pluggable architecture
+for container runtimes. This change has been demonstrated to increase performance, and also
+provides scope for using different runtimes on a case-by case basis.
 
-However, it is also possible to use Docker for running containers as in previous versions
-of **Charmed Kubernetes**.
+Upstream support for the Docker container runtime was removed in the 1.24 release. Thus, the
+`docker` subordinate charm will no longer function from **Charmed Kubernetes** 1.24 onwards.
 
 
 ## Configuring containerd
@@ -88,20 +87,9 @@ juju config containerd gpu_driver=none
 
 ## Migrating to containerd
 
-If you have upgraded to  **Charmed Kubernetes** version 1.15, you can transition to using containerd by following the steps outlined in
-[this section of the upgrade notes][docker2containerd].
-
-## Using Docker
-
-Although the default set up for **Charmed Kubernetes** from version 1.15 is to use containerd to provide the container runtime, it is also possible to
-run workers specifically using Docker. This is done by adding the Docker
-charm to your cluster and deploying Docker-based workers:
-
-```bash
-juju deploy cs:~containers/kubernetes-worker kubernetes-worker-docker
-juju deploy cs:~containers/docker
-juju relate docker kubernetes-worker-docker
-```
+If you are upgrading from a version of **Charmed Kubernetes** that uses the `docker`
+subordinate charm for the container runtime, transition to `containerd` by following
+the steps outlined in [this section of the upgrade notes][docker2containerd].
 
 
 <!-- LINKS -->

--- a/templates/kubernetes/docs/docker-registry.md
+++ b/templates/kubernetes/docs/docker-registry.md
@@ -41,7 +41,7 @@ If needed, consult the [quickstart guide][quickstart] to install
 follows.
 
 ```bash
-juju deploy cs:~containers/docker-registry
+juju deploy docker-registry
 juju add-relation docker-registry easyrsa:client
 juju config docker-registry \
   auth-basic-user='admin' \
@@ -143,8 +143,8 @@ comprehensive list sorted by release; not all images are required for all
 deployments. Take note of the images required by your deployment that will
 need to be hosted in your private registry. A list of images required by
 a specific release is also included on the 'components' page in the 
-documentation, for example, the list for the 1.20 release is located on the
-[1.20 components page][1.20]
+documentation, for example, the list for the 1.24 release is located on the
+[1.24 components page][1.24]
 
 ## Hosting images
 
@@ -180,12 +180,12 @@ juju config kubernetes-control-plane image-registry=$REGISTRY
 
 <!-- LINKS -->
 
-[registry-charm]: https://jaas.ai/u/containers/docker-registry
+[registry-charm]: https://charmhub.io/docker-registry
 [upstream-registry]: https://docs.docker.com/registry/
 [quickstart]: /kubernetes/docs/quickstart
 [container-runtime]: /kubernetes/docs/container-runtime
 [container-images-txt]: https://github.com/charmed-kubernetes/bundle/blob/master/container-images.txt
-[1.20]: /kubernetes/docs/1.20/components#images
+[1.24]: /kubernetes/docs/1.24/components#images
 
 <!-- FEEDBACK -->
 <div class="p-notification--information">

--- a/templates/kubernetes/docs/equinix.md
+++ b/templates/kubernetes/docs/equinix.md
@@ -76,7 +76,7 @@ machines:
     constraints: mem=32G
 applications:
   calico:
-    charm: cs:~containers/calico-826
+    charm: calico
     annotations:
       gui-x: '450'
       gui-y: '750'
@@ -105,7 +105,7 @@ applications:
     - lxd:1
     - lxd:2
   ceph-fs:
-    charm: cs:ceph-fs
+    charm: ceph-fs
     num_units: 1
     bindings:
       "": alpha
@@ -115,7 +115,7 @@ applications:
     to:
     - lxd:0
   ceph-mon:
-    charm: 'cs:ceph-mon'
+    charm: ceph-mon
     num_units: 3
     options:
       expected-osd-count: 3
@@ -129,7 +129,7 @@ applications:
      - lxd:1
      - lxd:2
   ceph-osd:
-    charm: cs:ceph-osd
+    charm: ceph-osd
     num_units: 3
     options:
       osd-devices: /dev/sda /dev/sdb
@@ -146,7 +146,7 @@ applications:
     annotations:
       gui-x: '1000'
       gui-y: '250'
-    charm: cs:ceph-radosgw
+    charm: ceph-radosgw
     num_units: 1
     bindings:
       "": alpha

--- a/templates/kubernetes/docs/gcp-integration.md
+++ b/templates/kubernetes/docs/gcp-integration.md
@@ -58,7 +58,7 @@ applications:
     annotations:
       gui-x: "600"
       gui-y: "300"
-    charm: cs:~containers/gcp-integrator
+    charm: gcp-integrator
     num_units: 1
     trust: true
 relations:

--- a/templates/kubernetes/docs/inclusive-naming.md
+++ b/templates/kubernetes/docs/inclusive-naming.md
@@ -62,9 +62,8 @@ transition the names of the default branches to `main`.
 
 <!-- LINKS -->
 
-[LXD-image]: https://linuxcontainers.org/lxd/docs/master/image-handling
 [kubernetes-control-plane]: https://charmhub.io/kubernetes-control-plane/docs
-[etcd]: /kubernetes/docs/charm-etcd
+[etcd]: https://charmhub.io/etcd
 [upgrading]: /kubernetes/docs/upgrading
 
 <!-- FEEDBACK -->

--- a/templates/kubernetes/docs/install-local.md
+++ b/templates/kubernetes/docs/install-local.md
@@ -229,7 +229,7 @@ This problem usually is related to the kernel parameters,
 `fs.inotify.max_user_instances` and `fs.inotify.max_user_watches`.
 
 At first, you should increase their values on the machine that is hosting
-the **Charmed Kubernetes** (`v1.23.4`) installation:
+the **Charmed Kubernetes** installation:
 
 ```bash
 sysctl -w fs.inotify.max_user_instances=8192

--- a/templates/kubernetes/docs/install-manual.md
+++ b/templates/kubernetes/docs/install-manual.md
@@ -40,11 +40,8 @@ containers to create a cluster), please see the separate
 
 ## Quick custom installs
 
-
-The details of how to edit and customise the **Charmed Kubernetes** bundle are
-outlined [below](#). However, using overlays (also explained in more
-detail below) you can make some common quick customisations for networking and
-cloud integration.
+Bundle overlays facilitate common, quick customisations for components such as
+networking and cloud integration.
 
 Overlay files can be applied when deploying Charmed Kubernetes by specifying them along with the deploy command:
 
@@ -65,15 +62,15 @@ each category!
 <div class="CNI">
  <div class="row">
  <div class="col-2 ">
-   <span>Calico</span>
+   <span>Flannel</span>
  </div>
   <div class="col-4 ">
-   <span>Calico provides out-of-the-box support for the
-   NetworkPolicy feature of Kubernetes, along with different modes of
-   network encapsulation. <a href="/kubernetes/docs/cni-calico"> Read more...</a></span>
+   <span>Flannel is a simple, lightweight layer 3 fabric for Kubernetes.
+   It manages an IPv4 network between multiple nodes in a cluster.
+   <a href="/kubernetes/docs/cni-flannel"> Read more...</a></span>
   </div>
   <div class="col-3 ">
-    <span><a href="https://raw.githubusercontent.com/charmed-kubernetes/bundle/main/overlays/calico-overlay.yaml" class="p-button--positive">Download calico-overlay.yaml</a></span>
+    <span><a href="https://raw.githubusercontent.com/charmed-kubernetes/bundle/main/overlays/flannel-overlay.yaml" class="p-button--positive">Download flannel-overlay.yaml</a></span>
   </div>
 </div>
 <br>
@@ -107,7 +104,7 @@ each category!
 <div class="p-notification--positive is-inline">
   <div markdown="1" class="p-notification__content">
     <span class="p-notification__title">Note:</span>
-    <p class="p-notification__message">By default, Charmed Kubernetes uses <em>Flannel</em> for networking. You can read more about CNI support <a href="/kubernetes/docs/cni-overview"> here </a>.</p>
+    <p class="p-notification__message">By default, Charmed Kubernetes uses <em>Calico</em> for networking. You can read more about CNI support <a href="/kubernetes/docs/cni-overview"> here </a>.</p>
   </div>
 </div>
 
@@ -204,22 +201,12 @@ juju deploy charmed-kubernetes
 ```
 
 It is also possible to deploy a specific version of the bundle by including the
-revision number. For example, to deploy the **Charmed Kubernetes** bundle for the Kubernetes 1.21
+revision number. For example, to deploy the **Charmed Kubernetes** bundle for the Kubernetes 1.23
 release, you could run:
 
 ```bash
-juju deploy charmed-kubernetes --revision=733
+juju deploy cs:charmed-kubernetes-862
 ```
-
-<div class="p-notification--positive is-inline">
-  <div markdown="1" class="p-notification__content">
-    <span class="p-notification__title">Older Versions:</span>
-    <p class="p-notification__message">Previous versions of <strong>Charmed Kubernetes</strong> used the name <code>canonical-kubernetes</code>. These versions are still available under that name
-    and links in the charm store. Versions from 1.14 onwards use
-    <code>charmed-kubernetes</code>.</p>
-  </div>
-</div>
-
 
 The revision numbers for bundles are generated automatically when the bundle is
 updated, including for testing and beta versions, so it isn't always the case
@@ -281,7 +268,7 @@ example, to replicate the steps to deploy and connect the
 ```yaml
 applications:
   aws-integrator:
-    charm: cs:~containers/aws-integrator
+    charm: aws-integrator
     num_units: 1
     trust: true
 relations:
@@ -339,16 +326,16 @@ kubernetes-worker:
   annotations:
     gui-x: '100'
     gui-y: '850'
-  charm: cs:~containers/kubernetes-worker
-  constraints: cores=4 mem=4G root-disk=16G
+  charm: kubernetes-worker
+  constraints: cores=2 mem=8G root-disk=16G
   expose: true
   num_units: 3
   options:
-    channel: 1.18/stable
+    channel: 1.24/stable
   resources:
-    cni-amd64: 12
-    cni-arm64: 10
-    cni-s390x: 11
+    cni-amd64: 0
+    cni-arm64: 0
+    cni-s390x: 0
     kube-proxy: 0
     kubectl: 0
     kubelet: 0

--- a/templates/kubernetes/docs/install-offline.md
+++ b/templates/kubernetes/docs/install-offline.md
@@ -78,8 +78,8 @@ The majority of charms, including all the core Charmed Kubernetes charms, rely o
 IoT that are easy to install, secure, cross‐platform and dependency‐free.
 
 The list of snaps required by Charmed Kubernetes is detailed in the "components"
-page for each release. For example, for 1.22, the
-[snaps are listed here][1.22-components].
+page for each release. For example, for 1.23, the
+[snaps are listed here][1.23-components].
 
 While it is _possible_ to download a snap package from the store, each snap will then
 need to be authenticated, and subsequent updates, even in the case of security
@@ -212,7 +212,7 @@ from an internet connected machine:
 ```bash
 git clone https://github.com/charmed-kubernetes/cdk-shrinkwrap.git /tmp/.shrinkwrap
 cd /tmp/.shrinkwrap
-BUNDLE=cs:charmed-kubernetes-733       # Choose a deployment bundle (example is 1.21.x)
+BUNDLE=cs:charmed-kubernetes-862       # Choose a deployment bundle (example is 1.23.x)
 ./shrinkwrap-lxc.sh $BUNDLE 
 ls /tmp/.shrinkwrap/build/
 ```
@@ -227,8 +227,8 @@ In air-gapped environment with access to the Juju controller,
    1. Ensure `applications.containerd.options` includes `custom_registries` settings
 1. Finally, deploy the Juju charms and resources from the provided local bundle.
 ```bash
-tar -xvf cs:charmed-kubernetes-733-stable-*.tar.gz --force-local
-cd cs:charmed-kubernetes-733-stable-*/
+tar -xvf cs:charmed-kubernetes-862-stable-*.tar.gz --force-local
+cd cs:charmed-kubernetes-862-stable-*/
 ./deploy.sh
 # examine provided instructions
 # ensure necessary modifications are considered
@@ -253,8 +253,7 @@ is covered in the [proxy documentation][].
 [maas-images]: https://maas.io/docs/snap/3.1/ui/using-image-streams
 [simplestreams]: https://juju.is/docs/olm/cloud-image-metadata
 [bundles]: /kubernetes/docs/supported-versions
-[containerd]: https://ubuntu.com/kubernetes/docs/1.21/charm-containerd
-[1.22-components]: https://ubuntu.com/kubernetes/docs/1.22/components#snaps
+[1.23-components]: /kubernetes/docs/1.23/components#snaps
 [cdk-shrinkwrap]: https://github.com/charmed-kubernetes/cdk-shrinkwrap
 [controller-config]: https://juju.is/docs/olm/controllers
 [credentials]: https://juju.is/docs/olm/credentials

--- a/templates/kubernetes/docs/ipv6.md
+++ b/templates/kubernetes/docs/ipv6.md
@@ -29,12 +29,12 @@ familiar with the [known issues](#known-issues) described below.
 ## Enabling IPv6 and dual-stack in Charmed Kubernetes
 
 These features can be used simply by changing the configuration for Calico and the
-Kubernetes master to include the relevant CIDRs.
+Kubernetes control-plane to include the relevant CIDRs.
 
 For Calico, the `cidr` configuration can contain two comma-separated values, with the
 first CIDR in the list being the preferred family for pods.
 
-For the Kubernetes master, the `service-cidr` configuration can contain two
+For the Kubernetes control-plane, the `service-cidr` configuration can contain two
 comma-separated values, with the first being the default family for services.
 
 Note that Kubernetes supports [explicitly setting the `ipFamilies`][ip-families] for a
@@ -48,8 +48,7 @@ enabled.
 ### Example deployment
 
 You can use the following overlay file ([download it here][asset-ipv4-ipv6-overlay])
-along with [the Calico overlay][asset-calico-overlay] to enable IPv4-preferred
-dual-stack:
+along with `charmed-kubernetes` to enable IPv4-preferred dual-stack:
 
 ```yaml
 description: Charmed Kubernetes overlay to enable IPv4-IPv6 dual-stack.
@@ -62,10 +61,10 @@ applications:
       service-cidr: "10.152.183.0/24,fd00:c00b:2::/112"
 ```
 
-You can deploy all of that with:
+Deploy with:
 
 ```
-juju deploy cs:charmed-kubernetes --overlay ./calico-overlay.yaml --overlay ipv4-ipv6-overlay.yaml
+juju deploy charmed-kubernetes --overlay ipv4-ipv6-overlay.yaml
 ```
 
 Once that is deployed, you can use the following spec ([download it

--- a/templates/kubernetes/docs/kata.md
+++ b/templates/kubernetes/docs/kata.md
@@ -48,7 +48,7 @@ the following YAML overlay:
 ```yaml
 applications:
   kata:
-    charm: cs:~containers/kata
+    charm: kata
 relations:
 - - kata:untrusted
   - containerd:untrusted
@@ -89,7 +89,7 @@ applications:
     constraints: instance-type=i3.metal
     num_units: 1
   kata:
-    charm: cs:~containers/kata
+    charm: kata
 relations:
 - - kata:untrusted
   - containerd:untrusted

--- a/templates/kubernetes/docs/ldap.md
+++ b/templates/kubernetes/docs/ldap.md
@@ -84,7 +84,7 @@ it is possible to re-use it for authenticating and authorising users in Kubernet
 To do so, first deploy the [openstack-integrator charm][openstack-integrator]
 
 ```bash
-juju deploy cs:~containers/openstack-integrator
+juju deploy openstack-integrator
 ```
 
 Use 'juju trust' to grant openstack-integrator a permission to access the OpenStack model,

--- a/templates/kubernetes/docs/metallb.md
+++ b/templates/kubernetes/docs/metallb.md
@@ -40,6 +40,7 @@ anti-affinity to prevent Kubernetes pods from stacking on a single node.
     <a href="https://metallb.universe.tf/"> MetalLB website</a></p>
   </div>
 </div>
+
 # Deployment
 
 ## Layer 2 mode

--- a/templates/kubernetes/docs/metallb.md
+++ b/templates/kubernetes/docs/metallb.md
@@ -64,7 +64,7 @@ juju add-model metallb-system k8s-cloud
 Then you can deploy MetalLB:
 
 ```bash
-juju deploy cs:~containers/metallb
+juju deploy metallb
 ```
 
 ### Configuration
@@ -89,7 +89,7 @@ applications:
 You would then specify this when deploying the bundle:
 
 ```bash
-juju deploy cs:~containers/metallb --overlay ./overlay.yaml
+juju deploy metallb --overlay ./overlay.yaml
 ```
 
 Alternatively, you can change the config directly on the metallb-controller

--- a/templates/kubernetes/docs/openstack-integration.md
+++ b/templates/kubernetes/docs/openstack-integration.md
@@ -43,7 +43,7 @@ applications:
     annotations:
       gui-x: "600"
       gui-y: "300"
-    charm: cs:~containers/openstack-integrator
+    charm: openstack-integrator
     num_units: 1
     trust: true
 relations:
@@ -169,7 +169,7 @@ applications:
     annotations:
       gui-x: "600"
       gui-y: "300"
-    charm: cs:~containers/openstack-integrator
+    charm: openstack-integrator
     num_units: 1
     trust: true
 relations:

--- a/templates/kubernetes/docs/overview.md
+++ b/templates/kubernetes/docs/overview.md
@@ -4,7 +4,7 @@ markdown_includes:
   nav: "kubernetes/docs/shared/_side-navigation.md"
 context:
   title: "Overview"
-  description: Understand how the Charmed Distribution of Kubernetes works.
+  description: Understand how Charmed Kubernetes works.
 keywords: juju, kubernetes, cdk
 tags: [intro]
 sidebar: k8smain-sidebar

--- a/templates/kubernetes/docs/proxies.md
+++ b/templates/kubernetes/docs/proxies.md
@@ -81,8 +81,8 @@ The majority of charms, including all the core Charmed Kubernetes charms, rely o
 IoT that are easy to install, secure, cross‐platform and dependency‐free.
 
 The list of snaps required by Charmed Kubernetes is detailed in the "components"
-page for each release. For example, for 1.22, the
-[snaps are listed here][1.22-components].
+page for each release. For example, for 1.23, the
+[snaps are listed here][1.23-components].
 
 If your installation needs to proxy the connection to the Snap Store for any reason,
 the recommended solution is to use the [Snap Store Proxy][] software. This can
@@ -92,7 +92,7 @@ also be configured for offline use (see the
 <!-- LINKS -->
 
 [Juju proxy documentation]: https://juju.is/docs/t/offline-mode-strategies/1071
-[1.22-components]: 1.22/components
+[1.23-components]: 1.23/components#snaps
 [offline]: install-offline
 [snap]: https://snapcraft.io
 [Snap Store Proxy]: https://docs.ubuntu.com/snap-store-proxy/en/

--- a/templates/kubernetes/docs/quickstart.md
+++ b/templates/kubernetes/docs/quickstart.md
@@ -23,7 +23,7 @@ Kubernetes cluster running on the cloud of your choice in minutes!
 
 ## What you'll need
 
-- An Ubuntu 20.04 LTS, 18.04 LTS or 16.04 LTS environment to run the commands (or another operating system which supports `snapd` - see the [snapd documentation][snapd-docs])
+- An Ubuntu 22.04 LTS, 20.04 LTS or 18.04 LTS environment to run the commands (or another operating system which supports `snapd` - see the [snapd documentation][snapd-docs])
 - Account credentials for one of the following public clouds:
   - [Amazon Web Services][cloud-aws], including AWS-China and AWS-gov
   - [CloudSigma][cloud-cloudsigma]

--- a/templates/kubernetes/docs/scaling.md
+++ b/templates/kubernetes/docs/scaling.md
@@ -144,7 +144,7 @@ units _will_not_ be re-used.
 
 ## etcd
 
-The **Charmed Distribution of Kubernetes<sup>&reg;</sup>** installs a three
+**Charmed Kubernetes** installs a three
 machine cluster for etcd, which provides tolerence for a single failure. Should you wish to
 extend the fault tolerance, you can add additional units of etcd.
 

--- a/templates/kubernetes/docs/supported-versions.md
+++ b/templates/kubernetes/docs/supported-versions.md
@@ -177,7 +177,7 @@ channels:
   1.5/candidate:    1.5.5          2017-05-17    (3) 17MB -
   1.5/beta:         1.5.5          2017-05-17    (3) 17MB -
   1.5/edge:         1.5.5          2017-05-17    (3) 17MB -
-
+```
 
 In the above output, the stable release is identified as 1.24, and so 1.23 and
 1.22 are also currently supported.

--- a/templates/kubernetes/docs/supported-versions.md
+++ b/templates/kubernetes/docs/supported-versions.md
@@ -18,7 +18,7 @@ of Kubernetes.
 
 Current Release: **1.24**
 
-Supported releases: **1.24.x,1.23.x, 1.21.x**
+Supported releases: **1.24.x,1.23.x, 1.22.x**
 
 ## Charmed Kubernetes bundle versions
 
@@ -30,23 +30,12 @@ juju deploy charmed-kubernetes
 ```
 
 It is also possible to deploy a specific version of the bundle by including the
-revision number. For example, to deploy the **Charmed Kubernetes** bundle for the Kubernetes 1.21
+revision number. For example, to deploy the **Charmed Kubernetes** bundle for the Kubernetes 1.23
 release, you could run:
 
 ```bash
-juju deploy charmed-kubernetes --revision=733
+juju deploy cs:charmed-kubernetes-862
 ```
-
-<div class="p-notification--positive is-inline">
-  <div markdown="1" class="p-notification__content">
-    <span class="p-notification__title">Older Versions:</span>
-    <p class="p-notification__message">Previous versions of <strong>Charmed Kubernetes</strong> used the name
-    <code>canonical-kubernetes</code>. These versions are still available under that name
-    and links in the charm store. Versions from 1.14 onwards will use
-    <code>charmed-kubernetes</code>.</p>
-  </div>
-</div>
-
 
 The revision numbers for bundles are generated automatically when the bundle is
 updated, including for testing and beta versions, so it isn't always the case
@@ -104,22 +93,22 @@ description: |
   documentation](https://kubernetes.io/docs/reference/command-line-tools-reference/kube-apiserver/).
 snap-id: KMZLusdClmUyLXAjjcI4sVnpjk1kM653
 channels:
-  latest/stable:    1.23.0         2021-12-15 (2493) 23MB -
-  latest/candidate: 1.23.0         2021-12-15 (2493) 23MB -
-  latest/beta:      1.23.0         2021-12-15 (2493) 23MB -
-  latest/edge:      1.23.0         2021-12-15 (2493) 23MB -
-  1.24/stable:      –                                     
-  1.24/candidate:   –                                     
-  1.24/beta:        –                                     
-  1.24/edge:        1.24.0-alpha.1 2021-12-11 (2513) 23MB -
-  1.23/stable:      1.23.0         2021-12-08 (2493) 23MB -
-  1.23/candidate:   1.23.0         2021-12-08 (2493) 23MB -
-  1.23/beta:        1.23.0         2021-12-08 (2493) 23MB -
-  1.23/edge:        1.23.0         2021-12-08 (2493) 23MB -
-  1.22/stable:      1.22.4         2021-11-18 (2456) 22MB -
-  1.22/candidate:   1.22.4         2021-11-18 (2456) 22MB -
-  1.22/beta:        1.22.4         2021-11-18 (2456) 22MB -
-  1.22/edge:        1.22.4         2021-11-18 (2456) 22MB -
+  latest/stable:    1.24.0         2022-05-07 (2764) 24MB -
+  latest/candidate: 1.24.0         2022-05-07 (2764) 24MB -
+  latest/beta:      1.24.0         2022-05-07 (2764) 24MB -
+  latest/edge:      1.24.0         2022-05-07 (2764) 24MB -
+  1.24/stable:      1.24.0         2022-05-04 (2764) 24MB -
+  1.24/candidate:   1.24.0         2022-05-04 (2764) 24MB -
+  1.24/beta:        1.24.0         2022-05-04 (2764) 24MB -
+  1.24/edge:        1.24.0         2022-05-04 (2764) 24MB -
+  1.23/stable:      1.23.6         2022-04-21 (2746) 23MB -
+  1.23/candidate:   1.23.6         2022-04-21 (2746) 23MB -
+  1.23/beta:        1.23.6         2022-04-21 (2746) 23MB -
+  1.23/edge:        1.23.6         2022-04-21 (2746) 23MB -
+  1.22/stable:      1.22.9         2022-04-21 (2745) 22MB -
+  1.22/candidate:   1.22.9         2022-04-21 (2745) 22MB -
+  1.22/beta:        1.22.9         2022-04-21 (2745) 22MB -
+  1.22/edge:        1.22.9         2022-04-21 (2745) 22MB -
   1.21/stable:      1.21.7         2021-11-18 (2433) 22MB -
   1.21/candidate:   1.21.7         2021-11-18 (2433) 22MB -
   1.21/beta:        1.21.7         2021-11-18 (2433) 22MB -
@@ -190,8 +179,8 @@ channels:
   1.5/edge:         1.5.5          2017-05-17    (3) 17MB -
 
 
-In the above output, the stable release is identified as 1.23, and so 1.22 and
-1.21 are also currently supported.
+In the above output, the stable release is identified as 1.24, and so 1.23 and
+1.22 are also currently supported.
 
 ## Professional support
 

--- a/templates/kubernetes/docs/tigera-secure-ee.md
+++ b/templates/kubernetes/docs/tigera-secure-ee.md
@@ -25,11 +25,8 @@ Support for Tigera Secure EE in **Charmed Kubernetes** is provided in the form o
 
 Before you start, you will need:
 
-*  Tigera Secure EE licence key
-*  Tigera private Docker registry credentials (provided as a Docker config.json)
-
-- Tigera Secure EE licence key
-- Tigera private Docker registry credentials (provided as a Docker config.json)
+* Tigera Secure EE licence key
+* Tigera private Docker registry credentials (provided as a Docker config.json)
 
 <div class="p-notification--information is-inline">
   <div class="p-notification__content">
@@ -40,11 +37,10 @@ Before you start, you will need:
   </div>
 </div>
 
-
-To start, deploy **Charmed Kubernetes** with Tigera Secure EE:
+Deploy the `charmed-kubernetes` bundle with the [tigera overlay][tigera-overlay]:
 
 ```bash
-juju deploy cs:~containers/kubernetes-tigera-secure-ee
+juju deploy charmed-kubernetes --overlay tigera-overlay.yaml
 ```
 
 Configure the `tigera-secure-ee` charm with your licence key and registry
@@ -228,6 +224,7 @@ juju config tigera-secure-ee registry=$REGISTRY
 
 <!-- LINKS -->
 
+[tigera-overlay]: https://raw.githubusercontent.com/charmed-kubernetes/bundle/main/overlays/tigera-overlay.yaml
 [elasticsearch-operator]: https://github.com/upmc-enterprises/elasticsearch-operator
 [tigera byo-elasticsearch]: https://docs.tigera.io/v2.2/getting-started/kubernetes/installation/byo-elasticsearch
 [storage]: /kubernetes/docs/storage

--- a/templates/kubernetes/docs/upgrade-notes.md
+++ b/templates/kubernetes/docs/upgrade-notes.md
@@ -152,7 +152,7 @@ To upgrade whilst retaining Docker as the runtime, you need to additionally depl
 and add relations to the master and worker components:
 
 ```bash
-juju deploy cs:~containers/docker
+juju deploy docker
 juju add-relation docker kubernetes-master
 juju add-relation docker kubernetes-worker
 ```
@@ -171,7 +171,7 @@ in some cluster down time. Adding temporary additional workers provides a place 
 CURRENT_WORKER_REV=$(juju status | grep '^kubernetes-worker\s' | awk '{print $7}')
 CURRENT_WORKER_COUNT=$(juju status | grep '^kubernetes-worker/' | wc -l | sed -e 's/^[ \t]*//')
 
-juju deploy cs:~containers/kubernetes-worker-$CURRENT_WORKER_REV  kubernetes-worker-temp -n $CURRENT_WORKER_COUNT
+juju deploy kubernetes-worker-$CURRENT_WORKER_REV  kubernetes-worker-temp -n $CURRENT_WORKER_COUNT
 ```
 
 #### Add necessary relations
@@ -196,7 +196,7 @@ the Docker subordinate includes clean-up code to uninstall Docker when the
 Docker charm is replaced with the containerd charm.
 
 ```bash
-juju deploy cs:~containers/docker
+juju deploy docker
 juju add-relation docker kubernetes-master
 juju add-relation docker kubernetes-worker
 ```
@@ -234,7 +234,7 @@ juju remove-application docker
 #### Deploy Containerd
 
 ```bash
-juju deploy cs:~containers/containerd
+juju deploy containerd
 juju add-relation containerd kubernetes-master
 juju add-relation containerd kubernetes-worker
 ```
@@ -277,8 +277,8 @@ Once you have a Containerd backed Charmed Kubernetes running, you can add Docker
 workers like so:
 
 ```bash
-juju deploy cs:~containers/kubernetes-worker kubernetes-worker-docker
-juju deploy cs:~containers/docker
+juju deploy kubernetes-worker kubernetes-worker-docker
+juju deploy docker
 juju relate docker kubernetes-worker-docker
 ```
 

--- a/templates/kubernetes/docs/upgrading.md
+++ b/templates/kubernetes/docs/upgrading.md
@@ -79,20 +79,19 @@ The applications which run alongside the core Kubernetes components can be upgra
 
 This includes:
 
-- Docker
+- containerd
 - easyrsa
 - etcd
-- flannel, calico or other CNI
+- calico, flannel or other CNI charms
 
 Note that this may include other applications which you may have installed, such as Elasticsearch, Prometheus, Nagios, Helm, etc.
-
 
 
 <a id='upgrading-containerd'> </a>
 
 ### Upgrading Containerd
 
-By default, Versions 1.15 and later use Containerd as the container
+By default, **Charmed Kubernetes** 1.15 and later use Containerd as the container
 runtime. This subordinate charm can be upgraded with the command:
 
 ```bash
@@ -103,10 +102,11 @@ juju upgrade-charm containerd
 
 ### Upgrading Docker (if used)
 
-By default, versions of Charmed Kubernetes since 1.15 use the Containerd
-runtime. You will only need to upgrade the Docker runtime if you have
-explicitly set that to be the container runtime. If this is not the case, you
-should skip this section.
+By default, **Charmed Kubernetes** 1.15 and later use Containerd as the container
+runtime. Support for the Docker container runtime was removed in 1.24. You will only
+need to upgrade the Docker runtime if you have explicitly configured it to be the
+runtime for a deployment prior to 1.24. If this is not the case, you should skip this
+section.
 
 **Charmed Kubernetes** will use the latest stable version of Docker when it is
 deployed. Since upgrading Docker can cause service disruption, there will be no
@@ -116,8 +116,6 @@ Note that this upgrade step only applies to deployments which actually use the
 Docker container runtime. Versions 1.15 and later use containerd by default,
 and you should instead follow the [instructions above](#upgrading-containerd).
 
-#### Version 1.15 and later
-
 The `kubernetes-control-plane` and `kubernetes-worker` are related to the docker subordinate
 charm where present. Whether you are running Docker on its own, or mixed with Containerd,
 the upgrade process is the same:
@@ -125,42 +123,6 @@ the upgrade process is the same:
 ```bash
 juju upgrade-charm docker
 ```
-
-#### Versions prior to 1.15
-Only the `kubernetes-control-plane` and `kubernetes-worker` units require Docker. The charms for each
-include an action to trigger the upgrade.
-
-Before the upgrade, it is useful to list all the units effected:
-
-```bash
-juju status kubernetes-* --format=short
-```
-
-...will return a list of the current `kubernetes-control-plane` and `kubernetes-worker` units.
-
-Start with the `kubernetes-control-plane` units and run the upgrade action on one unit at a time:
-
-```bash
-juju run-action kubernetes-control-plane/0 upgrade-docker --wait
-```
-
-As Docker is restarted on the unit, pods will be terminated. Wait for them to respawn before
-moving on to the next unit:
-
-```bash
-juju run-action kubernetes-control-plane/1 upgrade-docker --wait
-```
-
-Once all the `kubernetes-control-plane` units have been upgraded and the pods have respawned, the
-same procedure can then be applied to the `kubernetes-worker` units.
-
-```bash
-juju run-action kubernetes-worker/0 upgrade-docker --wait
-```
-
-As previously, wait between running the action on sucessive units to allow pods to migrate.
-
-
 
 
 ### Upgrading etcd
@@ -220,6 +182,7 @@ Once you know the correct channel, set the **etcd** charm's channel config:
 ```bash
 juju config etcd channel=3.4/stable
 ```
+
 
 ### Upgrading additional components
 

--- a/templates/kubernetes/docs/validation.md
+++ b/templates/kubernetes/docs/validation.md
@@ -31,7 +31,7 @@ through the charm's actions.
 Add the charm to your cluster:
 
 ```bash
-juju deploy cs:~containers/kubernetes-e2e --constraints mem=4G --channel edge
+juju deploy kubernetes-e2e --constraints mem=4G
 ```
 
 We also need to configure the charm to select the appropriate version of tests.
@@ -42,18 +42,17 @@ version your cluster is set to by running:
 juju config kubernetes-control-plane channel
 ```
 
-The output will be in the form of 'version.number/risk', e.g '1.12/stable'. You should set
+The output will be in the form of `version.number/risk`, e.g `1.24/stable`. You should set
 the `kubernetes-e2e` channel to the same value.
 
 ```
-juju config kubernetes-e2e channel=1.12/stable
+juju config kubernetes-e2e channel=1.24/stable
 ```
 
 Finally we relate the charm to `easyrsa` and `kubernetes-control-plane`:
 
 ```bash
 juju config kubernetes-control-plane allow-privileged=true
-juju config kubernetes-worker allow-privileged=true
 juju add-relation kubernetes-e2e easyrsa
 juju add-relation kubernetes-e2e:kubernetes-control-plane kubernetes-control-plane:kube-api-endpoint
 juju add-relation kubernetes-e2e:kube-control kubernetes-control-plane:kube-control

--- a/templates/kubernetes/docs/vsphere-integration.md
+++ b/templates/kubernetes/docs/vsphere-integration.md
@@ -44,7 +44,7 @@ applications:
     annotations:
       gui-x: "600"
       gui-y: "300"
-    charm: cs:~containers/vsphere-integrator
+    charm: vsphere-integrator
     num_units: 1
     trust: true
 relations:


### PR DESCRIPTION
## Done

- Various links and charm-store -> charmhub updates
- fixed old versions in some pages
-  clarified default cni
- 
## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
