### PR TITLE
Remove local styles overriding Vanilla's middot list styles

### DIFF
--- a/static/sass/_pattern_footer.scss
+++ b/static/sass/_pattern_footer.scss
@@ -307,10 +307,6 @@
     @media only screen and (min-width: $breakpoint-small) {
       .p-inline-list__item {
         display: inline-block;
-
-        &::after {
-          display: block;
-        }
       }
     }
   }

--- a/static/sass/_pattern_lists.scss
+++ b/static/sass/_pattern_lists.scss
@@ -5,7 +5,6 @@
   @include ubuntu-p-inline-definition-list;
   @include ubuntu-p-stepped-list;
   @include ubuntu-p-ordered-legal-list;
-  @include ubuntu-p-inline-list-middot;
   @include ubuntu-p-list-small;
   @include ubuntu-p-form-list-ticked;
 }
@@ -238,33 +237,6 @@
   div > .p-list--ordered-legal {
     margin-left: 0;
     padding-left: 0;
-  }
-}
-
-// small text has bigger padding top, so requires this to be factored into
-// the dot position top
-@mixin ubuntu-p-inline-list-middot {
-  .p-inline-list--middot {
-    .p-inline-list__item {
-      &::after {
-        bottom: 0;
-        height: 0;
-        right: -0.85em;
-        top: 0;
-      }
-    }
-
-    &.is-x-dense {
-      margin-bottom: $sp-unit - $nudge--small;
-
-      .p-inline-list__item {
-        &::after {
-          bottom: 0.5rem;
-          right: -0.75rem;
-          top: 0.4rem;
-        }
-      }
-    }
   }
 }
 


### PR DESCRIPTION
## Done

- Fixed middot lists in the footer and meganav

## QA

- Visit https://ubuntu-com-11870.demos.haus/
- See that the middot list in the footer looks correct
- Open the Enterprise dropdown from the meganav, and see that the middot lists at the bottom of the content window aren't broken (compare to live)

## Issue / Card

Fixes https://github.com/canonical-web-and-design/ubuntu.com/issues/11866
