### PR TITLE
Update /download/iot with new section and link tags

### DIFF
--- a/templates/download/iot/index.html
+++ b/templates/download/iot/index.html
@@ -55,7 +55,7 @@
         <h3>Supported platforms</h3>
       </div>
     </div>
-    <div class="row">
+    <div class="row u-sv3">
       <div class="col-3">
         {{
           image(
@@ -115,6 +115,23 @@
         </p>
       </div>
     </div>
+    <div class="row">
+      <div class="col-8">
+        <p>Ubuntu works along with silicon vendors and manufacturers to enable and certify Ubuntu on a wide range of hardware. The certified hardware passes our extensive testing and review process in our labs, ensuring that Ubuntu runs well out of the box, and regression tests are performed before every system update is delivered.</p>
+        <p><a href="https://ubuntu.com/certified" class="p-button">Browse the full list of certified hardware</a></p>
+      </div>
+      <div class="col-4 u-align--center">
+        {{ image (
+          url="https://assets.ubuntu.com/v1/20a610ea-Ubuntu_Certified_Hardware_partner.svg",
+          alt="",
+          width="102",
+          height="150",
+          hi_def=True,
+          loading="lazy"
+          ) | safe
+        }}
+      </div>
+    </div>
   </section>
 
   <section id="core" class="p-strip--light">
@@ -159,11 +176,11 @@
     <div class="row p-divider">
       <div class="col-3">
         <img src="https://assets.ubuntu.com/v1/977f2b7a-raspberry+pi+horizontal.svg" width="168" height="45" alt="Raspberry Pi">
-        <p><a href="/download/raspberry-pi-core">Install Ubuntu Core 20&nbsp;&rsaquo;</a></p>
+        <p><a href="/download/iot/raspberry-pi">Install Ubuntu Core 22&nbsp;&rsaquo;</a></p>
         </div>
         <div class="col-3">
           <img src="https://assets.ubuntu.com/v1/a69b2863-intel+nuc.svg" width="120" height="45" alt="Intel NUC">
-          <p><a href="/download/intel-nuc">Install Ubuntu Core 18&nbsp;&rsaquo;</a></p>
+          <p><a href="/download/intel-nuc">Install Ubuntu Core 22&nbsp;&rsaquo;</a></p>
         </div>
         <div class="col-3">
           <img src="https://assets.ubuntu.com/v1/db577ec7-tank-logo.svg" width="163" height="45" alt="Intel IEI TANK 870">

--- a/templates/download/iot/index.html
+++ b/templates/download/iot/index.html
@@ -120,7 +120,7 @@
         <p>Ubuntu works along with silicon vendors and manufacturers to enable and certify Ubuntu on a wide range of hardware. The certified hardware passes our extensive testing and review process in our labs, ensuring that Ubuntu runs well out of the box, and regression tests are performed before every system update is delivered.</p>
         <p><a href="https://ubuntu.com/certified" class="p-button">Browse the full list of certified hardware</a></p>
       </div>
-      <div class="col-4 u-align--center">
+      <div class="col-4 u-align--center u-hide--small u-hide--medium">
         {{ image (
           url="https://assets.ubuntu.com/v1/20a610ea-Ubuntu_Certified_Hardware_partner.svg",
           alt="",
@@ -142,7 +142,8 @@
           Ubuntu Core is a lean, strictly confined and fully transactional operating system. We designed it from the ground up, to focus on security and simplified maintenance, for appliances and large device networks. Ubuntu Core is powered by snaps - the universal Linux packaging format.
         </p>
         <p>
-          <a class="p-button is-inline" style="margin-left: 0;" href="/core">Learn more about Ubuntu Core</a><br class="u-hide--large u-hide--medium" /><a href="/download/kvm">Install on your workstation in a KVM&nbsp;&rsaquo;</a>
+          <a class="p-button is-inline" style="margin-left: 0;" href="/core">Learn more about Ubuntu Core</a>
+          <a href="/download/kvm">Install on your workstation in a KVM&nbsp;&rsaquo;</a>
         </p>
       </div>
       <div class="col-4 u-vertically-center u-hide--medium u-hide--small u-align--center">
@@ -157,16 +158,21 @@
           ) | safe
         }}
       </div>
-      <div class="u-fixed-width">
-        <h3 class="p-heading--2">Ubuntu Core 22 Beta is now available</h3>
-        <p>
-          Pre-built Ubuntu Core 22 Beta images are available to download for some of the most popular architectures. Developers have the chance to try the new features ahead of the planned stable release on May 24, 2022.
-        </p>
-        <p>
-          <a class="p-button is-inline" style="margin-left: 0;" href="https://cdimage.ubuntu.com/ubuntu-core/22/beta/current/">Browse all supported images</a><br class="u-hide--large u-hide--medium" /><a href="https://forum.snapcraft.io/t/ubuntu-core-22-beta-is-now-available/29955">Read the announcement&nbsp;&rsaquo;</a>
-        </p>
-      </div>
     </div>
+  </div>
+</section>
+
+<section class="p-strip--suru">
+  <div class="u-fixed-width">
+    <h3 class="p-heading--2">Ubuntu Core 22 Beta is now available</h3>
+    <p>
+      Pre-built Ubuntu Core 22 Beta images are available to download for some of the most popular architectures. Developers have the chance to try the new features ahead of the planned stable release on May 24, 2022.
+    </p>
+    <p>
+      <a class="p-button is-inline" style="margin-left: 0;" href="https://cdimage.ubuntu.com/ubuntu-core/22/beta/current/">Browse all supported images</a>
+      <a href="https://forum.snapcraft.io/t/ubuntu-core-22-beta-is-now-available/29955" class="p-link--inverted">Read the announcement&nbsp;&rsaquo;</a>
+    </p>
+  </div>
   </section>
 
   <section class="p-strip">

--- a/templates/pricing/shared/_enablement-strip.html
+++ b/templates/pricing/shared/_enablement-strip.html
@@ -31,7 +31,7 @@
     </div>
 
 
-    <div class="col-2 col-start-large-10 u-hide--small">
+    <div class="col-2 col-start-large-10 u-hide--small u-hide--medium">
       {{
         image(
         url="https://assets.ubuntu.com/v1/706b259a-ubuntu_certified_hex.svg",


### PR DESCRIPTION
## Done
**To go live on June 16th, see doc for more details**
- Update /download/iot with new section and link tags

## QA

- Go to https://ubuntu-com-11678.demos.haus/download/iot and compare against [copydoc](https://docs.google.com/document/d/1Sxdl5cGGe1wbHmKB2eL2zQLfVW3KBea02a2FIGx3VdQ/edit#heading=h.rcu78t62sv8b)

## Issue / Card

Fixes https://github.com/canonical-web-and-design/web-squad/issues/5423
