### PR TITLE
Update Credentialing exam links to point to QA

### DIFF
--- a/templates/credentialing/index.html
+++ b/templates/credentialing/index.html
@@ -50,7 +50,7 @@
           <div class="p-matrix__desc">
             <p>Prove your knowledge of the Linux community, history, and philosophy. Topics include common Linux commands, open source and software licensing, and basic knowledge of Linux architecture and file hierarchy.</p>
             <a
-              href="https://cube.ubuntu.com/courses/course-v1:Canonical+cue-linux+2022/course/"
+              href="https://qa.cube.ubuntu.com/auth/login/tpa-saml/?auth_entry=login&idp=ubuntuone&next=/courses/course-v1:Canonical%2bcue-linuxessentials%2b2022/courseware/2022/start/"
               class="p-button--positive"
               >Start</a
             >
@@ -74,7 +74,7 @@
           <div class="p-matrix__desc">
             <p>Demonstrate your knowledge of Ubuntu Desktop administrative essentials. Focus on package management, system installation, data gathering, and managing printing and displays.</p>
             <a
-              href="https://cube.ubuntu.com/courses/course-v1:Canonical+cue-desktop+2022/course/"
+              href="https://qa.cube.ubuntu.com/auth/login/tpa-saml/?auth_entry=login&idp=ubuntuone&next=/courses/course-v1:Canonical%2bcue-desktop%2b2022/courseware/2022/start/"
               class="p-button--positive"
               >Start</a
             >
@@ -98,7 +98,7 @@
           <div class="p-matrix__desc">
             <p>Illustrate your knowledge of common Ubuntu Server administrative tasks and troubleshooting. Topics include job control, performance tuning, services management, and Bash scripting.</p>
             <a
-              href="https://cube.ubuntu.com/courses/course-v1:Canonical+cue-server+2022/course/"
+              href="https://qa.cube.ubuntu.com/auth/login/tpa-saml/?auth_entry=login&idp=ubuntuone&next=/courses/course-v1:Canonical%2bcue-server%2b2022/courseware/2022/start/"
               class="p-button--positive"
               >Start</a
             >
@@ -131,7 +131,7 @@
             <div class="p-matrix__desc">
               <p> </p>
               <a
-                href="https://cube.ubuntu.com/courses/course-v1:Canonical+cue+2022/course/"
+                href="https://qa.cube.ubuntu.com/auth/login/tpa-saml/?auth_entry=login&idp=ubuntuone&next=/courses/course-v1:Canonical%2bcue%2b2022/courseware/2022/start/"
                 class="p-button--positive"
                 >Start
               </a>


### PR DESCRIPTION
## Done

- Exam links at [/credentialing](https://ubuntu-com-11784.demos.haus/credentialing) now point to the QA Open edX instance rather than the Production instance
- The links now also take care of SSO, so the user shouldn't have to click a "Log in" link after landing in Open edX

## QA

- Open the [demo](https://ubuntu-com-11784.demos.haus/credentialing)
- Click on the "Start" button for each exam
  - Verify that you land on the Welcome section of the exam in Open edX
  - Verify that you are on the QA instance (qa.cube.ubuntu.com)

## Issue / Card

Fixes https://github.com/canonical-web-and-design/commercial-squad/issues/630

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
