### PR TITLE
Updates /certified homepage with certified hardware links for 'devices' and 'socs'

### DIFF
--- a/templates/certified/index.html
+++ b/templates/certified/index.html
@@ -182,6 +182,14 @@
         </li>
         {% endfor %}
       </ul>
+      <p class="u-text--muted u-no-margin--bottom">Certified for:</p>
+      <ul class="p-inline-list--midline">
+        {% for iot_release in iot_releases %}
+        <li class="p-inline-list__item">
+          <a href="/certified/devices?release={{ iot_release.release }}">{{ iot_release.release }}&nbsp;({{ iot_release.smart_core }})</a>
+        </li>
+        {% endfor %}
+      </ul>
       <p><a href="/certified/devices" class="p-button--positive">See all devices</a></p>
     </div>
   </div>
@@ -201,6 +209,14 @@
         </li>
         {% endfor %}
       </ul>
+      <p class="u-text--muted u-no-margin--bottom">Certified for:</p>
+      <ul class="p-inline-list--midline">
+        {% for soc_release in soc_releases %}
+        <li class="p-inline-list__item">
+          <a href="/certified/socs?release={{ soc_release.release }}">{{ soc_release.release }}&nbsp;({{ soc_release.soc }})</a>
+        </li>
+        {% endfor %}
+      </ul>      
       <p><a href="/certified/socs" class="p-button--positive">See all SoCs</a></p>
     </div>
     <div class="col-4 u-align--center u-vertically-center u-hide--medium u-hide--small">


### PR DESCRIPTION
## Done

- Updates /certified homepage with certified hardware links for 'devices' and 'socs'

## QA

**Note: this request was made in the [issue](https://github.com/canonical-web-and-design/web-squad/issues/5609) not the [copy doc](https://docs.google.com/document/d/1Cq9RLNjSbX83WB5fFKYCFRvo_1JEfMydMecqrVeKBP8/edit#heading=h.kiqaim38ehoe)**
- Go to https://ubuntu-com-11805.demos.haus/certified and check that the 'iot devices' & 'socs' section includes links for 'Certified for:'
- Check that when these links are pressed they go to the certified devices search and apply the appropriate filter ie. if you click `20.04 LTS` it should take you to https://ubuntu-com-11805.demos.haus/certified/devices?release=20.04%20LTS

## Issue / Card

Fixes https://github.com/canonical-web-and-design/web-squad/issues/5609
