### PR TITLE
Fix broken links in PR templates

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/TAKEOVER_PR.md
+++ b/.github/PULL_REQUEST_TEMPLATE/TAKEOVER_PR.md
@@ -14,7 +14,7 @@ assignees: ''
 - Check out this feature branch
 - Run the site using the command `./run serve`
 - View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
-- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
+- Run through the following [QA steps](https://discourse.canonical.com/t/qa-steps/152)
 
 ### Takeover
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -21,4 +21,4 @@ Fixes #
 
 ## Help
 
-[QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html) - [Commit guidelines](https://canonical-web-and-design.github.io/practices/workflow/commit-messages.html)
+[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


### PR DESCRIPTION
## Done

- Fix links to "QA steps" and "Commit guidelines" in PR templates

## QA

- Before this PR is merged, the links in the **Help** section below should return a 404 error
- Once this PR is merged, open a new PR and verify that the links in the **Help** section go to [QA steps](https://discourse.canonical.com/t/qa-steps/152) and [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)

## Help

[QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html) - [Commit guidelines](https://canonical-web-and-design.github.io/practices/workflow/commit-messages.html)