### PR TITLE
Temporarily remove searches

### DIFF
--- a/templates/templates/docs/shared/_docs.html
+++ b/templates/templates/docs/shared/_docs.html
@@ -24,7 +24,7 @@
 {% endmacro %}
 
 {% block outer_content %}
-
+{% if request.path != "/server/docs" %}
   {% with
     search_action=search_action,
     siteSearch=siteSearch,
@@ -32,7 +32,7 @@
   %}
     {% include "templates/docs/shared/_search-box.html" %}
   {% endwith %}
-
+{% endif %}
 <div class="p-strip is-shallow">
   <div class="row">
     <aside class="col-3">

--- a/templates/tutorials/index.html
+++ b/templates/tutorials/index.html
@@ -18,7 +18,7 @@
 
 <section class="p-strip is-shallow l-tutorials__filters">
   <div class="row">
-    <div class="col-4">
+    <!-- <div class="col-4">
       <div class="p-form__group">
         <label for="tutorials-search-input">Search tutorials containing:</label>
         <form class="p-search-box u-no-margin--bottom" id="tutorials-search" action="">
@@ -27,7 +27,7 @@
           <button type="submit" class="p-search-box__button"><i class="p-icon--search"></i></button>
         </form>
       </div>
-    </div>
+    </div> -->
     <div class="col-4">
       <div class="p-form__group">
         <label for="tutorials-topic">Topic:</label>

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -754,16 +754,16 @@ server_docs = Docs(
 )
 
 # Server docs search
-app.add_url_rule(
-    "/server/docs/search",
-    "server-docs-search",
-    build_search_view(
-        session=session,
-        site="ubuntu.com/server/docs",
-        template_path="/server/docs/search-results.html",
-        search_engine_id=search_engine_id,
-    ),
-)
+# app.add_url_rule(
+#     "/server/docs/search",
+#     "server-docs-search",
+#     build_search_view(
+#         session=session,
+#         site="ubuntu.com/server/docs",
+#         template_path="/server/docs/search-results.html",
+#         search_engine_id=search_engine_id,
+#     ),
+# )
 
 server_docs.init_app(app)
 

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -16,7 +16,7 @@ from geolite2 import geolite2
 from requests import Session
 from requests.exceptions import HTTPError
 
-from canonicalwebteam.search.models import get_search_results
+# from canonicalwebteam.search.models import get_search_results
 from canonicalwebteam.search.views import NoAPIKeyError
 from bs4 import BeautifulSoup
 from werkzeug.exceptions import BadRequest
@@ -267,7 +267,7 @@ def build_tutorials_index(session, tutorials_docs):
         """
 
         # Web tribe websites custom search ID
-        search_engine_id = "adb2397a224a1fe55"
+        # search_engine_id = "adb2397a224a1fe55"
 
         # API key should always be provided as an environment variable
         search_api_key = os.getenv("SEARCH_API_KEY")
@@ -275,17 +275,17 @@ def build_tutorials_index(session, tutorials_docs):
         if query and not search_api_key:
             raise NoAPIKeyError("Unable to search: No API key provided")
 
-        results = None
+        # results = None
 
-        if query:
-            results = get_search_results(
-                session=session,
-                api_key=search_api_key,
-                search_engine_id=search_engine_id,
-                siteSearch="ubuntu.com/tutorials",
-                query=query,
-                site_restricted_search=False,
-            )
+        # if query:
+        #     results = get_search_results(
+        #         session=session,
+        #         api_key=search_api_key,
+        #         search_engine_id=search_engine_id,
+        #         siteSearch="ubuntu.com/tutorials",
+        #         query=query,
+        #         site_restricted_search=False,
+        #     )
 
         tutorials_docs.parser.parse()
         tutorials_docs.parser.parse_topic(tutorials_docs.parser.index_topic)
@@ -307,18 +307,18 @@ def build_tutorials_index(session, tutorials_docs):
                     item["categories"].replace(" ", "").lower().split(",")
                 )
 
-        if query:
-            temp_metadata = []
-            if results.get("entries"):
-                for result in results["entries"]:
-                    start = result["link"].find("tutorials/")
-                    end = len(result["link"])
-                    identifier = result["link"][start:end]
-                    if start != -1:
-                        for doc in tutorials:
-                            if identifier in doc["link"]:
-                                temp_metadata.append(doc)
-            tutorials = temp_metadata
+        # if query:
+        #     temp_metadata = []
+        #     if results.get("entries"):
+        #         for result in results["entries"]:
+        #             start = result["link"].find("tutorials/")
+        #             end = len(result["link"])
+        #             identifier = result["link"][start:end]
+        #             if start != -1:
+        #                 for doc in tutorials:
+        #                     if identifier in doc["link"]:
+        #                         temp_metadata.append(doc)
+        #     tutorials = temp_metadata
 
         if sort == "difficulty-desc":
             tutorials = sorted(


### PR DESCRIPTION
## Done

Quota is again [reaching its limits](https://console.cloud.google.com/apis/api/customsearch.googleapis.com/quotas?authuser=0&project=ubuntu-search-1530889417216) in the past few days. [Due to high levels of spamming](https://logging.comms.canonical.com/search?rangetype=relative&fields=source%2Cmessage%2Cpath%2Cquerystring%2Cservice&width=1848&highlightMessage=&relative=172800&q=path%3A+%22%2Ftutorials%22+querystring%3A+q%3D*), disable search /server/docs and /tutorials search again, which look like they are the most spammed.


## QA

- Check https://ubuntu-com-11790.demos.haus/tutorials doesn't have search box anymore
- Check https://ubuntu-com-11790.demos.haus/server/docs doesn't have search box anymore

## Issue / Card

Fixes https://github.com/canonical-web-and-design/ubuntu.com/issues/11780


## Help

[QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html) - [Commit guidelines](https://canonical-web-and-design.github.io/practices/workflow/commit-messages.html)
