### PR TITLE
update ubuntu core datasheet links to 22 version

### DIFF
--- a/templates/core/index.html
+++ b/templates/core/index.html
@@ -2,7 +2,7 @@
 
 {% block title %}Ubuntu Core{% endblock %}
 {% block meta_description %}Ubuntu Core is Ubuntu for IoT and embedded environments, optimised for security and reliable ota updates. Run snaps in a high-security confined sandbox with bulletproof upgrades and a private app store.{% endblock meta_description %}
-{% block meta_copydoc %}https://docs.google.com/document/d/1QoM0Yqx4JfDJ2G3OPt5bds-ximG1jASmU_PWX4iff3E/edit{% endblock meta_copydoc %}
+{% block meta_copydoc %}https://docs.google.com/document/d/1UFpefDRSAcndNBnWp0hDyzqk74aciqhBWJEi05htWmU/edit{% endblock meta_copydoc %}
 
 {% block content %}
 
@@ -406,7 +406,7 @@
   </div>
   <div class="u-fixed-width">
     <p>Check the full list of <a href="/core/features">features&nbsp;&rsaquo;</a></p>
-    <p><a href="https://assets.ubuntu.com/v1/b2c770ea-Ubuntu+Core20+Datasheet.pdf" class="p-button">Read the Ubuntu Core datasheet</a></p>
+    <p><a href="https://assets.ubuntu.com/v1/1870ea66-Ubuntu_Core22_DS.06.06.22.pdf" class="p-button">Read the Ubuntu Core datasheet</a></p>
   </div>
 </section>
 <section class="p-strip is-deep is-bordered">

--- a/templates/internet-of-things/smart-city.html
+++ b/templates/internet-of-things/smart-city.html
@@ -294,7 +294,7 @@
         </div>
       </div>
       <p>
-        <a href="/engage/ubuntu-core-20-webinar" class="p-link--inverted">An introduction to Ubuntu Core 22&nbsp;&rsaquo;</a>
+        <a href="/engage/intro-to-ubuntu-core22-webinar" class="p-link--inverted">An introduction to Ubuntu Core 22&nbsp;&rsaquo;</a>
       </p>
     </div>
     <div class="col-4">

--- a/templates/internet-of-things/smart-city.html
+++ b/templates/internet-of-things/smart-city.html
@@ -215,7 +215,7 @@
         </div>
       </div>
       <p>
-        <a href="https://assets.ubuntu.com/v1/b2c770ea-Ubuntu+Core20+Datasheet.pdf" class="p-link--inverted">Ubuntu Core 22&nbsp;&rsaquo;</a>
+        <a href="https://assets.ubuntu.com/v1/1870ea66-Ubuntu_Core22_DS.06.06.22.pdf" class="p-link--inverted">Ubuntu Core 22&nbsp;&rsaquo;</a>
       </p>
     </div>
     <div class="col-4">


### PR DESCRIPTION
## Done

- Updated link to the Ubuntu Core datasheet to point to the new 22 version
- Updated the copy doc link on /core

## QA

- visit https://ubuntu-com-11776.demos.haus/core
  - see that the "Read the Ubuntu Core datasheet" link takes you to the 22 version of the datasheet
  - see that the link to the copy doc takes you to [this copy doc](https://docs.google.com/document/d/1UFpefDRSAcndNBnWp0hDyzqk74aciqhBWJEi05htWmU/edit)
- visit https://ubuntu-com-11776.demos.haus/internet-of-things/smart-city
  - see that the "Ubuntu Core 22 ›" link takes you to the 22 version of the datasheet

## Issue / Card

Fixes https://github.com/canonical-web-and-design/web-squad/issues/5591 & https://github.com/canonical-web-and-design/web-squad/issues/5592
