### PR TITLE
Reenable search for /server/docs

### DIFF
--- a/webapp/app.py
+++ b/webapp/app.py
@@ -754,16 +754,16 @@ server_docs = Docs(
 )
 
 # Server docs search
-# app.add_url_rule(
-#     "/server/docs/search",
-#     "server-docs-search",
-#     build_search_view(
-#         session=session,
-#         site="ubuntu.com/server/docs",
-#         template_path="/server/docs/search-results.html",
-#         search_engine_id=search_engine_id,
-#     ),
-# )
+app.add_url_rule(
+    "/server/docs/search",
+    "server-docs-search",
+    build_search_view(
+        session=session,
+        site="ubuntu.com/server/docs",
+        template_path="/server/docs/search-results.html",
+        search_engine_id=search_engine_id,
+    ),
+)
 
 server_docs.init_app(app)
 


### PR DESCRIPTION
## QA

In the demo, go to `/server/docs`, do a search or two.