### PR TITLE
Fix 500 for groupless posts

### DIFF
--- a/webapp/views.py
+++ b/webapp/views.py
@@ -623,7 +623,7 @@ class BlogRedirects(BlogView):
         )
 
         # Redirect canonical annoucements
-        if article["group"]["id"] == 2100:
+        if article["group"] and article["group"]["id"] == 2100:
             return flask.redirect(f"https://canonical.com/blog/{slug}")
 
         return flask.render_template("blog/article.html", article=article)


### PR DESCRIPTION
## Done

- So blog posts don't have group data. Causing the `article["group"]["id"]` to return 500.

## QA

- Go to: https://ubuntu.com/blog/vodafone-cloud-smartphone-based-on-anbox-cloud
- It will give you 500
- Go to: https://ubuntu-com-11909.demos.haus/blog/vodafone-cloud-smartphone-based-on-anbox-cloud
- It will work