### PR TITLE
Fixes #11654 and #11655

### DIFF
--- a/templates/legal/ubuntu-advantage-service-description/index.md
+++ b/templates/legal/ubuntu-advantage-service-description/index.md
@@ -121,7 +121,7 @@ As a Standard or Advanced customer, you are entitled to all of the benefits of t
         14. Each Charm version is supported for one year from the release date
         15. Canonical will not provide support for any Charms that have been modified from the [supported version](https://docs.openstack.org/charm-guide/latest/reference/openstack-charms.html)
     9. <span id="uasd-storage-support">Storage support</span>
-        16. Canonical will provide support for 72TB of raw storage per storage node with Ceph or Swift storage exposed to the OpenStack cluster. This allowance can be used for Ceph, Swift, or a combination of these. Please note that only storage Nodes count towards the 72TB free tier of raw storage per node
+        16. Canonical will provide support for 192TB of raw storage per storage node with Ceph or Swift storage exposed to the OpenStack cluster. This allowance can be used for Ceph, Swift, or a combination of these. Please note that only storage Nodes count towards the 192TB free tier of raw storage per node
         17. If the Node allowance is exceeded, [additional Storage Support](https://ubuntu.com/pricing/infra) needs to be acquired
         18. Customers who have purchased Storage Support for an unlimited amount of storage are limited to support in a single Ceph Cluster or Swift Cluster
     10. <span id="uasd-maas-support">MAAS support</span>

--- a/templates/shared/pricing/_ua-advanced-storage.html
+++ b/templates/shared/pricing/_ua-advanced-storage.html
@@ -4,33 +4,40 @@
       <thead>
         <tr>
           <th><strong>UA Advanced Storage</strong></th>
-          <th width="400" class="u-align--right">From</th>
+          <th width="400" class="u-align--right">Tier Price</th>
+          <th width="400" class="u-align--right">Additional Per TB</th>
         </tr>
       </thead>
       <tbody>
         <tr>
           <td>Up to 150 TB</td>
           <td class="u-align--right">0</td>
+          <td class="u-align--right">$33.33</td>
         </tr>
         <tr>
           <td>150 - 1,500 TB</td>
           <td class="u-align--right">$5,000</td>
+          <td class="u-align--right">$25.00</td>
         </tr>
         <tr>
           <td>1,500 - 3,000 TB</td>
           <td class="u-align--right">$38,750</td>
+          <td class="u-align--right">$13.33</td>
         </tr>
         <tr>
           <td>3,000 to 15,000 TB</td>
           <td class="u-align--right">$58,750</td>
+          <td class="u-align--right">$6.67</td>
         </tr>
         <tr>
           <td>15,000 to 30,000 TB</td>
           <td class="u-align--right">$138,750</td>
+          <td class="u-align--right">$3.33</td>
         </tr>
         <tr>
           <td>Beyond 30,000 TB</td>
           <td class="u-align--right">$188,750</td>
+          <td class="u-align--right">$0.00</td>
         </tr>
       </tbody>
     </table>


### PR DESCRIPTION
## Done

- Added column to pricing table [https://ubuntu.com/pricing/infra](https://ubuntu.com/pricing/infra)
- Changed existing mentions of free tier upto 72TB instead of 192TB in [https://ubuntu.com/legal/ubuntu-advantage-service-description](https://ubuntu.com/legal/ubuntu-advantage-service-description)

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- Check if 72TB is replaced by 192TB[https://ubuntu.com/pricing/infra](https://ubuntu.com/pricing/infra)
- Check if pricing table is updated with the values in [internal document] (https://docs.google.com/document/d/1Ynk0iLa9hjrdich6ATTsybtPbDwW_k4vRI0nk_HNhcI/)

## Issue / Card

Fixes #11655  and #11654 
