### PR TITLE
update K8s chart to match upstream

### DIFF
--- a/static/js/src/chart-data.js
+++ b/static/js/src/chart-data.js
@@ -1278,19 +1278,19 @@ export var kubernetesReleases = [
   },
   {
     startDate: new Date("2021-08-01T00:00:00"),
-    endDate: new Date("2022-08-01T00:00:00"),
+    endDate: new Date("2022-10-28T00:00:00"),
     taskName: "Kubernetes 1.22",
     status: "CANONICAL_KUBERNETES_SUPPORT",
   },
   {
     startDate: new Date("2021-12-07T00:00:00"),
-    endDate: new Date("2022-12-07T00:00:00"),
+    endDate: new Date("2023-02-28T00:00:00"),
     taskName: "Kubernetes 1.23",
     status: "CANONICAL_KUBERNETES_SUPPORT",
   },
   {
     startDate: new Date("2022-05-06T00:00:00"),
-    endDate: new Date("2023-05-06T00:00:00"),
+    endDate: new Date("2023-07-28T00:00:00"),
     taskName: "Kubernetes 1.24",
     status: "CANONICAL_KUBERNETES_CURRENT_VERSION",
   },

--- a/templates/about/release-cycle.html
+++ b/templates/about/release-cycle.html
@@ -589,17 +589,17 @@
             <tr>
               <td><strong>1.24.x</strong></td>
               <td align='right'>May 2022</td>
-              <td align='right'>May 2023</td>
+              <td align='right'>Jul 2023</td>
             </tr>
             <tr>
               <td><strong>1.23.x</strong></td>
               <td align='right'>Dec 2021</td>
-              <td align='right'>Dec 2022</td>
+              <td align='right'>Feb 2023</td>
             </tr>
             <tr>
               <td><strong>1.22.x</strong></td>
               <td align='right'>Aug 2021</td>
-              <td align='right'>Aug 2022</td>
+              <td align='right'>Oct 2022</td>
             </tr>
             <tr>
               <td><strong>1.21.x</strong></td>


### PR DESCRIPTION
## Done

- Updates release-cycle graph for Kubernetes to match upstream

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
