### PR TITLE
Fix typo

### DIFF
--- a/templates/desktop/organisations.html
+++ b/templates/desktop/organisations.html
@@ -478,7 +478,7 @@
     <blockquote class="p-pull-quote has-image">
       <img class="p-pull-quote__image" src="https://assets.ubuntu.com/v1/52d4cc16-Nvidia_Logo_Horizontal.svg" alt="">
       <p class="p-pull-quote__quote">Developers and data science teams use the Ubuntu platform to support their most important work. Our collaboration with Canonical enables industry innovators to get AI-powered insights from their data faster.</p>
-      <span class="p-pull-quote__citation">Manuvir Das &mdash; NnVIDIA, Head of Enterprise Computing</span>
+      <span class="p-pull-quote__citation">Manuvir Das &mdash; NVIDIA, Head of Enterprise Computing</span>
     </blockquote>
   </div>
 </section>


### PR DESCRIPTION
## Done

- Remove this typo `n` 
<img width="337" alt="image" src="https://user-images.githubusercontent.com/57550290/177162808-87d260a7-51c1-4c4a-9a4d-3408c40ce056.png">

## QA

- Go to `/desktop/organisations` or https://ubuntu-com-11802.demos.haus/desktop/organisations
-  [Copy doc](https://docs.google.com/document/d/1RuxCA6GYh9UriNv26HCZP9UHo4b4_9fYaaMtGQuH_xc/edit?disco=AAAAbSJi0tc&usp=comment_email_document&ts=62bef0f9&usp_dm=false) (Note : another issue has been made for the other comments in the copy doc. This PR is just fixing this typo)
## Issue / Card

Fixes #https://github.com/canonical-web-and-design/web-squad/issues/5613

