### PR TITLE
Add 22.04 content to /aws/pro

### DIFF
--- a/templates/aws/pro.html
+++ b/templates/aws/pro.html
@@ -29,18 +29,23 @@
 
 <section class="p-strip is-shallow u-sv3">
   <div class="row p-divider">
-    <div class="col-4 p-divider__block">
+    <div class="col-3 p-divider__block">
+      <h3 class="p-heading--4">Ubuntu Pro 22.04 LTS</h3>
+      <p>The latest LTS release includes the 5.15 kernel out of the box. Ubuntu Pro 22.04 LTS provides extended maintenance through 2032.</p>
+      <p><a href="https://aws.amazon.com/marketplace/pp/prodview-uy7jg4dds3qjw" class="p-button--positive"><span>Launch now</span></a></p>
+    </div>    
+    <div class="col-3 p-divider__block">
       <h3 class="p-heading--4">Ubuntu Pro 20.04 LTS</h3>
       <p>The latest LTS release includes the 5.4 kernel out of the box. Ubuntu Pro 20.04 LTS provides extended maintenance through 2030.</p>
       <p><a href="https://aws.amazon.com/marketplace/pp/B087L1R4G4" class="p-button--positive"><span>Launch now</span></a></p>
     </div>
-    <div class="col-4 p-divider__block">
+    <div class="col-3 p-divider__block">
       <h3 class="p-heading--4">Ubuntu Pro 18.04 LTS</h3>
       <p>Ubuntu 18.04 LTS release includes 5.4 kernel and provides extended maintenance through 2028.
     </p>
       <p><a href="https://aws.amazon.com/marketplace/pp/B0821T9RL2" class="p-button--positive"><span>Launch now</span></a></p>
     </div>
-    <div class="col-4 p-divider__block">
+    <div class="col-3 p-divider__block">
       <h3 class="p-heading--4">Ubuntu Pro 16.04 LTS</h3>
       <p>Ubuntu 16.04 LTS shipped in 2016 with the 4.4 kernel, and is covered with Ubuntu Pro through 2026.</p>
       <p><a href="https://aws.amazon.com/marketplace/pp/B0821WW873" class="p-button--positive"><span>Launch now</span></a></p>

--- a/templates/aws/pro.html
+++ b/templates/aws/pro.html
@@ -32,23 +32,23 @@
     <div class="col-3 p-divider__block">
       <h3 class="p-heading--4">Ubuntu Pro 22.04 LTS</h3>
       <p>The latest LTS release includes the 5.15 kernel out of the box. Ubuntu Pro 22.04 LTS provides extended maintenance through 2032.</p>
-      <p><a href="https://aws.amazon.com/marketplace/pp/prodview-uy7jg4dds3qjw" class="p-button--positive"><span>Launch now</span></a></p>
+      <p><a href="https://aws.amazon.com/marketplace/pp/prodview-uy7jg4dds3qjw" class="p-button--positive">Launch now</a></p>
     </div>    
     <div class="col-3 p-divider__block">
       <h3 class="p-heading--4">Ubuntu Pro 20.04 LTS</h3>
       <p>The latest LTS release includes the 5.4 kernel out of the box. Ubuntu Pro 20.04 LTS provides extended maintenance through 2030.</p>
-      <p><a href="https://aws.amazon.com/marketplace/pp/B087L1R4G4" class="p-button--positive"><span>Launch now</span></a></p>
+      <p><a href="https://aws.amazon.com/marketplace/pp/B087L1R4G4" class="p-button--positive">Launch now</a></p>
     </div>
     <div class="col-3 p-divider__block">
       <h3 class="p-heading--4">Ubuntu Pro 18.04 LTS</h3>
       <p>Ubuntu 18.04 LTS release includes 5.4 kernel and provides extended maintenance through 2028.
     </p>
-      <p><a href="https://aws.amazon.com/marketplace/pp/B0821T9RL2" class="p-button--positive"><span>Launch now</span></a></p>
+      <p><a href="https://aws.amazon.com/marketplace/pp/B0821T9RL2" class="p-button--positive">Launch now</a></p>
     </div>
     <div class="col-3 p-divider__block">
       <h3 class="p-heading--4">Ubuntu Pro 16.04 LTS</h3>
       <p>Ubuntu 16.04 LTS shipped in 2016 with the 4.4 kernel, and is covered with Ubuntu Pro through 2026.</p>
-      <p><a href="https://aws.amazon.com/marketplace/pp/B0821WW873" class="p-button--positive"><span>Launch now</span></a></p>
+      <p><a href="https://aws.amazon.com/marketplace/pp/B0821WW873" class="p-button--positive">Launch now</a></p>
     </div>
   </div>
   <div class="u-fixed-width">


### PR DESCRIPTION
## Done

- Add 22.04 content to /aws/pro

## QA

- Go to https://ubuntu-com-11675.demos.haus/aws/pro and compare against [copydoc](https://docs.google.com/document/d/1pLRWJZSpE04nYt-yHBtCjxGI7VZsigcP2UJIBmR8i-0/edit#heading=h.4hyflila1isb)

## Issue / Card

Fixes https://github.com/canonical-web-and-design/web-squad/issues/5452
