### PR TITLE
Increase cypress timeout

### DIFF
--- a/.github/workflows/cypress-main.yaml
+++ b/.github/workflows/cypress-main.yaml
@@ -37,7 +37,7 @@ jobs:
           build: yarn run build
           start: yarn run serve
           wait-on: "http://0.0.0.0:8001/_status/check"
-          wait-on-timeout: 180
+          wait-on-timeout: 360
           browser: chrome
           config-file: tests/cypress/cypress.json
           config: baseUrl=http://0.0.0.0:8001,integrationFolder=tests/cypress/forms


### PR DESCRIPTION
## Done

- It seems the engage page not being loaded causes cypress test failure. Discourse can cause timeouts so I increased the timeout in cypress.. 

![image](https://user-images.githubusercontent.com/57550290/180015283-c9ca76a4-7208-4e7e-a95d-d3afbb19cf33.png)

## QA

- There is no way to QA. Just need to merge and see if it works.... 
