### PR TITLE
Fix broken CVE query filter

### DIFF
--- a/webapp/security/views.py
+++ b/webapp/security/views.py
@@ -526,7 +526,7 @@ def cve_index():
     is_cve_id = re.match(r"^CVE-\d{4}-\d{4,7}$", query.upper())
 
     # get cve with specific id
-    if is_cve_id and cves.get(query.upper()):
+    if is_cve_id and cves_response.get(query.upper()):
         return flask.redirect(f"/security/{query.lower()}")
 
     # releases in desc order


### PR DESCRIPTION
## Done

- Fixed broken CVE query filter

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/security/cves or https://ubuntu-com-11839.demos.haus/security/cves and search for "CVE-2022-2347" and see that it does not error out

## Issue / Card

Fixes https://github.com/canonical-web-and-design/ubuntu.com/issues/11838