### PR TITLE
Fix invoice status

### DIFF
--- a/templates/account/invoices/index.html
+++ b/templates/account/invoices/index.html
@@ -52,9 +52,9 @@
                     {% if invoice.invoice.status == "paid" %}
                       <div class="p-label--new">Paid</div>
                     {% elif invoice.invoice.status == "open" %}
-                      <div class="p-label--deprecated">Failed</div>
-                    {% else %}
                       <div class="p-label">Pending</div>
+                    {% else %}
+                      <div class="p-label--deprecated">Failed</div>
                     {% endif %}
                   {% else %}
                     <div class="p-label">Pending</div>

--- a/templates/account/invoices/index.html
+++ b/templates/account/invoices/index.html
@@ -50,12 +50,14 @@
                 <td aria-label="Status">
                   {% if invoice.invoice %}
                     {% if invoice.invoice.status == "paid" %}
-                      <div class="p-label--new">Paid</div>
+                      <div class="p-status-label--positive">Paid</div>
                     {% elif invoice.invoice.status == "open" %}
                       <div class="p-label">Pending</div>
                     {% else %}
-                      <div class="p-label--deprecated">Failed</div>
+                      <div class="p-status-label--negative">Failed</div>
                     {% endif %}
+                  {% elif invoice.status == "done" %}
+                    <div class="p-status-label--negative">Failed</div>
                   {% else %}
                     <div class="p-label">Pending</div>
                   {% endif %}


### PR DESCRIPTION
## Done

- Fix invoice status problem.

## QA

- Make a purchase with a 4000 0000 0000 0341
- Go to the backoffice tool and cancel your payment
- purchase will have an invoice with a `void` status
- Staging will should your payment with the status `pending` (incorrectly)
- Demo will show your payment with status `Failed` (correctly)
- Also discovered old payments with status `done` will forever show `pending`, due to missing invoices - Now shows `Failed` (yes, both payment.status exists as well as payment.invoice.status)
- Also fixed label css class

![image](https://user-images.githubusercontent.com/6387619/177629069-2aff9092-d928-4c94-ab3e-0bc816c7b33b.png)