### PR TITLE
update links on /download/xilinx

### DIFF
--- a/templates/download/amd-xilinx/index.html
+++ b/templates/download/amd-xilinx/index.html
@@ -16,6 +16,9 @@
       <h1>Install Ubuntu on Xilinx</h1>
       <p>Run Ubuntu on your Xilinx Zynq UltraScale+ MPSoC-based evaluation boards and Kria SOMs. </p>
       <p>Pick the OS image to match your hardware, flash it onto SD/microSD card, load it onto your board and away you go.</p>
+      <p>
+        <a href="/download/contact-us" class="js-invoke-modal p-button">Get in touch</a>
+      </p>
     </div>
     <div class="col-6 u-hide--medium u-hide--small u-align--center">
       {{ image (
@@ -58,7 +61,7 @@
             </div>
             <p>
               <a class="p-button--positive"
-                 href="https://people.canonical.com/~platform/images/xilinx/kria-ubuntu-22.04/iot-limerick-kria-classic-desktop-2204-x04-20220517-68.img.xz">Download 64-bit</a>
+                 href="https://people.canonical.com/~platform/images/xilinx/kria-ubuntu-22.04/iot-limerick-kria-classic-desktop-2204-x06-20220614-78.img.xz">Download 64-bit</a>
             </p>
             <p>Works on:</p>
             <ul class="p-list">
@@ -81,6 +84,14 @@
         <div class="u-fixed-width">
           <h4>First time installing Ubuntu on Xilinx?</h4>
           <p>Please see the <a href="https://www.xilinx.com/KR260-Start">Kria KR260 Getting Started Guide for Ubuntu 22.04</a> for more information.</p>
+
+          <div class="p-notification--information is-inline">
+            <div class="p-notification__content">
+              <h5 class="p-notification__title">Note:</h5>
+              <p class="p-notification__message">Please ensure that your Kria platform has the latest boot FW. FW updates and instructions are available on the <a href="https://xilinx-wiki.atlassian.net/wiki/spaces/A/pages/1641152513/Kria+K26+SOM">Xilinx K26 Wiki</a>.</p>
+            </div>
+          </div>
+
           <p><strong>Xilinx Ubuntu Software Development Kit</strong></p>
           <p>Ubuntu Developers targeting Kria KR260 and KV260 platform may also want to download the following files:</p>
         </div>
@@ -95,25 +106,25 @@
             <tbody>
               <tr>
                 <th>
-                  <a href="https://people.canonical.com/~platform/images/xilinx/kria-ubuntu-22.04/iot-limerick-kria-classic-desktop-2204-x04-20220517-68-sysroot.tar.xz">iot-limerick-kria-classic-desktop-2204-x04-20220517-68-sysroot.tar.xz</a>
+                  <a href="https://people.canonical.com/~platform/images/xilinx/kria-ubuntu-22.04/iot-limerick-kria-classic-desktop-2204-x06-20220614-78-sysroot.tar.xz">iot-limerick-kria-classic-desktop-2204-x06-20220614-78-sysroot.tar.xz</a>
                 </th>
                 <td colspan="2">Sysroot for cross-compilation</td>
               </tr>
               <tr>
                 <th>
-                  <a href="https://people.canonical.com/~platform/images/xilinx/kria-ubuntu-22.04/iot-limerick-kria-classic-desktop-2204-x04-20220517-68-rootfs.ext4.xz">iot-limerick-kria-classic-desktop-2204-x04-20220517-68-rootfs.ext4.xz</a>
+                  <a href="https://people.canonical.com/~platform/images/xilinx/kria-ubuntu-22.04/iot-limerick-kria-classic-desktop-2204-x06-20220614-78-rootfs.ext4.xz">iot-limerick-kria-classic-desktop-2204-x06-20220614-78-rootfs.ext4.xz</a>
                 </th>
                 <td colspan="2">EXT4 formatted partition containing entire raw rootfs</td>
               </tr>
               <tr>
                 <th>
-                  <a href="https://people.canonical.com/~platform/images/xilinx/kria-ubuntu-22.04/iot-limerick-kria-classic-desktop-2204-x04-20220517-68-rootfs.tar.gz">iot-limerick-kria-classic-desktop-2204-x04-20220517-68-rootfs.tar.gz</a>
+                  <a href="https://people.canonical.com/~platform/images/xilinx/kria-ubuntu-22.04/iot-limerick-kria-classic-desktop-2204-x06-20220614-78-rootfs.tar.gz">iot-limerick-kria-classic-desktop-2204-x06-20220614-78-rootfs.tar.gz</a>
                 </th>
                 <td colspan="2">Raw Root filesystem</td>
               </tr>
               <tr>
                 <th>
-                  <a href="https://people.canonical.com/~platform/images/xilinx/kria-ubuntu-22.04/iot-limerick-kria-classic-desktop-2204-x04-20220517-68-system-boot.tar.gz">iot-limerick-kria-classic-desktop-2204-x04-20220517-68-system-boot.tar.gz</a>
+                  <a href="https://people.canonical.com/~platform/images/xilinx/kria-ubuntu-22.04/iot-limerick-kria-classic-desktop-2204-x06-20220614-78-system-boot.tar.gz">iot-limerick-kria-classic-desktop-2204-x06-20220614-78-system-boot.tar.gz</a>
                 </th>
                 <td colspan="2">FAT Partition Contents</td>
               </tr>


### PR DESCRIPTION
## Done

- Updated /download/xilinx according to the [copy doc](https://docs.google.com/document/d/1cxQnEErs8FZ3dZ_IhlfcaJ03gE_vrMJfRC-5me9IDd4/edit#)

## QA

- View the site in your web browser at: http://0.0.0.0:8001/download/xilinx
- See that the updates match the copy doc

## Issue / Card

Fixes https://github.com/canonical-web-and-design/web-squad/issues/5526
