### PR TITLE
Updates alternative download section to /download & updates support platforms logo cloud on /iot

### DIFF
--- a/templates/download/index.html
+++ b/templates/download/index.html
@@ -138,6 +138,16 @@
   </div>
 </section>
 
+<section class="p-strip--light">
+  <div class="u-fixed-width">
+    <h2>Alternative downloads</h2>
+    <p>There are several other ways to get Ubuntu including torrents, which can potentially mean a quicker download, our network installer for older systems and special configurations and links to our regional mirrors for our older (and newer) releases.</p>
+    <p>
+      <a href="/download/alternative-downloads" class="p-button">Alternative downloads</a>
+    </p>
+  </div>
+</section>
+
 {% with first_item="_download_enterprise_support", second_item="_download_documentation", third_item="_download_helping_hands" %}{% include "shared/contextual_footers/_contextual_footer.html" %}{% endwith %}
 
 {% endblock content %}

--- a/templates/download/iot/index.html
+++ b/templates/download/iot/index.html
@@ -117,11 +117,11 @@
     </div>
     <br />
     <div class="row">
-      <div class="col-10">
+      <div class="col-8">
         <a class="p-button--positive" href="/certified">The ultimate Ubuntu Experience: Get Certified Hardware</a>
         <p>Ubuntu works along with silicon vendors and manufacturers to enable and certify Ubuntu on a wide range of hardware. The certified hardware passes our extensive testing and review process in our labs, ensuring that Ubuntu runs well out of the box, and regression tests are performed before every system update is delivered.</p>
       </div>
-      <div class="col-2">
+      <div class="col-4 u-align--center u-hide--medium u-hide--small">
         {{
           image (
           url="https://assets.ubuntu.com/v1/20a610ea-Ubuntu_Certified_Hardware_partner.svg",
@@ -129,7 +129,7 @@
           width="102",
           height="150",
           hi_def=True,
-          loading="auto|lazy"
+          loading="lazy"
           ) | safe
         }}
       </div>
@@ -163,11 +163,11 @@
   </section>
 
   <section class="p-strip">
-    <div class="u-fixed-width u-sv3 u-align--center">
+    <div class="u-fixed-width u-sv3">
       <h3>Supported platforms</h3>
     </div>
     <div class="row u-sv3">
