### PR TITLE
Temporarily remove all search

### DIFF
--- a/templates/templates/docs/shared/_docs.html
+++ b/templates/templates/docs/shared/_docs.html
@@ -24,6 +24,7 @@
 {% endmacro %}
 
 {% block outer_content %}
+{#
   {% with
     search_action=search_action,
     siteSearch=siteSearch,
@@ -31,7 +32,7 @@
   %}
     {% include "templates/docs/shared/_search-box.html" %}
   {% endwith %}
-
+#}
 <div class="p-strip is-shallow">
   <div class="row">
     <aside class="col-3">

--- a/templates/tutorials/index.html
+++ b/templates/tutorials/index.html
@@ -18,7 +18,7 @@
 
 <section class="p-strip is-shallow l-tutorials__filters">
   <div class="row">
-    <div class="col-4">
+    <!-- <div class="col-4">
       <div class="p-form__group">
         <label for="tutorials-search-input">Search tutorials containing:</label>
         <form class="p-search-box u-no-margin--bottom" id="tutorials-search" action="">
@@ -27,7 +27,7 @@
           <button type="submit" class="p-search-box__button"><i class="p-icon--search"></i></button>
         </form>
       </div>
-    </div>
+    </div> -->
     <div class="col-4">
       <div class="p-form__group">
         <label for="tutorials-topic">Topic:</label>

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -99,15 +99,15 @@ class TestRoutes(VCRTestCase):
             200,
         )
 
-    def test_tutorials_search(self):
-        """
-        Check the tutorials search works
-        """
+    # def test_tutorials_search(self):
+    #     """
+    #     Check the tutorials search works
+    #     """
 
-        search_response = self.client.get("/tutorials?q=ubuntu")
+    #     search_response = self.client.get("/tutorials?q=ubuntu")
 
