### PR TITLE
Reenable search

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,8 @@ canonicalwebteam.flask-base==1.0.5
 alembic==1.7.5
 canonicalwebteam.http==1.0.3
 canonicalwebteam.blog==6.4.0
-canonicalwebteam.search==1.2.2
+#canonicalwebteam.search==1.2.2
+git+https://github.com/nottrobin/canonicalwebteam.search@blacklists#canonicalwebteam.search
 canonicalwebteam.templatefinder==1.0.0
 canonicalwebteam.image-template==1.3.1
 canonicalwebteam.discourse==4.0.9

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,8 +2,7 @@ canonicalwebteam.flask-base==1.0.5
 alembic==1.7.5
 canonicalwebteam.http==1.0.3
 canonicalwebteam.blog==6.4.0
-#canonicalwebteam.search==1.2.3
-git+https://github.com/nottrobin/canonicalwebteam.search@consolidate-search-function#egg=canonicalwebteam.search
+canonicalwebteam.search==1.2.4
 canonicalwebteam.templatefinder==1.0.0
 canonicalwebteam.image-template==1.3.1
 canonicalwebteam.discourse==4.0.9

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ canonicalwebteam.flask-base==1.0.5
 alembic==1.7.5
 canonicalwebteam.http==1.0.3
 canonicalwebteam.blog==6.4.0
-canonicalwebteam.search==1.2.1
+git+https://github.com/nottrobin/canonicalwebteam.search@block-spam#egg=canonicalwebteam.search
 canonicalwebteam.templatefinder==1.0.0
 canonicalwebteam.image-template==1.3.1
 canonicalwebteam.discourse==4.0.9

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,8 @@ canonicalwebteam.flask-base==1.0.5
 alembic==1.7.5
 canonicalwebteam.http==1.0.3
 canonicalwebteam.blog==6.4.0
-canonicalwebteam.search==1.2.3
+#canonicalwebteam.search==1.2.3
+git+https://github.com/nottrobin/canonicalwebteam.search@consolidate-search-function#canonicalwebteam.search
 canonicalwebteam.templatefinder==1.0.0
 canonicalwebteam.image-template==1.3.1
 canonicalwebteam.discourse==4.0.9

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ canonicalwebteam.flask-base==1.0.5
 alembic==1.7.5
 canonicalwebteam.http==1.0.3
 canonicalwebteam.blog==6.4.0
-git+https://github.com/nottrobin/canonicalwebteam.search@block-spam#egg=canonicalwebteam.search
+canonicalwebteam.search==1.2.2
 canonicalwebteam.templatefinder==1.0.0
 canonicalwebteam.image-template==1.3.1
 canonicalwebteam.discourse==4.0.9

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ alembic==1.7.5
 canonicalwebteam.http==1.0.3
 canonicalwebteam.blog==6.4.0
 #canonicalwebteam.search==1.2.3
-git+https://github.com/nottrobin/canonicalwebteam.search@consolidate-search-function#canonicalwebteam.search
+git+https://github.com/nottrobin/canonicalwebteam.search@consolidate-search-function#egg=canonicalwebteam.search
 canonicalwebteam.templatefinder==1.0.0
 canonicalwebteam.image-template==1.3.1
 canonicalwebteam.discourse==4.0.9

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,8 +2,7 @@ canonicalwebteam.flask-base==1.0.5
 alembic==1.7.5
 canonicalwebteam.http==1.0.3
 canonicalwebteam.blog==6.4.0
-#canonicalwebteam.search==1.2.2
-git+https://github.com/nottrobin/canonicalwebteam.search@blacklists#canonicalwebteam.search
+canonicalwebteam.search==1.2.3
 canonicalwebteam.templatefinder==1.0.0
 canonicalwebteam.image-template==1.3.1
 canonicalwebteam.discourse==4.0.9

