### PR TITLE
Create section 1: Product type

### DIFF
--- a/static/js/src/advantage/subscribe/react/components/Form/Feature/Feature.test.tsx
+++ b/static/js/src/advantage/subscribe/react/components/Form/Feature/Feature.test.tsx
@@ -37,7 +37,7 @@ test("Feature sections disables Infra + Apps if destkop is selected", () => {
 
 test("The section is disabled if a public cloud is selected", () => {
   render(
-    <FormProvider initialType={ProductTypes.aws}>
+    <FormProvider initialType={ProductTypes.publicCloud}>
       <Feature />
     </FormProvider>
   );

--- a/static/js/src/advantage/subscribe/react/components/Form/ProductType/ProductType.test.tsx
+++ b/static/js/src/advantage/subscribe/react/components/Form/ProductType/ProductType.test.tsx
@@ -28,11 +28,9 @@ test("Type selector displays the public cloud section if a public cloud is selec
     </FormProvider>
   );
 
-  await userEvent.click(screen.getByText("AWS instances"));
+  await userEvent.click(screen.getByText("Public Cloud instances"));
 
-  expect(
-    screen.getByText(/^Ubuntu Pro on the AWS Marketplace/)
-  ).toHaveAttribute(
+  expect(screen.getByText(/^Visit AWS Marketplace/)).toHaveAttribute(
     "href",
     "https://aws.amazon.com/marketplace/search/results?page=1&filters=VendorId&VendorId=e6a5002c-6dd0-4d1e-8196-0a1d1857229b&searchTerms=ubuntu+pro"
   );

--- a/static/js/src/advantage/subscribe/react/components/Form/ProductType/ProductType.tsx
+++ b/static/js/src/advantage/subscribe/react/components/Form/ProductType/ProductType.tsx
@@ -75,7 +75,7 @@ const ProductType = () => {
             <>
               <div className="image-wrapper">
                 <img
-                  src="https://manager.assets.ubuntu.com/update?file-path=ca1ea583-icon-intro-cloud.svg"
+                  src="https://assets.ubuntu.com/v1/75a8a35a-cloud_orange.svg"
                   alt=""
                 />
               </div>

--- a/static/js/src/advantage/subscribe/react/components/Form/ProductType/ProductType.tsx
+++ b/static/js/src/advantage/subscribe/react/components/Form/ProductType/ProductType.tsx
@@ -1,47 +1,45 @@
-import React, { useContext } from "react";
+import React, { useContext, useState } from "react";
 import { Button, Col, Row } from "@canonical/react-components";
 import RadioCard from "../RadioCard";
 import {
   isPublicCloud,
   ProductTypes,
+  PublicClouds,
 } from "advantage/subscribe/react/utils/utils";
 import { FormContext } from "advantage/subscribe/react/utils/FormContext";
 
 const PublicCloudInfo = {
-  [ProductTypes.aws]: {
+  [PublicClouds.aws]: {
     name: "AWS Marketplace",
     link:
       "https://aws.amazon.com/marketplace/search/results?page=1&filters=VendorId&VendorId=e6a5002c-6dd0-4d1e-8196-0a1d1857229b&searchTerms=ubuntu+pro",
   },
-  [ProductTypes.azure]: {
+  [PublicClouds.azure]: {
     name: "Azure Marketplace",
     link:
       "https://azuremarketplace.microsoft.com/en-us/marketplace/apps?search=Ubuntu%20Pro&page=1",
   },
-  [ProductTypes.gcp]: {
+  [PublicClouds.gcp]: {
     name: "Google Cloud Console",
     link:
       "https://console.cloud.google.com/marketplace/browse?q=ubuntu%20pro%20canonical",
-  },
-  [ProductTypes.physical]: {
-    name: "",
-    link: "",
-  },
-  [ProductTypes.virtual]: {
-    name: "",
-    link: "",
-  },
-  [ProductTypes.desktop]: {
-    name: "",
-    link: "",
   },
 };
 
 const ProductType = () => {
   const { productType, setProductType } = useContext(FormContext);
+  const [publicCloud, setPublicCloud] = useState(PublicClouds.aws);
 
-  const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+  const handleProductTypeChange = (
+    event: React.ChangeEvent<HTMLInputElement>
+  ) => {
     setProductType(event.target.value as ProductTypes);
+  };
+
+  const handlePublicCloudChange = (
+    event: React.ChangeEvent<HTMLInputElement>
+  ) => {
+    setPublicCloud(event.target.value as PublicClouds);
   };
 
   const switchToVirtual = () => {
@@ -56,7 +54,7 @@ const ProductType = () => {
             name="type"
             value={ProductTypes.physical}
             selectedValue={productType}
-            handleChange={handleChange}
+            handleChange={handleProductTypeChange}
           >
             <>
               <div className="image-wrapper">
@@ -70,57 +68,25 @@ const ProductType = () => {
           </RadioCard>
           <RadioCard
             name="type"
-            value={ProductTypes.aws}
+            value={ProductTypes.publicCloud}
             selectedValue={productType}
-            handleChange={handleChange}
+            handleChange={handleProductTypeChange}
           >
             <>
               <div className="image-wrapper">
                 <img
-                  src="https://assets.ubuntu.com/v1/a82add58-profile-aws.svg"
+                  src="https://assets.ubuntu.com/v1/a33638f0-public-cloud.svg"
                   alt=""
                 />
               </div>
-              <span>AWS instances</span>
-            </>
-          </RadioCard>
-          <RadioCard
-            name="type"
-            value={ProductTypes.azure}
-            selectedValue={productType}
-            handleChange={handleChange}
-          >
-            <>
-              <div className="image-wrapper">
-                <img
-                  src="https://assets.ubuntu.com/v1/da9a1344-Microsoft-Azure-logo_stacked_transparent.png"
-                  alt=""
-                />
-              </div>
-              <span>Azure instances</span>
-            </>
-          </RadioCard>
-          <RadioCard
-            name="type"
-            value={ProductTypes.gcp}
-            selectedValue={productType}
-            handleChange={handleChange}
-          >
-            <>
-              <div className="image-wrapper">
-                <img
-                  src="https://assets.ubuntu.com/v1/216e5289-google-cloud.svg"
-                  alt=""
-                />
-              </div>
-              <span>Google Cloud instances</span>
+              <span>Public Cloud instances</span>
             </>
           </RadioCard>
           <RadioCard
             name="type"
             value={ProductTypes.virtual}
             selectedValue={productType}
-            handleChange={handleChange}
+            handleChange={handleProductTypeChange}
           >
             <>
               <div className="image-wrapper">
@@ -136,7 +102,7 @@ const ProductType = () => {
             name="type"
             value={ProductTypes.desktop}
             selectedValue={productType}
-            handleChange={handleChange}
+            handleChange={handleProductTypeChange}
           >
             <>
               <div className="image-wrapper">
@@ -150,35 +116,84 @@ const ProductType = () => {
           </RadioCard>
         </Col>
         {isPublicCloud(productType) ? (
-          <Col size={12} className="public-cloud-section">
-            <span>
-              <strong>
-                You can buy{" "}
-                <a href={PublicCloudInfo[productType]?.link}>
-                  Ubuntu Pro on the {PublicCloudInfo[productType]?.name}
-                </a>{" "}
-                at an hourly, per-machine rate, with all UA software features
-                included.
-              </strong>
-              If you need tech support as well,{" "}
-              <a href="/support/contact-us">contact us</a>.
-            </span>
-            <br />
-            <br />
-            <span>
-              <strong>
-                Looking to add support to an existing virtual machine running
-                Ubuntu 16.04 (Xenial)?
-              </strong>
-              <br />
-              Choose the &quot;
-              <Button appearance="link" onClick={switchToVirtual}>
-                Other VMs
-              </Button>
-              &quot; option to purchase a subscription you can attach to your
-              existing VM.
-            </span>
-          </Col>
+          <>
+            <Col size={12} className="radio-wrapper--staggering">
+              <RadioCard
+                name="type"
+                value={PublicClouds.aws}
+                selectedValue={publicCloud}
+                handleChange={handlePublicCloudChange}
+              >
+                <>
+                  <div className="image-wrapper">
+                    <img
+                      src="https://assets.ubuntu.com/v1/a82add58-profile-aws.svg"
+                      alt=""
+                    />
+                  </div>
+                  <span>AWS instances</span>
+                </>
+              </RadioCard>
+              <RadioCard
+                name="type"
+                value={PublicClouds.azure}
+                selectedValue={publicCloud}
+                handleChange={handlePublicCloudChange}
+              >
+                <>
+                  <div className="image-wrapper">
+                    <img
+                      src="https://assets.ubuntu.com/v1/da9a1344-Microsoft-Azure-logo_stacked_transparent.png"
+                      alt=""
+                    />
+                  </div>
+                  <span>Azure instances</span>
+                </>
+              </RadioCard>
+              <RadioCard
+                name="type"
+                value={PublicClouds.gcp}
+                selectedValue={publicCloud}
+                handleChange={handlePublicCloudChange}
+              >
+                <>
+                  <div className="image-wrapper">
+                    <img
+                      src="https://assets.ubuntu.com/v1/216e5289-google-cloud.svg"
+                      alt=""
+                    />
+                  </div>
+                  <span>Google Cloud instances</span>
+                </>
+              </RadioCard>
+            </Col>
+
+            <Col size={12} className="public-cloud-section">
+              <p>
+                <strong>
+                  You can buy Ubuntu Pro on the{" "}
+                  {PublicCloudInfo[publicCloud]?.name} at an hourly, per-machine
+                  rate, with all UA software features included.
+                </strong>
+                <br />
+                If you need tech support as well,{" "}
+                <a href="/support/contact-us">contact us</a>.
+              </p>
+              <Row>
+                <Col size={12} className="u-align--right">
+                  <Button
+                    appearance="positive"
+                    classn
+                    element="a"
+                    onClick={switchToVirtual}
+                    href={PublicCloudInfo[publicCloud]?.link}
+                  >
+                    Visit {PublicCloudInfo[publicCloud]?.name}
+                  </Button>
+                </Col>
+              </Row>
+            </Col>
+          </>
         ) : null}
       </Row>
     </>

--- a/static/js/src/advantage/subscribe/react/components/Form/ProductType/ProductType.tsx
+++ b/static/js/src/advantage/subscribe/react/components/Form/ProductType/ProductType.tsx
@@ -75,7 +75,7 @@ const ProductType = () => {
             <>
               <div className="image-wrapper">
                 <img
-                  src="https://assets.ubuntu.com/v1/a33638f0-public-cloud.svg"
+                  src="https://manager.assets.ubuntu.com/update?file-path=ca1ea583-icon-intro-cloud.svg"
                   alt=""
                 />
               </div>

--- a/static/js/src/advantage/subscribe/react/components/Form/Support/Support.test.tsx
+++ b/static/js/src/advantage/subscribe/react/components/Form/Support/Support.test.tsx
@@ -62,7 +62,7 @@ test("Standard and advanced support are disabled destkop and Apps are selected",
 
 test("The section is disabled if a public cloud is selected", () => {
   render(
-    <FormProvider initialType={ProductTypes.aws}>
+    <FormProvider initialType={ProductTypes.publicCloud}>
       <Support />
     </FormProvider>
   );

--- a/static/js/src/advantage/subscribe/react/components/Form/Version/Version.test.tsx
+++ b/static/js/src/advantage/subscribe/react/components/Form/Version/Version.test.tsx
@@ -39,7 +39,7 @@ test("It opens the modal if 'other versions' is clicked", async () => {
 
 test("The section is disabled if a public cloud is selected", () => {
   render(
-    <FormProvider initialType={ProductTypes.aws}>
+    <FormProvider initialType={ProductTypes.publicCloud}>
       <Version />
     </FormProvider>
   );

--- a/static/js/src/advantage/subscribe/react/components/ProductSummary/ProductSummary.tsx
+++ b/static/js/src/advantage/subscribe/react/components/ProductSummary/ProductSummary.tsx
@@ -10,9 +10,7 @@ const imgUrl = {
   [ProductTypes.virtual]:
     "https://assets.ubuntu.com/v1/9ed50294-Virtual+machine.svg",
   [ProductTypes.desktop]: "https://assets.ubuntu.com/v1/4b732966-Laptop.svg",
-  [ProductTypes.aws]: "",
-  [ProductTypes.azure]: "",
-  [ProductTypes.gcp]: "",
+  [ProductTypes.publicCloud]: "",
 };
 
 const ProductSummary = () => {

--- a/static/js/src/advantage/subscribe/react/utils/utils.ts
+++ b/static/js/src/advantage/subscribe/react/utils/utils.ts
@@ -105,6 +105,10 @@ export enum ProductTypes {
   physical = "physical",
   virtual = "virtual",
   desktop = "desktop",
+  publicCloud = "publicCloud",
+}
+
+export enum PublicClouds {
   aws = "aws",
   azure = "azure",
   gcp = "gcp",
@@ -165,9 +169,7 @@ export const isMonthlyAvailable = (product: Product | null) => {
 };
 
 export const isPublicCloud = (type: ProductTypes) =>
-  type === ProductTypes.aws ||
-  type === ProductTypes.azure ||
-  type === ProductTypes.gcp;
+  type === ProductTypes.publicCloud;
 
 export const shouldShowApps = () =>
   !!window.productList[

--- a/static/sass/_pattern_card.scss
+++ b/static/sass/_pattern_card.scss
@@ -60,6 +60,11 @@
       margin-bottom: 2.4rem;
     }
 
+    + .radio-wrapper--staggering {
+      border-top: solid 1px #d9d9d9;
+      padding-top: 1.5rem;
+    }
+
     @media only screen and (min-width: $breakpoint-medium) {
       display: flex;
 
@@ -72,6 +77,11 @@
         flex-basis: 0;
         flex-direction: column;
         flex-grow: 1;
+      }
+
+      +.radio-wrapper--staggering {
+        border-top: unset;
+        padding-top: unset;
       }
     }
   }

--- a/static/sass/_pattern_card.scss
+++ b/static/sass/_pattern_card.scss
@@ -79,7 +79,7 @@
         flex-grow: 1;
       }
 
-      +.radio-wrapper--staggering {
+      + .radio-wrapper--staggering {
         border-top: unset;
         padding-top: unset;
       }


### PR DESCRIPTION

## Done

- Replaced the separate public cloud options with a generic one
- Added the public cloud options once the generic one is selected
- Removed the "Looking to add support to an existing VM" section
- Added a button styled link to lnk to each marketplace

## QA

- go to [/advantage/subscribe](https://ubuntu-com-11846.demos.haus/advantage/subscribe)
- select the public cloud option
- see that everything matches the wireframes
![image](https://user-images.githubusercontent.com/11927929/179220044-def58bd8-c1bc-429f-889d-c5d833b754c3.png)


## Issue / Card

Fixes canonical-web-and-design/commercial-squad#643

## Screenshots

Closed:
![image](https://user-images.githubusercontent.com/11927929/179220089-f4f4cf5f-7bd9-4c50-b400-668dd14aa3bd.png)

Open:
![image](https://user-images.githubusercontent.com/11927929/179220148-84ebda76-7406-4193-8226-918094c2d50a.png)

## Questions
@wgx 

- [x] is the logo ok? I found it in the assets manager under "public cloud" but I have no idea what it represents
- [x] Looks weird on mobile. Any idea to make it less terrible? I thought of adding some space between the two buttons sections to separate them a bit clearer but vertical space is pretty expensive on mobile so idk. Maybe add a subtitle "which PC platform"?

Mobile:
![image](https://user-images.githubusercontent.com/11927929/179220542-865fbdda-5d6c-4347-881f-2799c69932bf.png)



