### PR TITLE
Update Xilinx logo on /iot

### DIFF
--- a/templates/internet-of-things/index.html
+++ b/templates/internet-of-things/index.html
@@ -445,10 +445,10 @@
     <div class="col-6 p-card">
       <header class="no-border u-align--center u-vertically-center u-hide--medium u-hide--small" style="min-height: 7rem;">
         {{ image (
-          url="https://assets.ubuntu.com/v1/22011fee-Xilinx_logo.svg.png",
+          url="https://assets.ubuntu.com/v1/f8ef46d3-AMD_Xilinx_logo.svg",
           alt="",
-          width="256",
-          height="52",
+          width="121",
+          height="75",
           hi_def=True,
           loading="lazy"
           ) | safe


### PR DESCRIPTION
## Done

- Updated as per [copy doc](https://docs.google.com/document/d/1nBx1SP3Y10gXX0rZPDaz1Gudy-hWP4XRMUcETyPBldI/edit#heading=h.wm0gfggkoe1y)

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/internet-of-things
    - Be sure to test on mobile, tablet and desktop screen sizes
- See that the logo has been updated

## Issue / Card

Fixes https://github.com/canonical-web-and-design/web-squad/issues/5481