### PR TITLE
update core rpi 22 links with latest checksums

### DIFF
--- a/releases.yaml
+++ b/releases.yaml
@@ -54,7 +54,7 @@ checksums:
   server-riscv64:
     "22.04": "e485892116d19d979967ab0873c78528b7d5c4636284428f51b26f0c0d8a7c3c *ubuntu-22.04-preinstalled-server-riscv64+unmatched.img.xz"
     "21.10": "8067892fa627eb219b31dc629f31f3bda6b015dfeabf2fdc9b0ed150bf7984b8 *ubuntu-21.10-preinstalled-server-riscv64+unmatched.img.xz"
-  core-20-arm64+raspi:
-    "20": "6a6f0dc12c4670d608fc9ca8ae3550167f129c6a1a027e638548bee1b4f8b238 *ubuntu-core-20-arm64+raspi.img.xz"
-  core-20-armhf+raspi:
-    "20": "434a497754d6a975d40ac97422a8425d46cdf198cd9bf5304f04e58fb8f4308f *ubuntu-core-20-armhf+raspi.img.xz"
+  core-22-arm64+raspi:
+    "22": "374697bd7324f10ff3c00007b75ca42885aff161cbddb63b1d14bc1551e69ce2 *ubuntu-core-22-arm64+raspi.img.xz"
+  core-22-armhf+raspi:
+    "22": "e495c578f6279d0bbb13437cf04574142013ec77d61855e8bc7f51919dc88739 *ubuntu-core-22-armhf+raspi.img.xz"

--- a/templates/download/shared/_core_raspberry_pi_download.html
+++ b/templates/download/shared/_core_raspberry_pi_download.html
@@ -1,8 +1,8 @@
 <p>
-  <a class="p-button--positive" href="/download/raspberry-pi/thank-you?version={{ releases.latest.core_version }}&amp;architecture=core-20-arm64+raspi" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'Raspberry Pi 64-bit - Ubuntu Core', 'eventLabel' : '{{ releases.latest.core_version }}', 'eventValue' : undefined });">
+  <a class="p-button--positive" href="/download/raspberry-pi/thank-you?version={{ releases.latest.core_version }}&amp;architecture=core-22-arm64+raspi" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'Raspberry Pi 64-bit - Ubuntu Core', 'eventLabel' : '{{ releases.latest.core_version }}', 'eventValue' : undefined });">
     Download 64-bit
   </a>
-  <a class="p-button" href="/download/raspberry-pi/thank-you?version={{ releases.latest.core_version }}&amp;architecture=core-20-armhf+raspi" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'Raspberry Pi 32-bit - Ubuntu Core', 'eventLabel' : '{{ releases.latest.core_version }}', 'eventValue' : undefined });">
+  <a class="p-button" href="/download/raspberry-pi/thank-you?version={{ releases.latest.core_version }}&amp;architecture=core-22-armhf+raspi" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'Raspberry Pi 32-bit - Ubuntu Core', 'eventLabel' : '{{ releases.latest.core_version }}', 'eventValue' : undefined });">
     Download 32-bit
   </a>
 </p>


### PR DESCRIPTION
## Done

- fixed broken core download links on /download/raspberry-pi

## QA

- View the site in your web browser at: http://0.0.0.0:8001/download/raspberry-pi
- See that the download links under "Download Ubuntu Core" work

