### PR TITLE
Fix /blog description formatting

### DIFF
--- a/templates/blog/blog-card.html
+++ b/templates/blog/blog-card.html
@@ -19,12 +19,12 @@
       <em>by
         <a href="/blog/author/{{article.author.slug}}">{{ article.author.name }}</a>
         on {{ article.date }}</em>
-      </p>
-    </div>
-    
-    {% if summary_visible or not article.image.source_url %}
-    <p class="u-no-padding--bottom{% if summary_visible %} u-hide--small{% endif %}">{{ article.excerpt.raw.replace("[…]", "")|truncate(162) }}</p>
-    {% endif %}
+    </p>
+      
+      {% if summary_visible or not article.image.source_url %}
+      <p class="{% if summary_visible %} u-hide--small{% endif %}" style="padding-top:1rem;">{{ article.excerpt.raw.replace("[…]", "")|truncate(162) }}</p>
+      {% endif %}
+  </div>
 
   <p class="blog-p-card__footer">
     {% include 'blog/singular-category.html' %}


### PR DESCRIPTION
## Done

- Fix /blog description formatting

## QA

- Go to https://ubuntu-com-11730.demos.haus/blog?page=3 and check the blog descriptions are rendering correctly. Note the small images look strange but this behavior was present before.

## Issue / Card

Fixes https://github.com/canonical-web-and-design/ubuntu.com/issues/11715
