### PR TITLE
add iot links section

### DIFF
--- a/templates/automotive/index.html
+++ b/templates/automotive/index.html
@@ -548,6 +548,10 @@
       </div>
     </div>
   </section>
+
+{% with current="automotive", strip_class="p-strip" %}
+  {% include "internet-of-things/shared/_links.html" %}
+{% endwith %}
   
   <!-- Set default Marketo information for contact form below-->
   <div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/automotive" data-form-id="4477" data-lp-id="2551" data-return-url="https://ubuntu.com/internet-of-things/thank-you?product=automotive" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">

--- a/templates/internet-of-things/gateways.html
+++ b/templates/internet-of-things/gateways.html
@@ -374,6 +374,10 @@
   </div>
 </section>
 
+{% with current="gateways", strip_class="p-strip--light" %}
+  {% include "internet-of-things/shared/_links.html" %}
+{% endwith %}
+
 {% with first_item="_iot_developers", second_item="_iot_newsletter_signup", third_item="_iot_further_reading" %}{% include "shared/contextual_footers/_contextual_footer.html" %}{% endwith %}
 
 <!-- Set default Marketo information for contact form below -->

--- a/templates/internet-of-things/networking.html
+++ b/templates/internet-of-things/networking.html
@@ -231,6 +231,10 @@
   </div>
 </section>
 
+{% with current="networking", strip_class="p-strip--light" %}
+  {% include "internet-of-things/shared/_links.html" %}
+{% endwith %}
+
 {% with first_item="_iot_developers", second_item="_iot_newsletter_signup", third_item="_iot_further_reading" %}{% include "shared/contextual_footers/_contextual_footer.html" %}{% endwith %}
 
 <!-- Set default Marketo information for contact form below-->

--- a/templates/internet-of-things/shared/_links.html
+++ b/templates/internet-of-things/shared/_links.html
@@ -1,0 +1,49 @@
+<section class="{{ strip_class }}">
+  <div class="row p-divider">
+    {% if current != "signage" %}
+    <div class="col-3 p-divider__block">
+      <h2 class="p-heading--3">Signage</h2>
+
+      <p>A small footprint and full OpenGL make Ubuntu Core the perfect platform for secure digital signs.</p>
+      <a href="/internet-of-things/smart-displays">Learn more&nbsp;&rsaquo;</a>
+    </div>
+    {% endif %}
+
+    {% if current != "gateways" %}
+    <div class="col-3 p-divider__block">
+      <h2 class="p-heading--3">Gateways</h2>
+
+      <p>Rich networking and comms make Ubuntu the perfect choice for your industrial gateways.</p>
+      <a href="/internet-of-things/gateways">Learn more&nbsp;&rsaquo;</a>
+    </div>
+    {% endif %}
+
+    {% if current != "automotive" %}
+    <div class="col-3 p-divider__block">
+      <h2 class="p-heading--3">Automotive</h2>
+
+
+      <p>Reinvent the automobile with Ubuntu, designed for critical embedded systems.</p>
+      <a href="/automotive">Learn more&nbsp;&rsaquo;</a>
+    </div>
+    {% endif %}
+
+    {% if current != "networking" %}
+    <div class="col-3 p-divider__block">
+      <h2 class="p-heading--3">Networking</h2>
+
+      <p>Build secure SmartNICs and operate them at scale on Ubuntu.</p>
+      <a href="/networking">Learn more&nbsp;&rsaquo;</a>
+    </div>
+    {% endif %}
+    
+    {% if current != "smart-city" %}
+    <div class="col-3 p-divider__block">
+      <h2 class="p-heading--3">Smart City</h2>
+
+      <p>Harness the power of Ubuntu Core to keep distributed devices connected and secure.</p>
+      <a href="/internet-of-things/smart-city">Learn more&nbsp;&rsaquo;</a>
+    </div>
+    {% endif %}
+  </div>
+</section>

