### PR TITLE
Fix missing patches and tags in CVEs

### DIFF
--- a/templates/security/cve/cve.html
+++ b/templates/security/cve/cve.html
@@ -199,7 +199,7 @@
                   {% endif %}
                 </tr>
               {% endfor %}
-              {% if patches %}
+              {% if package["name"] in patches|map(attribute="name")%}
                 <tr>
                   <td style="border-top: 0px"></td>
                   <td colspan="2" style="border-top: 5px double #cdcdcd">
@@ -229,8 +229,8 @@
                     </small>
                   </td>
                 </tr>
-              {% endif %}
-              {% if tags %}
+              {% endif%}
+              {% if package["name"] in tags|map(attribute="name") %}
                 <tr>
                   <td style="border-top: 0px"></td>
                   <td colspan="2" style="border-top: 5px double #cdcdcd">
@@ -316,7 +316,7 @@
           </li>
         </ul>
 
-        {% if cve.bugs %}
+        {% if cve.bugs|length > 1 %}
           <h2>Bugs</h2>
           <ul>
             {% for bug in cve.bugs %}

--- a/templates/security/cve/cve.html
+++ b/templates/security/cve/cve.html
@@ -199,7 +199,6 @@
                   {% endif %}
                 </tr>
               {% endfor %}
-
               {% if patches %}
                 <tr>
                   <td style="border-top: 0px"></td>
@@ -258,7 +257,6 @@
                               This vulnerability is mitigated in part by the use of <a href="https://wiki.ubuntu.com/Security/Features#pie">Position Independent Executables</a> in Ubuntu.
                             {% else %}
                               {{ tag.text }}
-                              <p>here</p>
                             {% endif %}
                           {% endif %}
                         {% endfor %}

--- a/templates/security/cve/cve.html
+++ b/templates/security/cve/cve.html
@@ -199,26 +199,30 @@
                   {% endif %}
                 </tr>
               {% endfor %}
-              {% if cve.patches[package_name]|length > 0  %}
+
+              {% if patches %}
                 <tr>
                   <td style="border-top: 0px"></td>
                   <td colspan="2" style="border-top: 5px double #cdcdcd">
                     Patches: <br>
                     <small>
-                      {% for patch in cve.formatted_patches[package_name] %}
-                        {% if patch.type == "text" %}
-                          {{ patch.content }}
-                        {% elif patch.type == "break-fix" %}
-                          Introduced by
-                          <a href="https://git.kernel.org/linus/{{ patch.content.introduced }}">{{ patch.content.introduced }}</a><br>
-                          Fixed by
-                          <a href="https://git.kernel.org/linus/{{ patch.content.fixed }}">{{ patch.content.fixed }}</a>
-                        {% elif patch.type == "link" %}
-                          {{ patch.content.prefix }}:
-                          {% if patch.content.suffix %}
-                            <a href="{{ cve.patch.content.suffix }}">{{ patch.content.suffix }}</a>
-                          {% else %}
-                            {{ patch.content.suffix }}
+                      {% for patch in patches %}
+                        {% if patch.name == package["name"]%}
+                          {% if patch.type == "text" %}
+                            {{ patch.content }}
+                          {% elif patch.type == "break-fix" %}
+                            Introduced by
+                            <p><a href="https://git.kernel.org/linus/{{ patch.content.introduced }}">{{ patch.content.introduced }}</a><br>
+                            </p>
+                              Fixed by
+                            <a href="https://git.kernel.org/linus/{{ patch.content.fixed }}">{{ patch.content.fixed }}</a>
+                          {% elif patch.type == "link" %}
+                            {{ patch.content.prefix }}:
+                            {% if patch.content.suffix %}
+                              <a href="{{ patch.content.suffix }}">{{ patch.content.suffix }}</a>
+                            {% else %}
+                              {{ patch.content.suffix }}
+                            {% endif %}
                           {% endif %}
                         {% endif %}
                         <br>
@@ -227,39 +231,42 @@
                   </td>
                 </tr>
               {% endif %}
-              {% if cve.tags[package_name]|length > 0  %}
+              {% if tags %}
                 <tr>
                   <td style="border-top: 0px"></td>
                   <td colspan="2" style="border-top: 5px double #cdcdcd">
                     <small>
