### PR TITLE
add 22.04 azure marketplace link to /azure

### DIFF
--- a/templates/azure/index.html
+++ b/templates/azure/index.html
@@ -135,8 +135,9 @@
           <li class="p-list__item is-ticked">FIPS 140-2 and CC-EAL certified components</li>
           <li class="p-list__item is-ticked">Integration with Azure security and compliance features</li>
           <li class="p-list__item is-ticked">10-year lifetime</li>
+          <li class="p-list__item is-ticked">FIPS-certified modules and CIS audit/hardening tooling for Ubuntu Pro 22.04 are in process. If you require these in the meantime, please use <a href="https://azuremarketplace.microsoft.com/en-us/marketplace/apps/canonical.0001-com-ubuntu-pro-focal">20.04 Pro</a></li>
         </ul>
-        <p><a href="https://azuremarketplace.microsoft.com/en-us/marketplace/apps/canonical.0001-com-ubuntu-pro-focal" class="p-button--positive">Launch Ubuntu Pro 20.04 LTS</a></p>
+        <p><a href="https://azuremarketplace.microsoft.com/en-us/marketplace/apps/canonical.0001-com-ubuntu-pro-jammy" class="p-button--positive">Launch Ubuntu Pro 22.04 LTS</a></p>
         <p><a href="/azure/pro">More about Ubuntu Pro for Azure&nbsp;&rsaquo;</a></p>
       </div>
     </div>
@@ -172,16 +173,19 @@
     </div>
   </div>
   <div class="row p-divider">
-    <div class="col-3 p-divider__block">
+    <div class="col-2 p-divider__block">
+      <h3 class="p-heading--4"><a href="https://azuremarketplace.microsoft.com/en-us/marketplace/apps/canonical.0001-com-ubuntu-pro-jammy">22.04 LTS</a></h3>
+    </div>
+    <div class="col-2 p-divider__block">
       <h3 class="p-heading--4"><a href="https://azuremarketplace.microsoft.com/en-us/marketplace/apps/canonical.0001-com-ubuntu-pro-focal">20.04 LTS</a></h3>
     </div>
-    <div class="col-3 p-divider__block">
+    <div class="col-2 p-divider__block">
       <h3 class="p-heading--4"><a href="https://azuremarketplace.microsoft.com/en-us/marketplace/apps/canonical.0001-com-ubuntu-pro-bionic">18.04 LTS</a></h3>
     </div>
-    <div class="col-3 p-divider__block">
+    <div class="col-2 p-divider__block">
       <h3 class="p-heading--4"><a href="https://azuremarketplace.microsoft.com/en-gb/marketplace/apps/canonical.0001-com-ubuntu-pro-xenial">16.04 LTS</a></h3>
     </div>
-    <div class="col-3 p-divider__block">
+    <div class="col-2 p-divider__block">
       <h3 class="p-heading--4"><a href="https://azuremarketplace.microsoft.com/en-gb/marketplace/apps/canonical.0001-com-ubuntu-pro-trusty">14.04 LTS</a></h3>
     </div>
   </div>


### PR DESCRIPTION
## Done

- Added a link to the 22.04 Ubuntu Pro image on Azure Marketplace, per the copy doc: https://docs.google.com/document/d/1GUlSATrqZmGrsk4DhP9W0s-gcOuFxpdKVgx7YE4g780/edit#

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site in your web browser at: https://ubuntu-com-11647.demos.haus/azure
- See that the page matches the copy doc suggestions

## Issue / Card

Fixes https://github.com/canonical-web-and-design/web-squad/issues/5381
