### PR TITLE
Update copy on /credentialing

### DIFF
--- a/templates/credentialing/index.html
+++ b/templates/credentialing/index.html
@@ -31,9 +31,9 @@
 
 <section class="p-strip is-grid-pinned">
   <div class="u-fixed-width">
-    <div class="p-notification--caution">
+    <div class="p-notification--information">
       <div class="p-notification__content">
-        <h5 class="p-notification__title">Caution</h5>
+        <h5 class="p-notification__title">Note</h5>
         <p class="p-notification__message">Certifications are still in the alpha stage and are available on an invitational basis only.</p>
       </div>
     </div>
@@ -83,7 +83,7 @@
         <div class="p-matrix__content">
           <h3 class="p-matrix__title">Ubuntu Desktop Essentials Microcertification</h3>
           <div class="p-matrix__desc">
-            <p>Demonstrate your knowledge of Ubuntu Desktop administrative essentials. Focus on package management, system installation, data gathering, and managing printing and displays.</p>
+            <p>Demonstrate your knowledge of Ubuntu Desktop administrative essentials. Topics include package management, system installation, data gathering, and managing printing and displays.</p>
             <a
               href="https://qa.cube.ubuntu.com/auth/login/tpa-saml/?auth_entry=login&idp=ubuntuone&next=/courses/course-v1:Canonical%2bcue-desktop%2b2022/courseware/2022/start/"
               class="p-button--positive"


### PR DESCRIPTION
## Done

- Change the Notification to the `information` type and the title to "Note"
- Replace "Focus on" to "Topics include" in Desktop exam description

## QA

- Go to https://ubuntu-com-11867.demos.haus/credentialing
  - Verify that the Notification is now the [information](https://vanillaframework.io/docs/patterns/notification#information) type and the title is "Note"
  - Verify that the text in the Desktop exam description has been changed to "Topics include package management..."

## Screenshots

![cred-note](https://user-images.githubusercontent.com/995051/180257996-e3235f19-c28c-4db0-8e35-75c87a5d560e.png)

![cred-microcerts](https://user-images.githubusercontent.com/995051/180257952-de60cc35-32bd-400e-8f6e-d0789f2b7720.png)

## Help

[QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html) - [Commit guidelines](https://canonical-web-and-design.github.io/practices/workflow/commit-messages.html)
