### PR TITLE
reinstate blog-p-card__header fallback styles

### DIFF
--- a/static/sass/_pattern_blog-card.scss
+++ b/static/sass/_pattern_blog-card.scss
@@ -64,6 +64,14 @@
     }
   }
 
+  // a fallback to catch any instances where a post.group exists,
+  // but we haven't yet defined a BEM variant to match
+  [class*="blog-p-card__header"] {
+    @extend %post-card-header;
+
+    border-top: 3px solid $color-mid-dark;
+  }
+
   .blog-p-card__header {
     border-radius: 2px;
     border-top: 3px solid $color-mid-dark;


### PR DESCRIPTION
## Done

- Fixed broken headings on tutorials and engage page cards

:information_source:  This will soon be replaced by [this pattern](https://github.com/canonical-web-and-design/vanilla-framework/issues/4495) in Vanilla, when it lands.

## QA

- Visit https://ubuntu-com-11868.demos.haus/tutorials
- See that all the card headings don't look broken (compare to live site)
- Visit https://ubuntu-com-11868.demos.haus/engage
- See that all the card headings don't look broken (compare to live site)
- Visit https://ubuntu-com-11868.demos.haus/blog
- See that the card headings still have category specific top border colors (compare to live site, should be no difference)

## Issue / Card

Fixes https://github.com/canonical-web-and-design/ubuntu.com/issues/11855