-        self.assertEqual(search_response.status_code, 200)
-        self.assertIn(b"search results", search_response.data)
+    #     self.assertEqual(search_response.status_code, 200)
+    #     self.assertIn(b"search results", search_response.data)
 
     def test_download(self):
         """

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -8,7 +8,8 @@ import talisker.requests
 import flask
 from canonicalwebteam.flask_base.app import FlaskBase
 from canonicalwebteam.templatefinder import TemplateFinder
-from canonicalwebteam.search import build_search_view
+
+# from canonicalwebteam.search import build_search_view
 from canonicalwebteam import image_template
 from canonicalwebteam.blog import build_blueprint, BlogViews, BlogAPI
 from canonicalwebteam.discourse import (
@@ -187,7 +188,7 @@ discourse_api = DiscourseAPI(
 )
 
 # Web tribe websites custom search ID
-search_engine_id = "adb2397a224a1fe55"
+# search_engine_id = "adb2397a224a1fe55"
 
 
 # Error pages
@@ -712,16 +713,16 @@ core_services_guide = Docs(
     blueprint_name="core-services-guide",
 )
 
-app.add_url_rule(
-    "/core/services/guide/search",
-    "core-services-guide-search",
-    build_search_view(
-        session=session,
-        site="ubuntu.com/core/services/guide",
-        template_path="core/services/guide/search-results.html",
-        search_engine_id=search_engine_id,
-    ),
-)
+# app.add_url_rule(
+#     "/core/services/guide/search",
+#     "core-services-guide-search",
+#     build_search_view(
+#         session=session,
+#         site="ubuntu.com/core/services/guide",
+#         template_path="core/services/guide/search-results.html",
+#         search_engine_id=search_engine_id,
+#     ),
+# )
 
 core_services_guide.init_app(app)
 
@@ -744,16 +745,16 @@ server_docs = Docs(
 )
 
 # Server docs search
-app.add_url_rule(
-    "/server/docs/search",
-    "server-docs-search",
-    build_search_view(
-        session=session,
-        site="ubuntu.com/server/docs",
-        template_path="/server/docs/search-results.html",
-        search_engine_id=search_engine_id,
-    ),
-)
+# app.add_url_rule(
+#     "/server/docs/search",
+#     "server-docs-search",
+#     build_search_view(
+#         session=session,
+#         site="ubuntu.com/server/docs",
+#         template_path="/server/docs/search-results.html",
+#         search_engine_id=search_engine_id,
+#     ),
+# )
 
 server_docs.init_app(app)
 
@@ -797,16 +798,16 @@ ceph_docs = Docs(
 ceph_docs.init_app(app)
 
 # Ceph docs search
-app.add_url_rule(
-    "/ceph/docs/search",
-    "ceph-docs-search",
-    build_search_view(
-        session=session,
-        site="ubuntu.com/ceph/docs",
-        template_path="ceph/docs/search-results.html",
-        search_engine_id=search_engine_id,
-    ),
-)
+# app.add_url_rule(
+#     "/ceph/docs/search",
+#     "ceph-docs-search",
+#     build_search_view(
+#         session=session,
+#         site="ubuntu.com/ceph/docs",
+#         template_path="ceph/docs/search-results.html",
+#         search_engine_id=search_engine_id,
+#     ),
+# )
 
 # Core docs
 core_docs = Docs(
@@ -818,16 +819,16 @@ core_docs = Docs(
     blueprint_name="core",
 )
 # Core docs search
-app.add_url_rule(
-    "/core/docs/search",
-    "core-docs-search",
-    build_search_view(
-        session=session,
-        site="ubuntu.com/core/docs",
-        template_path="/core/docs/search-results.html",
-        search_engine_id=search_engine_id,
-    ),
-)
+# app.add_url_rule(
+#     "/core/docs/search",
+#     "core-docs-search",
+#     build_search_view(
+#         session=session,
+#         site="ubuntu.com/core/docs",
+#         template_path="/core/docs/search-results.html",
+#         search_engine_id=search_engine_id,
+#     ),
+# )
 core_docs.init_app(app)
 
 # Core docs - Modem Manager
@@ -943,16 +944,16 @@ openstack_docs = Docs(
 )
 
 # Charmed OpenStack docs search
-app.add_url_rule(
-    "/openstack/docs/search",
-    "openstack-docs-search",
-    build_search_view(
-        session=session,
-        site="ubuntu.com/openstack/docs",
-        template_path="openstack/docs/search-results.html",
-        search_engine_id=search_engine_id,
-    ),
-)
+# app.add_url_rule(
+#     "/openstack/docs/search",
+#     "openstack-docs-search",
+#     build_search_view(
+#         session=session,
+#         site="ubuntu.com/openstack/docs",
+#         template_path="openstack/docs/search-results.html",
+#         search_engine_id=search_engine_id,
+#     ),
+# )
 
 openstack_docs.init_app(app)
 
@@ -969,16 +970,16 @@ security_livepatch_docs = Docs(
 )
 
 # Security Livepatch search
-app.add_url_rule(
-    "/security/livepatch/docs/search",
-    "security-livepatch-docs-search",
-    build_search_view(
-        session=session,
-        site="ubuntu.com/security/livepatch/docs",
-        template_path="/security/livepatch/docs/search-results.html",
-        search_engine_id=search_engine_id,
-    ),
-)
+# app.add_url_rule(
+#     "/security/livepatch/docs/search",
+#     "security-livepatch-docs-search",
+#     build_search_view(
+#         session=session,
+#         site="ubuntu.com/security/livepatch/docs",
+#         template_path="/security/livepatch/docs/search-results.html",
+#         search_engine_id=search_engine_id,
+#     ),
+# )
 
 security_livepatch_docs.init_app(app)
 
@@ -995,16 +996,16 @@ security_certs_docs = Docs(
 )
 
 # Security Certifications search
-app.add_url_rule(
-    "/security/certifications/docs/search",
-    "security-certs-docs-search",
-    build_search_view(
-        session=session,
-        site="ubuntu.com/security/certifications/docs",
-        template_path="/security/certifications/docs/search-results.html",
-        search_engine_id=search_engine_id,
-    ),
-)
+# app.add_url_rule(
+#     "/security/certifications/docs/search",
+#     "security-certs-docs-search",
+#     build_search_view(
+#         session=session,
+#         site="ubuntu.com/security/certifications/docs",
+#         template_path="/security/certifications/docs/search-results.html",
+#         search_engine_id=search_engine_id,
+#     ),
+# )
 
 security_certs_docs.init_app(app)
 

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -15,7 +15,8 @@ from ubuntu_release_info.data import Data
 from geolite2 import geolite2
 from requests import Session
 from requests.exceptions import HTTPError
-from canonicalwebteam.search.models import get_search_results
+
+# from canonicalwebteam.search.models import get_search_results
 from canonicalwebteam.search.views import NoAPIKeyError
 from bs4 import BeautifulSoup
 from werkzeug.exceptions import BadRequest
@@ -289,7 +290,7 @@ def build_tutorials_index(session, tutorials_docs):
         """
 
         # Web tribe websites custom search ID