--- a/templates/403.html
+++ b/templates/403.html
@@ -1,0 +1,34 @@
+{% extends "templates/one-column.html" %}
+{% block title %}404: Page not found{% endblock %}
+
+
+{% block content %}
+<div class="p-strip is-deep">
+  <div class="row u-equal-height">
+    <div class="col-6 u-vertically-center u-align--center">
+      {{
+        image(
+          url="https://assets.ubuntu.com/v1/bcdcf2c8-image-404.svg",
+          alt="",
+          height="365",
+          width="360",
+          hi_def=True,
+          loading="auto"
+        ) | safe
+      }}
+    </div>
+    <div class="col-6 u-vertically-center">
+      <div>
+        <h1>403: Forbidden</h1>
+        <p class="p-heading--4">
+          {% if message %}
+            {{ message }}
+          {% else %}
+            You're not allowed to access this page
+          {% endif %}
+        </p>
+      </div>
+    </div>
+  </div>
+</div>
+{% endblock content %}

--- a/templates/templates/docs/shared/_docs.html
+++ b/templates/templates/docs/shared/_docs.html
@@ -24,7 +24,6 @@
 {% endmacro %}
 
 {% block outer_content %}
-{% if siteSearch != "https://ubuntu.com/server/docs" %}
 {% with
   search_action=search_action,
   siteSearch=siteSearch,
@@ -32,7 +31,6 @@
 %}
   {% include "templates/docs/shared/_search-box.html" %}
 {% endwith %}
-{% endif %}
 
 <div class="p-strip is-shallow">
   <div class="row">

--- a/templates/templates/docs/shared/_docs.html
+++ b/templates/templates/docs/shared/_docs.html
@@ -24,15 +24,13 @@
 {% endmacro %}
 
 {% block outer_content %}
-{% if request.path != "/server/docs" %}
-  {% with
-    search_action=search_action,
-    siteSearch=siteSearch,
-    placeholder=placeholder
-  %}
-    {% include "templates/docs/shared/_search-box.html" %}
-  {% endwith %}
-{% endif %}
+{% with
+  search_action=search_action,
+  siteSearch=siteSearch,
+  placeholder=placeholder
+%}
+  {% include "templates/docs/shared/_search-box.html" %}
+{% endwith %}
 <div class="p-strip is-shallow">
   <div class="row">
     <aside class="col-3">

--- a/templates/templates/docs/shared/_docs.html
+++ b/templates/templates/docs/shared/_docs.html
@@ -24,6 +24,7 @@
 {% endmacro %}
 
 {% block outer_content %}
+{% if siteSearch != "https://ubuntu.com/server/docs" %}
 {% with
   search_action=search_action,
   siteSearch=siteSearch,
@@ -31,6 +32,8 @@
 %}
   {% include "templates/docs/shared/_search-box.html" %}
 {% endwith %}
+{% endif %}
+
 <div class="p-strip is-shallow">
   <div class="row">
     <aside class="col-3">

--- a/templates/tutorials/index.html
+++ b/templates/tutorials/index.html
@@ -18,7 +18,7 @@
 
 <section class="p-strip is-shallow l-tutorials__filters">
   <div class="row">
-    <!-- <div class="col-4">
+    <div class="col-4">
       <div class="p-form__group">
         <label for="tutorials-search-input">Search tutorials containing:</label>
         <form class="p-search-box u-no-margin--bottom" id="tutorials-search" action="">
@@ -27,7 +27,7 @@
           <button type="submit" class="p-search-box__button"><i class="p-icon--search"></i></button>
         </form>
       </div>
-    </div> -->
+    </div>
     <div class="col-4">
       <div class="p-form__group">
         <label for="tutorials-topic">Topic:</label>

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -197,6 +197,11 @@ def bad_request_error(error):
     return flask.render_template("400.html", message=error.description), 400
 
 
+@app.errorhandler(403)
+def forbidden_error(error):
+    return flask.render_template("403.html", message=error.description), 403
+
+
 @app.errorhandler(410)
 def deleted_error(error):
     return flask.render_template("410.html", message=error.description), 410

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -759,16 +759,16 @@ server_docs = Docs(
 )
 
 # Server docs search
-app.add_url_rule(
-    "/server/docs/search",
-    "server-docs-search",
-    build_search_view(
-        session=session,
-        site="ubuntu.com/server/docs",
-        template_path="/server/docs/search-results.html",
-        search_engine_id=search_engine_id,
-    ),
-)
+# app.add_url_rule(
+#     "/server/docs/search",
+#     "server-docs-search",
+#     build_search_view(
+#         session=session,
+#         site="ubuntu.com/server/docs",
+#         template_path="/server/docs/search-results.html",
+#         search_engine_id=search_engine_id,
+#     ),
+# )
 
 server_docs.init_app(app)
 

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -759,16 +759,16 @@ server_docs = Docs(
 )
 
 # Server docs search
