### PR TITLE
Update copy on /server 

### DIFF
--- a/templates/server/index.html
+++ b/templates/server/index.html
@@ -44,7 +44,7 @@
       <li class="p-list__item is-ticked">Native host and guest drivers for NVIDIA virtual GPU (vGPU) software 14</li>
       <li class="p-list__item is-ticked">Network acceleration improvements with SmartNIC support in Netplan</li>
       <li class="p-list__item is-ticked">General support for GlusterFS, FRRouting and realmd/adcli under the Ubuntu main component</li>
-      <li class="p-list__item is-ticked">Runs on all major architectures: x86-64, ARM v7, ARM64, POWER9/POWER10, IBM s390x (LinuxONE) and RISC-V</li>
+      <li class="p-list__item is-ticked">Runs on all major architectures: x86-64, ARM v7, ARM64, POWER9/POWER10, IBM zSystems and LinuxONE (s390x) and RISC-V</li>
       <li class="p-list__item is-ticked">The latest long-term Linux 5.15 kernel for the recent hardware and security updates</li>
       <li class="p-list__item is-ticked">Updates to QEMU (v6.2), libvirt (v8.0), PHP (v8.1), Ruby (v3.0), GCC (V11.2), Python (v3.10.1), MySQL (v8.0.28), OpenLDAP (v.2.5.11), Samba 4.15.5</li>
   </div>


### PR DESCRIPTION
## Done

- Updated as per [copy doc](https://docs.google.com/document/d/1vxLhtbjgPs9PCNEhr7fbhEoErCPMXYFfU4UTKH7Kbq4/edit#)

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: https://ubuntu-com-11632.demos.haus/server
    - Be sure to test on mobile, tablet and desktop screen sizes
- See that the requested change has been made

## Issue / Card

Fixes https://github.com/canonical-web-and-design/web-squad/issues/5368