### PR TITLE
Removed required on the org name in the CLA form

### DIFF
--- a/templates/legal/contributors/agreement.html
+++ b/templates/legal/contributors/agreement.html
@@ -369,7 +369,7 @@ defer></script>
                 <label id="tfa_Email1-L" class="label preField reqMark" for="tfa_Email1">Email</label><br><div class="inputWrapper"><input aria-required="true" type="text" id="tfa_Email1" name="tfa_Email1" value=""  title="Email" class="validate-email required"></div>
               </div>
               <div class="oneField field-container-D" id="tfa_2-D">
-                <label id="tfa_2-L" class="label preField reqMark" for="tfa_2">Organisation name</label><br><div class="inputWrapper"><input aria-required="true" type="text" id="tfa_2" name="tfa_2" value="" data-condition="`#tfa_Iamsigningonbeha1`" title="Organisation Name" class="required"></div>
+                <label id="tfa_2-L" class="label preField reqMark" for="tfa_2">Organisation name</label><br><div class="inputWrapper"><input type="text" id="tfa_2" name="tfa_2" value="" data-condition="`#tfa_Iamsigningonbeha1`" title="Organisation Name"></div>
                 </div>
               <div class="oneField field-container-D    " id="tfa_Phone-D">
                 <label id="tfa_Phone-L" class="label preField reqMark" for="tfa_Phone">Phone</label><br><div class="inputWrapper"><input aria-required="true" type="text" id="tfa_Phone" name="tfa_Phone" value=""  title="Phone" class="required"></div>


### PR DESCRIPTION
## Done
Removed required on the org name in the CLA form when signing as an individual.

## QA
- Open the demo
- Go to /legal/contributors/agreement
- Select "I am signing as an individual contributor."
- Compete the form and see it submits correctly

## Issue / Card
Fixes https://github.com/canonical/microk8s/issues/3345
