### PR TITLE
Add calculate price endpoint

### DIFF
--- a/tests/shop/advantage/test_api.py
+++ b/tests/shop/advantage/test_api.py
@@ -1201,3 +1201,73 @@ class TestPutContractEntitlements(unittest.TestCase):
         }
 
         self.assertEqual(session.request_kwargs, expected_args)
+
+
+class TestPostPurchaseCalculate(unittest.TestCase):
+    def test_errors(self):
+        cases = [
+            (500, False, UAContractsAPIError),
+            (500, True, UAContractsAPIErrorView),
+        ]
+
+        for code, is_for_view, expected_error in cases:
+            session = Session(response=Response(status_code=code, content={}))
+            client = make_client(session, is_for_view=is_for_view)
+
+            with self.assertRaises(expected_error):
+                client.post_purchase_calculate(
+                    marketplace="canonical-ua",
+                    request_body={
+                        "country": "GB",
+                        "productItems": [
+                            {
+                                "productListingID": "lAaBbCcDdEeFfHh",
+                                "value": 1,
+                            },
+                        ],
+                        "hasTaxID": True,
+                    },
+                )
+
+    def test_success(self):
+        session = Session(
+            response=Response(
+                status_code=200,
+                content={},
+            )
+        )
+        make_client(session).post_purchase_calculate(
+            marketplace="canonical-ua",
+            request_body={
+                "country": "GB",
+                "productItems": [
+                    {
+                        "productListingID": "lAaBbCcDdEeFfHh",
+                        "value": 1,
+                    },
+                ],
+                "hasTaxID": True,
+            },
+        )
+
+        expected_args = {
+            "headers": {"Authorization": "Macaroon secret-token"},
+            "json": {
+                "country": "GB",
+                "productItems": [
+                    {
+                        "productListingID": "lAaBbCcDdEeFfHh",
+                        "value": 1,
+                    },
+                ],
+                "hasTaxID": True,
+            },
+            "method": "post",
+            "params": None,
+            "url": (
+                "https://1.2.3.4"
+                "/v1/marketplace/canonical-ua/purchase/calculate"
+            ),
+        }
+
+        self.assertEqual(session.request_kwargs, expected_args)

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -90,6 +90,7 @@ from webapp.shop.views import (
     get_purchase_v2,
     post_stripe_invoice_id,
     get_last_purchase_ids,
+    post_purchase_calculate,
     support,
 )
 
@@ -473,6 +474,11 @@ app.add_url_rule(
     view_func=post_advantage_purchase,
     methods=["POST"],
     defaults={"preview": True},
+)
+app.add_url_rule(
+    "/account/<marketplace>/purchase/calculate",
+    view_func=post_purchase_calculate,
+    methods=["POST"],
 )
 # end of shop
 

--- a/webapp/shop/api/ua_contracts/api.py
+++ b/webapp/shop/api/ua_contracts/api.py
@@ -305,6 +305,18 @@ class UAContractsAPI:
 
         return {}
 
+    def post_purchase_calculate(
+        self,
+        marketplace: str,
+        request_body: dict,
+    ) -> dict:
+        return self._request(
+            method="post",
+            path=f"v1/marketplace/{marketplace}/purchase/calculate",
+            json=request_body,
+            error_rules=["default"],
+        ).json()
+
     def handle_error(self, error, error_rules=None):
         if not error_rules:
             return

--- a/webapp/shop/schemas.py
+++ b/webapp/shop/schemas.py
@@ -53,6 +53,13 @@ class CustomerInfo(Schema):
     tax_id = Nested(TaxIdSchema())
 
 
