### PR TITLE
Fix Focus not being visible on the radio card

### DIFF
--- a/static/js/src/advantage/subscribe/react/components/Form/ProductType/ProductType.tsx
+++ b/static/js/src/advantage/subscribe/react/components/Form/ProductType/ProductType.tsx
@@ -119,7 +119,7 @@ const ProductType = () => {
           <>
             <Col size={12} className="radio-wrapper--staggering">
               <RadioCard
-                name="type"
+                name="publicCloud"
                 value={PublicClouds.aws}
                 selectedValue={publicCloud}
                 handleChange={handlePublicCloudChange}
@@ -135,7 +135,7 @@ const ProductType = () => {
                 </>
               </RadioCard>
               <RadioCard
-                name="type"
+                name="publicCloud"
                 value={PublicClouds.azure}
                 selectedValue={publicCloud}
                 handleChange={handlePublicCloudChange}
@@ -151,7 +151,7 @@ const ProductType = () => {
                 </>
               </RadioCard>
               <RadioCard
-                name="type"
+                name="publicCloud"
                 value={PublicClouds.gcp}
                 selectedValue={publicCloud}
                 handleChange={handlePublicCloudChange}

--- a/static/js/src/advantage/subscribe/react/components/Form/RadioCard.tsx
+++ b/static/js/src/advantage/subscribe/react/components/Form/RadioCard.tsx
@@ -26,12 +26,22 @@ const RadioCard = <T extends string>({
   children,
 }: Props<T>) => {
   const checked = selectedValue === value;
+  const [isFocused, setIsFocused] = React.useState(false);
+
+  const handleFocus = () => {
+    setIsFocused(true);
+  };
+
+  const handleBlur = () => {
+    setIsFocused(false);
+  };
 
   return (
     <div
       className={classNames(className, {
         "p-card--radio": !className,
         "is-selected": checked,
+        "is-focused": isFocused,
         "u-disable": disabled,
       })}
       data-testid={dataTestid}
@@ -46,6 +56,8 @@ const RadioCard = <T extends string>({
           value={value}
           checked={checked}
           onChange={handleChange}
+          onFocus={handleFocus}
+          onBlur={handleBlur}
         />
         <span className="p-radio__label" id={`${name}-label`}>
           {children}

--- a/static/sass/_pattern_card.scss
+++ b/static/sass/_pattern_card.scss
@@ -183,6 +183,10 @@
       border: 0.1875rem solid #2e96ff;
       outline: none;
     }
+
+    &.is-focused {
+      box-shadow: 0px 0px 0px 1px #fff, 0px 0px 0 3px #2e96ff;
+    }
   }
 
   .p-card--radio--version {


### PR DESCRIPTION
## Done

- Added a focus state for the radio cards

## QA

- go to
- click the h1
- navigate using tab and shift+tab
- see that the focus is indicated clearly

## Issue / Card

Fixes #11861 

## Screenshots

![focus](https://user-images.githubusercontent.com/11927929/180952278-fe9706b1-ed7a-47ad-b4f3-5258ff634969.gif)
