### PR TITLE
Fix cve error for missing patches, tags, and bugs

### DIFF
--- a/templates/security/cve/cve.html
+++ b/templates/security/cve/cve.html
@@ -316,7 +316,7 @@
           </li>
         </ul>
 
-        {% if cve.bugs|length > 1 %}
+        {% if cve.bugs and cve.bugs|length > 1 %}
           <h2>Bugs</h2>
           <ul>
             {% for bug in cve.bugs %}

--- a/webapp/security/views.py
+++ b/webapp/security/views.py
@@ -728,50 +728,54 @@ def cve(cve_id):
     # format patches
     formatted_patches = []
 
-    for package_name, patches in cve["patches"].items():
-        for patch in patches:
-            prefix, suffix = patch.split(":", 1)
-            suffix = suffix.strip()
+    if cve["patches"]:
+        for package_name, patches in cve["patches"].items():
+            for patch in patches:
+                prefix, suffix = patch.split(":", 1)
+                suffix = suffix.strip()
 
-            if prefix == "break-fix" and " " in suffix:
-                introduced, fixed = suffix.split(" ", 1)
+                if prefix == "break-fix" and " " in suffix:
+                    introduced, fixed = suffix.split(" ", 1)
 
-                if introduced == "-":
-                    # First commit to Linux git tree
-                    introduced = "1da177e4c3f41524e886b7f1b8a0c1fc7321cac2"
+                    if introduced == "-":
+                        # First commit to Linux git tree
+                        introduced = "1da177e4c3f41524e886b7f1b8a0c1fc7321cac2"
 
-                formatted_patches.append(
-                    {
-                        "type": "break-fix",
-                        "content": {"introduced": introduced, "fixed": fixed},
-                        "name": package_name,
-                    }
-                )
+                    formatted_patches.append(
+                        {
+                            "type": "break-fix",
+                            "content": {
+                                "introduced": introduced,
+                                "fixed": fixed,
+                            },
+                            "name": package_name,
+                        }
+                    )
 
-            if (
-                "ftp://" in suffix
-                or "http://" in suffix
-                or "https://" in suffix
-            ):
-                formatted_patches.append(
-                    {
-                        "type": "link",
-                        "content": {"prefix": prefix, "suffix": suffix},
-                        "name": package_name,
-                    }
-                )
+                if (
+                    "ftp://" in suffix
+                    or "http://" in suffix
+                    or "https://" in suffix
+                ):
+                    formatted_patches.append(
+                        {
+                            "type": "link",
+                            "content": {"prefix": prefix, "suffix": suffix},
+                            "name": package_name,
+                        }
+                    )
 
-            if ":" not in patch:
-                formatted_patches.append(
-                    {"type": "text", "content": patch, "name": patch}
-                )
+                if ":" not in patch:
+                    formatted_patches.append(
+                        {"type": "text", "content": patch, "name": patch}
+                    )
 
     # format tags
     formatted_tags = []
-
-    for package_name, tags in cve["tags"].items():
-        for tag in tags:
-            formatted_tags.append({"name": package_name, "text": tag})
+    if cve["tags"]:
+        for package_name, tags in cve["tags"].items():
+            for tag in tags:
+                formatted_tags.append({"name": package_name, "text": tag})
 
     return flask.render_template(
         "security/cve/cve.html",


### PR DESCRIPTION
## Done

- Fix cve error for missing patches, tags, and bugs

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/security/CVE-2002-0391 or https://ubuntu-com-11801.demos.haus/security/CVE-2002-0391
    - Be sure to test on mobile, tablet and desktop screen sizes
- See that CVE template renders as expected

## Issue / Card

Fixes https://github.com/canonical-web-and-design/ubuntu.com/issues/11799