### PR TITLE
Only show certified search page of search query present

### DIFF
--- a/webapp/certified/views.py
+++ b/webapp/certified/views.py
@@ -277,8 +277,8 @@ def certified_home():
             else:
                 server_releases[release] = vendor[release]
 
-    if request.args:
-        query = request.args.get("q", default=None, type=str)
+    if "q" in request.args:
+        query = request.args["q"]
 
         # Old site replacements
         if set(request.args) & set(["query", "vendors"]):


### PR DESCRIPTION
Only show search results page if search query parameter present.

Fixes #11428 

## QA

Go to https://ubuntu-com-11740.demos.haus/certified?nonsense. Check you see the homepage.

Go to https://ubuntu-com-11740.demos.haus/certified?q=nonsense. Check you see the search results page.