### PR TITLE
Add finance newsletter signup

### DIFF
--- a/templates/blog/newsletter-form.html
+++ b/templates/blog/newsletter-form.html
@@ -47,8 +47,8 @@
         </li>
         <li class="p-list__item u-clearfix">
           <label class="p-checkbox">
-            <input class="p-checkbox__input" aria-labelledby="insightsfinance" name="insightsfinance" value="true" type="checkbox">
-            <span class="p-checkbox__label" id="insightsfinance">Finance</span>
+            <input class="p-checkbox__input" aria-labelledby="insightsfinserv" name="insightsfinserv" value="true" type="checkbox">
+            <span class="p-checkbox__label" id="insightsfinserv">Financial Services</span>
           </label>
         </li>
         {# These are honey pot fields to catch bots #}

--- a/templates/blog/newsletter-form.html
+++ b/templates/blog/newsletter-form.html
@@ -45,6 +45,12 @@
             <span class="p-checkbox__label" id="insightstutorials">Tutorials</span>
           </label>
         </li>
+        <li class="p-list__item u-clearfix">
+          <label class="p-checkbox">
+            <input class="p-checkbox__input" aria-labelledby="insightsfinance" name="insightsfinance" value="true" type="checkbox">
+            <span class="p-checkbox__label" id="insightsfinance">Finance</span>
+          </label>
+        </li>
         {# These are honey pot fields to catch bots #}
         <li class="u-off-screen">
           <label class="website" for="website">Website:</label>


### PR DESCRIPTION
## Done
Add finance option to newsletter signup

## QA

- Go to https://ubuntu-com-11664.demos.haus/blog
- Sign up for newsletters with the finance option checked (make a note of the email you use)
- Check that your submission has appeared in Marketo (Scott can help you with this if you need)

## Issue / Card

Fixes https://github.com/canonical-web-and-design/web-squad/issues/5449#event-6707591309


## Help

[QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html) - [Commit guidelines](https://canonical-web-and-design.github.io/practices/workflow/commit-messages.html)
