### PR TITLE
Disable tutorials search again

### DIFF
--- a/templates/tutorials/index.html
+++ b/templates/tutorials/index.html
@@ -18,6 +18,7 @@
 
 <section class="p-strip is-shallow l-tutorials__filters">
   <div class="row">
+    <!--
     <div class="col-4">
       <div class="p-form__group">
         <label for="tutorials-search-input">Search tutorials containing:</label>
@@ -28,7 +29,8 @@
         </form>
       </div>
     </div>
-    <div class="col-4">
+    -->
+    <div class="col-6">
       <div class="p-form__group">
         <label for="tutorials-topic">Topic:</label>
         <select name="tutorials-topic" id="tutorials-topic" class="u-no-margin--bottom">
@@ -45,7 +47,7 @@
         </select>
       </div>
     </div>
-    <div class="col-4">
+    <div class="col-6">
       <div class="p-form__group">
         <label for="tutorials-sort">Sorted by:</label>
         <select name="tutorials-sort" id="tutorials-sort" class="u-no-margin--bottom">

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -16,8 +16,8 @@ from geolite2 import geolite2
 from requests import Session
 from requests.exceptions import HTTPError
 
-from canonicalwebteam.search.models import get_search_results
-from canonicalwebteam.search.views import NoAPIKeyError
+# from canonicalwebteam.search.models import get_search_results
+# from canonicalwebteam.search.views import NoAPIKeyError
 from bs4 import BeautifulSoup
 from werkzeug.exceptions import BadRequest
 from canonicalwebteam.discourse import (
@@ -282,33 +282,33 @@ def build_tutorials_index(session, tutorials_docs):
         page = flask.request.args.get("page", default=1, type=int)
         topic = flask.request.args.get("topic", default=None, type=str)
         sort = flask.request.args.get("sort", default=None, type=str)
-        query = flask.request.args.get("q", default=None, type=str)
+        # query = flask.request.args.get("q", default=None, type=str)
         posts_per_page = 15
 
         """
         Get search results from Google Custom Search
         """
 
-        # Web tribe websites custom search ID
-        search_engine_id = "adb2397a224a1fe55"
+        # # Web tribe websites custom search ID
+        # search_engine_id = "adb2397a224a1fe55"
 
-        # API key should always be provided as an environment variable
-        search_api_key = os.getenv("SEARCH_API_KEY")
+        # # API key should always be provided as an environment variable
+        # search_api_key = os.getenv("SEARCH_API_KEY")
 
-        if query and not search_api_key:
-            raise NoAPIKeyError("Unable to search: No API key provided")
+        # if query and not search_api_key:
+        #     raise NoAPIKeyError("Unable to search: No API key provided")
 
-        results = None
+        # results = None
 
-        if query:
-            results = get_search_results(
-                session=session,
-                api_key=search_api_key,
-                search_engine_id=search_engine_id,
-                siteSearch="ubuntu.com/tutorials",
-                query=query,
-                site_restricted_search=False,
-            )
+        # if query:
+        #     results = get_search_results(
+        #         session=session,
+        #         api_key=search_api_key,
+        #         search_engine_id=search_engine_id,
+        #         siteSearch="ubuntu.com/tutorials",
+        #         query=query,
+        #         site_restricted_search=False,
+        #     )
 
         tutorials_docs.parser.parse()
         tutorials_docs.parser.parse_topic(tutorials_docs.parser.index_topic)
@@ -330,18 +330,18 @@ def build_tutorials_index(session, tutorials_docs):
                     item["categories"].replace(" ", "").lower().split(",")
                 )
 
-        if query:
-            temp_metadata = []
-            if results.get("entries"):
-                for result in results["entries"]:
-                    start = result["link"].find("tutorials/")
-                    end = len(result["link"])
-                    identifier = result["link"][start:end]
-                    if start != -1:
-                        for doc in tutorials:
-                            if identifier in doc["link"]:
-                                temp_metadata.append(doc)
-            tutorials = temp_metadata
+        # if query:
+        #     temp_metadata = []
+        #     if results.get("entries"):
+        #         for result in results["entries"]:
+        #             start = result["link"].find("tutorials/")
+        #             end = len(result["link"])
+        #             identifier = result["link"][start:end]
+        #             if start != -1:
+        #                 for doc in tutorials:
+        #                     if identifier in doc["link"]:
+        #                         temp_metadata.append(doc)
+        #     tutorials = temp_metadata
 
         if sort == "difficulty-desc":
             tutorials = sorted(
@@ -364,7 +364,7 @@ def build_tutorials_index(session, tutorials_docs):
             topic=topic,
             topics_list=sorted(list(topics_list)),
             sort=sort,
-            query=query,
+            # query=query,
             posts_per_page=posts_per_page,
             total_results=total_results,
             total_pages=total_pages,


### PR DESCRIPTION
Following on from https://github.com/canonical-web-and-design/ubuntu.com/pull/11759#issuecomment-1164171740, actually, a bunch of tutorials search URLs [exist in public web pages](https://www.google.com/search?q=%22ubuntu.com%2Ftutorials%3sFq%3D%22+-site%3Aubuntu.com). This means Google search bot could well hit us with searches by crawling these URLs. So we shouldn't reenable this search until we have bot protection.

## QA

Go to https://ubuntu-com-11764.demos.haus/tutorials?q=fish - check no search is performed and you see all results.