### PR TITLE
Fix broken link to /docs/robotics

### DIFF
--- a/templates/robotics/shared/_learn-more-about-robotics.html
+++ b/templates/robotics/shared/_learn-more-about-robotics.html
@@ -78,7 +78,7 @@
       </div>
       <ul class="p-list">
         <li class="p-list__item">
-          <a href="/docs/robotics">Containerisation for robotics applications</a>
+          <a href="https://snapcraft.io/docs/robotics">Containerisation for robotics applications</a>
         </li>
         <li class="p-list__item">
           <a href="/blog/feeling-at-home-in-a-lxd-container">Feeling at home in a LXD container</a>


### PR DESCRIPTION
## Done
- Fixed the broken link on the robotics page

## QA
- Check the link works

## Issue / Card
https://github.com/canonical-web-and-design/ubuntu.com/runs/7335407887?check_suite_focus=true
