### PR TITLE
update embedding programme title on /devices

### DIFF
--- a/templates/pricing/devices.html
+++ b/templates/pricing/devices.html
@@ -371,7 +371,7 @@
 <section class="p-strip--light is-bordered">
   <div class="row">
     <div class="col-8">
-      <h2>Ubuntu Embedding program </h2>
+      <h2>Canonical Embedding programme</h2>
       <h3 class="p-heading--4">Are your devices running Ubuntu Desktop or Server?</h3>
       <p>Treat every device on your fleet as a first-class server-grade managed asset, with monitoring, security, role-based access controls, and application lifecycle management. The embedding program includes:</p>
 

--- a/templates/pricing/devices.html
+++ b/templates/pricing/devices.html
@@ -2,7 +2,7 @@
 
 {% block title %}Ubuntu IoT and Devices | plans and pricing{% endblock %}
 
-{% block meta_description %}Canonical enables sophisticated devices to be designed, delivered and operated at scale with Ubuntu and Ubuntu Core, the all-snap solution to IoT software delivery and security.{% endblock %}
+{% block meta_description %}Canonical enables sophisticated devices to be designed, delivered, and operated at scale with Ubuntu and Ubuntu Core, the all-snap solution to IoT software delivery and security.{% endblock %}
 
 {% block meta_copydoc %}https://docs.google.com/document/d/1uiKNaT59tk2rvjuM24vpqVblcNO90PmE4wUlq9A9Rsk/edit#{% endblock meta_copydoc %}
 


### PR DESCRIPTION
## Done

- Made a small tweak to the Embedding Programme heading on /pricing/devices, according to the copy doc: https://docs.google.com/document/d/1uiKNaT59tk2rvjuM24vpqVblcNO90PmE4wUlq9A9Rsk/edit#heading=h.2r4boi163qbs

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site in your web browser at: http://0.0.0.0:8001/pricing/devices
- See that it matches the copy doc

## Issue / Card

Fixes https://github.com/canonical-web-and-design/web-squad/issues/5384
