### PR TITLE
Use release name instead of 'slug'

### DIFF
--- a/templates/about/release-cycle.html
+++ b/templates/about/release-cycle.html
@@ -57,7 +57,7 @@
 
       <h3>Version numbers are YY.MM</h3>
 
-      <p>Releases of Ubuntu get a development codename ('{{ releases.latest.slug }}') and are versioned by the year and month of delivery - for example, Ubuntu {{ releases.latest.short_version }} was released in {{ releases.latest.release_date }}.</p>
+      <p>Releases of Ubuntu get a development codename ('{{ releases.latest.name }}') and are versioned by the year and month of delivery - for example, Ubuntu {{ releases.latest.short_version }} was released in {{ releases.latest.release_date }}.</p>
 
       <p>LTS or 'Long Term Support' releases are published every two years in April. LTS releases are the 'enterprise grade' releases of Ubuntu and are used the most. An estimated 95% of all Ubuntu installations are LTS releases.</p>
 


### PR DESCRIPTION
'slug' seems to be an internal ID and not something to be used on the web page.

Signed-off-by: Anthony Wong <anthony.wong@canonical.com>