### PR TITLE
Disallow bots from hitting our /server/docs/search

### DIFF
--- a/static/files/robots.txt
+++ b/static/files/robots.txt
@@ -1,4 +1,5 @@
 User-Agent: *
 Disallow: /search
 Disallow: /search*
+Disallow: /server/docs/search*
 Sitemap: https://ubuntu.com/static/files/sitemap.xml


### PR DESCRIPTION
## Done

- [List of work items including drive-bys - remember to add the why and what of this work.]

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- [List additional steps to QA the new features or prove the bug has been resolved]

## Issue / Card

Fixes #

## Screenshots

[If relevant, please include a screenshot.]


## Help

[QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html) - [Commit guidelines](https://canonical-web-and-design.github.io/practices/workflow/commit-messages.html)
