### PR TITLE
Remove get eBook form, embed Ubuntu Core video

### DIFF
--- a/templates/download/iot/_login.html
+++ b/templates/download/iot/_login.html
@@ -1,6 +1,6 @@
 <li class="p-stepped-list__item">
   <h3 class="p-stepped-list__title">
-    Login
+    Connect to the device
   </h3>
   <div class="p-stepped-list__content">
     <p>Once setup is done, you can login with SSH into Ubuntu Core, from a machine on the same network, using the following command:</p>

--- a/templates/download/raspberry-pi-core.html
+++ b/templates/download/raspberry-pi-core.html
@@ -1,8 +1,8 @@
 {% extends "download/_base_download.html" %}
 
-{% block title %}Install Ubuntu Core on a Raspberry Pi{% endblock %}}
+{% block title %}Install Ubuntu Core on a Raspberry Pi{% endblock %}
 
-{% block meta_description %}Ubuntu is an open-source operating system for cross platform development, there’s no better place to get started than with Ubuntu on a Raspberry Pi{% endblock meta_description %}
+{% block meta_description %}Ubuntu is an open-source operating system for cross platform development, there's no better place to get started than with Ubuntu on a Raspberry Pi{% endblock meta_description %}
 {% block meta_copydoc %}https://docs.google.com/document/d/1Ig906jbgB39QHw61uHMvIsRbSBUjchJBDkMZl0WzlWM/edit{% endblock meta_copydoc %}
 
 {% block content %}
@@ -17,17 +17,18 @@
       <div class="u-equal-height row p-divider">
         <div class="col-6 p-divider__block">
           <h2>Install Ubuntu Core</h2>
-          <p>We will walk you through the steps of flashing Ubuntu Core on a Raspberry Pi 2, 3, 4 or CM4. At the end of this process, you will have a board ready for production or testing snaps.</p>
+          <p>This is a brief overview of the steps for installing Ubuntu Core on a Raspberry Pi 2, 3, or 4. At the end of this process, you will have a board ready for production or testing. Check the <a href="/core/docs/uc20/install-raspberry-pi">Ubuntu Core documentation for more detailed instructions</a>.</p>
         </div>
         <div class="col-6 p-divider__block">
           <h3>Minimum requirements</h3>
           <ul class="p-list">
-            <li class="p-list__item is-ticked">A Raspberry Pi 2, 3, 4 or CM3</li>
-            <li class="p-list__item is-ticked">A microSD card</li>
-            <li class="p-list__item is-ticked">An Ubuntu Core image</li>
+            <li class="p-list__item is-ticked">A Raspberry Pi 2, 3 or 4</li>
+            <li class="p-list__item is-ticked">A 4 GB+ microSD card and reader</li>
+            <li class="p-list__item is-ticked">A Wi-Fi network or an ethernet cable with an Internet connection</li>
             <li class="p-list__item is-ticked">A monitor with an HDMI interface</li>
             <li class="p-list__item is-ticked">An HDMI cable</li>
             <li class="p-list__item is-ticked">A USB keyboard</li>
+            <li>An <a href="https://login.ubuntu.com/">Ubuntu SSO account</a> with an associated SSH key</li>
           </ul>
         </div>
       </div>
@@ -39,19 +40,38 @@
   <div class="u-fixed-width">
     <h2>Installation instructions</h2>
     <ol class="p-stepped-list--detailed">
-      {% include "download/iot/_setup-ubuntu-sso.html" %}
       <li class="p-stepped-list__item">
-        <h3 class="p-stepped-list__title">
-          Download Ubuntu Core
-        </h3>
+        <h3 class="p-stepped-list__title">Prepare the SD card</h3>
         <div class="p-stepped-list__content">
-          {% include "download/shared/_core_raspberry_pi_download.html" %}
+          <p>Use the <a href="https://www.raspberrypi.com/software/">Raspberry Pi Imager</a> to download and write the latest Ubuntu Core release to the SD card. To get started on Ubuntu you can run:</p>
+          <code>sudo snap install rpi-imager</code>
+          <p>Once installed choose “Other general-purpose OS” then “Ubuntu”.</p>
+          <p>Choose “Ubuntu Core 32-bit armh” for the widest compatibility or “<i>Ubuntu Core 20 64-bit IoT OS for arm64</i>” if you need applications that require a 64-bit system, such as <a href="/tutorials/getting-started-with-microk8s-on-ubuntu-core#1-introduction">MicroK8s</a>.</p>
+        </div>
+      </li>
+      <li class="p-stepped-list__item ">
+        <h3 class="p-stepped-list__title">Set up an Ubuntu SSO account</h3>
+        <div class="p-stepped-list__content">
+          <p>An Ubuntu SSO account is required to create the first user on an Ubuntu Core installation.</p>
+          <ol class="u-no-margin--left">
+            <li>Start by creating an <a href="https://login.ubuntu.com/">Ubuntu SSO account</a>.</li>
+            <li>Import an SSH Key into your <a href="https://login.ubuntu.com/ssh-keys">Ubuntu SSO account</a>.</li>
+          </ol>
+          <p>More information on <a href="/tutorials/how-to-install-ubuntu-core-on-raspberry-pi#4-boot-and-configure-ubuntu-core">generating an SSH key pair</a> can be found in the tutorial and <a href="https://help.ubuntu.com/community/SSH/OpenSSH/Keys">community help wiki</a>.</p>
+        </div>
+      </li>
+      <li class="p-stepped-list__item">
+        <h3 class="p-stepped-list__title">Install Ubuntu Core</h3>
+        <div class="p-stepped-list__content">
+          <ol class="u-no-margin--left">
+            <li>Attach the monitor and keyboard to the board. You can alternatively use a serial cable.</li>
+            <li>Insert the SD card and plug the power adaptor into the board</li>
+          </ol>
         </div>
       </li>
       {% with card="microSD card" %}{% include "download/iot/_flash-image.html" %}{% endwith %}
       <li class="p-stepped-list__item">
         <h3 class="p-stepped-list__title">
