### PR TITLE
update support dates in /download/server

### DIFF
--- a/templates/download/server/step2.html
+++ b/templates/download/server/step2.html
@@ -17,8 +17,8 @@
         USB or DVD image based physical install
       </p>
       <ul class="p-list">
-        <li class="p-list__item is-ticked">OS security guaranteed until April 2025</li>
-        <li class="p-list__item is-ticked">Extended security maintenance until April 2030</li>
+        <li class="p-list__item is-ticked">OS security guaranteed until April 2027</li>
+        <li class="p-list__item is-ticked">Extended security maintenance until April 2032</li>
         <li class="p-list__item is-ticked">Commercial support for enterprise customers</li>
       </ul>
     </div>


### PR DESCRIPTION
## Done

- Updated the support dates on step 2 of /download/server to reflect the 22.04 release

## QA

- View the site in your web browser at: http://0.0.0.0:8001/download/server
- Click "Option 2"
- See that the dates match the suggestions in the copy doc

## Issue / Card

Fixes https://github.com/canonical-web-and-design/web-squad/issues/5559
