### PR TITLE
removed cred from navigation

### DIFF
--- a/templates/templates/navigation-developer-h.html
+++ b/templates/templates/navigation-developer-h.html
@@ -17,7 +17,6 @@
             <li class="p-list__item"><a href="/kernel">Kernel selection &amp; lifecycle</a></li>
             <li class="p-list__item"><a href="https://multipass.run">Multipass</a></li>
             <li class="p-list__item"><a href="/wsl">Ubuntu on WSL</a></li>
-            <li class="p-list__item"><a href="/cube">Become a Certified Ubuntu Engineer</a></li>
           </ul>
           <p><a class="p-button--positive p-button--small" href="/desktop/developers">Develop with Ubuntu</a></p>
         </div>

--- a/templates/templates/navigation-enterprise-h.html
+++ b/templates/templates/navigation-enterprise-h.html
@@ -122,7 +122,6 @@
             <li class="p-list__item"><a href="/certified">Hardware certification</a></li>
             <li class="p-list__item"><a href="/aws">Get Ubuntu Pro on AWS</a></li>
             <li class="p-list__item"><a href="/azure">Get Ubuntu Pro on Azure</a></li>
-            <li class="p-list__item"><a href="/cube">Become a Certified Ubuntu Engineer</a></li>
           </ul>
         </div>
       </div>


### PR DESCRIPTION
## Done

- Remove link to cred from navigation till Alpha/Beta ends
 
## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- Link cred pages should not appear
