### PR TITLE
fix version number typo on core page

### DIFF
--- a/templates/core/index.html
+++ b/templates/core/index.html
@@ -763,7 +763,7 @@
     <div class="col-4 p-divider__block">
       <h3 class="p-heading--4">Download Ubuntu Core</h3>
       <p>Try Ubuntu Core 22 on a popular development board</p>
-      <p><a class="p-button" href="https://cdimage.ubuntu.com/ubuntu-core/22/stable/current/">Download and install Ubuntu Core 20</a></p>
+      <p><a class="p-button" href="https://cdimage.ubuntu.com/ubuntu-core/22/stable/current/">Download and install Ubuntu Core 22</a></p>
     </div>
     <div class="col-4 p-divider__block">
       <h3 class="p-heading--4">Make your own Ubuntu Core device</h3>


### PR DESCRIPTION
## Done

- A download CTA incorrectly states version 20 of core, it should be 22

## QA

- Check the code