-      <div class="col-4 u-align--center">
+      <div class="col-4">
           {{ image (
             url="https://assets.ubuntu.com/v1/977f2b7a-raspberry+pi+horizontal.svg",
             alt="Raspberry Pi logo",
@@ -179,7 +179,7 @@
           }}
         <p><a href="/download/iot/raspberry-pi">Install Ubuntu Core 22&nbsp;&rsaquo;</a></p>
         </div>
-        <div class="col-4 u-align--center">
+        <div class="col-4">
           {{ image (
             url="https://assets.ubuntu.com/v1/a69b2863-intel+nuc.svg",
             alt="Intel NUC logo",
@@ -191,7 +191,7 @@
           }}
           <p><a href="/download/iot/intel-nuc">Install Ubuntu Core 22&nbsp;&rsaquo;</a></p>
         </div>
-        <div class="col-4 u-align--center">
+        <div class="col-4">
           {{ image (
             url="https://assets.ubuntu.com/v1/db577ec7-tank-logo.svg",
             alt="Intel Tank logo",
@@ -205,7 +205,7 @@
         </div>
       </div>
       <div class="row u-sv3">
-        <div class="col-4 u-align--center">
+        <div class="col-4">
           {{ image (
             url="https://assets.ubuntu.com/v1/2a6d29c9-snapdragon.svg",
             alt="Qualcomm Snapdragon logo",
@@ -217,7 +217,7 @@
           }}
           <p><a href="/download/qualcomm-dragonboard-410c">Install Ubuntu Core 18&nbsp;&rsaquo;</a></p>
         </div>
-        <div class="col-4 u-align--center">
+        <div class="col-4">
           {{ image (
             url="https://assets.ubuntu.com/v1/f8ef46d3-AMD_Xilinx_logo.svg",
             alt="AMD Xilinx logo",
@@ -229,7 +229,7 @@
           }}
           <p><a href="/download/amd-xilinx">Install Ubuntu Core 20&nbsp;&rsaquo;</a></p>
         </div>
-        <div class="col-4 u-align--center">
+        <div class="col-4">
           {{ image (
             url="https://assets.ubuntu.com/v1/26cbe599-intel-logo.jpg",
             alt="Intel logo",
@@ -245,7 +245,7 @@
         </div>
       </div>
       <div class="u-fixed-width">
-        <p class="u-align--center">
+        <p>
           <a class="p-button" href="https://cdimage.ubuntu.com/ubuntu-core/20/stable/current/">
             Browse all supported images
           </a>

--- a/templates/download/iot/index.html
+++ b/templates/download/iot/index.html
@@ -163,32 +163,64 @@
   </section>
 
   <section class="p-strip">
-    <div class="u-fixed-width">
+    <div class="u-fixed-width u-sv3 u-align--center">
       <h3>Supported platforms</h3>
     </div>
-    <div class="row p-divider">
-      <div class="col-3">
-        <img src="https://assets.ubuntu.com/v1/977f2b7a-raspberry+pi+horizontal.svg" width="168" height="45" alt="Raspberry Pi">
+    <div class="row u-sv3">
+      <div class="col-4 u-align--center">
+          {{ image (
+            url="https://assets.ubuntu.com/v1/977f2b7a-raspberry+pi+horizontal.svg",
+            alt="Raspberry Pi logo",
+            width="168",
+            height="45",
+            hi_def=True,
+            loading="lazy"
+            ) | safe
+          }}
         <p><a href="/download/iot/raspberry-pi">Install Ubuntu Core 22&nbsp;&rsaquo;</a></p>
         </div>
-        <div class="col-3">
-          <img src="https://assets.ubuntu.com/v1/a69b2863-intel+nuc.svg" width="120" height="45" alt="Intel NUC">
+        <div class="col-4 u-align--center">
+          {{ image (
+            url="https://assets.ubuntu.com/v1/a69b2863-intel+nuc.svg",
+            alt="Intel NUC logo",
+            width="120",
+            height="45",
+            hi_def=True,
+            loading="lazy"
+            ) | safe
+          }}
           <p><a href="/download/iot/intel-nuc">Install Ubuntu Core 22&nbsp;&rsaquo;</a></p>
         </div>
-        <div class="col-3">
-          <img src="https://assets.ubuntu.com/v1/db577ec7-tank-logo.svg" width="163" height="45" alt="Intel IEI TANK 870">
+        <div class="col-4 u-align--center">
+          {{ image (
+            url="https://assets.ubuntu.com/v1/db577ec7-tank-logo.svg",
+            alt="Intel Tank logo",
+            width="163",
+            height="45",
+            hi_def=True,
+            loading="lazy"
+            ) | safe
+          }}
           <p><a href="/download/intel-iei-tank-870">Install Ubuntu Core 18&nbsp;&rsaquo;</a></p>
         </div>
       </div>
-      <div class="row">
-        <div class="col-3">
-          <img src="https://assets.ubuntu.com/v1/2a6d29c9-snapdragon.svg" width="139" height="45" alt="Qualcomm Snapdragon">
+      <div class="row u-sv3">
+        <div class="col-4 u-align--center">
+          {{ image (
+            url="https://assets.ubuntu.com/v1/2a6d29c9-snapdragon.svg",
+            alt="Qualcomm Snapdragon logo",
+            width="139",
+            height="45",
+            hi_def=True,
+            loading="lazy"
+            ) | safe
+          }}
           <p><a href="/download/qualcomm-dragonboard-410c">Install Ubuntu Core 18&nbsp;&rsaquo;</a></p>
         </div>
-        <div class="col-3">
+        <div class="col-4 u-align--center">
           {{ image (
             url="https://assets.ubuntu.com/v1/f8ef46d3-AMD_Xilinx_logo.svg",
-            alt="",
+            alt="AMD Xilinx logo",
             width="72",
             height="45",
             hi_def=True,
@@ -197,10 +229,10 @@
           }}
           <p><a href="/download/amd-xilinx">Install Ubuntu Core 20&nbsp;&rsaquo;</a></p>
         </div>
-        <div class="col-3">
+        <div class="col-4 u-align--center">
           {{ image (
             url="https://assets.ubuntu.com/v1/26cbe599-intel-logo.jpg",
-            alt="",
+            alt="Intel logo",
             width="75",
             height="42",
             hi_def=True,
@@ -212,10 +244,10 @@
           </p>
         </div>
       </div>
-      <div class="u-fixed-width" style="margin-top: 2rem;">
-        <p>
+      <div class="u-fixed-width">
+        <p class="u-align--center">
           <a class="p-button" href="https://cdimage.ubuntu.com/ubuntu-core/20/stable/current/">
-            <span>Browse all supported images</span>
+            Browse all supported images
           </a>
         </p>
       </div>

--- a/templates/pricing/shared/_enablement-strip.html
+++ b/templates/pricing/shared/_enablement-strip.html
@@ -31,7 +31,7 @@
     </div>
 
 
-    <div class="col-2 col-start-large-10 u-hide--small">
+    <div class="col-2 col-start-large-10 u-hide--small u-hide--medium">
       {{
         image(
         url="https://assets.ubuntu.com/v1/706b259a-ubuntu_certified_hex.svg",


### PR DESCRIPTION
## Done

- Updates alternative download section to /download  
- Updates support platforms logo cloud on /iot

## QA

- Go to https://ubuntu-com-11793.demos.haus/download and compare against [copydoc](https://docs.google.com/document/d/1egsCcmFiz8czeHsvwoB9Jz815Ij5Urtf7Ngrru6Zd4o/edit#)
- go to https://ubuntu-com-11793.demos.haus/download/iot and see that the 'Supported platforms' sections look better than on the current live site. Design was based on this suggestion from @davegoddard42 : 
![image](https://user-images.githubusercontent.com/58276363/176713546-2348b4f9-bdc1-4c3a-b885-d2200bab2bd5.png)


## Issue / Card

Fixes https://github.com/canonical-web-and-design/web-squad/issues/5602
