### PR TITLE
Uncomment sign-in button

### DIFF
--- a/templates/templates/_navigation.html
+++ b/templates/templates/_navigation.html
@@ -48,15 +48,15 @@
           {% include "templates/header_noscript.html" %}
         </ul>
       </noscript>
-      <!-- <ul class="p-navigation__items u-hide--small">
-        <li class="p-navigation__item" id="link-4">
+      <ul class="p-navigation__items u-hide--small">
+        <!-- <li class="p-navigation__item" id="link-4">
           <a href="/search" class="js-search-button p-navigation__link-anchor" style="padding-right: 1rem;">
             <span class="u-hide u-show--large">Search</span> <i class="p-icon--search is-light"></i>
           </a>
-        </li>
+        </li> -->
         <li class="p-navigation__user js-account"></li>
       </ul>
-      <div class="p-navigation__search u-show--small u-hide" style="z-index: 39;">
+      <!-- <div class="p-navigation__search u-show--small u-hide" style="z-index: 39;">
         <form action="/search" class="p-search-box" id="ubuntu-global-search-form">
           <input type="search" class="p-search-box__input" name="q" placeholder="Search our sites" required="" aria-label="Search our sites">
           <button type="reset" class="p-search-box__reset"><i class="p-icon--close"></i></button>


### PR DESCRIPTION
## Done

[Previous PR merged](https://github.com/canonical-web-and-design/ubuntu.com/pull/11732), removed search AND sign in button - Uncomment sign-in button

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Make sure Sign in button shows and you can sign in
    - Be sure to test on mobile, tablet and desktop screen sizes
- [List additional steps to QA the new features or prove the bug has been resolved]


## Help

[QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html) - [Commit guidelines](https://canonical-web-and-design.github.io/practices/workflow/commit-messages.html)
