### PR TITLE
Update copy for 22.04 LTS and 20.04 LTS

### DIFF
--- a/static/js/src/advantage/subscribe/renderers/version-details.js
+++ b/static/js/src/advantage/subscribe/renderers/version-details.js
@@ -9,7 +9,8 @@ const FIPS =
 const DISA = "DISA STIG";
 const CommonCriteria = "Common Criteria EAL2";
 const ESMEndDate = "Extended Security Maintenance (ESM) until ";
-const MicrosoftActiveDirectory = "Advanced Group Policy Object support for Microsoft Active Directory";
+const MicrosoftActiveDirectory =
+  "Advanced Group Policy Object support for Microsoft Active Directory";
 
 const versionDetails = {
   22.04: [

--- a/static/js/src/advantage/subscribe/renderers/version-details.js
+++ b/static/js/src/advantage/subscribe/renderers/version-details.js
@@ -9,6 +9,7 @@ const FIPS =
 const DISA = "DISA STIG";
 const CommonCriteria = "Common Criteria EAL2";
 const ESMEndDate = "Extended Security Maintenance (ESM) until ";
+const MicrosoftActiveDirectory = "Advanced Group Policy Object support for Microsoft Active Directory";
 
 const versionDetails = {
   22.04: [
@@ -18,6 +19,7 @@ const versionDetails = {
     CISBenchmarkAndAutomation,
     landscape,
     knowledgeBase,
+    MicrosoftActiveDirectory,
   ],
   20.04: [
     `${ESMEndDate} 2030`,
@@ -27,6 +29,7 @@ const versionDetails = {
     CISBenchmarkAndAutomation,
     landscape,
     knowledgeBase,
+    MicrosoftActiveDirectory,
   ],
   18.04: [
     `${ESMEndDate} 2028`,


### PR DESCRIPTION
## Done

- Updated as per [relevant comment on doc](https://docs.google.com/document/d/1UqL8YJH9ywvOXnrt3syY0U8fiOakfAGWmLS9uerwAWk/edit?disco=AAAAZvdq89s)
**NOTE: This copy doc is massively out of sync with the live site. As it is unclear if the older comments are still relevant, this PR only addresses the most recently requested change in the comment linked above. See [comment](https://github.com/canonical-web-and-design/web-squad/issues/5432#issuecomment-1144814204)**

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/advantage/subscribe
    - Be sure to test on mobile, tablet and desktop screen sizes
- Under "What Ubuntu version are you running?" click on both 24.04 LTS and 20.04 LTS and see that the last bullet point shows as expected

## Issue / Card

Fixes https://github.com/canonical-web-and-design/web-squad/issues/5432