### PR TITLE
Expand to 2 gunicorn workers

### DIFF
--- a/entrypoint
+++ b/entrypoint
@@ -2,10 +2,14 @@
 
 set -e
 
-RUN_COMMAND="talisker.gunicorn.gevent webapp.app:app --bind $1 --worker-class gevent --name talisker-`hostname`"
+EXTRA_ARGS=""
 
+# Extra arguments for debug mode
 if [ "${FLASK_DEBUG}" = true ] || [ "${FLASK_DEBUG}" = 1 ]; then
-    ${RUN_COMMAND} --reload --log-level debug --timeout 9999
-else
-    ${RUN_COMMAND}
+    EXTRA_ARGS="--reload --log-level debug --timeout 9999"
 fi
+
+# Start server
+# ===
+talisker.gunicorn.gevent webapp.app:app --bind $1 --workers 2 --worker-class gevent --name talisker-`hostname` ${EXTRA_ARGS}
+


### PR DESCRIPTION
Fixes https://github.com/canonical/Web-design-systems-squad/issues/56 :

> This should help with stability of ubuntu.com. We do need to run more than one worker, as even with gevent multithreading, the worker still sometimes restarts and while it's restarting, requests can't be handled at all.
> 
> Should help with https://portal.admin.canonical.com/C136508/.

## QA

`dotrun`. Check the site runs.