### PR TITLE
update the order of subnav items on /openstack

### DIFF
--- a/navigation.yaml
+++ b/navigation.yaml
@@ -167,10 +167,13 @@ openstack:
       path: /openstack/what-is-openstack
     - title: Features
       path: /openstack/features
-    - title: Managed
-      path: /openstack/managed
     - title: Consulting
       path: /openstack/consulting
+    - title: Managed
+      path: /openstack/managed
+    - title: Support
+      path: /openstack/support
+      persist: True
     - title: Compare
       path: /openstack/compare
     - title: Install
@@ -180,9 +183,6 @@ openstack:
     - title: OpenStack cheat sheet
       path: /openstack/openstack-cheat-sheet
       hidden: True
-    - title: Support
-      path: /openstack/support
-      persist: True
     - title: Thank you
       path: /openstack/newsletter-thank-you
       hidden: True
@@ -1909,4 +1909,3 @@ landscape:
       path: https://docs.ubuntu.com/landscape/en/
     - title: Log in to Landscape
       path: https://landscape.canonical.com/login/authenticate
-


### PR DESCRIPTION
## Done

- Updated the order of sub nav items on /openstack according to the [brief](https://docs.google.com/document/d/1UENCzEvmi888-WzbYqdlmgPQyutF_VYVTxOW_RkofrM/edit)

## QA

- View the site in your web browser at: http://0.0.0.0:8001/openstack
- See that the sub nav order matches the brief

## Issue / Card

Fixes https://github.com/canonical-web-and-design/web-squad/issues/5564
