### PR TITLE
Add a link on `/gcp`

### DIFF
--- a/templates/gcp/pro.html
+++ b/templates/gcp/pro.html
@@ -46,7 +46,12 @@
     </div>
   </div>
   <div class="u-fixed-width">
-    <a href="/gcp/contact-us" class="js-invoke-modal">Contact us to discuss Ubuntu Pro with support&nbsp;&rsaquo;</a>
+    <p>
+      <a href="/gcp/contact-us" class="js-invoke-modal">Contact us to discuss Ubuntu Pro with support&nbsp;&rsaquo;</a>
+    </p>
+    <p>
+      <a href="https://cloud.google.com/compute/docs/images/premium/ubuntu-pro/upgrade-from-ubuntu">Upgrade your Ubuntu LTS to Pro&nbsp;&rsaquo;</a>
+    </p>
   </div>
 </section>
 


### PR DESCRIPTION
## Done

- Added a link on `/gcp`

## QA

- Go to https://ubuntu-com-11812.demos.haus/gcp
- Check the `Upgrade your Ubuntu LTS to Pro >` link works properly 
- Compare page against [copy doc](https://docs.google.com/document/d/1zR1m6CH1POU5tnzNzgNYanG2_EGQtKVNR3_dPew1pf4/edit#)
- 
## Issue / Card

Fixes #https://github.com/canonical-web-and-design/web-squad/issues/5598
