### PR TITLE
Create /automotive contact modal

### DIFF
--- a/templates/automotive/index.html
+++ b/templates/automotive/index.html
@@ -550,7 +550,7 @@
   </section>
   
   <!-- Set default Marketo information for contact form below-->
-  <div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/embedded" data-form-id="1266" data-lp-id="2551" data-return-url="https://ubuntu.com/internet-of-things/thank-you?product=iot" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
+  <div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/automotive" data-form-id="4477" data-lp-id="2551" data-return-url="https://ubuntu.com/internet-of-things/thank-you?product=automotive" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
   </div>
   
   {% endblock content %}

--- a/templates/automotive/index.html
+++ b/templates/automotive/index.html
@@ -552,6 +552,16 @@
   <!-- Set default Marketo information for contact form below-->
   <div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/automotive" data-form-id="4477" data-lp-id="2551" data-return-url="https://ubuntu.com/internet-of-things/thank-you?product=automotive" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
   </div>
+
+  <script>
+    function createLeadComment() {
+      var openQuestionEle = document.querySelector("#open-question");
+      var leadCommentEle = document.querySelector("#Comments_from_lead__c");
+      if (openQuestionEle.value) {
+        leadCommentEle.value = openQuestionEle.value;
+      }
+    }
+  </script>
   
   {% endblock content %}
   

--- a/templates/automotive/index.html
+++ b/templates/automotive/index.html
@@ -553,15 +553,5 @@
   <div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/automotive" data-form-id="4477" data-lp-id="2551" data-return-url="https://ubuntu.com/internet-of-things/thank-you?product=automotive" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
   </div>
 
-  <script>
-    function createLeadComment() {
-      var openQuestionEle = document.querySelector("#open-question");
-      var leadCommentEle = document.querySelector("#Comments_from_lead__c");
-      if (openQuestionEle.value) {
-        leadCommentEle.value = openQuestionEle.value;
-      }
-    }
-  </script>
-  
   {% endblock content %}
   

--- a/templates/shared/forms/interactive/automotive.html
+++ b/templates/shared/forms/interactive/automotive.html
@@ -13,7 +13,7 @@
       <h3 class="p-heading--4">How should we get in touch?</h3>
       <div class="row u-no-padding">
         <div class="col-6">
-          <form action="/marketo/submit" method="post" id="mktoForm_%% formid %%" class="modal-form">
+          <form action="/marketo/submit" onsubmit="createLeadComment()" method="post" id="mktoForm_%% formid %%" class="modal-form">
             <ul class="p-list">
               <li class="p-list__item">
                 <label for="firstName">First name:</label>

--- a/templates/shared/forms/interactive/automotive.html
+++ b/templates/shared/forms/interactive/automotive.html
@@ -5,15 +5,14 @@
       <h2 class="p-modal__title u-sv1" id="modal-title">Contact us</h2>
     </header>
     <div class="js-pagination js-pagination--1">
-      <div class="u-sv2 js-formfield">
-        <h3 class="p-heading--4">What can we help you with?</h3>
-        <textarea id="open-question" name="open-question" aria-label="What can we help you with?" rows="3"></textarea>
-      </div>
-
-      <h3 class="p-heading--4">How should we get in touch?</h3>
       <div class="row u-no-padding">
         <div class="col-6">
           <form action="/marketo/submit" onsubmit="createLeadComment()" method="post" id="mktoForm_%% formid %%" class="modal-form">
+            <div class="u-sv2">
+              <h3 class="p-heading--4">What can we help you with?</h3>
+              <textarea id="Comments_from_lead__c" name="Comments_from_lead__c" aria-label="What can we help you with?" maxlength="2000" rows="3"></textarea>
+            </div>
+            <h3 class="p-heading--4">How should we get in touch?</h3>
             <ul class="p-list">
               <li class="p-list__item">
                 <label for="firstName">First name:</label>