--- a/templates/internet-of-things/shared/_links.html
+++ b/templates/internet-of-things/shared/_links.html
@@ -33,7 +33,7 @@
       <h2 class="p-heading--3">Networking</h2>
 
       <p>Build secure SmartNICs and operate them at scale on Ubuntu.</p>
-      <a href="/networking">Learn more&nbsp;&rsaquo;</a>
+      <a href="/internet-of-things/networking">Learn more&nbsp;&rsaquo;</a>
     </div>
     {% endif %}
     

--- a/templates/internet-of-things/smart-city.html
+++ b/templates/internet-of-things/smart-city.html
@@ -694,6 +694,10 @@
   </div>
 </section>
 
+{% with current="smart-city", strip_class="p-strip" %}
+  {% include "internet-of-things/shared/_links.html" %}
+{% endwith %}
+
 <!-- Set default Marketo information for contact form below-->
 <div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/smart-city" data-form-id="4274" data-lp-id="2551" data-return-url="https://ubuntu.com/internet-of-things/thank-you?product=iot" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
 </div>

--- a/templates/internet-of-things/smart-displays.html
+++ b/templates/internet-of-things/smart-displays.html
@@ -337,6 +337,10 @@
   </div>
 </section>
 
+{% with current="signage", strip_class="p-strip" %}
+  {% include "internet-of-things/shared/_links.html" %}
+{% endwith %}
+
 {% with first_item="_iot_developers", second_item="_iot_newsletter_signup", third_item="_iot_further_reading" %}{% include "shared/contextual_footers/_contextual_footer.html" %}{% endwith %}
 
 <!-- Set default Marketo information for contact form below-->


### PR DESCRIPTION
## Done

**[Smart displays](https://ubuntu.com/internet-of-things/smart-displays)**
- Added cards linking to other IoT pages - [copy doc](https://docs.google.com/document/d/1fFvBl-ZZvKDFV6OMv7O4kudQKtyxfvSU60rfVdKluAQ/edit#heading=h.qkat7vybg1m)

**[Gateways](https://ubuntu.com/internet-of-things/gateways)**
- Added cards linking to other IoT pages - [copy doc](https://docs.google.com/document/d/18ffTcNolrtJS9AvjMfa8KW94uLfC0KzmHtTe-jMYmlo/edit#heading=h.nby4fxmsrrg3)

**[Automotive](https://ubuntu.com/automotive)**
- Added cards linking to other IoT pages - [copy doc](https://docs.google.com/document/d/1PVliB92h4ZqexaZV9F5MIcX7aRG6yBAGH1hG7x8UZTw/edit#heading=h.7zytw966kvza)

**[Networking](https://ubuntu.com/internet-of-things/networking)**
- Added cards linking to other IoT pages - [copy doc](https://docs.google.com/document/d/1EWlkTkGvul-ek4P1cR9pyNvyJsh5WtpOkChvk0igzVQ/edit#)

**[Smart city](https://ubuntu.com/internet-of-things/smart-city)**
- Added cards linking to other IoT pages - [copy doc](https://docs.google.com/document/d/1Zh-IkLDnaqmPr4TTeUZ3mtyY2_OGW4iElfntYWZyveY/edit#)

## QA

Visit:
- https://ubuntu-com-11758.demos.haus/internet-of-things/smart-displays
- https://ubuntu-com-11758.demos.haus/internet-of-things/gateways
- https://ubuntu-com-11758.demos.haus/automotive
- https://ubuntu-com-11758.demos.haus/internet-of-things/networking
- https://ubuntu-com-11758.demos.haus/internet-of-things/smart-city

See that the new section has been added to the bottom of each page

## Issue / Card

Fixes https://github.com/canonical-web-and-design/web-squad/issues/5236

## Screenshots
![image](https://user-images.githubusercontent.com/2376968/175057238-63ce88fe-8408-4d55-92fb-8c0e671531ac.png)