-                      {% for tag in cve.tags[package_name] %}
-                        {% if tag == "not-ue" %}
-                          This package is not directly supported by the Ubuntu Security Team
-                        {% elif tag == "universe-binary" %}
-                          Binaries built from this source package are in <a href="https://wiki.ubuntu.com/SecurityTeam/FAQ#Official_Support">Universe</a> and so are supported by the community.
-                        {% elif tag == "apparmor" %}
-                          This vulnerability is mitigated in part by an <a href="https://wiki.ubuntu.com/Security/Features#apparmor">AppArmor</a> profile.
-                        {% elif tag == "stack-protector" %}
-                          This vulnerability is mitigated in part by the use of gcc's <a href="https://wiki.ubuntu.com/Security/Features#stack-protector">stack protector</a> in Ubuntu.
-                        {% elif tag == "fortify-source" %}
-                          This vulnerability is mitigated in part by the use of <a href="https://wiki.ubuntu.com/Security/Features#fortify-source">-D_FORTIFY_SOURCE=2</a> in Ubuntu.
-                        {% elif tag == "symlink-restriction" %}
-                          This vulnerability is mitigated in part by the use of <a href="https://wiki.ubuntu.com/Security/Features#symlink">symlink</a> restrictions in Ubuntu.
-                        {% elif tag == "hardlink-restriction" %}
-                          This vulnerability is mitigated in part by the use of <a href="https://wiki.ubuntu.com/Security/Features#hardlink">hardlink</a> restrictions in Ubuntu.
-                        {% elif tag == "heap-protector" %}
-                          This vulnerability is mitigated in part by the use of GNU C Library <a href="https://wiki.ubuntu.com/Security/Features#heap-protector">heap protector</a> in Ubuntu.
-                        {% elif tag == "pie" %}
-                          This vulnerability is mitigated in part by the use of <a href="https://wiki.ubuntu.com/Security/Features#pie">Position Independent Executables</a> in Ubuntu.
-                        {% else %}
-                          {{ tag }}
-                        {% endif %}
-                      {% endfor %}
+                        {% for tag in tags %}
+                          {% if tag.name == package["name"] %}
+                            {% if tag.text == "not-ue" %}
+                              This package is not directly supported by the Ubuntu Security Team
+                            {% elif tag.text == "universe-binary" %}
+                              Binaries built from this source package are in <a href="https://wiki.ubuntu.com/SecurityTeam/FAQ#Official_Support">Universe</a> and so are supported by the community.
+                            {% elif tag.text == "apparmor" %}
+                              This vulnerability is mitigated in part by an <a href="https://wiki.ubuntu.com/Security/Features#apparmor">AppArmor</a> profile.
+                            {% elif tag.text == "stack-protector" %}
+                              This vulnerability is mitigated in part by the use of gcc's <a href="https://wiki.ubuntu.com/Security/Features#stack-protector">stack protector</a> in Ubuntu.
+                            {% elif tag.text == "fortify-source" %}
+                              This vulnerability is mitigated in part by the use of <a href="https://wiki.ubuntu.com/Security/Features#fortify-source">-D_FORTIFY_SOURCE=2</a> in Ubuntu.
+                            {% elif tag.text == "symlink-restriction" %}
+                              This vulnerability is mitigated in part by the use of <a href="https://wiki.ubuntu.com/Security/Features#symlink">symlink</a> restrictions in Ubuntu.
+                            {% elif tag.text == "hardlink-restriction" %}
+                              This vulnerability is mitigated in part by the use of <a href="https://wiki.ubuntu.com/Security/Features#hardlink">hardlink</a> restrictions in Ubuntu.
+                            {% elif tag.text == "heap-protector" %}
+                              This vulnerability is mitigated in part by the use of GNU C Library <a href="https://wiki.ubuntu.com/Security/Features#heap-protector">heap protector</a> in Ubuntu.
+                            {% elif tag.text == "pie" %}
+                              This vulnerability is mitigated in part by the use of <a href="https://wiki.ubuntu.com/Security/Features#pie">Position Independent Executables</a> in Ubuntu.
+                            {% else %}
+                              {{ tag.text }}
+                              <p>here</p>
+                            {% endif %}
+                          {% endif %}
+                        {% endfor %}
                     </small>
                   </td>
                 </tr>
               {% endif %}
-            {% endfor %}
+              {% endfor %}
           </tbody>
         </table>
       </div>

--- a/webapp/security/views.py
+++ b/webapp/security/views.py
@@ -762,18 +762,22 @@ def cve(cve_id):
                 )
 
             if ":" not in patch:
-                formatted_patches.append({"type": "text", "content": patch, "name": patch})
+                formatted_patches.append(
+                    {"type": "text", "content": patch, "name": patch}
+                )
 
     # format tags
     formatted_tags = []
-   
+
     for package_name, tags in cve["tags"].items():
         for tag in tags:
             formatted_tags.append({"name": package_name, "text": tag})
 
-
     return flask.render_template(
-        "security/cve/cve.html", cve=cve, patches=formatted_patches, tags=formatted_tags
+        "security/cve/cve.html",
+        cve=cve,
+        patches=formatted_patches,
+        tags=formatted_tags,
     )
 
 

--- a/webapp/security/views.py
+++ b/webapp/security/views.py
@@ -725,7 +725,56 @@ def cve(cve_id):
             "%-d %B %Y"
         )
 
-    return flask.render_template("security/cve/cve.html", cve=cve)
+    # format patches
+    formatted_patches = []
+
+    for package_name, patches in cve["patches"].items():
+        for patch in patches:
+            prefix, suffix = patch.split(":", 1)
+            suffix = suffix.strip()
+
+            if prefix == "break-fix" and " " in suffix:
+                introduced, fixed = suffix.split(" ", 1)
+
+                if introduced == "-":
+                    # First commit to Linux git tree
+                    introduced = "1da177e4c3f41524e886b7f1b8a0c1fc7321cac2"
+
+                formatted_patches.append(
+                    {
+                        "type": "break-fix",
+                        "content": {"introduced": introduced, "fixed": fixed},
+                        "name": package_name,
+                    }
+                )
+
+            if (
+                "ftp://" in suffix
+                or "http://" in suffix
+                or "https://" in suffix
+            ):
+                formatted_patches.append(
+                    {
+                        "type": "link",
+                        "content": {"prefix": prefix, "suffix": suffix},
+                        "name": package_name,
+                    }
+                )
+
+            if ":" not in patch:
+                formatted_patches.append({"type": "text", "content": patch, "name": patch})
+
+    # format tags
+    formatted_tags = []
+   
+    for package_name, tags in cve["tags"].items():
+        for tag in tags:
+            formatted_tags.append({"name": package_name, "text": tag})
+
+
+    return flask.render_template(
+        "security/cve/cve.html", cve=cve, patches=formatted_patches, tags=formatted_tags
+    )
 
 
 # CVE API


### PR DESCRIPTION
## Done

- Formatted patches and tags to pass through to template as needed
- Refactored template to comply with new data

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/security/CVE-2020-11984 (or any other cve containing patches or populated tags)
    - Be sure to test on mobile, tablet and desktop screen sizes
- See that are correctly shown

## Issue / Card

Fixes https://github.com/canonical-web-and-design/ubuntu.com/issues/11317