-
           Install Ubuntu Core
         </h3>
         <div class="p-stepped-list__content">
@@ -67,11 +87,68 @@
   </div>
 </section>
 
-{% with strip="p-strip--light" %}{% include "download/iot/_boot-tips-strip.html" %}{% endwith %}
+<section class="p-strip">
+  <div class="row u-equal-height">
+    <div class="col-8">
+      <h3>Get started with snaps</h3>
+      <p>Congratulations! Your board is now ready to have applications installed, it's time to use the snap command to install your first snap.</p>
+      <p>The <a href="https://snapcraft.io/store">Snap Store</a> is where you can find the best Linux apps packaged as snaps to install on your Ubuntu device and <a href="https://snapcraft.io/docs/getting-started">get started</a> with your secure IoT journey.</p>
+      <p>Visit the <a href="https://snapcraft.io/docs/snapcraft-overview">Snapcraft documentation</a> and learn <a href="/tutorials/create-your-first-snap#1-overview">how to create your first snap</a>.</p>
+    </div>
+    <div class="col-4 u-hide--medium u-hide--small u-align--center u-vertically-center">
+      {{
+        image(
+          url="https://assets.ubuntu.com/v1/bd695c08-app+store.svg",
+          alt="",
+          height="150",
+          width="150",
+          hi_def=True,
+          loading="lazy"
+        ) | safe
+      }}
+    </div>
+  </div>
+</section>
 
-{% include "download/iot/_install-snaps-strip.html" %}
+<section class="p-strip--light">
+  <div class="row">
+    <div class="col-4 u-align--center">
+      {{ image (
+        url="https://assets.ubuntu.com/v1/f833f94a-Core-stacked.svg",
+        alt="",
+        width="120",
+        height="162",
+        hi_def=True,
+        loading="lazy"
+        ) | safe
+      }}
+    </div>
+    <div class="col-8">
+      <h3>Learning more and getting help</h3>
+      <ul>
+        <li><a href="/core/docs/getting-started">Get started with Ubuntu Core documentation</a> to learn more about your new system and how to customise it.</li>
+        <li>Check out the <a href="https://askubuntu.com/questions/tagged/raspberrypi">Ask Ubuntu Q&amp;A</a>.</li>
+      </ul>
+    </div>
+  </div>
+</section>
 
-{% include "download/shared/_get-ebook-security.html"%}
+<section class="p-strip is-bordered">
+  <div class="u-fixed-width u-align--left">
+    <div class="jsBrightTALKEmbedWrapper u-vertically-center" style="width:100%; height:100%; position:relative;background: #ffffff;">
+      <script class="jsBrightTALKEmbedConfig" type="application/json">
+        { "channelId" : 6793, "language": "en-US", "commId" : 470687, "displayMode" : "standalone", "height" : "auto" }
+      </script>
+      <script src="https://www.brighttalk.com/clients/js/player-embed/player-embed.js" class="jsBrightTALKEmbed"></script>
+      <script>
+        const iframe = document.querySelector('.jsBrightTALKEmbedWrapper iframe');
+        iframe.addEventListener('load', () => {
+          iframe.scrolling = "yes";
+        });
+      </script>        
+    </div>
+  </div>
+</section>
 
 {% with first_item="_core_learn_more", second_item="_core_contribute", third_item="_iot_further_reading" %}{% include "shared/contextual_footers/_contextual_footer.html" %}{% endwith %}
 


### PR DESCRIPTION
## Done

- Removes the ebook Form
- Add a video on Ubuntu Core
- Updates copy **Note: suggestion tool was not used, so it isn't clear what is changed**
## QA

- Go to https://ubuntu-com-11633.demos.haus/download/raspberry-pi-core and compare against [copydoc](https://docs.google.com/document/d/1Ig906jbgB39QHw61uHMvIsRbSBUjchJBDkMZl0WzlWM/edit#heading=h.m0dm79vhykyd)

## Issue / Card

Fixes https://github.com/canonical-web-and-design/web-squad/issues/5375