-        search_engine_id = "adb2397a224a1fe55"
+        # search_engine_id = "adb2397a224a1fe55"
 
         # API key should always be provided as an environment variable
         search_api_key = os.getenv("SEARCH_API_KEY")
@@ -297,17 +298,17 @@ def build_tutorials_index(session, tutorials_docs):
         if query and not search_api_key:
             raise NoAPIKeyError("Unable to search: No API key provided")
 
-        results = None
+        # results = None
 
-        if query:
-            results = get_search_results(
-                session=session,
-                api_key=search_api_key,
-                search_engine_id=search_engine_id,
-                siteSearch="ubuntu.com/tutorials",
-                query=query,
-                site_restricted_search=False,
-            )
+        # if query:
+        #     results = get_search_results(
+        #         session=session,
+        #         api_key=search_api_key,
+        #         search_engine_id=search_engine_id,
+        #         siteSearch="ubuntu.com/tutorials",
+        #         query=query,
+        #         site_restricted_search=False,
+        #     )
 
         tutorials_docs.parser.parse()
         tutorials_docs.parser.parse_topic(tutorials_docs.parser.index_topic)
@@ -329,18 +330,18 @@ def build_tutorials_index(session, tutorials_docs):
                     item["categories"].replace(" ", "").lower().split(",")
                 )
 
-        if query:
-            temp_metadata = []
-            if results.get("entries"):
-                for result in results["entries"]:
-                    start = result["link"].find("tutorials/")
-                    end = len(result["link"])
-                    identifier = result["link"][start:end]
-                    if start != -1:
-                        for doc in tutorials:
-                            if identifier in doc["link"]:
-                                temp_metadata.append(doc)
-            tutorials = temp_metadata
+        # if query:
+        #     temp_metadata = []
+        #     if results.get("entries"):
+        #         for result in results["entries"]:
+        #             start = result["link"].find("tutorials/")
+        #             end = len(result["link"])
+        #             identifier = result["link"][start:end]
+        #             if start != -1:
+        #                 for doc in tutorials:
+        #                     if identifier in doc["link"]:
+        #                         temp_metadata.append(doc)
+        #     tutorials = temp_metadata
 
         if sort == "difficulty-desc":
             tutorials = sorted(


### PR DESCRIPTION
## Done

Temporarily remove all search

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes

Check that search and /search endpoints have been removed in the following URLs:
- https://ubuntu-com-11737.demos.haus/server/docs
- https://ubuntu-com-11737.demos.haus/core/services/guide
- https://ubuntu-com-11737.demos.haus/kubernetes/docs
- https://ubuntu-com-11737.demos.haus/core/docs
- https://ubuntu-com-11737.demos.haus/tutorials
- https://ubuntu-com-11737.demos.haus/ceph/docs
- https://ubuntu-com-11737.demos.haus/openstack/docs
- https://ubuntu-com-11737.demos.haus/security/livepatch/docs
- https://ubuntu-com-11737.demos.haus/security/certifications/docs

## Help

[QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html) - [Commit guidelines](https://canonical-web-and-design.github.io/practices/workflow/commit-messages.html)