-# app.add_url_rule(
-#     "/server/docs/search",
-#     "server-docs-search",
-#     build_search_view(
-#         session=session,
-#         site="ubuntu.com/server/docs",
-#         template_path="/server/docs/search-results.html",
-#         search_engine_id=search_engine_id,
-#     ),
-# )
+app.add_url_rule(
+    "/server/docs/search",
+    "server-docs-search",
+    build_search_view(
+        session=session,
+        site="ubuntu.com/server/docs",
+        template_path="/server/docs/search-results.html",
+        search_engine_id=search_engine_id,
+    ),
+)
 
 server_docs.init_app(app)
 

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -16,7 +16,7 @@ from geolite2 import geolite2
 from requests import Session
 from requests.exceptions import HTTPError
 
-# from canonicalwebteam.search.models import get_search_results
+from canonicalwebteam.search.models import get_search_results
 from canonicalwebteam.search.views import NoAPIKeyError
 from bs4 import BeautifulSoup
 from werkzeug.exceptions import BadRequest
@@ -267,7 +267,7 @@ def build_tutorials_index(session, tutorials_docs):
         """
 
         # Web tribe websites custom search ID
-        # search_engine_id = "adb2397a224a1fe55"
+        search_engine_id = "adb2397a224a1fe55"
 
         # API key should always be provided as an environment variable
         search_api_key = os.getenv("SEARCH_API_KEY")
@@ -275,17 +275,17 @@ def build_tutorials_index(session, tutorials_docs):
         if query and not search_api_key:
             raise NoAPIKeyError("Unable to search: No API key provided")
 
-        # results = None
+        results = None
 
-        # if query:
-        #     results = get_search_results(
-        #         session=session,
-        #         api_key=search_api_key,
-        #         search_engine_id=search_engine_id,
-        #         siteSearch="ubuntu.com/tutorials",
-        #         query=query,
-        #         site_restricted_search=False,
-        #     )
+        if query:
+            results = get_search_results(
+                session=session,
+                api_key=search_api_key,
+                search_engine_id=search_engine_id,
+                siteSearch="ubuntu.com/tutorials",
+                query=query,
+                site_restricted_search=False,
+            )
 
         tutorials_docs.parser.parse()
         tutorials_docs.parser.parse_topic(tutorials_docs.parser.index_topic)
@@ -307,18 +307,18 @@ def build_tutorials_index(session, tutorials_docs):
                     item["categories"].replace(" ", "").lower().split(",")
                 )
 
-        # if query:
-        #     temp_metadata = []
-        #     if results.get("entries"):
-        #         for result in results["entries"]:
-        #             start = result["link"].find("tutorials/")
-        #             end = len(result["link"])
-        #             identifier = result["link"][start:end]
-        #             if start != -1:
-        #                 for doc in tutorials:
-        #                     if identifier in doc["link"]:
-        #                         temp_metadata.append(doc)
-        #     tutorials = temp_metadata
+        if query:
+            temp_metadata = []
+            if results.get("entries"):
+                for result in results["entries"]:
+                    start = result["link"].find("tutorials/")
+                    end = len(result["link"])
+                    identifier = result["link"][start:end]
+                    if start != -1:
+                        for doc in tutorials:
+                            if identifier in doc["link"]:
+                                temp_metadata.append(doc)
+            tutorials = temp_metadata
 
         if sort == "difficulty-desc":
             tutorials = sorted(


### PR DESCRIPTION
- Reenable tutorials and server docs search
- Use canonicalwebteam.search 1.2.2 to block spam requests
- Add 403 template

QA
--

Go to https://ubuntu-com-11811.demos.haus/search, https://ubuntu-com-11811.demos.haus/server/docs https://ubuntu-com-11811.demos.haus/tutorials and perform some searches.

Try searching for something spammy like "【Telegram：HX99.COM】蝶之毒华之锁全CG包". Get 403 forbidden.

Try searching from the command-line:

```
curl -I "https://ubuntu-com-11811.demos.haus/server/docs/search?q=【Telegram：HX99.COM】蝶之毒华之锁全CG包"
```

You should get 403 forbidden, because curl useragent is blocked ^.