+class PurchaseTotalSchema(Schema):
+    currency = String(required=True)
+    subtotal = Int(required=True)
+    tax = Int()
+    total = Int(required=True)
+
+
 account_purhcase = {
     "account_id": String(),
     "captcha_value": String(requied=True),
@@ -158,4 +165,10 @@ put_contract_entitlements = {
 
 post_auto_renewal_settings = {
     "subscriptions": List(Nested(SubscriptionRenewalSchema), required=True)
+}
+
+post_purchase_calculate = {
+    "country": String(required=True),
+    "products": List(Nested(ProductSchema), required=True),
+    "has_tax": Boolean(),
 }

--- a/webapp/shop/views.py
+++ b/webapp/shop/views.py
@@ -281,20 +281,20 @@ def get_last_purchase_ids(advantage_mapper, **kwargs):
     return flask.jsonify(last_purchase_ids)
 
 
-@shop_decorator(area="account", permission="user_or_guest", response="json")
+@shop_decorator(area="account", response="json")
 @use_kwargs(post_purchase_calculate, location="json")
 def post_purchase_calculate(ua_contracts_api: UAContractsAPI, **kwargs):
     response = ua_contracts_api.post_purchase_calculate(
         marketplace=kwargs.get("marketplace"),
         request_body={
             "country": kwargs.get("country"),
-            "productItems": {
+            "purchaseItems": [
                 {
                     "value": product.get("quantity"),
                     "productListingID": product.get("product_listing_id"),
                 }
                 for product in kwargs.get("products")
-            },
+            ],
             "hasTaxID": kwargs.get("has_tax"),
         },
     )

--- a/webapp/shop/views.py
+++ b/webapp/shop/views.py
@@ -7,6 +7,7 @@ from webapp.shop.api.ua_contracts.advantage_mapper import AdvantageMapper
 from webapp.shop.decorators import shop_decorator, SERVICES
 from webapp.shop.flaskparser import use_kwargs
 from webapp.shop.api.ua_contracts.api import (
+    UAContractsAPI,
     UAContractsAPIError,
     UAContractsUserHasNoAccount,
     AccessForbiddenError,
@@ -16,11 +17,13 @@ from webapp.shop.api.ua_contracts.helpers import (
     to_dict,
 )
 from webapp.shop.schemas import (
+    PurchaseTotalSchema,
     post_anonymised_customer_info,
     post_customer_info,
     ensure_purchase_account,
     invoice_view,
     post_payment_methods,
+    post_purchase_calculate,
 )
 
 
@@ -276,6 +279,27 @@ def get_last_purchase_ids(advantage_mapper, **kwargs):
         )
 
     return flask.jsonify(last_purchase_ids)
+
+
+@shop_decorator(area="account", permission="user_or_guest", response="json")
+@use_kwargs(post_purchase_calculate, location="json")
+def post_purchase_calculate(ua_contracts_api: UAContractsAPI, **kwargs):
+    response = ua_contracts_api.post_purchase_calculate(
+        marketplace=kwargs.get("marketplace"),
+        request_body={
+            "country": kwargs.get("country"),
+            "productItems": {
+                {
+                    "value": product.get("quantity"),
+                    "productListingID": product.get("product_listing_id"),
+                }
+                for product in kwargs.get("products")
+            },
+            "hasTaxID": kwargs.get("has_tax"),
+        },
+    )
+
+    return PurchaseTotalSchema().load(response)
 
 
 @shop_decorator(area="account", response="html")


### PR DESCRIPTION
## Done

- Create new endpoint for calculating purchase price without user.

## QA

- Try this CURL command
```
curl --location --request POST 'https://ubuntu-com-11687.demos.haus/account/canonical-ua/purchase/calculate' \
--header 'Content-Type: application/json' \
--data-raw '{
    "country": "GB",
    "products": [
        {
            "product_listing_id": "lAFpm3dPX4PL26zY9tYA-6bA6-YR-VdzTz3nw-uNXlJY",
            "quantity": 1
        }
    ],
    "has_tax": false
}'
```
Does it work? Try different parameters. 

## Issue / Card

Fixes #https://github.com/canonical-web-and-design/commercial-squad/issues/599