### PR TITLE
update heading copy on /download/rpi

### DIFF
--- a/templates/download/raspberry-pi/index.html
+++ b/templates/download/raspberry-pi/index.html
@@ -82,7 +82,7 @@
 
   <div class="row u-hide--medium u-hide--large">
     <div class="col-6">
-      <p>Works on:</p>
+      <p>Certified for:</p>
       <ul class="p-list">
         <li class="p-list__item is-ticked">Raspberry Pi 4 - <em>At least 2 GB RAM required.</em></li>
         <li class="p-list__item is-ticked">Raspberry Pi 400</li>
@@ -93,7 +93,7 @@
 
   <div class="u-fixed-width u-hide--small">
     <h4>
-      Works on:
+      Certified for:
     </h4>
   </div>
   <div class="row u-hide--small">
@@ -198,7 +198,7 @@
 
   <div class="row u-hide--medium u-hide--large">
     <div class="col-6">
-      <p>Works on:</p>
+      <p>Certified for:</p>
       <ul class="p-list">
         <li class="p-list__item is-ticked">Raspberry Pi 2 - <em>32-bit only</em></li>
         <li class="p-list__item is-ticked">Raspberry Pi 3</li>
@@ -212,7 +212,7 @@
 
   <div class="u-fixed-width u-hide--small">
     <h4>
-      Works on:
+      Certified for:
     </h4>
   </div>
   <div class="row u-hide--small">
@@ -376,7 +376,7 @@
 
   <div class="row u-hide--medium u-hide--large">
     <div class="col-6">
-      <p>Works on:</p>
+      <p>Certified for:</p>
       <ul class="p-list">
         <li class="p-list__item is-ticked">Raspberry Pi 2 - <em>32-bit only</em></li>
         <li class="p-list__item is-ticked">Raspberry Pi 3</li>
@@ -390,7 +390,7 @@
 
   <div class="u-fixed-width u-hide--small">
     <h4>
-      Works on:
+      Certified for:
     </h4>
   </div>
   <div class="row u-hide--small">


### PR DESCRIPTION
## Done

- Updated headings on /download/raspberry-pi to read "Certified for" rather than "Works on", according to Oliver's comments in the [copy doc](https://docs.google.com/document/d/1KgnSBa8mbR7qwlxxtqbE5a1wXh5GjtVums8TIB7IGVw/edit)

**Note:** David Beamonte Arbues's comments are being addressed in another issue, those changes can't go live until June 16th, so please ignore those in this instance.

## QA

- View the site your web browser at: http://0.0.0.0:8001/download/raspberry-pi
- See that the changes match the copy doc

## Issue / Card

Fixes https://github.com/canonical-web-and-design/web-squad/issues/5434