--- a/templates/shared/forms/interactive/automotive.html
+++ b/templates/shared/forms/interactive/automotive.html
@@ -1,0 +1,78 @@
+<div class="p-modal" id="contact-modal">
+  <div class="p-modal__dialog" role="dialog" aria-labelledby="modal-title" aria-describedby="modal-description">
+    <div class="js-pagination js-pagination--1" style="padding-top:2rem;">
+      <div class="u-sv2 js-formfield">
+        <h3 class="p-heading--4">What can we help you with?</h3>
+        <textarea id="open-question" name="open-question" aria-label="What can we help you with?" rows="3"></textarea>
+      </div>
+
+      <h3 class="p-heading--4">How should we get in touch?</h3>
+      <div class="row u-no-padding">
+        <div class="col-6">
+          <form action="/marketo/submit" method="post" id="mktoForm_%% formid %%" class="modal-form">
+            <ul class="p-list">
+              <li class="p-list__item">
+                <label for="firstName">First name:</label>
+                <input required id="firstName" name="firstName" maxlength="255" type="text" />
+              </li>
+              <li class="p-list__item">
+                <label for="lastName">Last name:</label>
+                <input required id="lastName" name="lastName" maxlength="255" type="text" />
+              </li>
+              <li class="p-list__item">
+                <label for="email">Email address:</label>
+                <input data-testid="form-email" required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" />
+              </li>
+              <li class="p-list__item">
+                <label for="phone">Phone number:</label>
+                <input id="phone" name="phone" maxlength="255" type="tel">
+              </li>
+              <li class="p-list__item">
+                <label class="p-checkbox">
+                  <input class="p-checkbox__input" value="yes" aria-labelledby="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox" />
+                  <span class="p-checkbox__label" id="canonicalUpdatesOptIn">I agree to receive information about Canonical's products and services.</span>
+                </label>
+              </li>
+              <li class="p-list__item">In submitting this form, I confirm that I have read and agree to <a href="/legal/data-privacy/contact">Canonical's Privacy Notice</a> and <a href="/legal/data-privacy">Privacy Policy</a>.</li>
+              {# These are honey pot fields to catch bots #}
+              <li class="u-off-screen">
+                <label class="website" for="website">Website:</label>
+                <input name="website" type="text" class="website" autocomplete="off" value="" id="website" tabindex="-1" />
+              </li>
+              <li class="u-off-screen">
+                <label class="name" for="name">Name:</label>
+                <input name="name" type="text" class="name" autocomplete="off" value="" id="name" tabindex="-1" />
+              </li>
+              {# End of honey pots #}
+            </ul>
+
+            <div class="u-hide">
+              <h3>Your comments</h3>
+              <ul class="p-list">
+                <li class="p-list__item">
+                  <label for="Comments_from_lead__c">What would you like to talk to us about?</label>
+                  <textarea id="Comments_from_lead__c" name="Comments_from_lead__c" rows="5" maxlength="2000"></textarea>
+                </li>
+              </ul>
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="returnURL" value="%% returnURL %%" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formid" value="%% formid %%" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="Consent_to_Processing__c" value="yes" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" id="utm_campaign" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" id="utm_medium" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" id="utm_source" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content" id="utm_content" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" id="utm_term" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="GCLID__c" id="GCLID__c" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="Facebook_Click_ID__c" id="Facebook_Click_ID__c" value="" />
+            </div>
+
+            <div class="pagination">
+              <button type="submit" class="p-button--positive" aria-label="Submit">Let's discuss</button>
+							<a class="js-close p-button" href="">Close</a>
+            </div>
+          </form>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/templates/shared/forms/interactive/automotive.html
+++ b/templates/shared/forms/interactive/automotive.html
@@ -1,6 +1,10 @@
 <div class="p-modal" id="contact-modal">
   <div class="p-modal__dialog" role="dialog" aria-labelledby="modal-title" aria-describedby="modal-description">
-    <div class="js-pagination js-pagination--1" style="padding-top:2rem;">
+    <header class="p-modal__header" style="display: block; border-bottom: 0;">
+      <button class="p-modal__close" aria-label="Close active modal" style="margin-left: -1rem">Close</button>
+      <h2 class="p-modal__title u-sv1" id="modal-title">Contact us</h2>
+    </header>
+    <div class="js-pagination js-pagination--1">
       <div class="u-sv2 js-formfield">
         <h3 class="p-heading--4">What can we help you with?</h3>
         <textarea id="open-question" name="open-question" aria-label="What can we help you with?" rows="3"></textarea>
@@ -68,7 +72,6 @@
 
             <div class="pagination">
               <button type="submit" class="p-button--positive" aria-label="Submit">Let's discuss</button>
-							<a class="js-close p-button" href="">Close</a>
             </div>
           </form>
         </div>

--- a/templates/shared/forms/interactive/automotive.html
+++ b/templates/shared/forms/interactive/automotive.html
@@ -50,13 +50,6 @@
             </ul>
 
             <div class="u-hide">
-              <h3>Your comments</h3>
-              <ul class="p-list">
-                <li class="p-list__item">
-                  <label for="Comments_from_lead__c">What would you like to talk to us about?</label>
-                  <textarea id="Comments_from_lead__c" name="Comments_from_lead__c" rows="5" maxlength="2000"></textarea>
-                </li>
-              </ul>
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="returnURL" value="%% returnURL %%" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formid" value="%% formid %%" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="Consent_to_Processing__c" value="yes" />


### PR DESCRIPTION
## Done

- Create a contact modal for automotive. Previously it was using the general IoT one.

## QA

- Go to https://ubuntu-com-11636.demos.haus/automotive and click the 'Contact Canonical' button to trigger the modal.
-  Compare content against [copydoc](https://docs.google.com/document/d/1oY_lMp92TAzHNqGXEJZmWVtHf9hcChgZfmVA9gm324g/edit#)
- Complete the form and make sure it submit and sends you to a thank you.
- Check you can close the modal without submitting

## Issue / Card

Fixes https://github.com/canonical-web-and-design/web-squad/issues/5335
