### PR TITLE
Show cve bugs even when there's only one

### DIFF
--- a/templates/security/cve/cve.html
+++ b/templates/security/cve/cve.html
@@ -316,7 +316,7 @@
           </li>
         </ul>
 
-        {% if cve.bugs and cve.bugs|length > 1 %}
+        {% if cve.bugs and "" not in cve.bugs %}
           <h2>Bugs</h2>
           <ul>
             {% for bug in cve.bugs %}


### PR DESCRIPTION
## Done

- Update the cve bug check to be based on empty string rather than the length of array

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: 
    -  http://0.0.0.0:8001/security/CVE-2022-29526 and make sure multiple bugs are listed
    - http://0.0.0.0:8001/security/CVE-2022-33124 and make sure no bugs are listed 
    - http://0.0.0.0:8001security/CVE-2022-31625 and make sure single bug is listed

## Issue / Card

Fixes https://github.com/canonical-web-and-design/ubuntu.com/issues/11818