### PR TITLE
Fix a typo in a link on /core

### DIFF
--- a/templates/core/index.html
+++ b/templates/core/index.html
@@ -308,7 +308,7 @@
         <img src="https://assets.ubuntu.com/v1/1fbe51df-UC20_Full-disc-encryption.svg" class="p-media-object__image" alt="">
         <div class="p-media-object__details">
           <h3 class="p-media-object__title">
-            <a href="/core/featrues/full-disk-encryption">Full disk encryption</a>
+            <a href="/core/features/full-disk-encryption">Full disk encryption</a>
           </h3>
           <p class="p-media-object__content p-heading--5" style="margin-bottom: 0;">Protect sensitive customer data</p>
           <p class="p-media-object__content">Lock data to devices with hardware keys in TPM or TEE, and unlock disks for your system software only, to block a physical attack on sensitive information.</p>


### PR DESCRIPTION
## Done

- Fix a typo in a link on /core

## QA

- Click "Full disk encryption" in the key features section on https://ubuntu-com-11745.demos.haus/core and check it goes to https://ubuntu-com-11745.demos.haus/core/features/full-disk-encryption

## Issue / Card

Fixes #11741
