### PR TITLE
add link to datasheet on /desktop/orgs

### DIFF
--- a/templates/desktop/organisations.html
+++ b/templates/desktop/organisations.html
@@ -14,6 +14,7 @@
       </p>
       <p><a class="p-button--positive js-invoke-modal" href="/desktop/contact-us" data-testid="interactive-form-link">Contact us</a></p>
       <p><a href="/advantage/subscribe">Buy Ubuntu Advantage&nbsp;&rsaquo;</a></p>
+      <p><a href="https://assets.ubuntu.com/v1/e7bfeb79-Ubuntu.Desktop.DS.23.05.22.pdf">Read the datasheet&nbsp;&rsaquo;</a></p>
     </div>
     <div class="col-6">
       {{ image (


### PR DESCRIPTION
## Done

- Added a link in the hero strip to a datasheet according to the [copy doc](https://docs.google.com/document/d/1RuxCA6GYh9UriNv26HCZP9UHo4b4_9fYaaMtGQuH_xc/edit#)

**Note:** there's a second comment from Oliver in the copy doc that I think needs to be addressed separately when Dave is around.

## QA

- View the site in your web browser at: http://0.0.0.0:8001/desktop/organisations
- See that the changes match the copy doc, and the link works

## Issue / Card

Fixes https://github.com/canonical-web-and-design/web-squad/issues/5435

