### PR TITLE
Add a link on dropdown menu

### DIFF
--- a/templates/templates/navigation-developer-h.html
+++ b/templates/templates/navigation-developer-h.html
@@ -12,6 +12,7 @@
             <a href="/desktop/developers">Develop on Ubuntu&nbsp;&rsaquo;</a>
           </h4>
           <ul class="p-text-list--small is-bordered">
+            <li class="p-list__item"><a href="/desktop">Ubuntu Desktop</a></li>
             <li class="p-list__item"><a href="/about/packages">Deb, snap, and charm packages</a></li>
             <li class="p-list__item"><a href="/kernel">Kernel selection &amp; lifecycle</a></li>
             <li class="p-list__item"><a href="https://multipass.run">Multipass</a></li>


### PR DESCRIPTION
## Done

- Add `Ubuntu Desktop` on developer dropdown menu

## QA

- [Copy doc](https://docs.google.com/document/d/1JzZPBydcdyV96Hu4xRpa7VDU_WREr6gb05bL7GlQaYY/edit)
- Go to https://ubuntu-com-11683.demos.haus/
- Click developer in the navigation check `Ubuntu Desktop` is added 
![Screenshot 2022-06-06 at 3 45 54 pm](https://user-images.githubusercontent.com/57550290/172185213-89c4e382-7fa6-4cf5-b427-2b5513abfe11.png)



## Issue / Card

Fixes [#5464](https://github.com/canonical-web-and-design/web-squad/issues/5464)
