### PR TITLE
Remove mention of support from cloud options on /subscribe

### DIFF
--- a/templates/advantage/subscribe/form/_type_select.html
+++ b/templates/advantage/subscribe/form/_type_select.html
@@ -139,7 +139,7 @@
       <br />
       <span>
         <strong>
-          Looking to add support to an existing virtual machine running Ubuntu 16.04 (Xenial)?
+          Looking to extend security maintenance on an existing virtual machine running Ubuntu 16.04 (Xenial)?
         </strong>
         <br />
         Choose the "<a class="js-cloud-other-VM">Other VMs</a>" option to
@@ -170,7 +170,7 @@
       <br />
       <span>
         <strong>
-          Looking to add support to an existing virtual machine running Ubuntu
+          Looking to extend security maintenance on an existing virtual machine running Ubuntu
           16.04 (Xenial)?
         </strong>
         <br />
@@ -201,7 +201,7 @@
       <br />
       <span>
         <strong>
-          Looking to add support to an existing virtual machine running Ubuntu
+          Looking to extend security maintenance on an existing virtual machine running Ubuntu
           16.04 (Xenial)?
         </strong>
         <br />


### PR DESCRIPTION
## Done

- Updated the text accompanying the selection of either AWS, Azure or Google Cloud to remove mention of a support offer that is no longer available, according to Lech's comment in the [copy doc](https://docs.google.com/document/d/1UqL8YJH9ywvOXnrt3syY0U8fiOakfAGWmLS9uerwAWk/edit?disco=AAAAbrKej5s&usp=suggestion_email_discussion&usp_dm=true&ts=62bb1886)

:warning: there are many unresolved comments in the copy doc, I've spoken to Lech and he's going to clean it up, this PR addresses just one urgent comment

## QA

- Visit https://ubuntu-com-11779.demos.haus/advantage/subscribe
- Select AWS, Azure and Google Cloud in the first step, see that the copy in the box that appears below matches the comment in the copy doc.

## Issue / Card

Fixes https://github.com/canonical-web-and-design/web-squad/issues/5601
