### PR TITLE
Blog - 500 when article has no group

### DIFF
--- a/webapp/views.py
+++ b/webapp/views.py
@@ -623,7 +623,8 @@ class BlogRedirects(BlogView):
         )
 
         # Redirect canonical annoucements
-        if article["group"]["id"] == 2100:
+        group = article.get("group")
+        if isinstance(group, dict) and group["id"] == 2100:
             return flask.redirect(f"https://canonical.com/blog/{slug}")
 
         return flask.render_template("blog/article.html", article=article)


### PR DESCRIPTION
## Done
Check if the article has a group set before checking redirect condition

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- Find a blog article with no group set
- View the site locally in your web browser at: http://0.0.0.0:8001/blog/<atricle_slug>
- Make sure it does not 500

## Issues
Fixes https://github.com/canonical-web-and-design/ubuntu.com/issues/11908#event-7087743195