### PR TITLE
Update FAQ on /security/docker-images

### DIFF
--- a/templates/security/docker-images.html
+++ b/templates/security/docker-images.html
@@ -91,7 +91,9 @@
     <p class="p-heading--4"><strong>Is there a long-term commitment? How long?</strong></p>
     <p>LTS Images are security-maintained for the full ten year period of their underlying Ubuntu LTS release. Some applications will have versions on multiple Ubuntu LTS versions. In each case, the image is maintained for the full life of the underlying Ubuntu LTS.</p>
     <p class="p-heading--4"><strong>Can I use these images to build other applications?</strong></p>
-    <p>Yes. Our hardened images are optimised for the developer experience, layering, and minimality. Each image is engineered to be clean, without layering artifacts, making it an ideal foundation for enterprise continuous integration and golden images. If you are an ISV, Canonical can offer embedded terms for redistribution and specific support. <a href="/security/contact-us?product=docker" class="js-invoke-modal">Get in touch</a>.</p>
+    <p>Yes. Our hardened images are optimised for the developer experience, layering, and minimality. Each image is engineered to be clean, without layering artefacts, making it an ideal foundation for enterprise continuous integration and golden images. If you are an ISV, Canonical can offer embedded terms for redistribution and specific support. <a href="/security/contact-us?product=docker" class="js-invoke-modal">Get in touch</a>.</p>
+    <p class="p-heading--4"><strong>Can I enable FIPS mode on Ubuntu-based container images?</strong></p>
+    <p>Yes, with a valid UA subscription. Hosts or nodes running the hardened Ubuntu-based container images must be covered with UA subscriptions or be entitled Ubuntu Pro machines. You can read more about how to enable FIPS mode on container images <a href="/blog/fips-ubuntu-container-security-updates">in this blog post</a>.</p>
   </div>
 </section>
 


### PR DESCRIPTION
## Done

- Updated as per [copy doc](https://docs.google.com/document/d/1zZibtjU141e4mBxo_0PtfYxJ6e5fyaaAdFZ6v945XAM/edit#)

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: https://ubuntu-com-11668.demos.haus/security/docker-images
    - Be sure to test on mobile, tablet and desktop screen sizes
- See that the requested changes have been made

## Issue / Card

Fixes https://github.com/canonical-web-and-design/web-squad/issues/5463
