### PR TITLE
fix server section of certified home page

### DIFF
--- a/templates/certified/index.html
+++ b/templates/certified/index.html
@@ -125,9 +125,9 @@
       <p class="u-text--muted u-no-margin--bottom">Vendor:</p>
       <ul class="p-inline-list--midline" style="margin-bottom: 0.5rem;">
         {% for server_vendor in server_vendors %}
-          {% if server_vendor.vendor in ['Dell', 'Lenovo', 'HPE'] %}
+          {% if server_vendor.make in ['Dell Technologies', 'Lenovo', 'HPE'] %}
             <li class="p-inline-list__item">
-              <a href="/certified/servers?vendor={{ server_vendor.vendor }}">{{ server_vendor.vendor }}&nbsp;({{ server_vendor.total }})</a>
+              <a href="/certified/servers?vendor={{ server_vendor.make }}">{{ server_vendor.make }}&nbsp;({{ server_vendor.total }})</a>
             </li>
           {% endif %}
         {% endfor %}
@@ -135,9 +135,9 @@
 
       <p class="u-text--muted u-no-margin--bottom">Certified for:</p>
       <ul class="p-inline-list--midline">
-        {% for server_release, total in server_releases.items() %}
+        {% for server_release in server_releases %}
         <li class="p-inline-list__item">
-          <a href="/certified/servers?release={{ server_release }}">{{ server_release }}&nbsp;({{ total }})</a>
+          <a href="/certified/servers?release={{ server_release.release }}">{{ server_release.release }}&nbsp;({{ server_release.servers }})</a>
         </li>
         {% endfor %}
       </ul>

--- a/webapp/certified/views.py
+++ b/webapp/certified/views.py
@@ -214,6 +214,10 @@ def certified_home():
     iot_releases = []
     iot_vendors = []
 
+    # Server section
+    server_releases = []
+    server_vendors = []
+
     # Search results filters
     all_releases = []
     release_filters = []
@@ -243,6 +247,9 @@ def certified_home():
         if int(release["soc"] > 1):
             soc_releases.append(release)
 
+        if int(release["servers"] > 1):
+            server_releases.append(release)
+
     for vendor in certified_makes:
         make = vendor["make"]
 
@@ -266,16 +273,8 @@ def certified_home():
         if int(vendor["soc"] > 1):
             soc_vendors.append(vendor)
 
-    # Server section
-    server_releases = {}
-    server_vendors = api.vendor_summaries_server()["vendors"]
-
-    for vendor in server_vendors:
-        for release in vendor["releases"]:
-            if release in server_releases:
-                server_releases[release] += vendor[release]
-            else:
-                server_releases[release] = vendor[release]
+        if int(vendor["servers"] > 1):
+            server_vendors.append(vendor)
 
     if "q" in request.args:
         query = request.args["q"]


### PR DESCRIPTION
The certified home page server section was displaying
incorrect numbers and was missing the Dell Technologies
vendor.

## Done

This change updates the home view to make the logic that builds up the server section match the logic that builds up all of the other form factor types. It also updates the template to use the same pattern as well as changes the match string to _Dell Technologies_ since _Dell_ is not used.

This updates the servers section of the home page so that it includes Dell and also fixes the counts.

## QA

View https://ubuntu-com-11912.demos.haus/certified  and verify that a link for Dell Technologies shows up in the server section of the page with a count of 89.

## Issue / Card

Fixes #11907
