### PR TITLE
Add clarification to active directory bullet on /subscribe

### DIFF
--- a/static/js/src/advantage/subscribe/renderers/version-details.js
+++ b/static/js/src/advantage/subscribe/renderers/version-details.js
@@ -10,7 +10,7 @@ const DISA = "DISA STIG";
 const CommonCriteria = "Common Criteria EAL2";
 const ESMEndDate = "Extended Security Maintenance (ESM) until ";
 const MicrosoftActiveDirectory =
-  "Advanced Group Policy Object support for Microsoft Active Directory";
+  "Advanced Group Policy Object support for Microsoft Active Directory on Ubuntu Desktops";
 
 const versionDetails = {
   22.04: [


### PR DESCRIPTION
## Done

- Tweaked the copy on /advantage/subscribe when selecting 22.04 to indicate that Advanced Group Policy Object support for Microsoft Active Directory is for Ubuntu Desktops specifically, according to Oliver's second suggestion in the copy doc: https://docs.google.com/document/d/1UqL8YJH9ywvOXnrt3syY0U8fiOakfAGWmLS9uerwAWk/edit

## QA

- View the site in your web browser at: http://0.0.0.0:8001/advantage/subscribe
- Select 22.04 in the selector
- See that the bullet point about Active Directory matches the comment in the copy doc

## Issue / Card

Fixes https://github.com/canonical-web-and-design/web-squad/issues/5432

