### PR TITLE
Update README.md for a grammar mistake

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The site is largely maintained by the [Web and Design team](https://ubuntu.com/b
 
 If you have found a bug on the site or have an idea for a new feature, feel free to [create a new issue](https://github.com/canonical-web-and-design/ubuntu.com/issues/new), or suggest a fix by [creating a pull request](https://help.github.com/articles/creating-a-pull-request/). You can also find a link to create issues in the footer of every page of the site itself.
 
-If you have found a bug in the Ubuntu OS itself, the please file it [here](https://bugs.launchpad.net/ubuntu/).
+If you have found a bug in the Ubuntu OS itself, please file it [here](https://bugs.launchpad.net/ubuntu/).
 
 ## Local development
 


### PR DESCRIPTION
## Done
- Removes one "the" from a sentence.

## QA
- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- [List additional steps to QA the new features or prove the bug has been resolved]

## Issue / Card
No issue reference because the problem is too small to justify creating one.

## Screenshots
[If relevant, please include a screenshot.]

## Help
[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
