### PR TITLE
Disable the contribution button if total is 0

### DIFF
--- a/static/js/src/contributions.js
+++ b/static/js/src/contributions.js
@@ -109,12 +109,12 @@ function updateEquivalentItem(item) {
 }
 
 function toggleSubmit(total) {
-  const submit = document.querySelector(".js-contribute-submit");
+  const submitButton = document.querySelector(".js-contribute-submit");
 
-  if (total == 0) {
-    submit.disabled.disabled = true;
+  if (total <= 0) {
+    submitButton.disabled = true;
   } else {
-    submit.classList.disabled = false;
+    submitButton.disabled = false;
   }
 }
 

--- a/static/js/src/navigation.js
+++ b/static/js/src/navigation.js
@@ -80,9 +80,8 @@ if (window.location.hash) {
 
 var origin = window.location.href;
 
-addGANavEvents("#canonical-products", "www.ubuntu.com-nav-0-products");
+addGANavEvents("#canonical-global-nav", "www.ubuntu.com-nav-global");
 addGANavEvents("#canonical-login", "www.ubuntu.com-nav-0-login");
-addGANavEvents("#navigation", "www.ubuntu.com-nav-1");
 addGANavEvents("#enterprise-content", "www.ubuntu.com-nav-1-enterprise");
 addGANavEvents("#developer-content", "www.ubuntu.com-nav-1-developer");
 addGANavEvents("#community-content", "www.ubuntu.com-nav-1-community");
@@ -97,7 +96,8 @@ function addGANavEvents(target, category) {
   var t = document.querySelector(target);
   if (t) {
     [].slice.call(t.querySelectorAll("a")).forEach(function (a) {
-      a.addEventListener("click", function () {
+      a.addEventListener("click", function (e) {
+        e.stopPropagation();
         dataLayer.push({
           event: "GAEvent",
           eventCategory: category,

--- a/templates/templates/_navigation.html
+++ b/templates/templates/_navigation.html
@@ -54,7 +54,7 @@
             <span class="u-hide u-show--large">Search</span> <i class="p-icon--search is-light"></i>
           </a>
         </li>
-        <li class="p-navigation__user js-account"></li>
+        <li class="p-navigation__user js-account" id="canonical-login"></li>
       </ul>
       <div class="p-navigation__search u-show--small u-hide" style="z-index: 39;">
         <form action="/search" class="p-search-box" id="ubuntu-global-search-form">


### PR DESCRIPTION
## Done
**Improve navigation click events**
- The global nav id was not present so updated to target the parent

**Disable the contribution button if total is 0**
- Replaced the reserved variable name `submit` with `submitButton`
- Corrected the disable setting

## QA
- Go to /download/desktop/thank-you?version=22.04&architecture=amd64
- Cancel the download
- Set all the sliders to 0
- See the [Contribute with PayPal] button is disabled
- Move a slider and see it becomes enabled
